### PR TITLE
Improve Docker Build+Testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -75,6 +75,10 @@ Dockerfile.ubuntu
 # as they are not needed inside the Docker image.
 test/
 ci/local_docker_matrix.sh
+ci/docker_matrix.sh
 
 # Documentation files, which are not needed inside the Docker image.
 doc/
+
+# Exclude the PostGIS Docker build directory
+docker-postgis

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -17,21 +17,22 @@ jobs:
         compiler: [clang]
         distr: [alpine, ubuntu]
         include:
-          - distr-version: 3.19
+          - distr-version: "3.20"
             distr: alpine
-          - distr-version: focal
+          - distr-version: "focal"
             distr: ubuntu
 
     name: docker ${{ matrix.postgres }}-${{ matrix.compiler }}-${{ matrix.distr }}-${{ matrix.distr-version }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.alpine == 'edge' }}
+    continue-on-error: ${{ matrix.distr-version == 'edge' || matrix.distr-version == 'devel' }}
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
       - name: docker build orioletest:${{ matrix.postgres }}-${{ matrix.compiler }}-${{ matrix.distr }}-${{ matrix.distr-version }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
+        # https://github.com/docker/build-push-action
         with:
           context: .
           file: ${{ matrix.distr == 'ubuntu' && 'Dockerfile.ubuntu' || 'Dockerfile' }}
@@ -45,3 +46,22 @@ jobs:
             PG_MAJOR=${{ matrix.postgres }}
             BUILD_CC_COMPILER=${{ matrix.compiler }}
             DOCKER_PG_LLVM_DEPS=llvm-dev clang
+            DEBUG_MODE=false
+
+      # docker imgage testing with https://github.com/docker-library/official-images.git
+      # to check if the image is compatible with the official-images test suite
+      # the special orioledb test config is in the ./test/tests/orioledb-config.sh
+      # Read more: ./test/README.md
+      - name: Run Docker-official-postgres tests + minimal orioledb test
+        run: |
+          OFFIMG_LOCAL_CLONE=./log_docker_build/official-images
+          OFFIMG_REPO_URL=https://github.com/docker-library/official-images.git
+          mkdir -p "$OFFIMG_LOCAL_CLONE"
+          git clone --depth=1 --branch=master "$OFFIMG_REPO_URL" "$OFFIMG_LOCAL_CLONE"
+          "${OFFIMG_LOCAL_CLONE}/test/run.sh" \
+              -c "${OFFIMG_LOCAL_CLONE}/test/config.sh" \
+              -c "test/orioledb-config.sh" \
+              orioletest:${{ matrix.postgres }}-${{ matrix.compiler }}-${{ matrix.distr }}-${{ matrix.distr-version }}
+
+      # if you want to push the tested image
+      # check this example:  https://docs.docker.com/build/ci/github-actions/test-before-push/

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ lib*.pc
 /include/utils/stopevents_data.h
 /orioledb.typedefs
 !ci/antithesis/libvoidstar.so
+
+# Exclude the PostGIS Docker build directory
+/docker-postgis

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM alpine:${ALPINE_VERSION}
 ARG ALPINE_VERSION
 
 # Set PG_MAJOR = [ 17 16 ]
-ARG PG_MAJOR=16
+ARG PG_MAJOR=17
 ENV PG_MAJOR=${PG_MAJOR}
 
 # set compiler: [ clang gcc ]
@@ -140,7 +140,7 @@ RUN set -eux; \
 	cd /usr/src/postgresql; \
 	\
 	POSTGRESQL_VERSION=$(grep "PACKAGE_VERSION=" ./configure | cut -d"'" -f2) ; \
-    echo "POSTGRESQL_VERSION=$POSTGRESQL_VERSION" ; \
+	echo "POSTGRESQL_VERSION=$POSTGRESQL_VERSION" ; \
 	\
 # update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
 # see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -10,7 +10,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG UBUNTU_VERSION
 
 # Set PG_MAJOR = [ 17 16 ]
-ARG PG_MAJOR=16
+ARG PG_MAJOR=17
 ENV PG_MAJOR=${PG_MAJOR}
 
 # set compiler: [ clang gcc ]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,26 +1,32 @@
 # This is modified Dockerfile from 16/bookworm in
 # https://github.com/docker-library/postgres
 
-# Set UBUNTU_VERSION = [ devel 23.10  22.04 20.04 ]
-#                   or [ devel mantic jammy focal ]
-ARG UBUNTU_VERSION=focal
+# Set UBUNTU_VERSION = [ devel 24.10    24.04 22.04 20.04 ]
+#                   or [ devel oracular noble jammy focal ]
+
+ARG UBUNTU_VERSION=noble
 FROM ubuntu:${UBUNTU_VERSION}
 
 ARG UBUNTU_VERSION
 
-# Set PG_MAJOR = [16 15]
+# Set PG_MAJOR = [ 17 16 ]
 ARG PG_MAJOR=16
-ENV PG_MAJOR ${PG_MAJOR}
+ENV PG_MAJOR=${PG_MAJOR}
 
 # set compiler: [ clang gcc ]
 ARG BUILD_CC_COMPILER=clang
-ENV BUILD_CC_COMPILER ${BUILD_CC_COMPILER}
+ENV BUILD_CC_COMPILER=${BUILD_CC_COMPILER}
+
+# Enable debug mode and preserve the build environments for debugging.
+# In this case, each image size exceeds ~1GB
+ARG DEBUG_MODE=false
+ENV DEBUG_MODE=${DEBUG_MODE}
 
 # Define build dependencies for LLVM [ llvm-dev clang ]
 # These include the specific versions of 'llvm-dev' and 'clang' suitable for the current version of PostgreSQL.
 # Reference: https://github.com/docker-library/postgres/pull/1077
 ARG DOCKER_PG_LLVM_DEPS="llvm-dev clang"
-ENV DOCKER_PG_LLVM_DEPS ${DOCKER_PG_LLVM_DEPS}
+ENV DOCKER_PG_LLVM_DEPS=${DOCKER_PG_LLVM_DEPS}
 
 # explicitly set user/group IDs
 RUN set -eux; \
@@ -54,11 +60,11 @@ RUN set -eux; \
 	apt-get clean
 
 # make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
-ENV LANG en_US.utf8
+ENV LANG=en_US.utf8
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION 1.17
+ENV GOSU_VERSION=1.17
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
@@ -85,7 +91,9 @@ COPY . /usr/src/postgresql/contrib/orioledb
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
+
+ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 RUN set -eux; \
 	\
 	PGTAG=$(grep "^$PG_MAJOR: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
@@ -98,6 +106,7 @@ RUN set -eux; \
 	echo "ORIOLEDB_VERSION=$ORIOLEDB_VERSION" ; \
 	echo "ORIOLEDB_BUILDTIME=$ORIOLEDB_BUILDTIME" ; \
 	echo "DOCKER_PG_LLVM_DEPS=$DOCKER_PG_LLVM_DEPS" ; \
+	echo "DEBUG_MODE=$DEBUG_MODE" ;	\
 	\
 	LLVM_RUNTIME_DEPS=$(echo "$DOCKER_PG_LLVM_DEPS" | grep -o 'llvm[0-9]*') ; \
 	echo "LLVM_RUNTIME_DEPS=$LLVM_RUNTIME_DEPS" ; \
@@ -155,10 +164,14 @@ RUN set -eux; \
 	rm postgresql.tar.gz; \
 	\
 	cd /usr/src/postgresql; \
+	\
+	POSTGRESQL_VERSION=$(grep "PACKAGE_VERSION=" ./configure | cut -d"'" -f2) ; \
+    echo "POSTGRESQL_VERSION=$POSTGRESQL_VERSION" ; \
+	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
-	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
-	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	wget --tries=10 --timeout=60 -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	wget --tries=10 --timeout=60 -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
 # configure options taken from:
 # https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
 	( CC=${BUILD_CC_COMPILER} ./configure \
@@ -192,53 +205,63 @@ RUN set -eux; \
 		--with-llvm \
 		--with-lz4 \
 		--with-zstd \
-		--with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} ubuntu:${UBUNTU_VERSION}+${BUILD_CC_COMPILER} build:${ORIOLEDB_BUILDTIME}" \
+		# The "testgres" package expects the PostgreSQL version as the last word.
+		# Therefore, the extra ${POSTGRESQL_VERSION} is added as a workaround.
+		--with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} ubuntu:${UBUNTU_VERSION}+${BUILD_CC_COMPILER} build:${ORIOLEDB_BUILDTIME} ${POSTGRESQL_VERSION}" \
 	|| cat config.log ); \
 	echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	# install postgresql
 	make -j "$(nproc)"; \
 	make -C contrib -j "$(nproc)"; \
-	make -C contrib/orioledb -j "$(nproc)"; \
 	make install; \
 	make -C contrib install; \
-	make -C contrib/orioledb install; \
+	# install orioledb extension
+	cd /usr/src/postgresql/contrib/orioledb; \
+	make USE_PGXS=1 -j "$(nproc)"; \
+	make USE_PGXS=1 install; \
 	\
-	apt-get -y remove \
-		${DOCKER_PG_LLVM_DEPS} \
-		bison \
-		build-essential \
-		curl \
-		flex \
-		gdb \
-		git \
-		libicu-dev \
-		libipc-run-perl \
-		liblz4-dev \
-		libreadline-dev \
-		libxml2-dev \
-		libxslt1-dev \
-		libzstd-dev \
-		make \
-		pkg-config \
-		python3-dev \
-		python3-pip \
-		uuid-dev \
-		wget \
-	; \
-	apt-get -y autoremove; \
-	rm -rf /var/cache/apt/archives /var/lib/apt/lists/*; \
-	apt-get clean; \
+	# Clean up only if not in debug mode
+	if [ "$DEBUG_MODE" != "true" ]; then \
+		apt-get -y remove \
+			${DOCKER_PG_LLVM_DEPS} \
+			bison \
+			build-essential \
+			curl \
+			flex \
+			gdb \
+			git \
+			libicu-dev \
+			libipc-run-perl \
+			liblz4-dev \
+			libreadline-dev \
+			libxml2-dev \
+			libxslt1-dev \
+			libzstd-dev \
+			make \
+			pkg-config \
+			python3-dev \
+			python3-pip \
+			uuid-dev \
+			wget \
+		; \
+		apt-get -y autoremove; \
+		rm -rf /var/cache/apt/archives /var/lib/apt/lists/*; \
+		apt-get clean; \
+		rm -rf \
+			/usr/src/postgresql \
+			/usr/local/share/doc \
+			/usr/local/share/man \
+			/tmp/* \
+		; \
+	fi ; \
+	\
 	cd /; \
-	rm -rf \
-		/usr/src/postgresql \
-		/usr/local/share/doc \
-		/usr/local/share/man \
-	; \
-	\
-	postgres --version
+	# Verify PostgreSQL installation
+	ldconfig ; \
+	postgres --version ; \
+	initdb --version
 
-RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
-
-ENV PGDATA /var/lib/postgresql/data
+ENV PGDATA=/var/lib/postgresql/data
 # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
 RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA"
 VOLUME /var/lib/postgresql/data

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,13 @@ check: regresscheck isolationcheck testgrescheck
 	echo "All checks are successful!"
 endif
 
-COMMIT_HASH = $(shell git rev-parse HEAD)
+# Retrieve the current commit hash from the Git repository.
+# If the .git environment does not exist (e.g., in a Docker environment or a non-Git setup),
+# fallback to a default "fake" commit hash (all zeros) to avoid errors.
+COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null)
+ifeq ($(strip $(COMMIT_HASH)),)
+	COMMIT_HASH := 0000000000000000000000000000000000000000
+endif
 override CFLAGS_SL += -DCOMMIT_HASH=$(COMMIT_HASH) -Wno-error=deprecated-declarations
 
 ifdef VALGRIND

--- a/ci/docker_matrix.sh
+++ b/ci/docker_matrix.sh
@@ -3,7 +3,7 @@ set -Eeo pipefail
 
 # Default values
 BASE_MATRIX="ubuntu:24.04"
-PG_MAJOR="16"
+PG_MAJOR="17"
 COMPILER="clang"
 DEBUG="false"
 DRY_RUN="false"
@@ -18,8 +18,8 @@ base_lists[all-debian]="ubuntu:devel ubuntu:24.10 ubuntu:24.04 ubuntu:22.04 ubun
 base_lists[all]="${base_lists[all-alpine]} ${base_lists[all-debian]}"
 
 # Valid Alpine, Ubuntu, PG and Compiler versions
-VALID_ALPINE_VERSIONS="edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14"
-VALID_UBUNTU_VERSIONS="devel 24.10 24.04 22.04 20.04 oracular noble jammy focal"
+VALID_ALPINE_VERSIONS="edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14 latest"
+VALID_UBUNTU_VERSIONS="devel 24.10 24.04 22.04 20.04 oracular noble jammy focal latest rolling"
 VALID_PG_MAJOR_VERSIONS="17 16"
 VALID_COMPILERS="clang gcc"
 
@@ -72,7 +72,7 @@ and you can check the build logs with:
 
 Examples:
   ./ci/docker_matrix.sh --base all-dev --pg-major all --compiler clang
-  ./ci/docker_matrix.sh --base alpine:3.20 --pg-major 16 --compiler gcc --debug true
+  ./ci/docker_matrix.sh --base alpine:3.20 --pg-major 17 --compiler gcc --debug true
   ./ci/docker_matrix.sh --base ubuntu:oracular --pg-major 16 --compiler all --debug false
 
 Default behavior:

--- a/ci/docker_matrix.sh
+++ b/ci/docker_matrix.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+# Default values
+BASE_MATRIX="ubuntu:24.04"
+PG_MAJOR="16"
+COMPILER="clang"
+DEBUG="false"
+DRY_RUN="false"
+
+# Define base lists
+declare -A base_lists
+base_lists[all-oldest]="ubuntu:22.04 alpine:3.14"
+base_lists[all-latest]="ubuntu:24.10 alpine:3.20"
+base_lists[all-dev]="ubuntu:devel alpine:edge"
+base_lists[all-alpine]="alpine:edge alpine:3.20 alpine:3.19 alpine:3.18 alpine:3.17 alpine:3.16 alpine:3.15 alpine:3.14"
+base_lists[all-debian]="ubuntu:devel ubuntu:24.10 ubuntu:24.04 ubuntu:22.04 ubuntu:20.04 "
+base_lists[all]="${base_lists[all-alpine]} ${base_lists[all-debian]}"
+
+# Valid Alpine, Ubuntu, PG and Compiler versions
+VALID_ALPINE_VERSIONS="edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14"
+VALID_UBUNTU_VERSIONS="devel 24.10 24.04 22.04 20.04 oracular noble jammy focal"
+VALID_PG_MAJOR_VERSIONS="17 16"
+VALID_COMPILERS="clang gcc"
+
+
+# Function to display help message
+show_help() {
+    cat << EOF
+Usage: ./ci/docker_matrix.sh [options]
+This script should be run from the project root directory!
+
+Experimental OrioleDB Docker matrix build command
+  for testing multiple: PostgreSQL versions, compilers, and base images.
+
+Options:
+  --base MATRIX|IMAGE Specify the base/matrix option or individual image
+                      Matrix options:
+                        all-alpine # [ ${base_lists[all-alpine]} ],
+                        all-debian # [ ${base_lists[all-debian]} ],
+                        all-oldest # [ ${base_lists[all-oldest]} ],
+                        all-latest # [ ${base_lists[all-latest]} ],
+                        all-dev # [ ${base_lists[all-dev]} ],
+                        all,
+                      Individual image examples:
+                        alpine:* [ $VALID_ALPINE_VERSIONS ],
+                        ubuntu:* [ $VALID_UBUNTU_VERSIONS ],
+                      Default: $BASE_MATRIX
+  --pg-major VERSION  Specify PostgreSQL major version
+                      Valid options: [ all $VALID_PG_MAJOR_VERSIONS ]
+                      Default: $PG_MAJOR
+  --compiler TYPE     Specify compiler type
+                      Valid options: [ all $VALID_COMPILERS ]
+                      Default: $COMPILER
+  --debug BOOL        Enable debug mode and preserve the build environments.
+                      In this case, each image size exceeds +1GB
+                      Valid options: [ all true false ]
+                      Default: $DEBUG
+  --dry-run           Only print commands without executing
+                      Default: $([ "$DRY_RUN" = true ] && echo "enabled" || echo "disabled")
+  --clean             Clean Docker images ( remove orioletest:* )
+                      [ --dry-run mode is not working with this option! ]
+  --help              Display this help message
+
+For the details: check the "--dry-run" and the Dockerfiles in the root directory
+  - alpine Dockerfile : ./Dockerfile
+  - ubuntu Dockerfile : ./Dockerfile.ubuntu
+
+The Docker build logs generated in the ./log_docker_build directory,
+and you can check the build logs with:
+  grep -i -C 1 warning: ./log_docker_build/*/*.build.log
+
+Examples:
+  ./ci/docker_matrix.sh --base all-dev --pg-major all --compiler clang
+  ./ci/docker_matrix.sh --base alpine:3.20 --pg-major 16 --compiler gcc --debug true
+  ./ci/docker_matrix.sh --base ubuntu:oracular --pg-major 16 --compiler all --debug false
+
+Default behavior:
+  ./ci/docker_matrix.sh --base $BASE_MATRIX --pg-major $PG_MAJOR --compiler $COMPILER --debug $DEBUG
+
+EOF
+}
+
+# Function to check if the script is run from the correct directory
+check_directory() {
+    if [[ "$(basename "$(pwd)")" == "ci" ]]; then
+        echo "Error: This script should be run from the project root directory, not the 'ci' directory."
+        echo "Please change to the project root directory and run: ./ci/docker_matrix.sh"
+        exit 1
+    fi
+
+    if [[ ! -f "./ci/docker_matrix.sh" ]]; then
+        echo "Error: This script should be run from the project root directory."
+        echo "Please change to the project root directory and run: ./ci/docker_matrix.sh"
+        exit 1
+    fi
+}
+
+# Function to check if Docker is installed
+check_docker() {
+    if ! command -v docker &> /dev/null; then
+        echo "Warning: Docker is not installed or not in PATH. Please install Docker and try again."
+        exit 1
+    fi
+}
+
+# Function to clean Docker images
+clean_docker_images() {
+    echo "Cleaning Docker images..."
+    docker images | grep 'orioletest' | awk '{print $3}' | sort -u | xargs -r docker rmi -f
+}
+
+## Function to format and optionally execute a command
+execute_command() {
+    echo
+    echo "# -----------"
+    local cmd="$*"
+
+    # Formatting: insert line breaks before certain options
+    # and at '|' and 'tee' for readability
+    local formatted_cmd=$(echo "$cmd" | sed -E '
+        s/(\s)(\||tee|2>&1)/ \\\n  \2/g;
+        s/ (\-[^ ]+)/ \\\n  \1/g
+    ')
+
+    # Process each line to replace multiple spaces before backslash at end of lines
+    formatted_cmd=$(echo "$formatted_cmd" | sed -E 's/[[:space:]]+\\$/ \\/')
+
+    echo "$formatted_cmd"
+
+    if [ "$DRY_RUN" = false ]; then
+        eval "$cmd"
+    fi
+}
+
+
+
+# Function to validate and process the base parameter
+process_base_parameter() {
+    local base="$1"
+    if [[ "${base_lists[$base]}" ]]; then
+        echo "${base_lists[$base]}"
+    elif [[ $base == alpine:* ]]; then
+        local version="${base#alpine:}"
+        if [[ " $VALID_ALPINE_VERSIONS " == *" $version "* ]]; then
+            echo "$base"
+        else
+            echo "Invalid Alpine version: $version" >&2
+            exit 1
+        fi
+    elif [[ $base == ubuntu:* ]]; then
+        local version="${base#ubuntu:}"
+        if [[ " $VALID_UBUNTU_VERSIONS " == *" $version "* ]]; then
+            echo "$base"
+        else
+            echo "Invalid Ubuntu version: $version" >&2
+            exit 1
+        fi
+    else
+        echo "Invalid base parameter: $base" >&2
+        exit 1
+    fi
+}
+
+# Main build logic
+main() {
+    local pg_major_list compiler_list base_list
+
+    # Set up lists based on input parameters
+    [[ $PG_MAJOR == "all" ]] && pg_major_list=( $VALID_PG_MAJOR_VERSIONS ) || pg_major_list=( $PG_MAJOR )
+    [[ $COMPILER == "all" ]] && compiler_list=( $VALID_COMPILERS ) || compiler_list=( $COMPILER )
+    base_list=($(process_base_parameter "$BASE_MATRIX"))
+
+    # Prepare log directory
+    local logpath="./log_docker_build/$(date +%Y-%m-%d-%H%M%S)-pid-$$"
+    execute_command "mkdir -p $logpath"
+    execute_command "rm -f ${logpath}/*.log"
+
+    # Clone or update docker-library/official-images repository - for testing
+    local OFFIMG_LOCAL_CLONE="./log_docker_build/official-images"
+    local OFFIMG_REPO_URL="https://github.com/docker-library/official-images.git"
+    execute_command "mkdir -p $OFFIMG_LOCAL_CLONE"
+    if [ -d "$OFFIMG_LOCAL_CLONE/.git" ]; then
+        execute_command "pushd $OFFIMG_LOCAL_CLONE && git pull origin master && popd"
+    else
+        execute_command "git clone $OFFIMG_REPO_URL $OFFIMG_LOCAL_CLONE"
+    fi
+
+    # Build and test loop
+    for pg_major in "${pg_major_list[@]}"; do
+        for compiler in "${compiler_list[@]}"; do
+            for base in "${base_list[@]}"; do
+                for debug in $([[ $DEBUG == "all" ]] && echo "true false" || echo "$DEBUG"); do
+
+                        local base_os="${base%%:*}"
+                        local base_tag="${base##*:}"
+                        local base_os_upper="${base_os^^}"
+                        local dockerfile="Dockerfile"
+                        [[ $base_os == "ubuntu" ]] && dockerfile="Dockerfile.ubuntu"
+                        local docker_tag="${pg_major}-${compiler}-${base_os}-${base_tag}-debug-${debug}"
+
+                        echo "#------------ $docker_tag ------------------"
+
+                        # Build Docker image
+                        execute_command "docker build --pull --network=host --progress=plain \
+                            --build-arg ${base_os_upper}_VERSION=\"$base_tag\" \
+                            --build-arg BUILD_CC_COMPILER=\"$compiler\" \
+                            --build-arg PG_MAJOR=\"$pg_major\" \
+                            --build-arg DEBUG_MODE=\"$debug\" \
+                            -f \"$dockerfile\" \
+                            -t \"orioletest:${docker_tag}\" . \
+                            2>&1 | \
+                            tee \"${logpath}/${docker_tag}.build.log\""
+
+                        # Run Docker tests
+                        execute_command "\"${OFFIMG_LOCAL_CLONE}/test/run.sh\" \
+                            -c \"${OFFIMG_LOCAL_CLONE}/test/config.sh\" \
+                            -c \"test/orioledb-config.sh\" \"orioletest:${docker_tag}\" \
+                            2>&1 | \
+                            tee \"${logpath}/${docker_tag}.test.log\""
+
+                        #TODO - add regression test - running inside in the docker container
+
+                done
+            done
+        done
+    done
+
+    execute_command "docker images orioletest:* | sort"
+}
+
+# Run the main function if not sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    # Check if the script is run from the correct directory
+    check_directory
+
+    # Check if Docker is installed
+    check_docker
+
+    # Parse command line arguments
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --base)
+                BASE_MATRIX="$2"
+                shift 2
+                ;;
+            --pg-major)
+                PG_MAJOR="$2"
+                shift 2
+                ;;
+            --compiler)
+                COMPILER="$2"
+                shift 2
+                ;;
+            --debug)
+                DEBUG="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --clean)
+                clean_docker_images
+                exit 0
+                ;;
+            --help)
+                show_help
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+
+    # Run the main function
+    main
+
+    echo
+    echo "#----------------"
+    echo "# Build process completed. You can check the build logs with:"
+    echo "#  grep -i -C 1 warning: ./log_docker_build/*/*.build.log"
+    echo
+    echo "# To remove test images, run:"
+    echo "#  docker images | grep orioletest | awk '{print \$3}' | sort -u | xargs docker rmi -f"
+    echo "# ----------------------------------"
+
+fi

--- a/ci/local_docker_matrix.sh
+++ b/ci/local_docker_matrix.sh
@@ -10,16 +10,17 @@ pg_major_list=( 16 17)
 compiler_list=( clang gcc )
 base_list=(
    # alpine versions
+   alpine:3.20
    alpine:3.19
    alpine:3.18
    alpine:3.17
    alpine:3.16
    alpine:3.15
    alpine:3.14
-   alpine:3.13
 
    # ubuntu versions
-   ubuntu:23.10
+   ubuntu:24.10
+   ubuntu:24.04
    ubuntu:22.04
    ubuntu:20.04
 

--- a/doc/docker_usage.md
+++ b/doc/docker_usage.md
@@ -13,41 +13,43 @@ Before you begin, make sure you have Docker installed on your local machine. If 
 Open a terminal and navigate to the OrioleDB project directory, if you are not already in it:
 * `cd path/to/orioledb`
 
-Build (Alpine) PostgreSQL 16 + OrioleDB extension:
+Build (Alpine) PostgreSQL 17 + OrioleDB extension:
 
-* `docker build -t orioletest:16 --pull --network=host --progress=plain --build-arg PG_MAJOR="16" .`
+```bash
+docker build -t orioletest:17 --pull --network=host --progress=plain --build-arg PG_MAJOR="17" .
+```
 
 Create a simple password for testing:
-```
+```bash
 # echo -n OrioleDB | sha1sum
 8f50c87b77ab9621c9ac8bb396d0630f306adcb0  -
 ```
 
 Start server:
 
-```
-docker run --name orioletest16 \
-   -v orioletest16data:/var/lib/postgresql/data \
+```bash
+docker run --name orioletest17 \
+   -v orioletest17data:/var/lib/postgresql/data \
    -e POSTGRES_PASSWORD=8f50c87b77ab9621c9ac8bb396d0630f306adcb0 \
-   -d orioletest:16
+   -d orioletest:17
 ```
 
 Connect to the server via psql:
 
-```
-docker exec -ti orioletest16 psql -U postgres
+```bash
+docker exec -ti orioletest17 psql -U postgres
 ```
 
 You should expect a similar psql message:
-```
-psql (16.4 OrioleDB public beta 5 PGTAG=patches16_31 alpine:3.20+clang build:2024-10-25T05:38:48+00:00 16.4)
+```bash
+psql (17.0 OrioleDB public beta 5 PGTAG=patches17_3 alpine:3.20+clang build:2024-10-25T19:54:25+00:00 17.0)
 Type "help" for help.
 postgres=#
 ```
 
 Enable orioledb extension:
 
-```
+```sql
 create extension if not exists orioledb;
 ```
 
@@ -143,11 +145,19 @@ postgres=# \dx+ orioledb
  function pg_stopevents()
  function s3_get(text)
  function s3_put(text,text)
+ type orioledb_index
+ type orioledb_index[]
+ type orioledb_index_descr
+ type orioledb_index_descr[]
+ type orioledb_table
+ type orioledb_table[]
+ type orioledb_table_descr
+ type orioledb_table_descr[]
  view orioledb_index
  view orioledb_index_descr
  view orioledb_table
  view orioledb_table_descr
-(43 rows)
+(51 rows)
 ```
 
 Quit from the database:  `\q`
@@ -155,37 +165,19 @@ Quit from the database:  `\q`
 
 Stop the server:
 
-* `docker stop orioletest16`
+* `docker stop orioletest17`
 
 Remove container:
 
-* `docker container rm orioletest16`
+* `docker container rm orioletest17`
 
 Remove docker image:
 
-* `docker rmi orioletest:16`
+* `docker rmi orioletest:17`
 
 Remove the data volume:
 
-* `docker volume rm orioletest16data`
-
-## Building Docker Images
-
-To build a Docker image, use one of the following commands:
-
-#### To build PostgreSQL 17 + OrieleDB extension (alpine)
-```bash
-docker build --pull --network=host --progress=plain \
-   --build-arg PG_MAJOR="17" \
-   -t orioletest:17 .
-```
-
-#### To build PostgreSQL 16 + OrieleDB extension (alpine)
-```bash
-docker build --pull --network=host --progress=plain \
-   --build-arg PG_MAJOR="16" \
-   -t orioletest:16 .
-```
+* `docker volume rm orioletest17data`
 
 ## Supported environment variables:
 
@@ -206,14 +198,14 @@ Read more:  https://github.com/docker-library/docs/blob/master/postgres/README.m
 Please check the Dockerfiles for the full list of build args!
 - Alpine Linux: `./Dockerfile`
   - supported [ `edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14` ]
-  - example: `--build-arg ALPINE_VERSION="3.20"`
+  - example: `--build-arg ALPINE_VERSION="3.20" -f Dockerfile `
 - Ubuntu Linux: `./Dockerfile.ubuntu`
   - supported [ `devel 24.10 24.04 22.04 20.04 oracular noble jammy focal` ]
-  - example: `--build-arg UBUNTU_VERSION="24.04"`
+  - example: `--build-arg UBUNTU_VERSION="24.04" -f Dockerfile.ubuntu `
 
 Other important build args:
-* `--build-arg PG_MAJOR="16"`
-  * Choose the main version of PostgreSQL. Default is `16`.
+* `--build-arg PG_MAJOR="17"`
+  * Choose the main version of PostgreSQL. Default is `17`.
   * You can choose from `16`, `17`.
 * `--build-arg BUILD_CC_COMPILER="gcc"`
   * Choose the C compiler. Default is `clang`.
@@ -222,7 +214,7 @@ Other important build args:
 For example, to build an image using Alpine version `3.20`, the `gcc` compiler and PostgreSQL version `16`, use the following command:
 
 ```bash
-docker build --network=host --progress=plain \
+docker build --pull --network=host --progress=plain \
     --build-arg ALPINE_VERSION="3.20" \
     --build-arg BUILD_CC_COMPILER="gcc" \
     --build-arg PG_MAJOR="16" \
@@ -233,12 +225,12 @@ docker build --network=host --progress=plain \
 To build an image using Ubuntu version `devel`, the `clang` compiler and PostgreSQL version `17`, use the following command:
 
 ```bash
-docker build --network=host --progress=plain \
+docker build --pull --network=host --progress=plain \
     --build-arg UBUNTU_VERSION="devel" \
     --build-arg BUILD_CC_COMPILER="clang" \
     --build-arg PG_MAJOR="17" \
     -f Dockerfile.ubuntu \
-    -t orioletest:17-clang-ubuntudevel .
+    -t orioletest:17-clang-ubuntu-devel .
 ```
 The "devel" version is the latest development Ubuntu version, so it might not be stable.
 
@@ -317,5 +309,3 @@ PATH=/opt/homebrew/bin:/opt/homebrew/opt/gnu-getopt/bin:$PATH
 * Windows: If you encounter any problems, please use Windows Subsystem for Linux (WSL2).
 
 * Extending the current OrioleDB Docker images is not easy; you can't use Ubuntu PostgreSQL packages (like: `postgresql-16-mobilitydb`) - you need to build from source.
-
-* Some secu

--- a/doc/docker_usage.md
+++ b/doc/docker_usage.md
@@ -287,6 +287,25 @@ To build all Docker image variations on a local machine, run the following comma
 - Supported base image architectures:
   - [ amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x ]
 
+#### macOS
+On macOS you might need to install `bash` and `gnu-getopt` from Homebrew. To install them run the command:
+
+```bash
+brew install bash gnu-getopt
+```
+
+Update your `/etc/shells`:
+
+```bash
+echo /opt/homebrew/bin/bash >> /etc/shells
+```
+
+You may need to update your `PATH` variable in the `.bashrc` or `.zshrc` file:
+
+```
+PATH=/opt/homebrew/bin:/opt/homebrew/opt/gnu-getopt/bin:$PATH
+```
+
 ##### Other:
 
 * Testing: If you can test on architectures other than `amd64`, please let us know!

--- a/doc/docker_usage.md
+++ b/doc/docker_usage.md
@@ -13,53 +13,90 @@ Before you begin, make sure you have Docker installed on your local machine. If 
 Open a terminal and navigate to the OrioleDB project directory, if you are not already in it:
 * `cd path/to/orioledb`
 
-Build PostgreSQL 15 + OrioleDB extension:
+Build (Alpine) PostgreSQL 16 + OrioleDB extension:
 
-* `docker build -t orioletest:15 --pull --network=host --progress=plain --build-arg PG_MAJOR="15" .`
+* `docker build -t orioletest:16 --pull --network=host --progress=plain --build-arg PG_MAJOR="16" .`
+
+Create a simple password for testing:
+```
+# echo -n OrioleDB | sha1sum
+8f50c87b77ab9621c9ac8bb396d0630f306adcb0  -
+```
 
 Start server:
 
-* `docker run --name oriolest15 -v orioletest15data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=oriole123 -d orioletest:15`
+```
+docker run --name orioletest16 \
+   -v orioletest16data:/var/lib/postgresql/data \
+   -e POSTGRES_PASSWORD=8f50c87b77ab9621c9ac8bb396d0630f306adcb0 \
+   -d orioletest:16
+```
 
 Connect to the server via psql:
 
-* `docker exec -ti oriolest15 psql -U postgres`
+```
+docker exec -ti orioletest16 psql -U postgres
+```
 
 You should expect a similar psql message:
 ```
-psql (15.5 OrioleDB public beta 5 PGTAG=patches15_22 alpine:3.17+clang build:2023-11-01T22:43:27+00:00)
+psql (16.4 OrioleDB public beta 5 PGTAG=patches16_31 alpine:3.20+clang build:2024-10-25T05:38:48+00:00 16.4)
 Type "help" for help.
-
 postgres=#
 ```
 
 Enable orioledb extension:
 
-* `create extension if not exists orioledb;`
+```
+create extension if not exists orioledb;
+```
 
 Test some commands:
 ```
 postgres=# select orioledb_version();
     orioledb_version
 ------------------------
- OrioleDB public beta 4
+ OrioleDB public beta 5
 (1 row)
 
+postgres=# CREATE TABLE oriole_test (a int) USING orioledb;
+CREATE TABLE
+postgres=# INSERT INTO  oriole_test VALUES (1), (2);
+INSERT 0 2
+postgres=# SELECT * FROM oriole_test;
+ a
+---
+ 1
+ 2
+(2 rows)
+
+postgres=# VACUUM ANALYZE oriole_test;
+VACUUM
+
+postgres=# \d+ oriole_test
+                                       Table "public.oriole_test"
+ Column |  Type   | Collation | Nullable | Default | Storage | Compression | Stats target | Description
+--------+---------+-----------+----------+---------+---------+-------------+--------------+-------------
+ a      | integer |           |          |         | plain   |             |              |
+Access method: orioledb
+
+
 postgres=# \d+
-                                           List of relations
- Schema |         Name         | Type |  Owner   | Persistence | Access method |  Size   | Description
---------+----------------------+------+----------+-------------+---------------+---------+-------------
- public | orioledb_index       | view | postgres | permanent   |               | 0 bytes |
- public | orioledb_index_descr | view | postgres | permanent   |               | 0 bytes |
- public | orioledb_table       | view | postgres | permanent   |               | 0 bytes |
- public | orioledb_table_descr | view | postgres | permanent   |               | 0 bytes |
-(4 rows)
+                                             List of relations
+ Schema |         Name         | Type  |  Owner   | Persistence | Access method |    Size    | Description
+--------+----------------------+-------+----------+-------------+---------------+------------+-------------
+ public | oriole_test          | table | postgres | permanent   | orioledb      | 8192 bytes |
+ public | orioledb_index       | view  | postgres | permanent   |               | 0 bytes    |
+ public | orioledb_index_descr | view  | postgres | permanent   |               | 0 bytes    |
+ public | orioledb_table       | view  | postgres | permanent   |               | 0 bytes    |
+ public | orioledb_table_descr | view  | postgres | permanent   |               | 0 bytes    |
+(5 rows)
 
 postgres=# \dx
                               List of installed extensions
    Name   | Version |   Schema   |                     Description
 ----------+---------+------------+------------------------------------------------------
- orioledb | 1.0     | public     | OrioleDB -- the next generation transactional engine
+ orioledb | 1.2     | public     | OrioleDB -- the next generation transactional engine
  plpgsql  | 1.0     | pg_catalog | PL/pgSQL procedural language
 (2 rows)
 
@@ -71,6 +108,7 @@ postgres=# \dx+ orioledb
  function orioledb_commit_hash()
  function orioledb_compression_max_level()
  function orioledb_evict_pages(oid,integer)
+ function orioledb_get_evicted_trees()
  function orioledb_get_index_descrs()
  function orioledb_get_table_descrs()
  function orioledb_has_retained_undo()
@@ -92,6 +130,7 @@ postgres=# \dx+ orioledb
  function orioledb_table_pages(oid)
  function orioledb_tableam_handler(internal)
  function orioledb_tbl_are_indices_equal(regclass,regclass)
+ function orioledb_tbl_bin_structure(oid,boolean,integer)
  function orioledb_tbl_check(oid,boolean)
  function orioledb_tbl_compression_check(bigint,oid,integer[])
  function orioledb_tbl_indices(oid)
@@ -102,11 +141,13 @@ postgres=# \dx+ orioledb
  function pg_stopevent_reset(text)
  function pg_stopevent_set(text,jsonpath)
  function pg_stopevents()
+ function s3_get(text)
+ function s3_put(text,text)
  view orioledb_index
  view orioledb_index_descr
  view orioledb_table
  view orioledb_table_descr
-(39 rows)
+(43 rows)
 ```
 
 Quit from the database:  `\q`
@@ -114,34 +155,36 @@ Quit from the database:  `\q`
 
 Stop the server:
 
-* `docker stop oriolest15`
+* `docker stop orioletest16`
 
 Remove container:
 
-* `docker container rm oriolest15`
+* `docker container rm orioletest16`
 
 Remove docker image:
 
-* `docker rmi orioletest:15`
+* `docker rmi orioletest:16`
 
 Remove the data volume:
 
-* `docker volume rm orioletest15data`
-
-
+* `docker volume rm orioletest16data`
 
 ## Building Docker Images
 
 To build a Docker image, use one of the following commands:
 
-#### To build PostgreSQL 16 + OrieleDB extension
-```
-docker build -t orioletest:16 --pull --network=host --progress=plain --build-arg PG_MAJOR="16" .
+#### To build PostgreSQL 17 + OrieleDB extension (alpine)
+```bash
+docker build --pull --network=host --progress=plain \
+   --build-arg PG_MAJOR="17" \
+   -t orioletest:17 .
 ```
 
-#### To build PostgreSQL 15 + OrieleDB extension
-```
-docker build -t orioletest:15 --pull --network=host --progress=plain --build-arg PG_MAJOR="15" .
+#### To build PostgreSQL 16 + OrieleDB extension (alpine)
+```bash
+docker build --pull --network=host --progress=plain \
+   --build-arg PG_MAJOR="16" \
+   -t orioletest:16 .
 ```
 
 ## Supported environment variables:
@@ -160,61 +203,100 @@ Read more:  https://github.com/docker-library/docs/blob/master/postgres/README.m
 
 ## Available Docker build args
 
-* `--build-arg ALPINE_VERSION="3.18"`
-  *  Choose which version of Alpine Linux to use. Default is `3.17`.
-  *  You can choose from `edge`, `3.18`, `3.17`, `3.16`, `3.15`, `3.14`, `3.13`.
+Please check the Dockerfiles for the full list of build args!
+- Alpine Linux: `./Dockerfile`
+  - supported [ `edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14` ]
+  - example: `--build-arg ALPINE_VERSION="3.20"`
+- Ubuntu Linux: `./Dockerfile.ubuntu`
+  - supported [ `devel 24.10 24.04 22.04 20.04 oracular noble jammy focal` ]
+  - example: `--build-arg UBUNTU_VERSION="24.04"`
+
+Other important build args:
+* `--build-arg PG_MAJOR="16"`
+  * Choose the main version of PostgreSQL. Default is `16`.
+  * You can choose from `16`, `17`.
 * `--build-arg BUILD_CC_COMPILER="gcc"`
   * Choose the C compiler. Default is `clang`.
   * You can choose either `clang` or `gcc`.
 
-* `--build-arg PG_MAJOR="16"`
-  * Choose the main version of PostgreSQL. Default is `15`.
-  * You can choose from `16`, `15`.
-* `--build-arg DOCKER_PG_LLVM_DEPS='lvm15-dev clang15'`
-  * Choose the LLVM build environment. Default is `llvm-dev clang`.
-  * If you're using Alpine version `3.18` or higher, use `llvm15` because `llvm16` is not supported yet.
+For example, to build an image using Alpine version `3.20`, the `gcc` compiler and PostgreSQL version `16`, use the following command:
 
-For example, to build an image using Alpine version `3.17`, the `gcc` compiler and PostgreSQL version `14`, use the following command:
-
-```
+```bash
 docker build --network=host --progress=plain \
-    --build-arg ALPINE_VERSION="3.17" \
+    --build-arg ALPINE_VERSION="3.20" \
     --build-arg BUILD_CC_COMPILER="gcc" \
-    --build-arg PG_MAJOR="14" \
-    -t orioletest:14-gcc-alpine3.17 .
+    --build-arg PG_MAJOR="16" \
+    -f Dockerfile \
+    -t orioletest:16-gcc-alpine3.20 .
 ```
-This command will build the Docker image and tag it as `orioletest:14-gcc-alpine3.17.`
+
+To build an image using Ubuntu version `devel`, the `clang` compiler and PostgreSQL version `17`, use the following command:
+
+```bash
+docker build --network=host --progress=plain \
+    --build-arg UBUNTU_VERSION="devel" \
+    --build-arg BUILD_CC_COMPILER="clang" \
+    --build-arg PG_MAJOR="17" \
+    -f Dockerfile.ubuntu \
+    -t orioletest:17-clang-ubuntudevel .
+```
+The "devel" version is the latest development Ubuntu version, so it might not be stable.
 
 ## Experimental OrioleDB + PostGIS Extension build:
 
 Known limitations:
-- It only works with Alpine `3.18`. This is due to a Docker `postgis/docker-postgis` limitation. The build script expects the `sfcgal` package, which is only available in Alpine 3.18 or later versions.
 - OrioleDB `gist`, `sp-gist`, and other related indexes are not yet supported.
 
+#### Step 1: create image: `orioletest:17-gcc-alpine3.20`
 
-#### Step 1: create image: `orioletest:16-gcc-alpine3.18`
-
-```
+```bash
 docker build --pull --network=host --progress=plain \
-    --build-arg ALPINE_VERSION="3.18" \
+    --build-arg ALPINE_VERSION="3.20" \
     --build-arg BUILD_CC_COMPILER="gcc" \
-    --build-arg PG_MAJOR="16" \
-    --build-arg DOCKER_PG_LLVM_DEPS="llvm15-dev clang15" \
-    -t orioletest:16-gcc-alpine3.18 .
+    --build-arg PG_MAJOR="17" \
+    -t orioletest:17-gcc-alpine3.20 .
 ```
 
-#### Step2: Build the `oriolegis:16-3.4` image.
+#### Step2: Build the `oriolegis:17-3.5-alpine` image.
 
 in a new directory, run this commands:
 
-```
-git clone https://github.com/postgis/docker-postgis.git
-cd ./docker-postgis/16-3.4/alpine
+```bash
+git clone --depth=1 https://github.com/postgis/docker-postgis.git
+cd ./docker-postgis/17-3.5/alpine
 docker build --network=host --progress=plain \
-     --build-arg BASE_IMAGE=orioletest:16-gcc-alpine3.18 \
-    -t oriolegis:16-3.4 .
+     --build-arg BASE_IMAGE=orioletest:17-gcc-alpine3.20 \
+     -t oriolegis:17-3.5-alpine .
 ```
+
 ## Developer notes:
 
 To build all Docker image variations on a local machine, run the following command:
 * `./ci/local_docker_matrix.sh`
+* or (experimental)  `./ci/docker_matrix.sh --help`
+
+##### Ubuntu
+- Supported base images (with security updates):
+  - https://hub.docker.com/_/ubuntu
+- Supported base image architectures:
+  - [ amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x]
+
+##### Alpine
+- Supported base images (with security updates):
+  - https://hub.docker.com/_/alpine
+- Supported base image architectures:
+  - [ amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x ]
+
+##### Other:
+
+* Testing: If you can test on architectures other than `amd64`, please let us know!
+
+* Some QEMU versions can't emulate PostgreSQL JIT. In this case, use `jit=off`.
+
+* Security: Note that ports which are not bound to the host (i.e., `-p 5432:5432` instead of `-p 127.0.0.1:5432:5432`) will be accessible from the outside. This also applies if you configured UFW to block this specific port, as Docker manages its own iptables rules. ( [Read More](https://docs.docker.com/network/iptables/) ). With a simple password and open ports, you can be infected by [crypto miners]( https://github.com/docker-library/postgres/issues/770#issuecomment-704460980 ) !
+
+* Windows: If you encounter any problems, please use Windows Subsystem for Linux (WSL2).
+
+* Extending the current OrioleDB Docker images is not easy; you can't use Ubuntu PostgreSQL packages (like: `postgresql-16-mobilitydb`) - you need to build from source.
+
+* Some secu

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@ see: "Docker Official Images Test Suite":
 * https://github.com/docker-library/official-images/tree/master/test
 
 Used by:
-* `./docker_matrix.sh`
+* `./ci/docker_matrix.sh`
 * `./.github/workflows/dockertest.yml`
 * todo: add to `./.github/workflows/docker.yml`
 

--- a/test/README.md
+++ b/test/README.md
@@ -21,13 +21,13 @@ git clone "$OFFIMG_REPO_URL" "$OFFIMG_LOCAL_CLONE"
 "${OFFIMG_LOCAL_CLONE}/test/run.sh" \
     -c "${OFFIMG_LOCAL_CLONE}/test/config.sh" \
     -c "test/orioledb-config.sh" \
-    "orioletest:16-gcc-ubuntu-22.04"
+    "orioletest:17-gcc-ubuntu-22.04"
 ```
 
 If the test is ok, you can see:
 
 ```bash
-testing orioletest:16-gcc-ubuntu-22.04
+testing orioletest:17-gcc-ubuntu-22.04
 	'utc' [1/6]...passed
 	'no-hard-coded-passwords' [2/6]...passed
 	'override-cmd' [3/6]...passed

--- a/test/README.md
+++ b/test/README.md
@@ -1,15 +1,13 @@
-
-# Official Postgres Docker Image test
+# Testing OrioleDB Docker images
 
 Running the Docker Official Image tests against orioledb images,
 see: "Docker Official Images Test Suite":
 * https://github.com/docker-library/official-images/tree/master/test
 
-
-used by:
-* `./ci/local_docker_matrix.sh`
-* todo: add to Github CI
-
+Used by:
+* `./docker_matrix.sh`
+* `./.github/workflows/dockertest.yml`
+* todo: add to `./.github/workflows/docker.yml`
 
 ## Running docker test suite
 


### PR DESCRIPTION
Improve Docker Build+Testing

####   Alpine/Ubuntu Dockerfiles:
-  Lot of small updates .
-  New Build Options:
   - DEBUG_MODE (default: false): Option to preserve the build environment for debugging.
     
####  New  `./ci/docker_matrix.sh` for enhanced testing. ( experimental )
* Supports multiple base images (Ubuntu, Alpine).
* Allows testing across various PostgreSQL versions and compilers.
* Includes debug mode and dry-run capability.     

#### Update CI Workflow (`dockertest.yml`) 
* Refactored test configurations in the CI matrix.
* Added a regression flag to control test execution.
* Integrated the official PostgreSQL Docker test suite.

#### Handle Missing COMMIT_HASH in Docker Builds 
 * Implemented a fake COMMIT_HASH (000...000) when .git history is unavailable (e.g., in Docker builds from tarballs).
 * Ensured that regression tests for orioledb_commit_hash() pass without Git history
 
+ Updated docker related docs .

+ see commit messages 

EDIT:
*  Set PostgreSQL 17 - as a default ( Dockerfiles + Docker related docs, scripts  )
