### PR TITLE
Minor changes to the CI build script

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 if [ $COMPILER = "clang" ]; then
 	export CC=clang-$LLVM_VER
@@ -21,8 +21,8 @@ fi
 
 cd postgresql
 ./configure $CONFIG_ARGS
-make -sj4
-make -sj4 install
+make -j4
+make -j4 install
 cd ..
 
 if [ $CHECK_TYPE = "static" ] && [ $COMPILER = "clang" ]; then
@@ -39,4 +39,5 @@ elif [ $CHECK_TYPE = "check_page" ]; then
 elif [ $CHECK_TYPE != "static" ]; then
 	make USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -coverage"
 fi
+make USE_PGXS=1 install
 cd ..

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -39,5 +39,5 @@ elif [ $CHECK_TYPE = "check_page" ]; then
 elif [ $CHECK_TYPE != "static" ]; then
 	make -j `nproc` USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -coverage"
 fi
-mak -j `nproc` USE_PGXS=1 install
+make -j `nproc` USE_PGXS=1 install
 cd ..

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -21,8 +21,8 @@ fi
 
 cd postgresql
 ./configure $CONFIG_ARGS
-make -j4
-make -j4 install
+make -j `nproc`
+make -j `nproc` install
 cd ..
 
 if [ $CHECK_TYPE = "static" ] && [ $COMPILER = "clang" ]; then
@@ -33,11 +33,11 @@ export PATH="$GITHUB_WORKSPACE/pgsql/bin:$PATH"
 
 cd orioledb
 if [ $CHECK_TYPE = "alignment" ]; then
-	make USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -fsanitize=alignment -fno-sanitize-recover=alignment" LDFLAGS_SL="-lubsan"
+	make -j `nproc` USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -fsanitize=alignment -fno-sanitize-recover=alignment" LDFLAGS_SL="-lubsan"
 elif [ $CHECK_TYPE = "check_page" ]; then
-	make USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -DCHECK_PAGE_STRUCT"
+	make -j `nproc` USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -DCHECK_PAGE_STRUCT"
 elif [ $CHECK_TYPE != "static" ]; then
-	make USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -coverage"
+	make -j `nproc` USE_PGXS=1 CFLAGS_SL="$(pg_config --cflags_sl) -Werror -coverage"
 fi
-make USE_PGXS=1 install
+mak -j `nproc` USE_PGXS=1 install
 cd ..


### PR DESCRIPTION
## Why?
As part of trying to compile OrioleDB, I faced some problems compiling it using the CI build script.     
This changeset is a collection of the fixes I put in.

## What?
1. The CI build script did not have executable permissions
2. Maximize the number of parallel threads during compilation
3. Increase verbosity during build