### PR TITLE
feature: Put into S3 unchanged PostgreSQL files only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ OBJS = src/btree/btree.o \
 	   src/s3/archive.o \
 	   src/s3/checkpoint.o \
 	   src/s3/control.o \
+	   src/s3/checksum.o \
 	   src/s3/headers.o \
 	   src/s3/queue.o \
 	   src/s3/requests.o \

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -204,7 +204,7 @@ CREATE TABLE s3_test
 )  USING orioledb
 ```
 
-In S3 mode all the tables and materialized views created with `using orioledb` are synchronized with S3 incrementally.  That is, only modified blocks are to be put into S3 bucket.  The table/materialized view not created with `using orioledb` will be saved completely at every checkpoint.  So, it's recommended to use S3 mode when you store the majority of your data using the OrioleDB engine.
+In S3 mode, all tables and materialized views are incrementally synchronized with S3, meaning only modified blocks are uploaded to the S3 bucket. However, for tables and materialized views not created with `using orioledb`, OrioleDB’s background workers will compute file checksums during each checkpoint. Therefore, it is recommended to use S3 mode when storing the majority of your data with the OrioleDB engine.
 
 For best results, it's recommended to turn on `Transfer acceleration` in **General** AWS S3 bucket settings (endpoint address will be given with `s3-accelerate.amazonaws.com` suffix) and have the bucket and compute instance within the same AWS region. Even better is to use **Directory** AWS bucket within the same AWS region and sub-region as the compute instance.
 

--- a/include/s3/checkpoint.h
+++ b/include/s3/checkpoint.h
@@ -13,6 +13,6 @@
 #ifndef __S3_CHECKPOINT_H__
 #define __S3_CHECKPOINT_H__
 
-extern void s3_perform_backup(int flags, S3TaskLocation location);
+extern void s3_perform_backup(int flags, S3TaskLocation maxLocation);
 
 #endif							/* __S3_CHECKPOINT_H__ */

--- a/include/s3/checksum.h
+++ b/include/s3/checksum.h
@@ -1,0 +1,53 @@
+/*-------------------------------------------------------------------------
+ *
+ * checksum.h
+ * 		Declarations for calculating checksums of S3-specific data.
+ *
+ * Copyright (c) 2024, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/utils/checksum.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef __S3_CHECKSUM_H__
+#define __S3_CHECKSUM_H__
+
+#include "utils/hsearch.h"
+
+#include "openssl/sha.h"
+
+#define O_SHA256_DIGEST_STRING_LENGTH	(SHA256_DIGEST_LENGTH * 2 + 1)
+
+typedef struct S3FileChecksum
+{
+	char		filename[MAXPGPATH];
+	char		checksum[O_SHA256_DIGEST_STRING_LENGTH];
+
+	bool		changed;		/* true if the checksum changed since last
+								 * checkpoint */
+	uint32		checkpointNumber;
+} S3FileChecksum;
+
+typedef struct S3ChecksumState
+{
+	HTAB	   *hashTable;
+	uint32		checkpointNumber;
+
+	S3FileChecksum *fileChecksums;	/* Buffer of S3FileChecksum entries */
+	uint32		fileChecksumsMaxLen;
+	uint32		fileChecksumsLen;
+} S3ChecksumState;
+
+extern S3ChecksumState *makeS3ChecksumState(uint32 checkpointNumber,
+											S3FileChecksum *fileChecksums,
+											uint32 fileChecksumsMaxLen,
+											const char *filename);
+extern void freeS3ChecksumState(S3ChecksumState *state);
+extern void flushS3ChecksumState(S3ChecksumState *state, const char *filename);
+
+extern S3FileChecksum *getS3FileChecksum(S3ChecksumState *state,
+										 const char *filename,
+										 Pointer data, uint64 size);
+
+#endif							/* __S3_CHECKSUM_H__ */

--- a/include/s3/requests.h
+++ b/include/s3/requests.h
@@ -23,7 +23,12 @@ extern void s3_get_file(char *objectname, char *filename);
 extern void s3_put_empty_dir(char *objectname);
 extern long s3_put_file_part(char *objectname, char *filename, int partnum);
 extern void s3_get_file_part(char *objectname, char *filename, int partnum);
+extern long s3_put_object_with_contents(char *objectname, Pointer data,
+										uint64 dataSize, char *dataChecksum,
+										bool ifNoneMatch);
 extern long s3_get_object(char *objectname, StringInfo str, bool missing_ok);
 extern void s3_delete_object(char *objectname);
+
+extern Pointer read_file(const char *filename, uint64 *size);
 
 #endif							/* __S3_REQUESTS_H__ */

--- a/include/s3/worker.h
+++ b/include/s3/worker.h
@@ -24,7 +24,8 @@ typedef enum
 	S3TaskTypeWriteWALFile,
 	S3TaskTypeWriteUndoFile,
 	S3TaskTypeWriteEmptyDir,
-	S3TaskTypeWriteRootFile
+	S3TaskTypeWriteRootFile,
+	S3TaskTypeWritePGFile
 } S3TaskType;
 
 /*
@@ -65,13 +66,23 @@ typedef struct
 			bool		delete;
 			char		filename[FLEXIBLE_ARRAY_MEMBER];
 		}			writeRootFile;
+		struct
+		{
+			uint32		chkpNum;
+			char		filename[FLEXIBLE_ARRAY_MEMBER];
+		}			writePGFile;
 	}			typeSpecific;
 } S3Task;
+
+#define FILE_CHECKSUMS_FILENAME		ORIOLEDB_DATA_DIR "/file_checksums"
 
 extern Size s3_workers_shmem_needs(void);
 extern void s3_workers_init_shmem(Pointer ptr, bool found);
 extern void register_s3worker(int num);
+extern void s3_workers_checkpoint_init(void);
+extern void s3_workers_checkpoint_finish(void);
 PGDLLEXPORT void s3worker_main(Datum);
+
 extern S3TaskLocation s3_schedule_file_write(uint32 chkpNum, char *filename,
 											 bool delete);
 extern S3TaskLocation s3_schedule_empty_dir_write(uint32 chkpNum,
@@ -88,6 +99,7 @@ extern S3TaskLocation s3_schedule_undo_file_write(UndoLogType undoType,
 extern S3TaskLocation s3_schedule_downlink_load(struct BTreeDescr *desc,
 												uint64 downlink);
 extern S3TaskLocation s3_schedule_root_file_write(char *filename, bool delete);
+extern S3TaskLocation s3_schedule_pg_file_write(uint32 chkpNum, char *filename);
 extern void s3_load_file_part(uint32 chkpNum, Oid datoid, Oid relnode,
 							  int32 segNum, int32 partNum);
 extern void s3_load_map_file(uint32 chkpNum, Oid datoid, Oid relnode);

--- a/src/s3/checksum.c
+++ b/src/s3/checksum.c
@@ -1,0 +1,254 @@
+/*-------------------------------------------------------------------------
+ *
+ * checksum.c
+ * 		Declarations for calculating checksums of S3-specific data.
+ *
+ * Copyright (c) 2024, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/src/s3/checksum.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "s3/checksum.h"
+
+#include "common/string.h"
+#include "storage/fd.h"
+#include "utils/hsearch.h"
+
+#include "openssl/sha.h"
+
+static void initHashTable(S3ChecksumState *state, const char *filename);
+
+/*
+ * Allocate S3ChecksumState and initalize hashTable by reading filename.  A
+ * caller should prepare a buffer for S3FileChecksum entries, the caller is
+ * responsible to release the buffer.
+ */
+S3ChecksumState *
+makeS3ChecksumState(uint32 checkpointNumber, S3FileChecksum *fileChecksums,
+					uint32 fileChecksumsMaxLen, const char *filename)
+{
+	S3ChecksumState *res;
+
+	res = (S3ChecksumState *) palloc(sizeof(S3ChecksumState));
+	res->hashTable = NULL;
+	res->checkpointNumber = checkpointNumber;
+	res->fileChecksums = fileChecksums;
+	res->fileChecksumsMaxLen = fileChecksumsMaxLen;
+	res->fileChecksumsLen = 0;
+
+	initHashTable(res, filename);
+
+	return res;
+}
+
+/*
+ * Free S3ChecksumState and hashTable.  A caller is responsible to release the
+ * buffer of S3FileChecksum entries.
+ */
+void
+freeS3ChecksumState(S3ChecksumState *state)
+{
+	if (state == NULL)
+		return;
+
+	hash_destroy(state->hashTable);
+	pfree(state);
+}
+
+/*
+ * Initialize a hash table to store checksums of database files.
+ */
+static void
+initHashTable(S3ChecksumState *state, const char *filename)
+{
+	FILE	   *file;
+	StringInfoData buf;
+	HASHCTL		ctl;
+
+	Assert(state->hashTable == NULL);
+
+	MemSet(&ctl, 0, sizeof(ctl));
+	ctl.keysize = MAXPGPATH;
+	ctl.entrysize = sizeof(S3FileChecksum);
+	ctl.hcxt = CurrentMemoryContext;
+
+	file = AllocateFile(filename, "r");
+	if (file == NULL)
+	{
+		/* Just ignore if the file doesn't exist */
+		if (errno == ENOENT)
+			return;
+
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read file \"%s\": %m", filename)));
+	}
+
+	state->hashTable = hash_create("S3FileChecksum hash table",
+								   32,	/* arbitrary initial size */
+								   &ctl,
+								   HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+
+	initStringInfo(&buf);
+
+	while (pg_get_line_buf(file, &buf))
+	{
+		S3FileChecksum fileEntry;
+
+		if (sscanf(buf.data, "FILE: %1023[^,], CHECKSUM: %64[^,], CHECKPOINT: %d",
+				   fileEntry.filename, fileEntry.checksum, &fileEntry.checkpointNumber) == 3)
+		{
+			char		key[MAXPGPATH];
+			S3FileChecksum *newEntry;
+			bool		found;
+
+			MemSet(key, 0, sizeof(key));
+			strlcpy(key, fileEntry.filename, sizeof(key));
+
+			if (fileEntry.checkpointNumber >= state->checkpointNumber)
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("unexpected checkpoint number in the checksum file \"%s\": %s",
+								filename, buf.data)));
+
+			/* Put the filename and its checksum into the hash table */
+			newEntry = (S3FileChecksum *) hash_search(state->hashTable,
+													  key, HASH_ENTER, &found);
+			/* Normally we shouldn't have duplicated keys in the file */
+			if (found)
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("the file name is duplicated in the checksum file \"%s\": %s",
+								filename, buf.data)));
+
+			/* filename is already filled in */
+			strlcpy(newEntry->checksum, fileEntry.checksum, sizeof(fileEntry.checksum));
+			newEntry->checkpointNumber = fileEntry.checkpointNumber;
+			newEntry->changed = false;
+		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("invalid line format of the checksum file \"%s\": %s",
+							filename, buf.data)));
+	}
+
+	pfree(buf.data);
+
+	if (ferror(file))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not read file \"%s\": %m", filename)));
+
+	FreeFile(file);
+}
+
+/*
+ * Save current workers' fileChecksums array into a temporary file.
+ */
+void
+flushS3ChecksumState(S3ChecksumState *state, const char *filename)
+{
+	FILE	   *file;
+
+	Assert(state->fileChecksums != NULL);
+
+	/*
+	 * We open the file for append in case if previous flush already created
+	 * the file.
+	 */
+	file = AllocateFile(filename, "a");
+	if (file == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not create file \"%s\": %m", filename)));
+
+	for (int i = 0; i < state->fileChecksumsLen; i++)
+	{
+		if (fprintf(file, "FILE: %s, CHECKSUM: %s, CHECKPOINT: %u\n",
+					state->fileChecksums[i].filename, state->fileChecksums[i].checksum,
+					state->fileChecksums[i].checkpointNumber) < 0)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not write file \"%s\": %m",
+							filename)));
+	}
+
+	if (fflush(file) || ferror(file) || FreeFile(file))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write file \"%s\": %m",
+						filename)));
+
+	state->fileChecksumsLen = 0;
+}
+
+/*
+ * Check if a PostgreSQL file changed since last checkpoint and return
+ * S3FileChecksum.
+ */
+S3FileChecksum *
+getS3FileChecksum(S3ChecksumState *state, const char *filename,
+				  Pointer data, uint64 size)
+{
+	S3FileChecksum *prevEntry = NULL;
+	S3FileChecksum *newEntry;
+	unsigned char checksumbuf[SHA256_DIGEST_LENGTH];
+	char		checksumstringbuf[O_SHA256_DIGEST_STRING_LENGTH];
+
+	/*
+	 * hashTable might not have been initialized before if a checksum file
+	 * hasn't been found.
+	 */
+	if (state->hashTable != NULL)
+	{
+		char		key[MAXPGPATH];
+
+		MemSet(key, 0, sizeof(key));
+		strlcpy(key, filename, MAXPGPATH);
+
+		prevEntry = (S3FileChecksum *) hash_search(state->hashTable, key,
+												   HASH_FIND, NULL);
+	}
+
+	(void) SHA256((unsigned char *) data, size, checksumbuf);
+
+	hex_encode((char *) checksumbuf, sizeof(checksumbuf), checksumstringbuf);
+	checksumstringbuf[O_SHA256_DIGEST_STRING_LENGTH - 1] = '\0';
+
+	newEntry = (S3FileChecksum *) palloc0(sizeof(S3FileChecksum));
+
+	strlcpy(newEntry->filename, filename, sizeof(newEntry->filename));
+	strlcpy(newEntry->checksum, checksumstringbuf, sizeof(newEntry->checksum));
+
+	if (prevEntry == NULL ||
+		strncmp(prevEntry->checksum, newEntry->checksum, sizeof(newEntry->checksum)) != 0)
+	{
+		newEntry->changed = true;
+		newEntry->checkpointNumber = state->checkpointNumber;
+	}
+	else
+	{
+		Assert(prevEntry != NULL);
+
+		newEntry->changed = false;
+		newEntry->checkpointNumber = prevEntry->checkpointNumber;
+	}
+
+	/* Store new entry into the checksum state */
+	if (state->fileChecksumsLen >= state->fileChecksumsMaxLen)
+		elog(ERROR, "size of S3FileChecksum buffer is smaller than requested, "
+			 "current size is %d", state->fileChecksumsMaxLen);
+
+	memcpy(state->fileChecksums + state->fileChecksumsLen, newEntry, sizeof(S3FileChecksum));
+	state->fileChecksumsLen += 1;
+
+	return newEntry;
+}

--- a/t/s3_test.py
+++ b/t/s3_test.py
@@ -259,7 +259,7 @@ class S3Test(S3BaseTest):
 		node.start()
 
 		small_file_checksums = os.path.join(node.data_dir, "orioledb_data",
-											"small_file_checksums")
+		                                    "small_file_checksums")
 
 		# Test that CHECKPOINT will fail in case of lack of permissions
 		open(small_file_checksums, "a").close()
@@ -269,12 +269,14 @@ class S3Test(S3BaseTest):
 			node.safe_psql("CHECKPOINT")
 
 		assert e.exception.message is not None
-		self.assertTrue(e.exception.message.startswith("ERROR:  checkpoint request failed"))
+		self.assertTrue(
+		    e.exception.message.startswith(
+		        "ERROR:  checkpoint request failed"))
 
 		with open(node.pg_log_file) as f:
 			self.assertIn(
-				'ERROR:  could not read file "orioledb_data/small_file_checksums": Permission denied',
-				f.read())
+			    'ERROR:  could not read file "orioledb_data/small_file_checksums": Permission denied',
+			    f.read())
 
 		os.unlink(small_file_checksums)
 
@@ -290,18 +292,22 @@ class S3Test(S3BaseTest):
 			assert m is not None
 
 			f.seek(0, os.SEEK_END)
-			f.write(f"FILE: {m.groups()[0]}, CHECKSUM: {m.groups()[1]}, CHECKPOINT: 100")
+			f.write(
+			    f"FILE: {m.groups()[0]}, CHECKSUM: {m.groups()[1]}, CHECKPOINT: 100"
+			)
 
 		with self.assertRaises(QueryException) as e:
 			node.safe_psql("CHECKPOINT")
 
 		assert e.exception.message is not None
-		self.assertTrue(e.exception.message.startswith("ERROR:  checkpoint request failed"))
+		self.assertTrue(
+		    e.exception.message.startswith(
+		        "ERROR:  checkpoint request failed"))
 
 		with open(node.pg_log_file) as f:
 			self.assertIn(
-				'ERROR:  unexpected checkpoint number in the checksum file',
-				f.read())
+			    'ERROR:  unexpected checkpoint number in the checksum file',
+			    f.read())
 
 		# Test that CHECKPOINT will fail in case of duplicated entries
 		shutil.copy(f"{small_file_checksums}.copy", small_file_checksums)
@@ -315,12 +321,14 @@ class S3Test(S3BaseTest):
 			node.safe_psql("CHECKPOINT")
 
 		assert e.exception.message is not None
-		self.assertTrue(e.exception.message.startswith("ERROR:  checkpoint request failed"))
+		self.assertTrue(
+		    e.exception.message.startswith(
+		        "ERROR:  checkpoint request failed"))
 
 		with open(node.pg_log_file) as f:
 			self.assertIn(
-				'ERROR:  the file name is duplicated in the checksum file',
-				f.read())
+			    'ERROR:  the file name is duplicated in the checksum file',
+			    f.read())
 
 		# Test that CHECKPOINT will fail in case of invalid file
 		shutil.copy(f"{small_file_checksums}.copy", small_file_checksums)
@@ -336,13 +344,13 @@ class S3Test(S3BaseTest):
 			node.safe_psql("CHECKPOINT")
 
 		assert e.exception.message is not None
-		self.assertTrue(e.exception.message.startswith("ERROR:  checkpoint request failed"))
+		self.assertTrue(
+		    e.exception.message.startswith(
+		        "ERROR:  checkpoint request failed"))
 
 		with open(node.pg_log_file) as f:
-			self.assertIn(
-				'ERROR:  invalid line format of the checksum file',
-				f.read())
-
+			self.assertIn('ERROR:  invalid line format of the checksum file',
+			              f.read())
 
 	def test_s3_ddl_recovery(self):
 		node = self.node


### PR DESCRIPTION
## Changes

### Hash files

`orioledb_data/pg_files.crc`, `orioledb_data/pg_small_files.crc` files contain hashes of changed and unchanged PostgreSQL files. To be able to read them easily by external tools, like `orioledb_s3_loader.py`, they are written as text files.
Each line of the files contains string in the following format:

```
FILE: <filename>, HASH: <hash>, CHECKPOINT: <checkpoint>
```

Where `<checkpoint>` is the latest checkpoint when the file was changed.

### S3 Workers

Each of S3 worker during processing a PG file checks its hash and accumulates them into a `orioledb_data/pg_files.crc.<worker_num>` temporary file.

### Checkpointer

The checkpointer (within `s3_perform_backup()`) waits until all PG files processed and merges all temporary hash files into the `orioledb_data/pg_files.crc` file.

The checkpointer separately processed small PG files, checks their hash and stores hashes into the `orioledb_data/pg_small_files.crc`.

Both `orioledb_data/pg_files.crc`, `orioledb_data/pg_small_files.crc` files are put into a S3 bucket.

### orioledb_s3_loader.py

`orioledb_s3_loader.py` can download unchanged files from previous checkpoints using `pg_files.crc`, `pg_small_files.crc` files.

## Tests

I added new tests into `s3_test.py`.