### PR TITLE
fix script error and icu-data-full install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,7 @@ RUN set -eux; \
 # https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
 		tzdata \
 # install extra icu packages ( >=Alpine3.16 )
-		$(EXTRA_ICU_PACKAGES)  \
+		$EXTRA_ICU_PACKAGES \
 	; \
 	apk del --no-network .build-deps; \
 	cd /; \


### PR DESCRIPTION
fix script warnings and `icu-data-full` install.

now in the logs: `#10 284.2 /bin/sh: EXTRA_ICU_PACKAGES: not found`


