### PR TITLE
Abstract page chunk API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ lib*.pc
 /test/tmp_check_iso/
 /test/tmp_check_t/
 /test/output_iso/
+/test/regression.diffs
+/test/regression.out
 /include/utils/stopevents_defs.h
 /include/utils/stopevents_data.h
 /orioledb.typedefs

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ OBJS = src/btree/btree.o \
 	   src/btree/build.o \
 	   src/btree/check.o \
 	   src/btree/chunk_ops.o \
+	   src/btree/chunk_ops_test.o \
 	   src/btree/find.o \
 	   src/btree/hikey_chunk.o \
 	   src/btree/insert.o \
@@ -94,6 +95,7 @@ OBJS = src/btree/btree.o \
 REGRESSCHECKS = btree_sys_check \
 				alter_type \
 				bitmap_scan \
+				btree_chunk_ops \
 				btree_compression \
 				btree_print \
 				createas \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ OBJS = src/btree/btree.o \
 	   src/btree/check.o \
 	   src/btree/chunk_ops.o \
 	   src/btree/find.o \
+	   src/btree/hikey_chunk.o \
 	   src/btree/insert.o \
 	   src/btree/io.o \
 	   src/btree/iterator.o \
@@ -26,6 +27,7 @@ OBJS = src/btree/btree.o \
 	   src/btree/print.o \
 	   src/btree/scan.o \
 	   src/btree/split.o \
+	   src/btree/tuple_chunk.o \
 	   src/btree/undo.o \
 	   src/catalog/ddl.o \
 	   src/catalog/free_extents.o \

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ EXTRA_CLEAN = include/utils/stopevents_defs.h \
 OBJS = src/btree/btree.o \
 	   src/btree/build.o \
 	   src/btree/check.o \
+	   src/btree/chunk_ops.o \
 	   src/btree/find.o \
 	   src/btree/insert.o \
 	   src/btree/io.o \

--- a/include/btree/chunk_ops.h
+++ b/include/btree/chunk_ops.h
@@ -1,0 +1,173 @@
+/*-------------------------------------------------------------------------
+ *
+ * chunk_ops.h
+ *		OrioleDB abstract page chunk access API.
+ *
+ * Copyright (c) 2025, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/btree/chunk_ops.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef __BTREE_CHUNK_OPS_H__
+#define __BTREE_CHUNK_OPS_H__
+
+#include "btree/btree.h"
+#include "btree/page_contents.h"
+
+typedef enum BTreeChunkOperationType
+{
+	BTreeChunkOperationInsert,
+	BTreeChunkOperationUpdate,
+	BTreeChunkOperationDelete
+} BTreeChunkOperationType;
+
+typedef struct PartialPageState PartialPageState;
+
+typedef struct BTreeChunkOps BTreeChunkOps;
+
+typedef struct BTreeChunkBuilderItem
+{
+	Pointer		data;
+	uint16		size;
+	uint8		flags;
+} BTreeChunkBuilderItem;
+
+typedef struct BTreeChunkBuilder
+{
+	BTreeDescr *treeDesc;
+	const BTreeChunkOps *const ops;
+
+	/* Array of offsets of chunk items */
+	BTreeChunkBuilderItem chunkItems[BTREE_PAGE_MAX_CHUNK_ITEMS];
+	/* Number of chunk items */
+	uint16		chunkItemsCount;
+} BTreeChunkBuilder;
+
+typedef struct BTreeChunkDesc
+{
+	BTreeDescr *treeDesc;
+	const BTreeChunkOps *const ops;
+
+	/* Page which contains the chunk */
+	Page		page;
+	/* Offset of the chunk within the page */
+	OffsetNumber chunkOffset;
+} BTreeChunkDesc;
+
+typedef struct BTreeChunkOps
+{
+	uint16		itemHeaderSize;
+	BTreeKeyType itemKeyType;
+	OLengthType itemLengthType;
+
+	/*
+	 * Main API functions.
+	 */
+
+	/*
+	 * Initialize the chunk using the given page and optional chunk offset.
+	 */
+	void		(*init) (BTreeChunkDesc *chunk, Page page,
+						 OffsetNumber chunkOffset);
+
+	/*
+	 * Estimate the new chunk size after the operation.
+	 */
+	int32		(*estimate_change) (BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+									BTreeChunkOperationType operation,
+									OTuple tuple);
+
+	/*
+	 * Perform the operation.  A caller should take care about the size of the
+	 * chunk.  Extension of the chunk should be performed before
+	 * "perform_change", and shrinking of the chunk should be performed after
+	 * "perform_change".
+	 */
+	void		(*perform_change) (BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+								   BTreeChunkOperationType operation,
+								   Pointer tupleHeader, OTuple tuple);
+
+	/*
+	 * Performa compaction of the chunk by moving items and releasing gaps.  A
+	 * caller is responsible to take care of deleted and non-visible tuples in
+	 * the chunk.
+	 */
+	void		(*compact) (BTreeChunkDesc *chunk);
+
+	/*
+	 * Get available size for compaction.
+	 */
+	uint16		(*get_available_size) (BTreeChunkDesc *chunk, CommitSeqNo csn);
+
+	/*
+	 * Compare given key to the chunk tuple.  Return false if the chunk was
+	 * changed concurrently.
+	 */
+	bool		(*cmp) (BTreeChunkDesc *chunk, PartialPageState *partial,
+						Page page, OffsetNumber itemOffset,
+						void *key, BTreeKeyType keyType, int *result);
+
+	/*
+	 * Search for the given key in the chunk tuple.  Return false if the chunk
+	 * was changed concurrently.
+	 */
+	bool		(*search) (BTreeChunkDesc *chunk, PartialPageState *partial,
+						   Page page, void *key, BTreeKeyType keyType,
+						   OffsetNumber *itemOffset);
+
+	/*
+	 * Read the tuple from the chunk.  Return false if the chunk was changed
+	 * concurrently.
+	 */
+	bool		(*read_tuple) (BTreeChunkDesc *chunk, PartialPageState *partial,
+							   Page page, OffsetNumber itemOffset,
+							   Pointer *tupleHeader, OTuple *tuple,
+							   bool *isCopy);
+
+	/*
+	 * Chunk builder functions.
+	 */
+
+	/*
+	 * Initialize the chunk builder.
+	 */
+	void		(*builder_init) (BTreeChunkBuilder *chunkBuilder);
+
+	/*
+	 * Estimate the chunk size after adding the tuple to the builder.
+	 */
+	int32		(*builder_estimate) (BTreeChunkBuilder *chunkBuilder, OTuple tuple);
+
+	/*
+	 * Add the tuple to the builder.
+	 */
+	void		(*builder_add) (BTreeChunkBuilder *chunkBuilder,
+								BTreeChunkBuilderItem *chunkItem);
+
+	/*
+	 * Finish building the chunk.
+	 */
+	void		(*builder_finish) (BTreeChunkBuilder *chunkBuilder,
+								   BTreeChunkDesc *chunk);
+} BTreeChunkOps;
+
+extern const BTreeChunkOps BTreeLeafTupleChunkOps;
+extern const BTreeChunkOps BTreeInternalTupleChunkOps;
+extern const BTreeChunkOps BTreeHiKeyChunkOps;
+
+/*
+ * Chunk initialization functions.
+ */
+
+extern void init_btree_chunk_desc(BTreeChunkDesc *desc,
+								  const BTreeChunkOps *ops,
+								  BTreeDescr *treeDesc, Page page,
+								  OffsetNumber chunkOffset);
+
+extern void init_btree_chunk_builder(BTreeChunkBuilder *chunkBuilder,
+									 const BTreeChunkOps *ops,
+									 BTreeDescr *treeDesc);
+
+#endif							/* __BTREE_CHUNK_OPS_H__ */

--- a/include/btree/page_contents.h
+++ b/include/btree/page_contents.h
@@ -92,6 +92,10 @@ typedef struct
 
 struct BTreePageItemLocator
 {
+	/*
+	 * TODO: BTreeChunkDesc type field should be added here instead of
+	 * "chunk", "chunkSize", "chunkItemsCount" fields.
+	 */
 	OffsetNumber chunkOffset;
 	OffsetNumber itemOffset;
 	OffsetNumber chunkItemsCount;

--- a/include/btree/print.h
+++ b/include/btree/print.h
@@ -13,7 +13,12 @@
 #ifndef __BTREE_PRINT_H__
 #define __BTREE_PRINT_H__
 
-#include "btree.h"
+#include "fmgr.h"
+
+#include "btree/btree.h"
+#include "tuple/format.h"
+
+#include "access/tupdesc.h"
 
 typedef enum
 {
@@ -46,5 +51,9 @@ extern void o_print_btree_pages(BTreeDescr *desc, StringInfo outbuf,
 								PrintFunc tuplePrintFunc,
 								Pointer printArg,
 								BTreePrintOptions *options, int depth);
+
+extern void o_tuple_print(TupleDesc tupDesc, OTupleFixedFormatSpec *spec,
+						  FmgrInfo *outputFns, StringInfo buf, OTuple tup,
+						  Datum *values, bool *nulls, bool printVersion);
 
 #endif							/* __BTREE_PRINT_H__ */

--- a/include/tuple/format.h
+++ b/include/tuple/format.h
@@ -205,6 +205,8 @@ extern void o_tuple_fill(TupleDesc tupleDesc, OTupleFixedFormatSpec *spec,
 extern OTuple o_form_tuple(TupleDesc tupleDesc, OTupleFixedFormatSpec *spec,
 						   uint32 version, Datum *values, bool *isnull,
 						   BrigeData *bridge_data);
+extern void o_deform_tuple(TupleDesc tupleDesc, OTupleFixedFormatSpec *spec,
+						   OTuple tuple, Datum *values, bool *isnull);
 extern uint32 o_tuple_get_version(OTuple tuple);
 extern void o_tuple_set_version(OTupleFixedFormatSpec *spec, OTuple *tuple,
 								uint32 version);

--- a/orioledb.control
+++ b/orioledb.control
@@ -1,5 +1,5 @@
 # orioledb extension
 comment = 'OrioleDB -- the next generation transactional engine'
-default_version = '1.4'
+default_version = '1.5'
 module_pathname = '$libdir/orioledb'
 relocatable = true

--- a/sql/orioledb--1.4--1.5.sql
+++ b/sql/orioledb--1.4--1.5.sql
@@ -1,0 +1,26 @@
+/* contrib/orioledb/sql/orioledb--1.4--1.5.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.5'" to load this file. \quit
+
+-- tuple_chunk implementation testing functions
+
+CREATE FUNCTION test_btree_leaf_tuple_chunk(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION test_btree_leaf_tuple_chunk_builder(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION test_btree_hikey_chunk(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION test_btree_hikey_chunk_builder(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.4--1.5_dev.sql
+++ b/sql/orioledb--1.4--1.5_dev.sql
@@ -1,0 +1,22 @@
+
+-- tuple_chunk implementation testing functions
+
+CREATE FUNCTION test_btree_leaf_tuple_chunk(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION test_btree_leaf_tuple_chunk_builder(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION test_btree_hikey_chunk(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION test_btree_hikey_chunk_builder(relation regclass)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.4--1.5_prod.sql
+++ b/sql/orioledb--1.4--1.5_prod.sql
@@ -1,0 +1,4 @@
+/* contrib/orioledb/sql/orioledb--1.4--1.5.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.5'" to load this file. \quit

--- a/src/btree/chunk_ops.c
+++ b/src/btree/chunk_ops.c
@@ -1,0 +1,40 @@
+/*-------------------------------------------------------------------------
+ *
+ * chunk_ops.c
+ *		Utility functions for OrioleDB abstract page chunk access API.
+ *
+ * Copyright (c) 2025, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/src/btree/chunk_ops.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "btree/chunk_ops.h"
+
+/*
+ * Chunk initialization functions.
+ */
+
+void
+init_btree_chunk_desc(BTreeChunkDesc *desc, const BTreeChunkOps *ops,
+					  BTreeDescr *treeDesc, Page page,
+					  OffsetNumber chunkOffset)
+{
+	desc->treeDesc = treeDesc;
+	*((const BTreeChunkOps **) &desc->ops) = ops;
+	ops->init(desc, page, chunkOffset);
+}
+
+void
+init_btree_chunk_builder(BTreeChunkBuilder *chunkBuilder,
+						 const BTreeChunkOps *ops, BTreeDescr *treeDesc)
+{
+	chunkBuilder->treeDesc = treeDesc;
+	*((const BTreeChunkOps **) &chunkBuilder->ops) = ops;
+	ops->builder_init(chunkBuilder);
+}

--- a/src/btree/chunk_ops_test.c
+++ b/src/btree/chunk_ops_test.c
@@ -1,0 +1,1007 @@
+/*-------------------------------------------------------------------------
+ *
+ * tuple_chunk.c
+ *		OrioleDB implementation of chunk API over tuple chunks.
+ *
+ * Copyright (c) 2025, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/btree/tuple_chunk.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "btree/chunk_ops.h"
+#include "btree/page_chunks.h"
+#include "btree/print.h"
+#include "tableam/descr.h"
+
+#include "access/relation.h"
+#include "funcapi.h"
+#include "utils/lsyscache.h"
+
+typedef struct TupleChunkTestDesc
+{
+	OTableDescr tableDesc;
+	OIndexDescr *indexDesc;
+
+	BTreeChunkDesc chunk;
+	BTreeChunkBuilder chunkBuilder;
+
+	TuplePrintOpaque printOpaque;
+	StringInfoData buf;
+
+	char		page[ORIOLEDB_BLCKSZ];
+} TupleChunkTestDesc;
+
+PG_FUNCTION_INFO_V1(test_btree_leaf_tuple_chunk);
+PG_FUNCTION_INFO_V1(test_btree_leaf_tuple_chunk_builder);
+PG_FUNCTION_INFO_V1(test_btree_hikey_chunk);
+PG_FUNCTION_INFO_V1(test_btree_hikey_chunk_builder);
+
+/*
+ * Utility functions.
+ */
+
+static void
+init_test_desc(TupleChunkTestDesc *testDesc, Oid relid)
+{
+	ORelOids	oids;
+	OTable	   *oTable;
+	Relation	rel;
+
+	MemSet(testDesc, 0, sizeof(TupleChunkTestDesc));
+
+	/* Get information about the table to get BTreeDescr */
+
+	rel = relation_open(relid, AccessShareLock);
+	ORelOidsSetFromRel(oids, rel);
+	relation_close(rel, AccessShareLock);
+
+	oTable = o_tables_get(oids);
+	if (oTable->nindices == 0)
+		elog(ERROR, "relation %d doesn't have indexes", relid);
+
+	o_fill_tmp_table_descr(&testDesc->tableDesc, oTable);
+
+	/* Initialize resulting BTreeChunkDesc and TupleChunkTestDesc */
+
+	testDesc->indexDesc = GET_PRIMARY(&testDesc->tableDesc);
+
+	pfree(oTable);
+}
+
+static void
+free_test_desc(TupleChunkTestDesc *testDesc)
+{
+	o_free_tmp_table_descr(&testDesc->tableDesc);
+}
+
+static void
+init_print_opaque(TupleChunkTestDesc *testDesc)
+{
+	TuplePrintOpaque *printOpaque = &testDesc->printOpaque;
+
+	printOpaque->desc = testDesc->indexDesc->leafTupdesc;
+	printOpaque->spec = &testDesc->indexDesc->leafSpec;
+	printOpaque->keyDesc = testDesc->indexDesc->nonLeafTupdesc;
+	printOpaque->keySpec = &testDesc->indexDesc->nonLeafSpec;
+	printOpaque->values = (Datum *) palloc(sizeof(Datum) * printOpaque->desc->natts);
+	printOpaque->nulls = (bool *) palloc(sizeof(bool) * printOpaque->desc->natts);
+	printOpaque->outputFns = (FmgrInfo *) palloc(sizeof(FmgrInfo) * printOpaque->desc->natts);
+	printOpaque->keyOutputFns = (FmgrInfo *) palloc(sizeof(FmgrInfo) * printOpaque->desc->natts);
+	printOpaque->printRowVersion = false;
+
+	for (int i = 0; i < printOpaque->desc->natts; i++)
+	{
+		Oid			output;
+		bool		varlena;
+
+		getTypeOutputInfo(printOpaque->desc->attrs[i].atttypid, &output, &varlena);
+		fmgr_info(output, &printOpaque->outputFns[i]);
+	}
+
+	for (int i = 0; i < printOpaque->keyDesc->natts; i++)
+	{
+		Oid			output;
+		bool		varlena;
+
+		getTypeOutputInfo(printOpaque->keyDesc->attrs[i].atttypid, &output, &varlena);
+		fmgr_info(output, &printOpaque->keyOutputFns[i]);
+	}
+}
+
+static OTuple
+make_otuple(TupleChunkTestDesc *testDesc, Datum *values, bool *nulls, bool isLeaf)
+{
+	TupleDesc	tupleDesc;
+	OTupleFixedFormatSpec *spec;
+
+	if (isLeaf)
+	{
+		tupleDesc = testDesc->indexDesc->leafTupdesc;
+		spec = &testDesc->indexDesc->leafSpec;
+	}
+	else
+	{
+		tupleDesc = testDesc->indexDesc->nonLeafTupdesc;
+		spec = &testDesc->indexDesc->nonLeafSpec;
+	}
+
+	/* Make the result OTuple */
+	return o_form_tuple(tupleDesc, spec, 0, values, nulls, NULL);
+}
+
+static void
+print_otuple(TupleChunkTestDesc *testDesc, OTuple tuple, bool isLeaf)
+{
+	TuplePrintOpaque *printOpaque = &testDesc->printOpaque;
+	TupleDesc	tupleDesc;
+	OTupleFixedFormatSpec *spec;
+	FmgrInfo   *outputFns;
+
+	if (isLeaf)
+	{
+		tupleDesc = printOpaque->desc;
+		spec = printOpaque->spec;
+		outputFns = printOpaque->outputFns;
+	}
+	else
+	{
+		tupleDesc = printOpaque->keyDesc;
+		spec = printOpaque->keySpec;
+		outputFns = printOpaque->keyOutputFns;
+	}
+
+	o_tuple_print(tupleDesc, spec, outputFns, &testDesc->buf, tuple,
+				  printOpaque->values, printOpaque->nulls, false);
+}
+
+static void
+test_estimate_change(TupleChunkTestDesc *testDesc, OffsetNumber itemOffset,
+					 BTreeChunkOperationType operation,
+					 Datum *values, bool *nulls, bool isLeaf)
+{
+	OTuple		tuple = {0};
+	int32		estimate;
+
+	if (operation != BTreeChunkOperationDelete)
+		tuple = make_otuple(testDesc, values, nulls, isLeaf);
+
+	estimate = testDesc->chunk.ops->estimate_change(&testDesc->chunk, itemOffset,
+													operation, tuple);
+
+	if (operation != BTreeChunkOperationDelete)
+	{
+		resetStringInfo(&testDesc->buf);
+		print_otuple(testDesc, tuple, isLeaf);
+	}
+
+	if (operation == BTreeChunkOperationInsert)
+		elog(INFO, "Estimate INSERT operation %s at position %d: %d",
+			 testDesc->buf.data, itemOffset, estimate);
+	else if (operation == BTreeChunkOperationUpdate)
+		elog(INFO, "Estimate UPDATE operation %s at position %d: %d",
+			 testDesc->buf.data, itemOffset, estimate);
+	else if (operation == BTreeChunkOperationDelete)
+		elog(INFO, "Estimate DELETE operation at position %d: %d",
+			 itemOffset, estimate);
+	else
+		elog(ERROR, "Unexpected operation type: %d", operation);
+
+	if (operation != BTreeChunkOperationDelete)
+		pfree(tuple.data);
+}
+
+static void
+test_perform_change(TupleChunkTestDesc *testDesc, OffsetNumber itemOffset,
+					BTreeChunkOperationType operation,
+					Datum *values, bool *nulls, Pointer header, bool isLeaf)
+{
+	OTuple		tuple = {0};
+
+	if (operation != BTreeChunkOperationDelete)
+		tuple = make_otuple(testDesc, values, nulls, isLeaf);
+
+	testDesc->chunk.ops->perform_change(&testDesc->chunk, itemOffset,
+										operation, header, tuple);
+
+	if (operation != BTreeChunkOperationDelete)
+	{
+		resetStringInfo(&testDesc->buf);
+		print_otuple(testDesc, tuple, isLeaf);
+	}
+
+	if (operation == BTreeChunkOperationInsert)
+		elog(INFO, "Perform INSERT operation %s at position %d",
+			 testDesc->buf.data, itemOffset);
+	else if (operation == BTreeChunkOperationUpdate)
+		elog(INFO, "Perform UPDATE operation %s at position %d",
+			 testDesc->buf.data, itemOffset);
+	else if (operation == BTreeChunkOperationDelete)
+		elog(INFO, "Perform DELETE operation at position %d",
+			 itemOffset);
+	else
+		elog(ERROR, "Unexpected operation type: %d", operation);
+
+	if (operation != BTreeChunkOperationDelete)
+		pfree(tuple.data);
+}
+
+static void
+test_read_tuple(TupleChunkTestDesc *testDesc, OffsetNumber itemOffset,
+				bool isLeaf)
+{
+	Pointer		header = NULL;
+	OTuple		tuple = {0};
+	bool		needsFree;
+
+	testDesc->chunk.ops->read_tuple(&testDesc->chunk, NULL, NULL, itemOffset,
+									&header, &tuple, &needsFree);
+	Assert(!needsFree);
+
+	resetStringInfo(&testDesc->buf);
+	print_otuple(testDesc, tuple, isLeaf);
+
+	if (isLeaf)
+	{
+		BTreeLeafTuphdr *leafHeader = (BTreeLeafTuphdr *) header;
+
+		if (leafHeader->deleted != BTreeLeafTupleNonDeleted)
+		{
+			if (leafHeader->deleted == BTreeLeafTupleDeleted)
+				appendStringInfoString(&testDesc->buf, ", deleted");
+			else if (leafHeader->deleted == BTreeLeafTupleMovedPartitions)
+				appendStringInfoString(&testDesc->buf, ", moved partitions");
+			else if (leafHeader->deleted == BTreeLeafTuplePKChanged)
+				appendStringInfoString(&testDesc->buf, ", PK changed");
+		}
+	}
+
+	elog(INFO, "Read tuple at position %d: %s", itemOffset, testDesc->buf.data);
+}
+
+static void
+test_read_hikey(TupleChunkTestDesc *testDesc, OffsetNumber itemOffset)
+{
+	OTuple		tuple = {0};
+	bool		needsFree;
+
+	testDesc->chunk.ops->read_tuple(&testDesc->chunk, NULL, NULL, itemOffset,
+									NULL, &tuple, &needsFree);
+	Assert(!needsFree);
+
+	resetStringInfo(&testDesc->buf);
+	print_otuple(testDesc, tuple, false);
+
+	elog(INFO, "Read tuple at position %d: %s", itemOffset, testDesc->buf.data);
+}
+
+static void
+test_cmp_tuple(TupleChunkTestDesc *testDesc, OffsetNumber itemOffset,
+			   Datum *values, bool *nulls, bool isLeaf)
+{
+	OTuple		tuple = {0};
+	int			cmp = 0;
+
+	tuple = make_otuple(testDesc, values, nulls, isLeaf);
+
+	testDesc->chunk.ops->cmp(&testDesc->chunk, NULL, NULL, itemOffset, &tuple,
+							 testDesc->chunk.ops->itemKeyType, &cmp);
+
+	resetStringInfo(&testDesc->buf);
+	print_otuple(testDesc, tuple, isLeaf);
+
+	elog(INFO, "Compare tuple %s at position %d: %d", testDesc->buf.data,
+		 itemOffset, cmp);
+
+	pfree(tuple.data);
+}
+
+static void
+test_search_tuple(TupleChunkTestDesc *testDesc, Datum *values, bool *nulls,
+				  bool isLeaf)
+{
+	OTuple		tuple = {0};
+	OffsetNumber itemOffset;
+
+	tuple = make_otuple(testDesc, values, nulls, isLeaf);
+
+	testDesc->chunk.ops->search(&testDesc->chunk, NULL, NULL, &tuple,
+								testDesc->chunk.ops->itemKeyType, &itemOffset);
+
+	resetStringInfo(&testDesc->buf);
+	print_otuple(testDesc, tuple, isLeaf);
+
+	elog(INFO, "Search for tuple %s: %d", testDesc->buf.data, itemOffset);
+
+	pfree(tuple.data);
+}
+
+static void
+test_builder_estimate(TupleChunkTestDesc *testDesc, Datum *values, bool *nulls,
+					  bool isLeaf)
+{
+	OTuple		tuple = {0};
+	int32		estimate;
+
+	tuple = make_otuple(testDesc, values, nulls, isLeaf);
+
+	estimate = testDesc->chunkBuilder.ops->builder_estimate(&testDesc->chunkBuilder,
+															tuple);
+
+	resetStringInfo(&testDesc->buf);
+	print_otuple(testDesc, tuple, isLeaf);
+
+	elog(INFO, "Estimate adding tuple %s to builder: %d", testDesc->buf.data,
+		 estimate);
+
+	pfree(tuple.data);
+}
+
+static void
+test_builder_add(TupleChunkTestDesc *testDesc, Datum *values, bool *nulls,
+				 Pointer header, bool isLeaf)
+{
+	const BTreeChunkOps *ops = testDesc->chunkBuilder.ops;
+	OTuple		tuple;
+	uint16		tupleSize;
+	char	   *tupleData;
+	BTreeChunkBuilderItem chunkItem = {0};
+
+	tuple = make_otuple(testDesc, values, nulls, isLeaf);
+	tupleSize = o_btree_len(testDesc->chunkBuilder.treeDesc, tuple,
+							ops->itemLengthType);
+
+	chunkItem.flags = tuple.formatFlags;
+	if (header != NULL)
+		chunkItem.size = ops->itemHeaderSize + MAXALIGN(tupleSize);
+	else
+		chunkItem.size = MAXALIGN(tupleSize);
+
+	/* Do not pfree the tuple since we only copy pointer to the tuple */
+	tupleData = palloc0(chunkItem.size);
+
+	if (header != NULL)
+	{
+		Assert(ops->itemHeaderSize > 0);
+
+		memcpy(tupleData, header, ops->itemHeaderSize);
+		memcpy(tupleData + ops->itemHeaderSize, tuple.data, tupleSize);
+	}
+	else
+		memcpy(tupleData, tuple.data, tupleSize);
+
+	chunkItem.data = (Pointer) tupleData;
+	ops->builder_add(&testDesc->chunkBuilder, &chunkItem);
+
+	resetStringInfo(&testDesc->buf);
+	print_otuple(testDesc, tuple, isLeaf);
+
+	elog(INFO, "Perform adding tuple %s to builder", testDesc->buf.data);
+
+	pfree(tuple.data);
+}
+
+/*
+ * Utility functions for leaf tuple chunks testing.
+ */
+
+static void
+ltc_init_desc(TupleChunkTestDesc *testDesc)
+{
+	init_page_first_chunk(&testDesc->indexDesc->desc, testDesc->page, 0);
+
+	init_btree_chunk_desc(&testDesc->chunk, &BTreeLeafTupleChunkOps,
+						  &testDesc->indexDesc->desc, testDesc->page, 0);
+}
+
+static void
+ltc_test_compact(TupleChunkTestDesc *testDesc)
+{
+	BTreeChunkDesc *chunk = &testDesc->chunk;
+	uint16		sizeBefore = chunk->chunkDataSize,
+				itemsCountBefore = chunk->chunkItemsCount;
+
+	chunk->ops->compact(chunk);
+
+	elog(INFO, "Compaction: before: chunkDataSize %d, chunkItemsCount %d, "
+		 "after: chunkDataSize %d, chunkItemsCount %d",
+		 sizeBefore, itemsCountBefore,
+		 chunk->chunkDataSize, chunk->chunkItemsCount);
+}
+
+static void
+ltc_init_builder(TupleChunkTestDesc *testDesc)
+{
+	init_btree_chunk_builder(&testDesc->chunkBuilder, &BTreeLeafTupleChunkOps,
+							 &testDesc->indexDesc->desc);
+}
+
+/*
+ * Utility functions for hikey chunks testing.
+ */
+
+static void
+htc_init_desc(TupleChunkTestDesc *testDesc)
+{
+	init_page_first_chunk(&testDesc->indexDesc->desc, testDesc->page, 0);
+
+	init_btree_chunk_desc(&testDesc->chunk, &BTreeHiKeyChunkOps,
+						  &testDesc->indexDesc->desc, testDesc->page, 0);
+	testDesc->chunk.chunkItemsCount = 0;
+}
+
+static void
+htc_init_builder(TupleChunkTestDesc *testDesc)
+{
+	init_btree_chunk_builder(&testDesc->chunkBuilder, &BTreeHiKeyChunkOps,
+							 &testDesc->indexDesc->desc);
+}
+
+/*
+ * Main test functions.
+ */
+
+Datum
+test_btree_leaf_tuple_chunk(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	TupleChunkTestDesc testDesc;
+	BTreeChunkDesc *chunk;
+
+	init_test_desc(&testDesc, relid);
+	ltc_init_desc(&testDesc);
+	init_print_opaque(&testDesc);
+	initStringInfo(&testDesc.buf);
+
+	chunk = &testDesc.chunk;
+
+	/* Test - Estimate INSERT operation */
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationInsert;
+		Datum	   *values = (Datum[]) {Int32GetDatum(1), CStringGetTextDatum("value 1")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_estimate_change(&testDesc, itemOffset, operation, values, nulls,
+							 true);
+	}
+
+	/* Test - Perform INSERT operation */
+	for (OffsetNumber itemOffset = 0; itemOffset < 50; itemOffset++)
+	{
+		BTreeChunkOperationType operation = BTreeChunkOperationInsert;
+		int32		intVal = itemOffset + 1;
+		char	   *stringVal = psprintf("value %d", intVal);
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum(stringVal)};
+		bool	   *nulls = (bool[]) {false, false};
+		BTreeLeafTuphdr header = {0};
+
+		header.deleted = BTreeLeafTupleNonDeleted;
+		test_perform_change(&testDesc, itemOffset, operation, values, nulls,
+							(Pointer) &header, true);
+
+		pfree(stringVal);
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_tuple(&testDesc, itemOffset, true);
+	}
+
+	/* Test - Compare a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		int32		intVal = itemOffset;
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum("value")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, true);
+
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Compare a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		int32		intVal = itemOffset + 1;
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum("value")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, true);
+
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Compare a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		int32		intVal = itemOffset + 2;
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum("value")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, true);
+
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Search for a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount + 2; itemOffset++)
+	{
+		int32		intVal = itemOffset;
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum("value")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_search_tuple(&testDesc, values, nulls, true);
+
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Estimate UPDATE operation */
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationUpdate;
+		Datum	   *values = (Datum[]) {Int32GetDatum(1), CStringGetTextDatum("value 2")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_estimate_change(&testDesc, itemOffset, operation, values, nulls,
+							 true);
+	}
+
+	/* Test - Estimate DELETE operation */
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationDelete;
+
+		test_estimate_change(&testDesc, itemOffset, operation, NULL, NULL,
+							 true);
+	}
+
+	/* Test - Perform UPDATE operation */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		BTreeChunkOperationType operation = BTreeChunkOperationUpdate;
+		int32		intVal = itemOffset + 100;
+		char	   *stringVal = psprintf("value %d", intVal);
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum(stringVal)};
+		bool	   *nulls = (bool[]) {false, false};
+		BTreeLeafTuphdr header = {0};
+
+		header.deleted = BTreeLeafTupleNonDeleted;
+		test_perform_change(&testDesc, itemOffset, operation, values, nulls,
+							(Pointer) &header, true);
+
+		pfree(stringVal);
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_tuple(&testDesc, itemOffset, true);
+	}
+
+	/* Test - Compare a tuple */
+	{
+		OffsetNumber itemOffset = 0;
+		Datum	   *values = (Datum[]) {Int32GetDatum(100), CStringGetTextDatum("value 100")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, true);
+	}
+
+	/* Test - Search for a tuple */
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(100), CStringGetTextDatum("value 100")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_search_tuple(&testDesc, values, nulls, true);
+	}
+
+	/* Test - Perform UPDATE operation with smaller values */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		BTreeChunkOperationType operation = BTreeChunkOperationUpdate;
+		int32		intVal = itemOffset + 100;
+		char	   *stringVal = psprintf("%d", intVal);
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum(stringVal)};
+		bool	   *nulls = (bool[]) {false, false};
+		BTreeLeafTuphdr header = {0};
+
+		header.deleted = BTreeLeafTupleNonDeleted;
+		test_perform_change(&testDesc, itemOffset, operation, values, nulls,
+							(Pointer) &header, true);
+
+		pfree(stringVal);
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Perform DELETE operation */
+	for (int i = 0; i < 10; i++)
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationDelete;
+
+		test_perform_change(&testDesc, itemOffset, operation, NULL, NULL,
+							NULL, true);
+	}
+
+	/* Test - Perform DELETE operation */
+	for (int i = 0; i < 10; i++)
+	{
+		OffsetNumber itemOffset = chunk->chunkItemsCount - 1;
+		BTreeChunkOperationType operation = BTreeChunkOperationDelete;
+
+		test_perform_change(&testDesc, itemOffset, operation, NULL, NULL,
+							NULL, true);
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_tuple(&testDesc, itemOffset, true);
+	}
+
+	/* Test - Compare a tuple */
+	{
+		OffsetNumber itemOffset = 0;
+		Datum	   *values = (Datum[]) {Int32GetDatum(100), CStringGetTextDatum("value 100")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, true);
+	}
+
+	/* Test - Search for a tuple */
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(100), CStringGetTextDatum("value 100")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_search_tuple(&testDesc, values, nulls, true);
+	}
+
+	/* Test - Compaction */
+	ltc_test_compact(&testDesc);
+
+	/* Test - Perform soft delete */
+	for (OffsetNumber itemOffset = 10; itemOffset < 20; itemOffset++)
+	{
+		BTreeChunkOperationType operation = BTreeChunkOperationUpdate;
+		int32		intVal = itemOffset + 100;
+		char	   *stringVal = psprintf("%d", intVal);
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum(stringVal)};
+		bool	   *nulls = (bool[]) {false, false};
+		BTreeLeafTuphdr header = {0};
+
+		header.deleted = BTreeLeafTupleDeleted;
+		test_perform_change(&testDesc, itemOffset, operation, values, nulls,
+							(Pointer) &header, true);
+
+		pfree(stringVal);
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_tuple(&testDesc, itemOffset, true);
+	}
+
+	/* Test - Compaction */
+	ltc_test_compact(&testDesc);
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_tuple(&testDesc, itemOffset, true);
+	}
+
+	free_test_desc(&testDesc);
+
+	PG_RETURN_VOID();
+}
+
+Datum
+test_btree_leaf_tuple_chunk_builder(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	TupleChunkTestDesc testDesc;
+
+	init_test_desc(&testDesc, relid);
+	ltc_init_desc(&testDesc);
+	ltc_init_builder(&testDesc);
+	init_print_opaque(&testDesc);
+	initStringInfo(&testDesc.buf);
+
+	/* Test - Estimate new tuple */
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(1), CStringGetTextDatum("value 1")};
+		bool	   *nulls = (bool[]) {false, false};
+
+		test_builder_estimate(&testDesc, values, nulls, true);
+	}
+
+	/* Test - Add new tuple */
+	for (OffsetNumber itemOffset = 0; itemOffset < 50; itemOffset++)
+	{
+		int32		intVal = itemOffset + 1;
+		char	   *stringVal = psprintf("value %d", intVal);
+
+		Datum	   *values =
+		(Datum[]) {Int32GetDatum(intVal), CStringGetTextDatum(stringVal)};
+		bool	   *nulls = (bool[]) {false, false};
+		BTreeLeafTuphdr header = {0};
+
+		test_builder_add(&testDesc, values, nulls, (Pointer) &header, true);
+
+		pfree(stringVal);
+		pfree(DatumGetPointer(values[1]));
+	}
+
+	/* Test - Finish building */
+	{
+		testDesc.chunkBuilder.ops->builder_finish(&testDesc.chunkBuilder,
+												  &testDesc.chunk);
+		elog(INFO, "Finished building tuple chunk");
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < testDesc.chunk.chunkItemsCount; itemOffset++)
+	{
+		test_read_tuple(&testDesc, itemOffset, true);
+	}
+
+	free_test_desc(&testDesc);
+
+	PG_RETURN_VOID();
+}
+
+Datum
+test_btree_hikey_chunk(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	TupleChunkTestDesc testDesc;
+	BTreeChunkDesc *chunk;
+
+	init_test_desc(&testDesc, relid);
+	htc_init_desc(&testDesc);
+	init_print_opaque(&testDesc);
+	initStringInfo(&testDesc.buf);
+
+	chunk = &testDesc.chunk;
+
+	/* Test - Estimate INSERT operation */
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationInsert;
+		Datum	   *values = (Datum[]) {Int32GetDatum(1)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_estimate_change(&testDesc, itemOffset, operation, values, nulls,
+							 false);
+	}
+
+	/* Test - Perform INSERT operation */
+	for (OffsetNumber itemOffset = 0; itemOffset < BTREE_PAGE_MAX_CHUNKS; itemOffset++)
+	{
+		BTreeChunkOperationType operation = BTreeChunkOperationInsert;
+		Datum	   *values = (Datum[]) {Int32GetDatum(itemOffset + 1)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_perform_change(&testDesc, itemOffset, operation, values, nulls,
+							NULL, false);
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_hikey(&testDesc, itemOffset);
+	}
+
+	/* Test - Compare a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(itemOffset)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, false);
+	}
+
+	/* Test - Compare a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(itemOffset + 1)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, false);
+	}
+
+	/* Test - Search for a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount + 2; itemOffset++)
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(itemOffset)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_search_tuple(&testDesc, values, nulls, false);
+	}
+
+	/* Test - Estimate UPDATE operation */
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationUpdate;
+		Datum	   *values = (Datum[]) {Int32GetDatum(1)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_estimate_change(&testDesc, itemOffset, operation, values, nulls,
+							 false);
+	}
+
+	/* Test - Estimate DELETE operation */
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationDelete;
+
+		test_estimate_change(&testDesc, itemOffset, operation, NULL, NULL,
+							 false);
+	}
+
+	/* Test - Perform UPDATE operation */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		BTreeChunkOperationType operation = BTreeChunkOperationUpdate;
+
+		Datum	   *values = (Datum[]) {Int32GetDatum(itemOffset + 100)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_perform_change(&testDesc, itemOffset, operation, values, nulls,
+							NULL, false);
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_hikey(&testDesc, itemOffset);
+	}
+
+	/* Test - Compare a tuple */
+	{
+		OffsetNumber itemOffset = 0;
+		Datum	   *values = (Datum[]) {Int32GetDatum(100)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, false);
+	}
+
+	/* Test - Search for a tuple */
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(100)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_search_tuple(&testDesc, values, nulls, false);
+	}
+
+	/* Test - Perform DELETE operation */
+	for (int i = 0; i < 10; i++)
+	{
+		OffsetNumber itemOffset = 0;
+		BTreeChunkOperationType operation = BTreeChunkOperationDelete;
+
+		test_perform_change(&testDesc, itemOffset, operation, NULL, NULL,
+							NULL, false);
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < chunk->chunkItemsCount; itemOffset++)
+	{
+		test_read_hikey(&testDesc, itemOffset);
+	}
+
+	/* Test - Compare a tuple */
+	{
+		OffsetNumber itemOffset = 0;
+		Datum	   *values = (Datum[]) {Int32GetDatum(100)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_cmp_tuple(&testDesc, itemOffset, values, nulls, false);
+	}
+
+	/* Test - Search for a tuple */
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(100)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_search_tuple(&testDesc, values, nulls, false);
+	}
+
+	free_test_desc(&testDesc);
+
+	PG_RETURN_VOID();
+}
+
+Datum
+test_btree_hikey_chunk_builder(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	TupleChunkTestDesc testDesc;
+
+	init_test_desc(&testDesc, relid);
+	htc_init_desc(&testDesc);
+	htc_init_builder(&testDesc);
+	init_print_opaque(&testDesc);
+	initStringInfo(&testDesc.buf);
+
+	/* Test - Estimate new tuple */
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(1)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_builder_estimate(&testDesc, values, nulls, false);
+	}
+
+	/* Test - Add new tuple */
+	for (OffsetNumber itemOffset = 0; itemOffset < BTREE_PAGE_MAX_CHUNKS; itemOffset++)
+	{
+		Datum	   *values = (Datum[]) {Int32GetDatum(itemOffset + 1)};
+		bool	   *nulls = (bool[]) {false};
+
+		test_builder_add(&testDesc, values, nulls, NULL, false);
+	}
+
+	/* Test - Finish building */
+	{
+		testDesc.chunkBuilder.ops->builder_finish(&testDesc.chunkBuilder,
+												  &testDesc.chunk);
+		elog(INFO, "Finished building tuple chunk");
+	}
+
+	/* Test - Read a tuple */
+	for (OffsetNumber itemOffset = 0;
+		 itemOffset < testDesc.chunk.chunkItemsCount; itemOffset++)
+	{
+		test_read_hikey(&testDesc, itemOffset);
+	}
+
+	free_test_desc(&testDesc);
+
+	PG_RETURN_VOID();
+}

--- a/src/btree/hikey_chunk.c
+++ b/src/btree/hikey_chunk.c
@@ -1,0 +1,587 @@
+/*-------------------------------------------------------------------------
+ *
+ * hikey_chunk.c
+ *		OrioleDB implementation of chunk API over hikey chunks.
+ *
+ * Copyright (c) 2025, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/btree/hikey_chunk.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "btree/chunk_ops.h"
+
+#include "utils/memdebug.h"
+
+const BTreeChunkOps BTreeHiKeyChunkOps;
+
+/*
+ * Implementation of hikey chunks.
+ */
+
+static inline uint16
+htc_get_chunk_items_count(BTreeChunkDesc *chunk)
+{
+	return ((BTreePageHeader *) chunk->page)->chunksCount;
+}
+
+static inline BTreePageChunkDesc *
+htc_get_chunk_items(BTreeChunkDesc *chunk)
+{
+	return ((BTreePageHeader *) chunk->page)->chunkDesc;
+}
+
+static inline Pointer
+htc_get_chunk_start(BTreeChunkDesc *chunk)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	LocationIndex chunkLocation =
+		MAXALIGN(offsetof(BTreePageHeader, chunkDesc) +
+				 (sizeof(BTreePageChunkDesc) * header->chunksCount));
+
+	return (Pointer) chunk->page + chunkLocation;
+}
+
+static inline uint16
+htc_get_chunk_size(BTreeChunkDesc *chunk)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	LocationIndex chunkLocation =
+		MAXALIGN(offsetof(BTreePageHeader, chunkDesc) +
+				 (sizeof(BTreePageChunkDesc) * header->chunksCount));
+
+	return header->hikeysEnd - chunkLocation;
+}
+
+static inline uint8
+htc_get_item_flags(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	Assert(itemOffset < htc_get_chunk_items_count(chunk));
+
+	return htc_get_chunk_items(chunk)[itemOffset].hikeyFlags;
+}
+
+static inline void
+htc_set_item_flags(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				   uint8 flags)
+{
+	Assert(itemOffset < htc_get_chunk_items_count(chunk));
+
+	htc_get_chunk_items(chunk)[itemOffset].hikeyFlags = flags;
+}
+
+static inline Pointer
+htc_get_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	Assert(itemOffset < htc_get_chunk_items_count(chunk));
+
+	return htc_get_chunk_start(chunk) +
+		SHORT_GET_LOCATION(htc_get_chunk_items(chunk)[itemOffset].hikeyShortLocation);
+}
+
+/*
+ * Get size of the item as a substraction of offset of the next item and the
+ * target.
+ */
+static inline uint16
+htc_get_item_size(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	LocationIndex itemLocation;
+	uint16		chunkItemsCount = htc_get_chunk_items_count(chunk);
+	BTreePageChunkDesc *items;
+
+	Assert(itemOffset < chunkItemsCount);
+
+	items = htc_get_chunk_items(chunk);
+
+	/* Calculate offset form the beginning of the chunk */
+	itemLocation = SHORT_GET_LOCATION(items[itemOffset].hikeyShortLocation);
+
+	if (itemOffset + 1 < chunkItemsCount)
+		return SHORT_GET_LOCATION(items[itemOffset + 1].hikeyShortLocation) - itemLocation;
+	else
+		return htc_get_chunk_size(chunk) - itemLocation;
+}
+
+/*
+ * Allocate space for the new item in the chunk.  A caller is responsible to
+ * copy the item afterwards.
+ */
+static void
+htc_allocate_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				  uint16 itemSize)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	BTreePageChunkDesc *items = htc_get_chunk_items(chunk);
+	Pointer		chunkStart = htc_get_chunk_start(chunk);
+	uint16		chunkSize = htc_get_chunk_size(chunk);
+	LocationIndex itemsShift,
+				dataShift;
+	Pointer		itemPtr,
+				endPtr;
+
+	Assert(itemSize == MAXALIGN(itemSize));
+	Assert(itemOffset < BTREE_PAGE_MAX_CHUNKS);
+
+	itemsShift = MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * (header->chunksCount + 1))) -
+		MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * header->chunksCount));
+
+	/* Calculate the shift of the data after new item is inserted */
+	dataShift = itemsShift + itemSize;
+
+	if (itemOffset < header->chunksCount)
+		itemPtr = htc_get_item(chunk, itemOffset);
+	else
+	{
+		Assert(itemOffset == header->chunksCount);
+
+		itemPtr = chunkStart + chunkSize;
+	}
+
+	endPtr = chunkStart + chunkSize;
+
+	/* Data should still fit to the page */
+	Assert(chunkSize + dataShift <= ORIOLEDB_BLCKSZ);
+
+	/* Shift the data after insert location */
+	Assert(itemPtr <= endPtr);
+
+	memmove(itemPtr + dataShift, itemPtr, endPtr - itemPtr);
+
+	header->chunksCount++;
+	header->hikeysEnd += dataShift;
+
+	chunkSize += dataShift;
+
+	if (itemsShift != 0)
+	{
+		/*
+		 * If items array size is changed, then we have to also move the items
+		 * before insert location and adjust those locations in the items
+		 * array.
+		 */
+		memmove(chunkStart + itemsShift, chunkStart, itemPtr - chunkStart);
+		for (OffsetNumber i = 0; i < itemOffset; i++)
+			items[i].hikeyShortLocation += LOCATION_GET_SHORT(itemsShift);
+	}
+
+	/* Add the new item to the items array  */
+	for (int i = header->chunksCount - 1; i > itemOffset; i--)
+		items[i].hikeyShortLocation = items[i - 1].hikeyShortLocation +
+			LOCATION_GET_SHORT(dataShift);
+	items[itemOffset].hikeyShortLocation = LOCATION_GET_SHORT(itemPtr - chunk->page);
+}
+
+/*
+ * Resize the chunk to fit the new item size.  A caller is responsible to copy
+ * the new item.
+ */
+static void
+htc_resize_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				uint16 newItemSize)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	BTreePageChunkDesc *items = htc_get_chunk_items(chunk);
+	Pointer		chunkStart = htc_get_chunk_start(chunk);
+	uint16		chunkSize = htc_get_chunk_size(chunk);
+	int32		dataShift;
+	Pointer		nextItemPtr,
+				endPtr;
+
+	Assert(newItemSize == MAXALIGN(newItemSize));
+
+	/* Calculate the shift of the data after the item resize */
+	dataShift = newItemSize - htc_get_item_size(chunk, itemOffset);
+	Assert(dataShift == MAXALIGN(dataShift));
+
+	/* We don't move items to fill the gap if the new tuple is smaller */
+	if (dataShift <= 0)
+		return;
+
+	Assert(itemOffset < header->chunksCount);
+
+	if (itemOffset + 1 < header->chunksCount)
+		nextItemPtr = htc_get_item(chunk, itemOffset + 1);
+	else
+		nextItemPtr = chunkStart + chunkSize;
+
+	endPtr = chunkStart + chunkSize;
+
+	/* Data should still fit to the page */
+	Assert(chunkSize + dataShift <= ORIOLEDB_BLCKSZ);
+
+	/* Shift the data after the item */
+	memmove(nextItemPtr + dataShift, nextItemPtr, endPtr - nextItemPtr);
+
+	/* Adjust the items array */
+	for (OffsetNumber i = itemOffset + 1; i < header->chunksCount; i++)
+		items[i].hikeyShortLocation += LOCATION_GET_SHORT(dataShift);
+
+	header->hikeysEnd += dataShift;
+}
+
+/*
+ * Delete the item from the chunk by the provided offset.
+ */
+static void
+htc_delete_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	BTreePageChunkDesc *items = htc_get_chunk_items(chunk);
+	Pointer		chunkStart = htc_get_chunk_start(chunk);
+	uint16		chunkSize = htc_get_chunk_size(chunk);
+	uint16		itemSize;
+	LocationIndex itemsShift,
+				dataShift;
+	Pointer		itemPtr,
+				endPtr;
+
+	itemSize = htc_get_item_size(chunk, itemOffset);
+	Assert(itemSize == MAXALIGN(itemSize));
+
+	Assert(header->chunksCount > 0 && header->chunksCount < itemOffset);
+
+	itemsShift = MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * (header->chunksCount))) -
+		MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * header->chunksCount - 1));
+
+	/* Calculate the shift of the data after the item is deleted */
+	dataShift = itemsShift + itemSize;
+
+	itemPtr = htc_get_item(chunk, itemOffset);
+
+	endPtr = chunkStart + chunkSize;
+	Assert(endPtr - dataShift >= itemPtr - itemsShift);
+
+	/*
+	 * Adjust the items array.
+	 */
+	for (OffsetNumber i = itemOffset; i < header->chunksCount - 1; i++)
+		items[i].hikeyShortLocation = items[i + 1].hikeyShortLocation -
+			LOCATION_GET_SHORT(dataShift);
+
+	if (itemsShift != 0)
+	{
+		/* Shift the data before deleted item when items arrays is shorten. */
+		memmove(chunkStart - itemsShift, chunkStart, itemPtr - chunkStart);
+
+		/* Shift item pointers of those items */
+		for (OffsetNumber i = 0; i < itemOffset; i++)
+			items[i].hikeyShortLocation -= LOCATION_GET_SHORT(itemsShift);
+	}
+
+	/* Move the data after deleted item */
+	memmove(itemPtr, itemPtr + itemSize, endPtr - itemPtr - itemSize);
+
+	header->chunksCount--;
+	header->hikeysEnd -= dataShift;
+}
+
+/*
+ * Initialize hikey tuples chunk and copy the items array.
+ */
+static void
+htc_init(BTreeChunkDesc *chunk, Page page, OffsetNumber chunkOffset)
+{
+	Assert(chunkOffset == 0);
+
+	chunk->page = page;
+}
+
+/*
+ * Estimate size shift of the operation over the hikey tuple chunk.
+ */
+static int32
+htc_estimate_change(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+					BTreeChunkOperationType operation, OTuple tuple)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	int32		itemsShift = 0,
+				sizeNeeded = 0;
+
+	if (operation == BTreeChunkOperationInsert)
+	{
+		itemsShift = MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * (header->chunksCount + 1))) -
+			MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * header->chunksCount));
+
+		sizeNeeded = MAXALIGN(o_btree_len(chunk->treeDesc, tuple,
+										  chunk->ops->itemLengthType)) +
+			itemsShift;
+	}
+	else if (operation == BTreeChunkOperationUpdate)
+	{
+		sizeNeeded = MAXALIGN(o_btree_len(chunk->treeDesc, tuple,
+										  chunk->ops->itemLengthType)) -
+			htc_get_item_size(chunk, itemOffset);
+
+		/* We don't move items to fill the gap if the new tuple is smaller */
+		if (sizeNeeded < 0)
+			sizeNeeded = 0;
+	}
+	else if (operation == BTreeChunkOperationDelete)
+	{
+		itemsShift = MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * (header->chunksCount))) -
+			MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * header->chunksCount - 1));
+
+		sizeNeeded = (-1) * (htc_get_item_size(chunk, itemOffset) + itemsShift);
+	}
+	else
+		Assert(false);
+
+	return sizeNeeded;
+}
+
+/*
+ * Perform the operation over the hikey tuple chunk.  A caller is responsible
+ * that the chunk has enough space.
+ */
+static void
+htc_perform_change(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				   BTreeChunkOperationType operation,
+				   Pointer tupleHeader, OTuple tuple)
+{
+	Pointer		itemPtr;
+	uint16		tupleSize;
+
+	Assert(tupleHeader == NULL);
+	Assert(itemOffset < BTREE_PAGE_MAX_CHUNKS);
+
+	if (operation == BTreeChunkOperationInsert ||
+		operation == BTreeChunkOperationUpdate)
+		tupleSize = o_btree_len(chunk->treeDesc, tuple,
+								chunk->ops->itemLengthType);
+
+	if (operation == BTreeChunkOperationInsert)
+	{
+		/* Allocate space for the new item, move other items if necessary */
+		htc_allocate_item(chunk, itemOffset, MAXALIGN(tupleSize));
+
+		/* Copy the new tuple */
+		itemPtr = htc_get_item(chunk, itemOffset);
+
+		memcpy(itemPtr, tuple.data, tupleSize);
+
+		htc_set_item_flags(chunk, itemOffset, tuple.formatFlags);
+	}
+	else if (operation == BTreeChunkOperationUpdate)
+	{
+		htc_resize_item(chunk, itemOffset, MAXALIGN(tupleSize));
+
+		/* Copy the new tuple */
+		itemPtr = htc_get_item(chunk, itemOffset);
+
+		memcpy(itemPtr, tuple.data, tupleSize);
+
+		htc_set_item_flags(chunk, itemOffset, tuple.formatFlags);
+	}
+	else if (operation == BTreeChunkOperationDelete)
+	{
+		htc_delete_item(chunk, itemOffset);
+	}
+	else
+		elog(ERROR, "invalid BTreeChunkOperationType: %d", operation);
+}
+
+/*
+ * Compare the given key to a tuple at the given offset.
+ */
+static bool
+htc_cmp(BTreeChunkDesc *chunk, PartialPageState *partial, Page page,
+		OffsetNumber itemOffset, void *key, BTreeKeyType keyType, int *result)
+{
+	OTuple		tuple2 = {0};
+	bool		isCopy = false;
+	OBTreeKeyCmp cmpFunc = chunk->treeDesc->ops->cmp;
+
+	Assert(itemOffset < htc_get_chunk_items_count(chunk));
+	Assert(partial == NULL);
+
+	chunk->ops->read_tuple(chunk, NULL, NULL, itemOffset,
+						   NULL, &tuple2, &isCopy);
+
+	Assert(!isCopy);
+
+	*result = cmpFunc(chunk->treeDesc, key, keyType,
+					  &tuple2, chunk->ops->itemKeyType);
+	return true;
+}
+
+/*
+ * Search for a item by the given key.
+ */
+static bool
+htc_search(BTreeChunkDesc *chunk, PartialPageState *partial, Page page,
+		   void *key, BTreeKeyType keyType, OffsetNumber *itemOffset)
+{
+	uint16		chunkItemsCount = htc_get_chunk_items_count(chunk);
+	OffsetNumber mid,
+				low,
+				high;
+	int			targetCmpVal,
+				result;
+	bool		nextkey;
+	OBTreeKeyCmp cmpFunc = chunk->treeDesc->ops->cmp;
+
+	Assert(chunkItemsCount > 0);
+	Assert(partial == NULL);
+
+	low = 0;
+	high = chunkItemsCount - 1;
+	nextkey = (keyType != BTreeKeyPageHiKey);
+
+	if (unlikely(high < low))
+		return low;
+
+	targetCmpVal = nextkey ? 0 : 1; /* a target value of cmpFunc() */
+
+	/*
+	 * Don't pass BTreeHiKey to comparison function, we've set nextkey flag
+	 * instead.
+	 */
+	if (keyType == BTreeKeyPageHiKey)
+		keyType = BTreeKeyNonLeafKey;
+
+	while (high > low)
+	{
+		OTuple		midTuple;
+		bool		isCopy;
+
+		mid = low + ((high - low) / 2);
+
+		Assert(mid < chunkItemsCount - 1);
+
+		chunk->ops->read_tuple(chunk, NULL, NULL, mid,
+							   NULL, &midTuple, &isCopy);
+
+		result = cmpFunc(chunk->treeDesc, key, keyType, &midTuple,
+						 BTreeKeyNonLeafKey);
+
+		if (result >= targetCmpVal)
+			low = mid + 1;
+		else
+			high = mid;
+	}
+
+	*itemOffset = low;
+
+	return true;
+}
+
+/*
+ * Read a chunk item by the given offset.
+ */
+static bool
+htc_read_tuple(BTreeChunkDesc *chunk, PartialPageState *partial, Page page,
+			   OffsetNumber itemOffset, Pointer *tupleHeader, OTuple *tuple,
+			   bool *isCopy)
+{
+	Assert(itemOffset < htc_get_chunk_items_count(chunk));
+	Assert(tupleHeader == NULL);
+	Assert(partial == NULL);
+
+	tuple->data = htc_get_item(chunk, itemOffset);
+	tuple->formatFlags = htc_get_item_flags(chunk, itemOffset);
+
+	/* Set always to false in the current implementation */
+	*isCopy = false;
+
+	return true;
+}
+
+/*
+ * Initialize hikey chunk builder.
+ */
+static void
+htc_builder_init(BTreeChunkBuilder *chunkBuilder)
+{
+	chunkBuilder->chunkItemsCount = 0;
+}
+
+/*
+ * Estimate the size shift of the result chunk after the operation.
+ */
+static int32
+htc_builder_estimate(BTreeChunkBuilder *chunkBuilder, OTuple tuple)
+{
+	return chunkBuilder->ops->itemHeaderSize +
+		MAXALIGN(o_btree_len(chunkBuilder->treeDesc, tuple, OKeyLength));
+}
+
+/*
+ * Copy the pointer to the tuple to the chunk builder buffer.
+ */
+static void
+htc_builder_add(BTreeChunkBuilder *chunkBuilder, BTreeChunkBuilderItem *chunkItem)
+{
+	Assert(chunkBuilder->chunkItemsCount < BTREE_PAGE_MAX_CHUNK_ITEMS);
+
+	chunkBuilder->chunkItems[chunkBuilder->chunkItemsCount++] = *chunkItem;
+}
+
+/*
+ * Finalizer the builder and copy tuples to the new chunk buffer.
+ */
+static void
+htc_builder_finish(BTreeChunkBuilder *chunkBuilder, BTreeChunkDesc *chunk)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	BTreePageChunkDesc *items = htc_get_chunk_items(chunk);
+	uint16		dataShift = 0;
+	Pointer		ptr;
+
+	header->chunksCount = chunkBuilder->chunkItemsCount;
+
+	dataShift = MAXALIGN(offsetof(BTreePageHeader, chunkDesc) + (sizeof(BTreePageChunkDesc) * (header->chunksCount)));
+	for (int i = 0; i < chunkBuilder->chunkItemsCount; i++)
+		dataShift += chunkBuilder->chunkItems[i].size;
+
+	header->hikeysEnd = dataShift;
+	ptr = chunk->page + header->hikeysEnd;
+
+	/*
+	 * Move the tuples backwards to be sure that data is not overridden.
+	 */
+	for (int i = chunkBuilder->chunkItemsCount - 1; i >= 0; i--)
+	{
+		ptr -= chunkBuilder->chunkItems[i].size;
+		memmove(ptr, chunkBuilder->chunkItems[i].data, chunkBuilder->chunkItems[i].size);
+	}
+
+	/*
+	 * Calculate the chunk items offsets.
+	 */
+	dataShift = 0;
+	for (OffsetNumber i = 0; i < header->chunksCount; i++)
+	{
+		items[i].hikeyShortLocation = LOCATION_GET_SHORT(dataShift);
+		items[i].hikeyFlags = chunkBuilder->chunkItems[i].flags;
+
+		dataShift += chunkBuilder->chunkItems[i].size;
+	}
+
+	VALGRIND_CHECK_MEM_IS_DEFINED(chunk->chunkData, chunk->chunkDataSize);
+}
+
+const BTreeChunkOps BTreeHiKeyChunkOps = {
+	.itemHeaderSize = 0,
+	.itemKeyType = BTreeKeyNonLeafKey,
+	.itemLengthType = OKeyLength,
+	/* Main functions */
+	.init = htc_init,
+	.estimate_change = htc_estimate_change,
+	.perform_change = htc_perform_change,
+	.compact = NULL,
+	.get_available_size = NULL,
+	.cmp = htc_cmp,
+	.search = htc_search,
+	.read_tuple = htc_read_tuple,
+	/* Builder functions */
+	.builder_init = htc_builder_init,
+	.builder_estimate = htc_builder_estimate,
+	.builder_add = htc_builder_add,
+	.builder_finish = htc_builder_finish,
+};

--- a/src/btree/tuple_chunk.c
+++ b/src/btree/tuple_chunk.c
@@ -1,0 +1,1027 @@
+/*-------------------------------------------------------------------------
+ *
+ * tuple_chunk.c
+ *		OrioleDB implementation of chunk API over tuple chunks.
+ *
+ * Copyright (c) 2025, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/btree/tuple_chunk.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "btree/btree.h"
+
+#include "btree/chunk_ops.h"
+#include "btree/find.h"
+
+const BTreeChunkOps BTreeLeafTupleChunkOps;
+const BTreeChunkOps BTreeInternalTupleChunkOps;
+
+/*
+ * Implementation of leaf tuple chunks.
+ */
+
+static inline uint16
+ltc_get_chunk_items_count(BTreeChunkDesc *chunk)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+
+	if (chunk->chunkOffset + 1 < header->chunksCount)
+		return header->chunkDesc[chunk->chunkOffset + 1].offset -
+			header->chunkDesc[chunk->chunkOffset].offset;
+	else
+		return header->itemsCount - header->chunkDesc[chunk->chunkOffset].offset;
+}
+
+static inline Pointer
+ltc_get_chunk_start(BTreeChunkDesc *chunk)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+
+	Assert(chunk->chunkOffset < header->chunksCount);
+
+	return (Pointer) chunk->page +
+		SHORT_GET_LOCATION(header->chunkDesc[chunk->chunkOffset].shortLocation);
+}
+
+static inline uint16
+ltc_get_chunk_size(BTreeChunkDesc *chunk)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	LocationIndex	chunkLocation;
+
+	Assert(chunk->chunkOffset < header->chunksCount);
+
+	chunkLocation = SHORT_GET_LOCATION(header->chunkDesc[chunk->chunkOffset].shortLocation);
+
+	if (chunk->chunkOffset + 1 < header->chunksCount)
+		return SHORT_GET_LOCATION(header->chunkDesc[chunk->chunkOffset + 1].shortLocation) -
+			chunkLocation;
+	else
+		return header->dataSize - chunkLocation;
+}
+
+static inline uint8
+ltc_get_item_flags(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	LocationIndex *items = (LocationIndex *) ltc_get_chunk_start(chunk);
+
+	Assert(itemOffset < ltc_get_chunk_items_count(chunk));
+
+	return ITEM_GET_FLAGS(items[itemOffset]);
+}
+
+static inline void
+ltc_set_item_flags(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				   uint8 flags)
+{
+	LocationIndex *items = (LocationIndex *) ltc_get_chunk_start(chunk);
+
+	Assert(itemOffset < ltc_get_chunk_items_count(chunk));
+
+	items[itemOffset] = ITEM_SET_FLAGS(items[itemOffset], flags);
+}
+
+static inline Pointer
+ltc_get_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	Pointer		chunkStart = ltc_get_chunk_start(chunk);
+
+	Assert(itemOffset < ltc_get_chunk_items_count(chunk));
+
+	return chunkStart +
+		ITEM_GET_OFFSET(((LocationIndex *) chunkStart)[itemOffset]);
+}
+
+/*
+ * Get size of the item as a substraction of offset of the next item and the
+ * target.
+ */
+static inline uint16
+ltc_get_item_size(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	uint16		chunkItemsCount = ltc_get_chunk_items_count(chunk);
+	LocationIndex *items = (LocationIndex *) ltc_get_chunk_start(chunk);
+	LocationIndex itemLocation;
+
+	Assert(itemOffset < chunkItemsCount);
+
+	/* Calculate offset form the beginning of the chunk */
+	itemLocation = ITEM_GET_OFFSET(items[itemOffset]);
+
+	if (itemOffset + 1 < chunkItemsCount)
+		return ITEM_GET_OFFSET(items[itemOffset + 1]) -
+			itemLocation;
+	else
+		return ltc_get_chunk_size(chunk) - itemLocation;
+}
+
+/*
+ * Allocate space for the new item in the chunk.  A caller is responsible to
+ * copy the item afterwards.
+ */
+static void
+ltc_allocate_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				  uint16 itemSize)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	uint16		chunkItemsCount = ltc_get_chunk_items_count(chunk);
+	Pointer		chunkStart = ltc_get_chunk_start(chunk);
+	uint16		chunkSize = ltc_get_chunk_size(chunk);
+	LocationIndex *items = (LocationIndex *) ltc_get_chunk_start(chunk);
+	LocationIndex itemsShift,
+				dataShift;
+	Pointer		firstItemPtr,
+				itemPtr,
+				endPtr;
+
+	Assert(itemSize == MAXALIGN(itemSize));
+
+	/* Calculate the change of (maxaligned) item array size */
+	itemsShift = MAXALIGN(sizeof(LocationIndex) * (chunkItemsCount + 1)) -
+		MAXALIGN(sizeof(LocationIndex) * chunkItemsCount);
+
+	/* Calculate the shift of the data after new item is inserted */
+	dataShift = itemsShift + itemSize;
+	Assert(dataShift == MAXALIGN(dataShift));
+
+	if (chunkItemsCount > 0)
+		firstItemPtr = ltc_get_item(chunk, 0);
+	else
+		firstItemPtr = chunkStart +
+			MAXALIGN(sizeof(LocationIndex) * chunkItemsCount);
+
+	if (itemOffset < chunkItemsCount)
+		itemPtr = ltc_get_item(chunk, itemOffset);
+	else
+	{
+		Assert(itemOffset == chunkItemsCount);
+
+		itemPtr = chunkStart + chunkSize;
+	}
+
+	endPtr = chunkStart + chunkSize;
+
+	/* Data should still fit to the page */
+	Assert(chunkSize + dataShift <= ORIOLEDB_BLCKSZ);
+
+	/* Shift the data after insert location */
+	Assert(itemPtr <= endPtr);
+
+	memmove(itemPtr + dataShift, itemPtr, endPtr - itemPtr);
+
+	/* Adjust chunks parameters */
+	for (int i = chunk->chunkOffset + 1; i < header->chunksCount; i++)
+		header->chunkDesc[i].offset++;
+	header->itemsCount++;
+	/*
+	 * Adjust size in the header only for the last chunk. For other chunks it is
+	 * a users responsibility to move other chunks.
+	 */
+	if (chunk->chunkOffset == header->chunksCount - 1)
+		header->dataSize += dataShift;
+
+	chunkItemsCount++;
+	chunkSize += dataShift;
+
+	if (itemsShift != 0)
+	{
+		/*
+		 * If items array size is changed, then we have to also move the items
+		 * before insert location and adjust those locations in the items
+		 * array.
+		 */
+		memmove(firstItemPtr + itemsShift, firstItemPtr, itemPtr - firstItemPtr);
+		for (OffsetNumber i = 0; i < itemOffset; i++)
+			items[i] += itemsShift;
+	}
+
+	/* Add the new item to the items array  */
+	for (int i = chunkItemsCount - 1; i > itemOffset; i--)
+		items[i] = items[i - 1] + dataShift;
+	items[itemOffset] = itemPtr - chunkStart + itemsShift;
+}
+
+/*
+ * Resize the chunk to fit the new item size.  A caller is responsible to copy
+ * the new item.
+ */
+static void
+ltc_resize_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				uint16 newItemSize)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	uint16		chunkItemsCount = ltc_get_chunk_items_count(chunk);
+	Pointer		chunkStart = ltc_get_chunk_start(chunk);
+	uint16		chunkSize = ltc_get_chunk_size(chunk);
+	LocationIndex *items = (LocationIndex *) ltc_get_chunk_start(chunk);
+	int32		dataShift;
+	Pointer		nextItemPtr,
+				endPtr;
+
+	Assert(newItemSize == MAXALIGN(newItemSize));
+
+	/* Calculate the shift of the data after the item resize */
+	dataShift = newItemSize - ltc_get_item_size(chunk, itemOffset);
+	Assert(dataShift == MAXALIGN(dataShift));
+
+	/* We don't move items to fill the gap if the new tuple is smaller */
+	if (dataShift <= 0)
+		return;
+
+	Assert(itemOffset < chunkItemsCount);
+	if (itemOffset + 1 < chunkItemsCount)
+		nextItemPtr = ltc_get_item(chunk, itemOffset + 1);
+	else
+		nextItemPtr = chunkStart + chunkSize;
+
+	endPtr = chunkStart + chunkSize;
+
+	/* Data should still fit to the page */
+	Assert(chunkSize + dataShift <= ORIOLEDB_BLCKSZ);
+
+	/* Shift the data after the item */
+	memmove(nextItemPtr + dataShift, nextItemPtr, endPtr - nextItemPtr);
+
+	header->dataSize += dataShift;
+
+	chunkSize += dataShift;
+
+	/* Adjust the items array */
+	for (int i = itemOffset + 1; i < chunkItemsCount; i++)
+		items[i] += dataShift;
+}
+
+/*
+ * Delete the item from the chunk by the provided offset.
+ */
+static void
+ltc_delete_item(BTreeChunkDesc *chunk, OffsetNumber itemOffset)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	uint16		chunkItemsCount = ltc_get_chunk_items_count(chunk);
+	Pointer		chunkStart = ltc_get_chunk_start(chunk);
+	uint16		chunkSize = ltc_get_chunk_size(chunk);
+	LocationIndex *items = (LocationIndex *) ltc_get_chunk_start(chunk);
+	uint16		itemSize;
+	LocationIndex itemsShift,
+				dataShift;
+	Pointer		firstItemPtr,
+				itemPtr,
+				endPtr;
+
+	itemSize = ltc_get_item_size(chunk, itemOffset);
+	Assert(itemSize == MAXALIGN(itemSize));
+
+	Assert(chunkItemsCount > 0);
+
+	/* Calculate the change of (maxaligned) item array size */
+	itemsShift = MAXALIGN(sizeof(LocationIndex) * chunkItemsCount) -
+		MAXALIGN(sizeof(LocationIndex) * (chunkItemsCount - 1));
+
+	/* Calculate the shift of the data after the item is deleted */
+	dataShift = itemsShift + itemSize;
+	Assert(dataShift == MAXALIGN(dataShift));
+
+	firstItemPtr = ltc_get_item(chunk, 0);
+
+	Assert(itemOffset < chunkItemsCount);
+	itemPtr = ltc_get_item(chunk, itemOffset);
+
+	endPtr = chunkStart + chunkSize;
+	Assert(endPtr - dataShift >= itemPtr - itemsShift);
+
+	/*
+	 * Adjust the items array.  We should do this first to prevent it been
+	 * overridden by the data when it's shorten.
+	 */
+	for (int i = itemOffset; i < chunkItemsCount - 1; i++)
+		items[i] = items[i + 1] - dataShift;
+
+	if (itemsShift != 0)
+	{
+		/* Shift the data before deleted item when items arrays is shorten. */
+		memmove(firstItemPtr - itemsShift, firstItemPtr, itemPtr - firstItemPtr);
+
+		/* Shift item pointers of those items */
+		for (OffsetNumber i = 0; i < itemOffset; i++)
+			items[i] -= itemsShift;
+	}
+
+	/* Move the data after deleted item */
+	memmove(itemPtr - itemsShift, itemPtr + itemSize, endPtr - itemPtr - itemSize);
+
+	header->itemsCount--;
+	header->dataSize -= dataShift;
+}
+
+static bool
+ltc_load_partially(BTreeChunkDesc *chunk, PartialPageState *partial, Page page)
+{
+	BTreePageHeader *header = (BTreePageHeader *) page;
+	Pointer		chunkStart = ltc_get_chunk_start(chunk);
+	uint16		chunkSize = ltc_get_chunk_size(chunk);
+	Page		sourcePage = partial->src;
+	uint32		pageState,
+				sourceState;
+	LocationIndex chunkLocation =
+		SHORT_GET_LOCATION(header->chunkDesc[chunk->chunkOffset].shortLocation);
+
+	Assert(partial != NULL);
+
+	if (!partial->isPartial || partial->chunkIsLoaded[chunk->chunkOffset])
+		return true;
+
+	/* chunk->ops->init(chunk, page, chunk->chunkOffset); */
+
+	memcpy(chunkStart, (Pointer) sourcePage + chunkLocation, chunkSize);
+
+	pg_read_barrier();
+
+	pageState = pg_atomic_read_u32(&(O_PAGE_HEADER(page)->state));
+	sourceState = pg_atomic_read_u32(&(O_PAGE_HEADER(sourcePage)->state));
+	if ((pageState & PAGE_STATE_CHANGE_COUNT_MASK) != (sourceState & PAGE_STATE_CHANGE_COUNT_MASK) ||
+		O_PAGE_STATE_READ_IS_BLOCKED(sourceState))
+		return false;
+
+	if (O_PAGE_GET_CHANGE_COUNT(page) != O_PAGE_GET_CHANGE_COUNT(sourcePage))
+		return false;
+
+	partial->chunkIsLoaded[chunk->chunkOffset] = true;
+
+	return true;
+}
+
+/*
+ * Initialize leaf tuple chunk.  Directly use passed pointers to the chunk and
+ * the chunk items array as is.
+ */
+static void
+ltc_init(BTreeChunkDesc *chunk, Page page, OffsetNumber chunkOffset)
+{
+	BTreePageHeader *header = (BTreePageHeader *) page;
+
+	Assert(chunkOffset < header->chunksCount);
+
+	chunk->chunkOffset = chunkOffset;
+	chunk->page = page;
+}
+
+/*
+ * Estimate size shift of the operation over the leaf tuple chunk.
+ */
+static int32
+ltc_estimate_change(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+					BTreeChunkOperationType operation, OTuple tuple)
+{
+	uint16		chunkItemsCount = ltc_get_chunk_items_count(chunk);
+	int32		itemsShift = 0,
+				sizeNeeded = 0;
+
+	if (operation == BTreeChunkOperationInsert)
+	{
+		/* Calculate the change of (maxaligned) item array size */
+		itemsShift = MAXALIGN(sizeof(LocationIndex) * (chunkItemsCount + 1)) -
+			MAXALIGN(sizeof(LocationIndex) * chunkItemsCount);
+
+		sizeNeeded = chunk->ops->itemHeaderSize +
+			MAXALIGN(o_btree_len(chunk->treeDesc, tuple, chunk->ops->itemLengthType)) +
+			itemsShift;
+	}
+	else if (operation == BTreeChunkOperationUpdate)
+	{
+		sizeNeeded = (chunk->ops->itemHeaderSize +
+					  MAXALIGN(o_btree_len(chunk->treeDesc, tuple,
+										   chunk->ops->itemLengthType))) -
+			ltc_get_item_size(chunk, itemOffset);
+
+		/* We don't move items to fill the gap if the new tuple is smaller */
+		if (sizeNeeded < 0)
+			sizeNeeded = 0;
+	}
+	else if (operation == BTreeChunkOperationDelete)
+	{
+		/* Calculate the change of (maxaligned) item array size */
+		itemsShift = MAXALIGN(sizeof(LocationIndex) * chunkItemsCount) -
+			MAXALIGN(sizeof(LocationIndex) * (chunkItemsCount - 1));
+
+		sizeNeeded = (-1) * (ltc_get_item_size(chunk, itemOffset) +
+							 itemsShift);
+	}
+	else
+		Assert(false);
+
+	return sizeNeeded;
+}
+
+/*
+ * Perform the operation over the leaf tuple chunk.  A caller is responsible
+ * that the chunk has enough space.
+ */
+static void
+ltc_perform_change(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				   BTreeChunkOperationType operation,
+				   Pointer tupleHeader, OTuple tuple)
+{
+	Pointer		itemPtr;
+	uint16		tupleSize;
+
+	if (operation == BTreeChunkOperationInsert ||
+		operation == BTreeChunkOperationUpdate)
+		tupleSize = o_btree_len(chunk->treeDesc, tuple,
+								chunk->ops->itemLengthType);
+
+	if (operation == BTreeChunkOperationInsert)
+	{
+		/* Allocate space for the new item, move other items if necessary */
+		ltc_allocate_item(chunk, itemOffset,
+						  chunk->ops->itemHeaderSize + MAXALIGN(tupleSize));
+
+		/* Copy the new tuple and its header */
+		itemPtr = ltc_get_item(chunk, itemOffset);
+
+		memcpy(itemPtr, tupleHeader, chunk->ops->itemHeaderSize);
+		itemPtr += chunk->ops->itemHeaderSize;
+		memcpy(itemPtr, tuple.data, tupleSize);
+
+		ltc_set_item_flags(chunk, itemOffset, tuple.formatFlags);
+	}
+	else if (operation == BTreeChunkOperationUpdate)
+	{
+		ltc_resize_item(chunk, itemOffset,
+						chunk->ops->itemHeaderSize + MAXALIGN(tupleSize));
+
+		/* Copy the new tuple and its header */
+		itemPtr = ltc_get_item(chunk, itemOffset);
+
+		memcpy(itemPtr, tupleHeader, chunk->ops->itemHeaderSize);
+		itemPtr += chunk->ops->itemHeaderSize;
+		memcpy(itemPtr, tuple.data, tupleSize);
+
+		ltc_set_item_flags(chunk, itemOffset, tuple.formatFlags);
+	}
+	else if (operation == BTreeChunkOperationDelete)
+	{
+		Assert(tupleHeader == NULL);
+
+		ltc_delete_item(chunk, itemOffset);
+	}
+	else
+		elog(ERROR, "invalid BTreeChunkOperationType: %d", operation);
+}
+
+/*
+ * Compact the chunk by releasing space occupied by deleted tuples.  Currently
+ * supports only leaf tuple chunks.
+ */
+static void
+ltc_compact(BTreeChunkDesc *chunk)
+{
+	BTreePageHeader *header = (BTreePageHeader *) chunk->page;
+	uint16		chunkItemsCount = ltc_get_chunk_items_count(chunk);
+	LocationIndex *items = (LocationIndex *) ltc_get_chunk_start(chunk);
+	uint16		itemsSize;
+	Pointer		batchDst,
+				batchSrc;
+	OffsetNumber batchOffset = 0,
+				lastOffset = 0;
+	uint16		batchSize = 0;
+
+	if (unlikely(chunkItemsCount == 0))
+		return;
+
+	/* Detect deleted items and delete them from the items array */
+	for (int itemOffset = 0; itemOffset < chunkItemsCount; itemOffset++)
+	{
+		Pointer		tupleHeader = NULL;
+		OTuple		tuple = {0};
+		bool		isCopy = false;
+
+		chunk->ops->read_tuple(chunk, NULL, NULL, itemOffset,
+							   &tupleHeader, &tuple, &isCopy);
+
+		/* TODO: Consider CommitSeqNo */
+		if (((BTreeLeafTuphdr *) tupleHeader)->deleted == BTreeLeafTupleNonDeleted)
+			items[lastOffset++] = items[itemOffset];
+	}
+
+	/* Adjust chunks parameters */
+	for (int i = chunk->chunkOffset + 1; i < header->chunksCount; i++)
+	{
+		header->chunkDesc[i].shortLocation += LOCATION_GET_SHORT(dataShift);
+		header->chunkDesc[i].offset++;
+	}
+	header->itemsCount++;
+	chunk->chunkItemsCount = lastOffset;
+
+	/* All items were deleted, just exit */
+	if (unlikely(chunk->chunkItemsCount == 0))
+	{
+		chunk->chunkDataSize = 0;
+		return;
+	}
+
+	itemsSize = MAXALIGN(sizeof(LocationIndex) * chunk->chunkItemsCount);
+	batchDst = chunk->chunkData + itemsSize;
+
+	/* Move items in batches in order to reduce number of memmove() calls */
+	for (OffsetNumber itemOffset = 0; itemOffset < chunk->chunkItemsCount;
+		 itemOffset++)
+	{
+		Pointer		tupleHeader = NULL;
+		OTuple		tuple = {0};
+		bool		isCopy = false;
+
+		/*
+		 * If there is a gap between the batch and the current item then move
+		 * the batch and start new batch from the current item.
+		 */
+		if (itemOffset > 0 && ltc_get_item(chunk, itemOffset) >
+			(batchDst + batchSize))
+		{
+			batchSrc = ltc_get_item(chunk, batchOffset);
+			/* Do we actually need to move the batch? */
+			if (batchDst != batchSrc)
+			{
+				uint16		dataShift = batchSrc - batchDst;
+
+				memmove(batchDst, batchSrc, batchSize);
+
+				/* Adjust the items array */
+				for (OffsetNumber i = batchOffset; i < itemOffset; i++)
+					chunk->chunkItems.tupleItems[i] -= dataShift;
+			}
+
+			/* Update next batch offsets */
+			batchDst += batchSize;
+			batchOffset = itemOffset;
+			batchSize = 0;
+		}
+
+		chunk->ops->read_tuple(chunk, NULL, NULL, itemOffset,
+							   &tupleHeader, &tuple, &isCopy);
+		batchSize += chunk->ops->itemHeaderSize +
+			MAXALIGN(o_btree_len(chunk->treeDesc, tuple,
+								 chunk->ops->itemLengthType));
+	}
+
+	/* Move the last batch */
+	batchSrc = ltc_get_item(chunk, batchOffset);
+	if (batchDst != batchSrc)
+	{
+		uint16		dataShift = batchSrc - batchDst;
+
+		memmove(batchDst, batchSrc, batchSize);
+
+		/* Adjust the items array */
+		for (OffsetNumber i = batchOffset; i < chunk->chunkItemsCount; i++)
+			chunk->chunkItems.tupleItems[i] -= dataShift;
+
+		chunk->chunkDataSize -= dataShift;
+	}
+}
+
+/*
+ * Get available size for compaction.
+ */
+static uint16
+ltc_get_available_size(BTreeChunkDesc *chunk, CommitSeqNo csn)
+{
+	uint16		available_size = 0;
+
+	if (unlikely(chunk->chunkItemsCount == 0))
+		return 0;
+
+	for (OffsetNumber itemOffset = 0; itemOffset < chunk->chunkItemsCount;
+		 itemOffset++)
+	{
+		BTreeLeafTuphdr *header = NULL;
+		OTuple		tuple = {0};
+		bool		isCopy = false;
+
+		chunk->ops->read_tuple(chunk, NULL, NULL, itemOffset,
+							   (Pointer *) &header, &tuple, &isCopy);
+
+		if (XACT_INFO_FINISHED_FOR_EVERYBODY(header->xactInfo))
+		{
+			if (header->deleted)
+			{
+				if (COMMITSEQNO_IS_INPROGRESS(csn) ||
+					XACT_INFO_MAP_CSN(header->xactInfo) < csn)
+					available_size += ltc_get_item_size((BTreeChunkDesc *) chunk,
+														itemOffset);
+			}
+			else
+			{
+				available_size += ltc_get_item_size((BTreeChunkDesc *) chunk,
+													itemOffset) -
+					(chunk->ops->itemHeaderSize +
+					 MAXALIGN(o_btree_len(chunk->treeDesc, tuple,
+										  chunk->ops->itemLengthType)));
+			}
+		}
+	}
+
+	return available_size;
+}
+
+/*
+ * Compare the given key to a tuple at the given offset.  Partially load the
+ * chunk from the page if necessary.
+ */
+static bool
+ltc_cmp(BTreeChunkDesc *chunk, PartialPageState *partial, Page page,
+		OffsetNumber itemOffset, void *key, BTreeKeyType keyType, int *result)
+{
+	Pointer		header2 = NULL;
+	OTuple		tuple2 = {0};
+	bool		isCopy = false;
+	OBTreeKeyCmp cmpFunc = chunk->treeDesc->ops->cmp;
+
+	if (partial && !ltc_load_partially(chunk, partial, page))
+		return false;
+
+	Assert(itemOffset < chunk->chunkItemsCount);
+
+	chunk->ops->read_tuple(chunk, NULL, NULL, itemOffset,
+						   &header2, &tuple2, &isCopy);
+
+	Assert(!isCopy);
+
+	*result = cmpFunc(chunk->treeDesc, key, keyType,
+					  &tuple2, chunk->ops->itemKeyType);
+	return true;
+}
+
+/*
+ * Search for a item by the given key.  Supports leaf and internal tuple chunks.
+ */
+static bool
+ltc_search(BTreeChunkDesc *chunk, PartialPageState *partial, Page page,
+		   void *key, BTreeKeyType keyType, OffsetNumber *itemOffset)
+{
+	bool		isLeaf = chunk->ops->itemKeyType == BTreeKeyLeafTuple,
+				nextKey;
+	OffsetNumber low,
+				mid,
+				high;
+	OBTreeKeyCmp cmpFunc = chunk->treeDesc->ops->cmp;
+	int			targetCmpVal,
+				result;
+
+	if (partial && !ltc_load_partially(chunk, partial, page))
+		return false;
+
+	if (chunk->chunkItemsCount == 0)
+	{
+		*itemOffset = 0;
+		return true;
+	}
+
+	low = 0;
+	high = chunk->chunkItemsCount - 1;
+	nextKey = (!isLeaf && keyType != BTreeKeyPageHiKey);
+
+	/* Shouldn't look for hikey on leafs, because we're already here */
+	Assert(!(isLeaf && keyType == BTreeKeyPageHiKey));
+
+	/*
+	 * Binary search to find the first key on the page >= `key`, or first page
+	 * key > `key` when nextkey is true.
+	 *
+	 * For nextkey=false (cmp=1), the loop invariant is: all slots before
+	 * `low` are < `key`, all slots at or after `high` are >= `key`.
+	 *
+	 * For nextkey=true (cmp=0), the loop invariant is: all slots before `low`
+	 * are <= `key`, all slots at or after `high` are > `key`.
+	 *
+	 * We can fall out when `high` == `low`.
+	 */
+	high++;						/* establish the loop invariant for high */
+
+	targetCmpVal = nextKey ? 0 : 1; /* a target value of cmpFunc() */
+
+	/*
+	 * Don't pass BTreeHiKey to comparison function, we've set nextkey flag
+	 * instead.
+	 */
+	if (keyType == BTreeKeyPageHiKey)
+		keyType = BTreeKeyNonLeafKey;
+
+	while (high > low)
+	{
+		mid = low + ((high - low) / 2);
+
+		if (!isLeaf && mid == 0 && *itemOffset == 0)
+			result = 1;
+		else
+		{
+			Pointer		midHeader;
+			OTuple		midTuple;
+			bool		isCopy;
+
+			*itemOffset = mid;
+			chunk->ops->read_tuple(chunk, NULL, NULL, *itemOffset,
+								   &midHeader, &midTuple, &isCopy);
+
+			result = cmpFunc(chunk->treeDesc, key, keyType, &midTuple,
+							 chunk->ops->itemKeyType);
+		}
+
+		if (result >= targetCmpVal)
+			low = mid + 1;
+		else
+			high = mid;
+	}
+
+	*itemOffset = low;
+
+	return true;
+}
+
+/*
+ * Read a chunk item by the given offset.  Supports leaf and internal tuple chunks.
+ */
+static bool
+ltc_read_tuple(BTreeChunkDesc *chunk, PartialPageState *partial, Page page,
+			   OffsetNumber itemOffset, Pointer *tupleHeader, OTuple *tuple,
+			   bool *isCopy)
+{
+	Pointer		item;
+
+	if (partial && !ltc_load_partially(chunk, partial, page))
+		return false;
+
+	Assert(itemOffset < chunk->chunkItemsCount);
+
+	item = ltc_get_item(chunk, itemOffset);
+
+	*tupleHeader = item;
+	tuple->data = item + chunk->ops->itemHeaderSize;
+	tuple->formatFlags = ltc_get_item_flags(chunk, itemOffset);
+
+	/* Set always to false in the current implementation */
+	*isCopy = false;
+
+	return true;
+}
+
+/*
+ * Initialize leaf tuple chunk builder.
+ */
+static void
+ltc_builder_init(BTreeChunkBuilder *chunkBuilder)
+{
+	chunkBuilder->chunkItemsCount = 0;
+}
+
+/*
+ * Estimate the size shift of the result chunk after the operation.
+ */
+static int32
+ltc_builder_estimate(BTreeChunkBuilder *chunkBuilder, OTuple tuple)
+{
+	LocationIndex itemsShift;
+
+	itemsShift = MAXALIGN(sizeof(LocationIndex) * (chunkBuilder->chunkItemsCount + 1)) -
+		MAXALIGN(sizeof(LocationIndex) * chunkBuilder->chunkItemsCount);
+
+	return chunkBuilder->ops->itemHeaderSize +
+		MAXALIGN(o_btree_len(chunkBuilder->treeDesc, tuple,
+							 chunkBuilder->ops->itemLengthType)) +
+		itemsShift;
+}
+
+/*
+ * Copy the pointer to the tuple to the chunk builder buffer.
+ */
+static void
+ltc_builder_add(BTreeChunkBuilder *chunkBuilder, BTreeChunkBuilderItem *chunkItem)
+{
+	Assert(chunkBuilder->chunkItemsCount < BTREE_PAGE_MAX_CHUNK_ITEMS);
+
+	chunkBuilder->chunkItems[chunkBuilder->chunkItemsCount++] = *chunkItem;
+}
+
+/*
+ * Finalizer the builder and copy tuples to the new chunk buffer.
+ */
+static void
+ltc_builder_finish(BTreeChunkBuilder *chunkBuilder, BTreeChunkDesc *chunk)
+{
+	uint16		itemsShift,
+				dataShift = 0;
+	Pointer		ptr;
+
+	chunk->treeDesc = chunkBuilder->treeDesc;
+	chunk->chunkItemsCount = chunkBuilder->chunkItemsCount;
+
+	itemsShift = MAXALIGN(sizeof(LocationIndex) * chunk->chunkItemsCount);
+	for (int i = 0; i < chunkBuilder->chunkItemsCount; i++)
+		dataShift += chunkBuilder->chunkItems[i].size;
+
+	chunk->chunkDataSize = itemsShift + dataShift;
+	ptr = chunk->chunkData + chunk->chunkDataSize;
+
+	/*
+	 * Move the tuples backwards to be sure that data is not overridden.
+	 */
+	for (int i = chunkBuilder->chunkItemsCount - 1; i >= 0; i--)
+	{
+		ptr -= chunkBuilder->chunkItems[i].size;
+		memmove(ptr, chunkBuilder->chunkItems[i].data, chunkBuilder->chunkItems[i].size);
+	}
+
+	/*
+	 * Calculate the chunk items offsets.
+	 */
+	for (OffsetNumber i = 0; i < chunk->chunkItemsCount; i++)
+	{
+		chunk->chunkItems.tupleItems[i] = itemsShift;
+		ltc_set_item_flags(chunk, i, chunkBuilder->chunkItems[i].flags);
+
+		itemsShift += chunkBuilder->chunkItems[i].size;
+	}
+}
+
+/*
+ * Implementation of internal tuple chunks.
+ */
+
+/*
+ * Estimate size shift of the operation over the internal tuple chunk.
+ */
+static int32
+itc_estimate_change(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+					BTreeChunkOperationType operation, OTuple tuple)
+{
+	uint16		tupleSize = 0;
+	int32		itemsShift = 0,
+				sizeNeeded = 0;
+
+	if (operation == BTreeChunkOperationInsert ||
+		operation == BTreeChunkOperationUpdate)
+	{
+		if (chunk->chunkOffset != 0 && itemOffset != 0)
+			tupleSize = o_btree_len(chunk->treeDesc, tuple,
+									chunk->ops->itemLengthType);
+		else
+		{
+			/*
+			 * The leftmost tuple of the leftmost chunk doesn't store any
+			 * data, therefore don't expect any passed data here.
+			 */
+			Assert(tuple.data == NULL);
+		}
+	}
+
+	if (operation == BTreeChunkOperationInsert)
+	{
+		/* Calculate the change of (maxaligned) item array size */
+		itemsShift = MAXALIGN(sizeof(LocationIndex) * (chunk->chunkItemsCount + 1)) -
+			MAXALIGN(sizeof(LocationIndex) * chunk->chunkItemsCount);
+
+		sizeNeeded = chunk->ops->itemHeaderSize + MAXALIGN(tupleSize) +
+			itemsShift;
+	}
+	else if (operation == BTreeChunkOperationUpdate)
+	{
+		sizeNeeded = (chunk->ops->itemHeaderSize + MAXALIGN(tupleSize)) -
+			ltc_get_item_size(chunk, itemOffset);
+
+		/* We don't move items to fill the gap if the new tuple is smaller */
+		if (sizeNeeded < 0)
+			sizeNeeded = 0;
+	}
+	else if (operation == BTreeChunkOperationDelete)
+	{
+		/* Calculate the change of (maxaligned) item array size */
+		itemsShift = MAXALIGN(sizeof(LocationIndex) * chunk->chunkItemsCount) -
+			MAXALIGN(sizeof(LocationIndex) * (chunk->chunkItemsCount - 1));
+
+		sizeNeeded = (-1) * (ltc_get_item_size(chunk, itemOffset) +
+							 itemsShift);
+	}
+	else
+		Assert(false);
+
+	return sizeNeeded;
+}
+
+/*
+ * Perform the operation over the internal tuple chunk.  A caller is responsible
+ * that the chunk has enough space.
+ */
+static void
+itc_perform_change(BTreeChunkDesc *chunk, OffsetNumber itemOffset,
+				   BTreeChunkOperationType operation,
+				   Pointer tupleHeader, OTuple tuple)
+{
+	Pointer		itemPtr;
+	uint16		tupleSize = 0;
+
+	if (operation == BTreeChunkOperationInsert ||
+		operation == BTreeChunkOperationUpdate)
+	{
+		if (chunk->chunkOffset != 0 && itemOffset != 0)
+			tupleSize = o_btree_len(chunk->treeDesc, tuple,
+									chunk->ops->itemLengthType);
+		else
+		{
+			/*
+			 * The leftmost tuple of the leftmost chunk doesn't store any
+			 * data, therefore don't expect any passed data here.
+			 */
+			Assert(tuple.data == NULL);
+		}
+	}
+
+	if (operation == BTreeChunkOperationInsert)
+	{
+		/* Allocate space for the new item, move other items if necessary */
+		ltc_allocate_item(chunk, itemOffset,
+						  chunk->ops->itemHeaderSize + MAXALIGN(tupleSize));
+
+		/* Copy the new tuple and its header */
+		itemPtr = ltc_get_item(chunk, itemOffset);
+
+		memcpy(itemPtr, tupleHeader, chunk->ops->itemHeaderSize);
+		if (tupleSize > 0)
+		{
+			itemPtr += chunk->ops->itemHeaderSize;
+			memcpy(itemPtr, tuple.data, tupleSize);
+		}
+
+		ltc_set_item_flags(chunk, itemOffset, tuple.formatFlags);
+	}
+	else if (operation == BTreeChunkOperationUpdate)
+	{
+		ltc_resize_item(chunk, itemOffset,
+						chunk->ops->itemHeaderSize + MAXALIGN(tupleSize));
+
+		/* Copy the new tuple and its header */
+		itemPtr = ltc_get_item(chunk, itemOffset);
+
+		memcpy(itemPtr, tupleHeader, chunk->ops->itemHeaderSize);
+		if (tupleSize > 0)
+		{
+			itemPtr += chunk->ops->itemHeaderSize;
+			memcpy(itemPtr, tuple.data, tupleSize);
+		}
+
+		ltc_set_item_flags(chunk, itemOffset, tuple.formatFlags);
+	}
+	else if (operation == BTreeChunkOperationDelete)
+	{
+		Assert(tupleHeader == NULL);
+
+		ltc_delete_item(chunk, itemOffset);
+	}
+	else
+		elog(ERROR, "invalid BTreeChunkOperationType: %d", operation);
+}
+
+const BTreeChunkOps BTreeLeafTupleChunkOps = {
+	.itemHeaderSize = BTreeLeafTuphdrSize,
+	.itemKeyType = BTreeKeyLeafTuple,
+	.itemLengthType = OTupleLength,
+	/* Main functions */
+	.init = ltc_init,
+	.estimate_change = ltc_estimate_change,
+	.perform_change = ltc_perform_change,
+	.compact = ltc_compact,
+	.get_available_size = ltc_get_available_size,
+	.cmp = ltc_cmp,
+	.search = ltc_search,
+	.read_tuple = ltc_read_tuple,
+	/* Builder functions */
+	.builder_init = ltc_builder_init,
+	.builder_estimate = ltc_builder_estimate,
+	.builder_add = ltc_builder_add,
+	.builder_finish = ltc_builder_finish,
+};
+
+const BTreeChunkOps BTreeInternalTupleChunkOps = {
+	.itemHeaderSize = BTreeNonLeafTuphdrSize,
+	.itemKeyType = BTreeKeyNonLeafKey,
+	.itemLengthType = OKeyLength,
+	/* Main functions */
+	.init = ltc_init,
+	.estimate_change = itc_estimate_change,
+	.perform_change = itc_perform_change,
+	.compact = NULL,
+	.get_available_size = NULL,
+	.cmp = ltc_cmp,
+	.search = ltc_search,
+	.read_tuple = ltc_read_tuple,
+	/* Builder functions */
+	.builder_init = ltc_builder_init,
+	.builder_estimate = ltc_builder_estimate,
+	.builder_add = ltc_builder_add,
+	.builder_finish = ltc_builder_finish,
+};

--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -58,51 +58,6 @@ PG_FUNCTION_INFO_V1(orioledb_tree_stat);
 extern void log_btree(BTreeDescr *desc);
 
 static void
-o_tuple_print(TupleDesc tupDesc, OTupleFixedFormatSpec *spec,
-			  FmgrInfo *outputFns, StringInfo buf, OTuple tup,
-			  Datum *values, bool *nulls, bool printVersion)
-{
-	Form_pg_attribute atti;
-	int			attnum,
-				i;
-
-	appendStringInfo(buf, "(");
-
-	if (printVersion)
-		appendStringInfo(buf, "(%u) ", o_tuple_get_version(tup));
-
-	for (i = 0; i < tupDesc->natts; i++)
-	{
-		if (i > 0)
-			appendStringInfo(buf, ", ");
-		attnum = i + 1;
-		values[i] = o_fastgetattr(tup, attnum, tupDesc, spec, &nulls[i]);
-		if (nulls[i])
-		{
-			appendStringInfo(buf, "null");
-		}
-		else
-		{
-			atti = TupleDescAttr(tupDesc, i);
-			if (!atti->attbyval && atti->attlen && !nulls[i])
-			{
-				Pointer		p = DatumGetPointer(values[i]);
-
-				if (IS_TOAST_POINTER(p))
-				{
-					appendStringInfo(buf, "TOASTed");
-					continue;
-				}
-			}
-			appendStringInfo(buf, "'%s'",
-							 OutputFunctionCall(&outputFns[i], values[i]));
-		}
-	}
-
-	appendStringInfo(buf, ")");
-}
-
-static void
 idx_key_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg)
 {
 	TuplePrintOpaque *opaque = (TuplePrintOpaque *) arg;

--- a/src/tuple/format.c
+++ b/src/tuple/format.c
@@ -815,6 +815,13 @@ o_form_tuple(TupleDesc tupleDesc, OTupleFixedFormatSpec *spec,
 	return result;
 }
 
+void
+o_deform_tuple(TupleDesc tupleDesc, OTupleFixedFormatSpec *spec, OTuple tuple,
+			   Datum *values, bool *isnull)
+{
+	for (int i = 0; i < tupleDesc->natts; i++)
+		values[i] = o_fastgetattr(tuple, i + 1, tupleDesc, spec, &isnull[i]);
+}
 
 uint32
 o_tuple_get_version(OTuple tuple)

--- a/test/expected/btree_chunk_ops.out
+++ b/test/expected/btree_chunk_ops.out
@@ -1,0 +1,1101 @@
+CREATE SCHEMA tuple_chunk;
+SET SESSION search_path = 'tuple_chunk';
+CREATE EXTENSION orioledb;
+CREATE TABLE tuple_chunk_test
+(
+    id int PRIMARY KEY,
+    value text
+) USING orioledb;
+SELECT test_btree_leaf_tuple_chunk('tuple_chunk_test'::regclass);
+INFO:  Estimate INSERT operation ('1', 'value 1') at position 0: 48
+INFO:  Perform INSERT operation ('1', 'value 1') at position 0
+INFO:  Perform INSERT operation ('2', 'value 2') at position 1
+INFO:  Perform INSERT operation ('3', 'value 3') at position 2
+INFO:  Perform INSERT operation ('4', 'value 4') at position 3
+INFO:  Perform INSERT operation ('5', 'value 5') at position 4
+INFO:  Perform INSERT operation ('6', 'value 6') at position 5
+INFO:  Perform INSERT operation ('7', 'value 7') at position 6
+INFO:  Perform INSERT operation ('8', 'value 8') at position 7
+INFO:  Perform INSERT operation ('9', 'value 9') at position 8
+INFO:  Perform INSERT operation ('10', 'value 10') at position 9
+INFO:  Perform INSERT operation ('11', 'value 11') at position 10
+INFO:  Perform INSERT operation ('12', 'value 12') at position 11
+INFO:  Perform INSERT operation ('13', 'value 13') at position 12
+INFO:  Perform INSERT operation ('14', 'value 14') at position 13
+INFO:  Perform INSERT operation ('15', 'value 15') at position 14
+INFO:  Perform INSERT operation ('16', 'value 16') at position 15
+INFO:  Perform INSERT operation ('17', 'value 17') at position 16
+INFO:  Perform INSERT operation ('18', 'value 18') at position 17
+INFO:  Perform INSERT operation ('19', 'value 19') at position 18
+INFO:  Perform INSERT operation ('20', 'value 20') at position 19
+INFO:  Perform INSERT operation ('21', 'value 21') at position 20
+INFO:  Perform INSERT operation ('22', 'value 22') at position 21
+INFO:  Perform INSERT operation ('23', 'value 23') at position 22
+INFO:  Perform INSERT operation ('24', 'value 24') at position 23
+INFO:  Perform INSERT operation ('25', 'value 25') at position 24
+INFO:  Perform INSERT operation ('26', 'value 26') at position 25
+INFO:  Perform INSERT operation ('27', 'value 27') at position 26
+INFO:  Perform INSERT operation ('28', 'value 28') at position 27
+INFO:  Perform INSERT operation ('29', 'value 29') at position 28
+INFO:  Perform INSERT operation ('30', 'value 30') at position 29
+INFO:  Perform INSERT operation ('31', 'value 31') at position 30
+INFO:  Perform INSERT operation ('32', 'value 32') at position 31
+INFO:  Perform INSERT operation ('33', 'value 33') at position 32
+INFO:  Perform INSERT operation ('34', 'value 34') at position 33
+INFO:  Perform INSERT operation ('35', 'value 35') at position 34
+INFO:  Perform INSERT operation ('36', 'value 36') at position 35
+INFO:  Perform INSERT operation ('37', 'value 37') at position 36
+INFO:  Perform INSERT operation ('38', 'value 38') at position 37
+INFO:  Perform INSERT operation ('39', 'value 39') at position 38
+INFO:  Perform INSERT operation ('40', 'value 40') at position 39
+INFO:  Perform INSERT operation ('41', 'value 41') at position 40
+INFO:  Perform INSERT operation ('42', 'value 42') at position 41
+INFO:  Perform INSERT operation ('43', 'value 43') at position 42
+INFO:  Perform INSERT operation ('44', 'value 44') at position 43
+INFO:  Perform INSERT operation ('45', 'value 45') at position 44
+INFO:  Perform INSERT operation ('46', 'value 46') at position 45
+INFO:  Perform INSERT operation ('47', 'value 47') at position 46
+INFO:  Perform INSERT operation ('48', 'value 48') at position 47
+INFO:  Perform INSERT operation ('49', 'value 49') at position 48
+INFO:  Perform INSERT operation ('50', 'value 50') at position 49
+INFO:  Read tuple at position 0: ('1', 'value 1')
+INFO:  Read tuple at position 1: ('2', 'value 2')
+INFO:  Read tuple at position 2: ('3', 'value 3')
+INFO:  Read tuple at position 3: ('4', 'value 4')
+INFO:  Read tuple at position 4: ('5', 'value 5')
+INFO:  Read tuple at position 5: ('6', 'value 6')
+INFO:  Read tuple at position 6: ('7', 'value 7')
+INFO:  Read tuple at position 7: ('8', 'value 8')
+INFO:  Read tuple at position 8: ('9', 'value 9')
+INFO:  Read tuple at position 9: ('10', 'value 10')
+INFO:  Read tuple at position 10: ('11', 'value 11')
+INFO:  Read tuple at position 11: ('12', 'value 12')
+INFO:  Read tuple at position 12: ('13', 'value 13')
+INFO:  Read tuple at position 13: ('14', 'value 14')
+INFO:  Read tuple at position 14: ('15', 'value 15')
+INFO:  Read tuple at position 15: ('16', 'value 16')
+INFO:  Read tuple at position 16: ('17', 'value 17')
+INFO:  Read tuple at position 17: ('18', 'value 18')
+INFO:  Read tuple at position 18: ('19', 'value 19')
+INFO:  Read tuple at position 19: ('20', 'value 20')
+INFO:  Read tuple at position 20: ('21', 'value 21')
+INFO:  Read tuple at position 21: ('22', 'value 22')
+INFO:  Read tuple at position 22: ('23', 'value 23')
+INFO:  Read tuple at position 23: ('24', 'value 24')
+INFO:  Read tuple at position 24: ('25', 'value 25')
+INFO:  Read tuple at position 25: ('26', 'value 26')
+INFO:  Read tuple at position 26: ('27', 'value 27')
+INFO:  Read tuple at position 27: ('28', 'value 28')
+INFO:  Read tuple at position 28: ('29', 'value 29')
+INFO:  Read tuple at position 29: ('30', 'value 30')
+INFO:  Read tuple at position 30: ('31', 'value 31')
+INFO:  Read tuple at position 31: ('32', 'value 32')
+INFO:  Read tuple at position 32: ('33', 'value 33')
+INFO:  Read tuple at position 33: ('34', 'value 34')
+INFO:  Read tuple at position 34: ('35', 'value 35')
+INFO:  Read tuple at position 35: ('36', 'value 36')
+INFO:  Read tuple at position 36: ('37', 'value 37')
+INFO:  Read tuple at position 37: ('38', 'value 38')
+INFO:  Read tuple at position 38: ('39', 'value 39')
+INFO:  Read tuple at position 39: ('40', 'value 40')
+INFO:  Read tuple at position 40: ('41', 'value 41')
+INFO:  Read tuple at position 41: ('42', 'value 42')
+INFO:  Read tuple at position 42: ('43', 'value 43')
+INFO:  Read tuple at position 43: ('44', 'value 44')
+INFO:  Read tuple at position 44: ('45', 'value 45')
+INFO:  Read tuple at position 45: ('46', 'value 46')
+INFO:  Read tuple at position 46: ('47', 'value 47')
+INFO:  Read tuple at position 47: ('48', 'value 48')
+INFO:  Read tuple at position 48: ('49', 'value 49')
+INFO:  Read tuple at position 49: ('50', 'value 50')
+INFO:  Compare tuple ('0', 'value') at position 0: -1
+INFO:  Compare tuple ('1', 'value') at position 1: -1
+INFO:  Compare tuple ('2', 'value') at position 2: -1
+INFO:  Compare tuple ('3', 'value') at position 3: -1
+INFO:  Compare tuple ('4', 'value') at position 4: -1
+INFO:  Compare tuple ('5', 'value') at position 5: -1
+INFO:  Compare tuple ('6', 'value') at position 6: -1
+INFO:  Compare tuple ('7', 'value') at position 7: -1
+INFO:  Compare tuple ('8', 'value') at position 8: -1
+INFO:  Compare tuple ('9', 'value') at position 9: -1
+INFO:  Compare tuple ('10', 'value') at position 10: -1
+INFO:  Compare tuple ('11', 'value') at position 11: -1
+INFO:  Compare tuple ('12', 'value') at position 12: -1
+INFO:  Compare tuple ('13', 'value') at position 13: -1
+INFO:  Compare tuple ('14', 'value') at position 14: -1
+INFO:  Compare tuple ('15', 'value') at position 15: -1
+INFO:  Compare tuple ('16', 'value') at position 16: -1
+INFO:  Compare tuple ('17', 'value') at position 17: -1
+INFO:  Compare tuple ('18', 'value') at position 18: -1
+INFO:  Compare tuple ('19', 'value') at position 19: -1
+INFO:  Compare tuple ('20', 'value') at position 20: -1
+INFO:  Compare tuple ('21', 'value') at position 21: -1
+INFO:  Compare tuple ('22', 'value') at position 22: -1
+INFO:  Compare tuple ('23', 'value') at position 23: -1
+INFO:  Compare tuple ('24', 'value') at position 24: -1
+INFO:  Compare tuple ('25', 'value') at position 25: -1
+INFO:  Compare tuple ('26', 'value') at position 26: -1
+INFO:  Compare tuple ('27', 'value') at position 27: -1
+INFO:  Compare tuple ('28', 'value') at position 28: -1
+INFO:  Compare tuple ('29', 'value') at position 29: -1
+INFO:  Compare tuple ('30', 'value') at position 30: -1
+INFO:  Compare tuple ('31', 'value') at position 31: -1
+INFO:  Compare tuple ('32', 'value') at position 32: -1
+INFO:  Compare tuple ('33', 'value') at position 33: -1
+INFO:  Compare tuple ('34', 'value') at position 34: -1
+INFO:  Compare tuple ('35', 'value') at position 35: -1
+INFO:  Compare tuple ('36', 'value') at position 36: -1
+INFO:  Compare tuple ('37', 'value') at position 37: -1
+INFO:  Compare tuple ('38', 'value') at position 38: -1
+INFO:  Compare tuple ('39', 'value') at position 39: -1
+INFO:  Compare tuple ('40', 'value') at position 40: -1
+INFO:  Compare tuple ('41', 'value') at position 41: -1
+INFO:  Compare tuple ('42', 'value') at position 42: -1
+INFO:  Compare tuple ('43', 'value') at position 43: -1
+INFO:  Compare tuple ('44', 'value') at position 44: -1
+INFO:  Compare tuple ('45', 'value') at position 45: -1
+INFO:  Compare tuple ('46', 'value') at position 46: -1
+INFO:  Compare tuple ('47', 'value') at position 47: -1
+INFO:  Compare tuple ('48', 'value') at position 48: -1
+INFO:  Compare tuple ('49', 'value') at position 49: -1
+INFO:  Compare tuple ('1', 'value') at position 0: 0
+INFO:  Compare tuple ('2', 'value') at position 1: 0
+INFO:  Compare tuple ('3', 'value') at position 2: 0
+INFO:  Compare tuple ('4', 'value') at position 3: 0
+INFO:  Compare tuple ('5', 'value') at position 4: 0
+INFO:  Compare tuple ('6', 'value') at position 5: 0
+INFO:  Compare tuple ('7', 'value') at position 6: 0
+INFO:  Compare tuple ('8', 'value') at position 7: 0
+INFO:  Compare tuple ('9', 'value') at position 8: 0
+INFO:  Compare tuple ('10', 'value') at position 9: 0
+INFO:  Compare tuple ('11', 'value') at position 10: 0
+INFO:  Compare tuple ('12', 'value') at position 11: 0
+INFO:  Compare tuple ('13', 'value') at position 12: 0
+INFO:  Compare tuple ('14', 'value') at position 13: 0
+INFO:  Compare tuple ('15', 'value') at position 14: 0
+INFO:  Compare tuple ('16', 'value') at position 15: 0
+INFO:  Compare tuple ('17', 'value') at position 16: 0
+INFO:  Compare tuple ('18', 'value') at position 17: 0
+INFO:  Compare tuple ('19', 'value') at position 18: 0
+INFO:  Compare tuple ('20', 'value') at position 19: 0
+INFO:  Compare tuple ('21', 'value') at position 20: 0
+INFO:  Compare tuple ('22', 'value') at position 21: 0
+INFO:  Compare tuple ('23', 'value') at position 22: 0
+INFO:  Compare tuple ('24', 'value') at position 23: 0
+INFO:  Compare tuple ('25', 'value') at position 24: 0
+INFO:  Compare tuple ('26', 'value') at position 25: 0
+INFO:  Compare tuple ('27', 'value') at position 26: 0
+INFO:  Compare tuple ('28', 'value') at position 27: 0
+INFO:  Compare tuple ('29', 'value') at position 28: 0
+INFO:  Compare tuple ('30', 'value') at position 29: 0
+INFO:  Compare tuple ('31', 'value') at position 30: 0
+INFO:  Compare tuple ('32', 'value') at position 31: 0
+INFO:  Compare tuple ('33', 'value') at position 32: 0
+INFO:  Compare tuple ('34', 'value') at position 33: 0
+INFO:  Compare tuple ('35', 'value') at position 34: 0
+INFO:  Compare tuple ('36', 'value') at position 35: 0
+INFO:  Compare tuple ('37', 'value') at position 36: 0
+INFO:  Compare tuple ('38', 'value') at position 37: 0
+INFO:  Compare tuple ('39', 'value') at position 38: 0
+INFO:  Compare tuple ('40', 'value') at position 39: 0
+INFO:  Compare tuple ('41', 'value') at position 40: 0
+INFO:  Compare tuple ('42', 'value') at position 41: 0
+INFO:  Compare tuple ('43', 'value') at position 42: 0
+INFO:  Compare tuple ('44', 'value') at position 43: 0
+INFO:  Compare tuple ('45', 'value') at position 44: 0
+INFO:  Compare tuple ('46', 'value') at position 45: 0
+INFO:  Compare tuple ('47', 'value') at position 46: 0
+INFO:  Compare tuple ('48', 'value') at position 47: 0
+INFO:  Compare tuple ('49', 'value') at position 48: 0
+INFO:  Compare tuple ('50', 'value') at position 49: 0
+INFO:  Compare tuple ('2', 'value') at position 0: 1
+INFO:  Compare tuple ('3', 'value') at position 1: 1
+INFO:  Compare tuple ('4', 'value') at position 2: 1
+INFO:  Compare tuple ('5', 'value') at position 3: 1
+INFO:  Compare tuple ('6', 'value') at position 4: 1
+INFO:  Compare tuple ('7', 'value') at position 5: 1
+INFO:  Compare tuple ('8', 'value') at position 6: 1
+INFO:  Compare tuple ('9', 'value') at position 7: 1
+INFO:  Compare tuple ('10', 'value') at position 8: 1
+INFO:  Compare tuple ('11', 'value') at position 9: 1
+INFO:  Compare tuple ('12', 'value') at position 10: 1
+INFO:  Compare tuple ('13', 'value') at position 11: 1
+INFO:  Compare tuple ('14', 'value') at position 12: 1
+INFO:  Compare tuple ('15', 'value') at position 13: 1
+INFO:  Compare tuple ('16', 'value') at position 14: 1
+INFO:  Compare tuple ('17', 'value') at position 15: 1
+INFO:  Compare tuple ('18', 'value') at position 16: 1
+INFO:  Compare tuple ('19', 'value') at position 17: 1
+INFO:  Compare tuple ('20', 'value') at position 18: 1
+INFO:  Compare tuple ('21', 'value') at position 19: 1
+INFO:  Compare tuple ('22', 'value') at position 20: 1
+INFO:  Compare tuple ('23', 'value') at position 21: 1
+INFO:  Compare tuple ('24', 'value') at position 22: 1
+INFO:  Compare tuple ('25', 'value') at position 23: 1
+INFO:  Compare tuple ('26', 'value') at position 24: 1
+INFO:  Compare tuple ('27', 'value') at position 25: 1
+INFO:  Compare tuple ('28', 'value') at position 26: 1
+INFO:  Compare tuple ('29', 'value') at position 27: 1
+INFO:  Compare tuple ('30', 'value') at position 28: 1
+INFO:  Compare tuple ('31', 'value') at position 29: 1
+INFO:  Compare tuple ('32', 'value') at position 30: 1
+INFO:  Compare tuple ('33', 'value') at position 31: 1
+INFO:  Compare tuple ('34', 'value') at position 32: 1
+INFO:  Compare tuple ('35', 'value') at position 33: 1
+INFO:  Compare tuple ('36', 'value') at position 34: 1
+INFO:  Compare tuple ('37', 'value') at position 35: 1
+INFO:  Compare tuple ('38', 'value') at position 36: 1
+INFO:  Compare tuple ('39', 'value') at position 37: 1
+INFO:  Compare tuple ('40', 'value') at position 38: 1
+INFO:  Compare tuple ('41', 'value') at position 39: 1
+INFO:  Compare tuple ('42', 'value') at position 40: 1
+INFO:  Compare tuple ('43', 'value') at position 41: 1
+INFO:  Compare tuple ('44', 'value') at position 42: 1
+INFO:  Compare tuple ('45', 'value') at position 43: 1
+INFO:  Compare tuple ('46', 'value') at position 44: 1
+INFO:  Compare tuple ('47', 'value') at position 45: 1
+INFO:  Compare tuple ('48', 'value') at position 46: 1
+INFO:  Compare tuple ('49', 'value') at position 47: 1
+INFO:  Compare tuple ('50', 'value') at position 48: 1
+INFO:  Compare tuple ('51', 'value') at position 49: 1
+INFO:  Search for tuple ('0', 'value'): 0
+INFO:  Search for tuple ('1', 'value'): 0
+INFO:  Search for tuple ('2', 'value'): 1
+INFO:  Search for tuple ('3', 'value'): 2
+INFO:  Search for tuple ('4', 'value'): 3
+INFO:  Search for tuple ('5', 'value'): 4
+INFO:  Search for tuple ('6', 'value'): 5
+INFO:  Search for tuple ('7', 'value'): 6
+INFO:  Search for tuple ('8', 'value'): 7
+INFO:  Search for tuple ('9', 'value'): 8
+INFO:  Search for tuple ('10', 'value'): 9
+INFO:  Search for tuple ('11', 'value'): 10
+INFO:  Search for tuple ('12', 'value'): 11
+INFO:  Search for tuple ('13', 'value'): 12
+INFO:  Search for tuple ('14', 'value'): 13
+INFO:  Search for tuple ('15', 'value'): 14
+INFO:  Search for tuple ('16', 'value'): 15
+INFO:  Search for tuple ('17', 'value'): 16
+INFO:  Search for tuple ('18', 'value'): 17
+INFO:  Search for tuple ('19', 'value'): 18
+INFO:  Search for tuple ('20', 'value'): 19
+INFO:  Search for tuple ('21', 'value'): 20
+INFO:  Search for tuple ('22', 'value'): 21
+INFO:  Search for tuple ('23', 'value'): 22
+INFO:  Search for tuple ('24', 'value'): 23
+INFO:  Search for tuple ('25', 'value'): 24
+INFO:  Search for tuple ('26', 'value'): 25
+INFO:  Search for tuple ('27', 'value'): 26
+INFO:  Search for tuple ('28', 'value'): 27
+INFO:  Search for tuple ('29', 'value'): 28
+INFO:  Search for tuple ('30', 'value'): 29
+INFO:  Search for tuple ('31', 'value'): 30
+INFO:  Search for tuple ('32', 'value'): 31
+INFO:  Search for tuple ('33', 'value'): 32
+INFO:  Search for tuple ('34', 'value'): 33
+INFO:  Search for tuple ('35', 'value'): 34
+INFO:  Search for tuple ('36', 'value'): 35
+INFO:  Search for tuple ('37', 'value'): 36
+INFO:  Search for tuple ('38', 'value'): 37
+INFO:  Search for tuple ('39', 'value'): 38
+INFO:  Search for tuple ('40', 'value'): 39
+INFO:  Search for tuple ('41', 'value'): 40
+INFO:  Search for tuple ('42', 'value'): 41
+INFO:  Search for tuple ('43', 'value'): 42
+INFO:  Search for tuple ('44', 'value'): 43
+INFO:  Search for tuple ('45', 'value'): 44
+INFO:  Search for tuple ('46', 'value'): 45
+INFO:  Search for tuple ('47', 'value'): 46
+INFO:  Search for tuple ('48', 'value'): 47
+INFO:  Search for tuple ('49', 'value'): 48
+INFO:  Search for tuple ('50', 'value'): 49
+INFO:  Search for tuple ('51', 'value'): 50
+INFO:  Estimate UPDATE operation ('1', 'value 2') at position 0: 0
+INFO:  Estimate DELETE operation at position 0: -40
+INFO:  Perform UPDATE operation ('100', 'value 100') at position 0
+INFO:  Perform UPDATE operation ('101', 'value 101') at position 1
+INFO:  Perform UPDATE operation ('102', 'value 102') at position 2
+INFO:  Perform UPDATE operation ('103', 'value 103') at position 3
+INFO:  Perform UPDATE operation ('104', 'value 104') at position 4
+INFO:  Perform UPDATE operation ('105', 'value 105') at position 5
+INFO:  Perform UPDATE operation ('106', 'value 106') at position 6
+INFO:  Perform UPDATE operation ('107', 'value 107') at position 7
+INFO:  Perform UPDATE operation ('108', 'value 108') at position 8
+INFO:  Perform UPDATE operation ('109', 'value 109') at position 9
+INFO:  Perform UPDATE operation ('110', 'value 110') at position 10
+INFO:  Perform UPDATE operation ('111', 'value 111') at position 11
+INFO:  Perform UPDATE operation ('112', 'value 112') at position 12
+INFO:  Perform UPDATE operation ('113', 'value 113') at position 13
+INFO:  Perform UPDATE operation ('114', 'value 114') at position 14
+INFO:  Perform UPDATE operation ('115', 'value 115') at position 15
+INFO:  Perform UPDATE operation ('116', 'value 116') at position 16
+INFO:  Perform UPDATE operation ('117', 'value 117') at position 17
+INFO:  Perform UPDATE operation ('118', 'value 118') at position 18
+INFO:  Perform UPDATE operation ('119', 'value 119') at position 19
+INFO:  Perform UPDATE operation ('120', 'value 120') at position 20
+INFO:  Perform UPDATE operation ('121', 'value 121') at position 21
+INFO:  Perform UPDATE operation ('122', 'value 122') at position 22
+INFO:  Perform UPDATE operation ('123', 'value 123') at position 23
+INFO:  Perform UPDATE operation ('124', 'value 124') at position 24
+INFO:  Perform UPDATE operation ('125', 'value 125') at position 25
+INFO:  Perform UPDATE operation ('126', 'value 126') at position 26
+INFO:  Perform UPDATE operation ('127', 'value 127') at position 27
+INFO:  Perform UPDATE operation ('128', 'value 128') at position 28
+INFO:  Perform UPDATE operation ('129', 'value 129') at position 29
+INFO:  Perform UPDATE operation ('130', 'value 130') at position 30
+INFO:  Perform UPDATE operation ('131', 'value 131') at position 31
+INFO:  Perform UPDATE operation ('132', 'value 132') at position 32
+INFO:  Perform UPDATE operation ('133', 'value 133') at position 33
+INFO:  Perform UPDATE operation ('134', 'value 134') at position 34
+INFO:  Perform UPDATE operation ('135', 'value 135') at position 35
+INFO:  Perform UPDATE operation ('136', 'value 136') at position 36
+INFO:  Perform UPDATE operation ('137', 'value 137') at position 37
+INFO:  Perform UPDATE operation ('138', 'value 138') at position 38
+INFO:  Perform UPDATE operation ('139', 'value 139') at position 39
+INFO:  Perform UPDATE operation ('140', 'value 140') at position 40
+INFO:  Perform UPDATE operation ('141', 'value 141') at position 41
+INFO:  Perform UPDATE operation ('142', 'value 142') at position 42
+INFO:  Perform UPDATE operation ('143', 'value 143') at position 43
+INFO:  Perform UPDATE operation ('144', 'value 144') at position 44
+INFO:  Perform UPDATE operation ('145', 'value 145') at position 45
+INFO:  Perform UPDATE operation ('146', 'value 146') at position 46
+INFO:  Perform UPDATE operation ('147', 'value 147') at position 47
+INFO:  Perform UPDATE operation ('148', 'value 148') at position 48
+INFO:  Perform UPDATE operation ('149', 'value 149') at position 49
+INFO:  Read tuple at position 0: ('100', 'value 100')
+INFO:  Read tuple at position 1: ('101', 'value 101')
+INFO:  Read tuple at position 2: ('102', 'value 102')
+INFO:  Read tuple at position 3: ('103', 'value 103')
+INFO:  Read tuple at position 4: ('104', 'value 104')
+INFO:  Read tuple at position 5: ('105', 'value 105')
+INFO:  Read tuple at position 6: ('106', 'value 106')
+INFO:  Read tuple at position 7: ('107', 'value 107')
+INFO:  Read tuple at position 8: ('108', 'value 108')
+INFO:  Read tuple at position 9: ('109', 'value 109')
+INFO:  Read tuple at position 10: ('110', 'value 110')
+INFO:  Read tuple at position 11: ('111', 'value 111')
+INFO:  Read tuple at position 12: ('112', 'value 112')
+INFO:  Read tuple at position 13: ('113', 'value 113')
+INFO:  Read tuple at position 14: ('114', 'value 114')
+INFO:  Read tuple at position 15: ('115', 'value 115')
+INFO:  Read tuple at position 16: ('116', 'value 116')
+INFO:  Read tuple at position 17: ('117', 'value 117')
+INFO:  Read tuple at position 18: ('118', 'value 118')
+INFO:  Read tuple at position 19: ('119', 'value 119')
+INFO:  Read tuple at position 20: ('120', 'value 120')
+INFO:  Read tuple at position 21: ('121', 'value 121')
+INFO:  Read tuple at position 22: ('122', 'value 122')
+INFO:  Read tuple at position 23: ('123', 'value 123')
+INFO:  Read tuple at position 24: ('124', 'value 124')
+INFO:  Read tuple at position 25: ('125', 'value 125')
+INFO:  Read tuple at position 26: ('126', 'value 126')
+INFO:  Read tuple at position 27: ('127', 'value 127')
+INFO:  Read tuple at position 28: ('128', 'value 128')
+INFO:  Read tuple at position 29: ('129', 'value 129')
+INFO:  Read tuple at position 30: ('130', 'value 130')
+INFO:  Read tuple at position 31: ('131', 'value 131')
+INFO:  Read tuple at position 32: ('132', 'value 132')
+INFO:  Read tuple at position 33: ('133', 'value 133')
+INFO:  Read tuple at position 34: ('134', 'value 134')
+INFO:  Read tuple at position 35: ('135', 'value 135')
+INFO:  Read tuple at position 36: ('136', 'value 136')
+INFO:  Read tuple at position 37: ('137', 'value 137')
+INFO:  Read tuple at position 38: ('138', 'value 138')
+INFO:  Read tuple at position 39: ('139', 'value 139')
+INFO:  Read tuple at position 40: ('140', 'value 140')
+INFO:  Read tuple at position 41: ('141', 'value 141')
+INFO:  Read tuple at position 42: ('142', 'value 142')
+INFO:  Read tuple at position 43: ('143', 'value 143')
+INFO:  Read tuple at position 44: ('144', 'value 144')
+INFO:  Read tuple at position 45: ('145', 'value 145')
+INFO:  Read tuple at position 46: ('146', 'value 146')
+INFO:  Read tuple at position 47: ('147', 'value 147')
+INFO:  Read tuple at position 48: ('148', 'value 148')
+INFO:  Read tuple at position 49: ('149', 'value 149')
+INFO:  Compare tuple ('100', 'value 100') at position 0: 0
+INFO:  Search for tuple ('100', 'value 100'): 0
+INFO:  Perform UPDATE operation ('100', '100') at position 0
+INFO:  Perform UPDATE operation ('101', '101') at position 1
+INFO:  Perform UPDATE operation ('102', '102') at position 2
+INFO:  Perform UPDATE operation ('103', '103') at position 3
+INFO:  Perform UPDATE operation ('104', '104') at position 4
+INFO:  Perform UPDATE operation ('105', '105') at position 5
+INFO:  Perform UPDATE operation ('106', '106') at position 6
+INFO:  Perform UPDATE operation ('107', '107') at position 7
+INFO:  Perform UPDATE operation ('108', '108') at position 8
+INFO:  Perform UPDATE operation ('109', '109') at position 9
+INFO:  Perform UPDATE operation ('110', '110') at position 10
+INFO:  Perform UPDATE operation ('111', '111') at position 11
+INFO:  Perform UPDATE operation ('112', '112') at position 12
+INFO:  Perform UPDATE operation ('113', '113') at position 13
+INFO:  Perform UPDATE operation ('114', '114') at position 14
+INFO:  Perform UPDATE operation ('115', '115') at position 15
+INFO:  Perform UPDATE operation ('116', '116') at position 16
+INFO:  Perform UPDATE operation ('117', '117') at position 17
+INFO:  Perform UPDATE operation ('118', '118') at position 18
+INFO:  Perform UPDATE operation ('119', '119') at position 19
+INFO:  Perform UPDATE operation ('120', '120') at position 20
+INFO:  Perform UPDATE operation ('121', '121') at position 21
+INFO:  Perform UPDATE operation ('122', '122') at position 22
+INFO:  Perform UPDATE operation ('123', '123') at position 23
+INFO:  Perform UPDATE operation ('124', '124') at position 24
+INFO:  Perform UPDATE operation ('125', '125') at position 25
+INFO:  Perform UPDATE operation ('126', '126') at position 26
+INFO:  Perform UPDATE operation ('127', '127') at position 27
+INFO:  Perform UPDATE operation ('128', '128') at position 28
+INFO:  Perform UPDATE operation ('129', '129') at position 29
+INFO:  Perform UPDATE operation ('130', '130') at position 30
+INFO:  Perform UPDATE operation ('131', '131') at position 31
+INFO:  Perform UPDATE operation ('132', '132') at position 32
+INFO:  Perform UPDATE operation ('133', '133') at position 33
+INFO:  Perform UPDATE operation ('134', '134') at position 34
+INFO:  Perform UPDATE operation ('135', '135') at position 35
+INFO:  Perform UPDATE operation ('136', '136') at position 36
+INFO:  Perform UPDATE operation ('137', '137') at position 37
+INFO:  Perform UPDATE operation ('138', '138') at position 38
+INFO:  Perform UPDATE operation ('139', '139') at position 39
+INFO:  Perform UPDATE operation ('140', '140') at position 40
+INFO:  Perform UPDATE operation ('141', '141') at position 41
+INFO:  Perform UPDATE operation ('142', '142') at position 42
+INFO:  Perform UPDATE operation ('143', '143') at position 43
+INFO:  Perform UPDATE operation ('144', '144') at position 44
+INFO:  Perform UPDATE operation ('145', '145') at position 45
+INFO:  Perform UPDATE operation ('146', '146') at position 46
+INFO:  Perform UPDATE operation ('147', '147') at position 47
+INFO:  Perform UPDATE operation ('148', '148') at position 48
+INFO:  Perform UPDATE operation ('149', '149') at position 49
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 39
+INFO:  Perform DELETE operation at position 38
+INFO:  Perform DELETE operation at position 37
+INFO:  Perform DELETE operation at position 36
+INFO:  Perform DELETE operation at position 35
+INFO:  Perform DELETE operation at position 34
+INFO:  Perform DELETE operation at position 33
+INFO:  Perform DELETE operation at position 32
+INFO:  Perform DELETE operation at position 31
+INFO:  Perform DELETE operation at position 30
+INFO:  Read tuple at position 0: ('110', '110')
+INFO:  Read tuple at position 1: ('111', '111')
+INFO:  Read tuple at position 2: ('112', '112')
+INFO:  Read tuple at position 3: ('113', '113')
+INFO:  Read tuple at position 4: ('114', '114')
+INFO:  Read tuple at position 5: ('115', '115')
+INFO:  Read tuple at position 6: ('116', '116')
+INFO:  Read tuple at position 7: ('117', '117')
+INFO:  Read tuple at position 8: ('118', '118')
+INFO:  Read tuple at position 9: ('119', '119')
+INFO:  Read tuple at position 10: ('120', '120')
+INFO:  Read tuple at position 11: ('121', '121')
+INFO:  Read tuple at position 12: ('122', '122')
+INFO:  Read tuple at position 13: ('123', '123')
+INFO:  Read tuple at position 14: ('124', '124')
+INFO:  Read tuple at position 15: ('125', '125')
+INFO:  Read tuple at position 16: ('126', '126')
+INFO:  Read tuple at position 17: ('127', '127')
+INFO:  Read tuple at position 18: ('128', '128')
+INFO:  Read tuple at position 19: ('129', '129')
+INFO:  Read tuple at position 20: ('130', '130')
+INFO:  Read tuple at position 21: ('131', '131')
+INFO:  Read tuple at position 22: ('132', '132')
+INFO:  Read tuple at position 23: ('133', '133')
+INFO:  Read tuple at position 24: ('134', '134')
+INFO:  Read tuple at position 25: ('135', '135')
+INFO:  Read tuple at position 26: ('136', '136')
+INFO:  Read tuple at position 27: ('137', '137')
+INFO:  Read tuple at position 28: ('138', '138')
+INFO:  Read tuple at position 29: ('139', '139')
+INFO:  Compare tuple ('100', 'value 100') at position 0: -1
+INFO:  Search for tuple ('100', 'value 100'): 0
+INFO:  Compaction: before: chunkDataSize 1264, chunkItemsCount 30, after: chunkDataSize 1032, chunkItemsCount 30
+INFO:  Perform UPDATE operation ('110', '110') at position 10
+INFO:  Perform UPDATE operation ('111', '111') at position 11
+INFO:  Perform UPDATE operation ('112', '112') at position 12
+INFO:  Perform UPDATE operation ('113', '113') at position 13
+INFO:  Perform UPDATE operation ('114', '114') at position 14
+INFO:  Perform UPDATE operation ('115', '115') at position 15
+INFO:  Perform UPDATE operation ('116', '116') at position 16
+INFO:  Perform UPDATE operation ('117', '117') at position 17
+INFO:  Perform UPDATE operation ('118', '118') at position 18
+INFO:  Perform UPDATE operation ('119', '119') at position 19
+INFO:  Read tuple at position 0: ('110', '110')
+INFO:  Read tuple at position 1: ('111', '111')
+INFO:  Read tuple at position 2: ('112', '112')
+INFO:  Read tuple at position 3: ('113', '113')
+INFO:  Read tuple at position 4: ('114', '114')
+INFO:  Read tuple at position 5: ('115', '115')
+INFO:  Read tuple at position 6: ('116', '116')
+INFO:  Read tuple at position 7: ('117', '117')
+INFO:  Read tuple at position 8: ('118', '118')
+INFO:  Read tuple at position 9: ('119', '119')
+INFO:  Read tuple at position 10: ('110', '110'), deleted
+INFO:  Read tuple at position 11: ('111', '111'), deleted
+INFO:  Read tuple at position 12: ('112', '112'), deleted
+INFO:  Read tuple at position 13: ('113', '113'), deleted
+INFO:  Read tuple at position 14: ('114', '114'), deleted
+INFO:  Read tuple at position 15: ('115', '115'), deleted
+INFO:  Read tuple at position 16: ('116', '116'), deleted
+INFO:  Read tuple at position 17: ('117', '117'), deleted
+INFO:  Read tuple at position 18: ('118', '118'), deleted
+INFO:  Read tuple at position 19: ('119', '119'), deleted
+INFO:  Read tuple at position 20: ('130', '130')
+INFO:  Read tuple at position 21: ('131', '131')
+INFO:  Read tuple at position 22: ('132', '132')
+INFO:  Read tuple at position 23: ('133', '133')
+INFO:  Read tuple at position 24: ('134', '134')
+INFO:  Read tuple at position 25: ('135', '135')
+INFO:  Read tuple at position 26: ('136', '136')
+INFO:  Read tuple at position 27: ('137', '137')
+INFO:  Read tuple at position 28: ('138', '138')
+INFO:  Read tuple at position 29: ('139', '139')
+INFO:  Compaction: before: chunkDataSize 1032, chunkItemsCount 30, after: chunkDataSize 688, chunkItemsCount 20
+INFO:  Read tuple at position 0: ('110', '110')
+INFO:  Read tuple at position 1: ('111', '111')
+INFO:  Read tuple at position 2: ('112', '112')
+INFO:  Read tuple at position 3: ('113', '113')
+INFO:  Read tuple at position 4: ('114', '114')
+INFO:  Read tuple at position 5: ('115', '115')
+INFO:  Read tuple at position 6: ('116', '116')
+INFO:  Read tuple at position 7: ('117', '117')
+INFO:  Read tuple at position 8: ('118', '118')
+INFO:  Read tuple at position 9: ('119', '119')
+INFO:  Read tuple at position 10: ('130', '130')
+INFO:  Read tuple at position 11: ('131', '131')
+INFO:  Read tuple at position 12: ('132', '132')
+INFO:  Read tuple at position 13: ('133', '133')
+INFO:  Read tuple at position 14: ('134', '134')
+INFO:  Read tuple at position 15: ('135', '135')
+INFO:  Read tuple at position 16: ('136', '136')
+INFO:  Read tuple at position 17: ('137', '137')
+INFO:  Read tuple at position 18: ('138', '138')
+INFO:  Read tuple at position 19: ('139', '139')
+ test_btree_leaf_tuple_chunk 
+-----------------------------
+ 
+(1 row)
+
+SELECT test_btree_leaf_tuple_chunk_builder('tuple_chunk_test'::regclass);
+INFO:  Estimate adding tuple ('1', 'value 1') to builder: 48
+INFO:  Perform adding tuple ('1', 'value 1') to builder
+INFO:  Perform adding tuple ('2', 'value 2') to builder
+INFO:  Perform adding tuple ('3', 'value 3') to builder
+INFO:  Perform adding tuple ('4', 'value 4') to builder
+INFO:  Perform adding tuple ('5', 'value 5') to builder
+INFO:  Perform adding tuple ('6', 'value 6') to builder
+INFO:  Perform adding tuple ('7', 'value 7') to builder
+INFO:  Perform adding tuple ('8', 'value 8') to builder
+INFO:  Perform adding tuple ('9', 'value 9') to builder
+INFO:  Perform adding tuple ('10', 'value 10') to builder
+INFO:  Perform adding tuple ('11', 'value 11') to builder
+INFO:  Perform adding tuple ('12', 'value 12') to builder
+INFO:  Perform adding tuple ('13', 'value 13') to builder
+INFO:  Perform adding tuple ('14', 'value 14') to builder
+INFO:  Perform adding tuple ('15', 'value 15') to builder
+INFO:  Perform adding tuple ('16', 'value 16') to builder
+INFO:  Perform adding tuple ('17', 'value 17') to builder
+INFO:  Perform adding tuple ('18', 'value 18') to builder
+INFO:  Perform adding tuple ('19', 'value 19') to builder
+INFO:  Perform adding tuple ('20', 'value 20') to builder
+INFO:  Perform adding tuple ('21', 'value 21') to builder
+INFO:  Perform adding tuple ('22', 'value 22') to builder
+INFO:  Perform adding tuple ('23', 'value 23') to builder
+INFO:  Perform adding tuple ('24', 'value 24') to builder
+INFO:  Perform adding tuple ('25', 'value 25') to builder
+INFO:  Perform adding tuple ('26', 'value 26') to builder
+INFO:  Perform adding tuple ('27', 'value 27') to builder
+INFO:  Perform adding tuple ('28', 'value 28') to builder
+INFO:  Perform adding tuple ('29', 'value 29') to builder
+INFO:  Perform adding tuple ('30', 'value 30') to builder
+INFO:  Perform adding tuple ('31', 'value 31') to builder
+INFO:  Perform adding tuple ('32', 'value 32') to builder
+INFO:  Perform adding tuple ('33', 'value 33') to builder
+INFO:  Perform adding tuple ('34', 'value 34') to builder
+INFO:  Perform adding tuple ('35', 'value 35') to builder
+INFO:  Perform adding tuple ('36', 'value 36') to builder
+INFO:  Perform adding tuple ('37', 'value 37') to builder
+INFO:  Perform adding tuple ('38', 'value 38') to builder
+INFO:  Perform adding tuple ('39', 'value 39') to builder
+INFO:  Perform adding tuple ('40', 'value 40') to builder
+INFO:  Perform adding tuple ('41', 'value 41') to builder
+INFO:  Perform adding tuple ('42', 'value 42') to builder
+INFO:  Perform adding tuple ('43', 'value 43') to builder
+INFO:  Perform adding tuple ('44', 'value 44') to builder
+INFO:  Perform adding tuple ('45', 'value 45') to builder
+INFO:  Perform adding tuple ('46', 'value 46') to builder
+INFO:  Perform adding tuple ('47', 'value 47') to builder
+INFO:  Perform adding tuple ('48', 'value 48') to builder
+INFO:  Perform adding tuple ('49', 'value 49') to builder
+INFO:  Perform adding tuple ('50', 'value 50') to builder
+INFO:  Finished building tuple chunk
+INFO:  Read tuple at position 0: ('1', 'value 1')
+INFO:  Read tuple at position 1: ('2', 'value 2')
+INFO:  Read tuple at position 2: ('3', 'value 3')
+INFO:  Read tuple at position 3: ('4', 'value 4')
+INFO:  Read tuple at position 4: ('5', 'value 5')
+INFO:  Read tuple at position 5: ('6', 'value 6')
+INFO:  Read tuple at position 6: ('7', 'value 7')
+INFO:  Read tuple at position 7: ('8', 'value 8')
+INFO:  Read tuple at position 8: ('9', 'value 9')
+INFO:  Read tuple at position 9: ('10', 'value 10')
+INFO:  Read tuple at position 10: ('11', 'value 11')
+INFO:  Read tuple at position 11: ('12', 'value 12')
+INFO:  Read tuple at position 12: ('13', 'value 13')
+INFO:  Read tuple at position 13: ('14', 'value 14')
+INFO:  Read tuple at position 14: ('15', 'value 15')
+INFO:  Read tuple at position 15: ('16', 'value 16')
+INFO:  Read tuple at position 16: ('17', 'value 17')
+INFO:  Read tuple at position 17: ('18', 'value 18')
+INFO:  Read tuple at position 18: ('19', 'value 19')
+INFO:  Read tuple at position 19: ('20', 'value 20')
+INFO:  Read tuple at position 20: ('21', 'value 21')
+INFO:  Read tuple at position 21: ('22', 'value 22')
+INFO:  Read tuple at position 22: ('23', 'value 23')
+INFO:  Read tuple at position 23: ('24', 'value 24')
+INFO:  Read tuple at position 24: ('25', 'value 25')
+INFO:  Read tuple at position 25: ('26', 'value 26')
+INFO:  Read tuple at position 26: ('27', 'value 27')
+INFO:  Read tuple at position 27: ('28', 'value 28')
+INFO:  Read tuple at position 28: ('29', 'value 29')
+INFO:  Read tuple at position 29: ('30', 'value 30')
+INFO:  Read tuple at position 30: ('31', 'value 31')
+INFO:  Read tuple at position 31: ('32', 'value 32')
+INFO:  Read tuple at position 32: ('33', 'value 33')
+INFO:  Read tuple at position 33: ('34', 'value 34')
+INFO:  Read tuple at position 34: ('35', 'value 35')
+INFO:  Read tuple at position 35: ('36', 'value 36')
+INFO:  Read tuple at position 36: ('37', 'value 37')
+INFO:  Read tuple at position 37: ('38', 'value 38')
+INFO:  Read tuple at position 38: ('39', 'value 39')
+INFO:  Read tuple at position 39: ('40', 'value 40')
+INFO:  Read tuple at position 40: ('41', 'value 41')
+INFO:  Read tuple at position 41: ('42', 'value 42')
+INFO:  Read tuple at position 42: ('43', 'value 43')
+INFO:  Read tuple at position 43: ('44', 'value 44')
+INFO:  Read tuple at position 44: ('45', 'value 45')
+INFO:  Read tuple at position 45: ('46', 'value 46')
+INFO:  Read tuple at position 46: ('47', 'value 47')
+INFO:  Read tuple at position 47: ('48', 'value 48')
+INFO:  Read tuple at position 48: ('49', 'value 49')
+INFO:  Read tuple at position 49: ('50', 'value 50')
+ test_btree_leaf_tuple_chunk_builder 
+-------------------------------------
+ 
+(1 row)
+
+SELECT test_btree_hikey_chunk('tuple_chunk_test'::regclass);
+INFO:  Estimate INSERT operation ('1') at position 0: 8
+INFO:  Perform INSERT operation ('1') at position 0
+INFO:  Perform INSERT operation ('2') at position 1
+INFO:  Perform INSERT operation ('3') at position 2
+INFO:  Perform INSERT operation ('4') at position 3
+INFO:  Perform INSERT operation ('5') at position 4
+INFO:  Perform INSERT operation ('6') at position 5
+INFO:  Perform INSERT operation ('7') at position 6
+INFO:  Perform INSERT operation ('8') at position 7
+INFO:  Perform INSERT operation ('9') at position 8
+INFO:  Perform INSERT operation ('10') at position 9
+INFO:  Perform INSERT operation ('11') at position 10
+INFO:  Perform INSERT operation ('12') at position 11
+INFO:  Perform INSERT operation ('13') at position 12
+INFO:  Perform INSERT operation ('14') at position 13
+INFO:  Perform INSERT operation ('15') at position 14
+INFO:  Perform INSERT operation ('16') at position 15
+INFO:  Perform INSERT operation ('17') at position 16
+INFO:  Perform INSERT operation ('18') at position 17
+INFO:  Perform INSERT operation ('19') at position 18
+INFO:  Perform INSERT operation ('20') at position 19
+INFO:  Perform INSERT operation ('21') at position 20
+INFO:  Perform INSERT operation ('22') at position 21
+INFO:  Perform INSERT operation ('23') at position 22
+INFO:  Perform INSERT operation ('24') at position 23
+INFO:  Perform INSERT operation ('25') at position 24
+INFO:  Perform INSERT operation ('26') at position 25
+INFO:  Perform INSERT operation ('27') at position 26
+INFO:  Perform INSERT operation ('28') at position 27
+INFO:  Perform INSERT operation ('29') at position 28
+INFO:  Perform INSERT operation ('30') at position 29
+INFO:  Perform INSERT operation ('31') at position 30
+INFO:  Perform INSERT operation ('32') at position 31
+INFO:  Perform INSERT operation ('33') at position 32
+INFO:  Perform INSERT operation ('34') at position 33
+INFO:  Perform INSERT operation ('35') at position 34
+INFO:  Perform INSERT operation ('36') at position 35
+INFO:  Perform INSERT operation ('37') at position 36
+INFO:  Perform INSERT operation ('38') at position 37
+INFO:  Read tuple at position 0: ('1')
+INFO:  Read tuple at position 1: ('2')
+INFO:  Read tuple at position 2: ('3')
+INFO:  Read tuple at position 3: ('4')
+INFO:  Read tuple at position 4: ('5')
+INFO:  Read tuple at position 5: ('6')
+INFO:  Read tuple at position 6: ('7')
+INFO:  Read tuple at position 7: ('8')
+INFO:  Read tuple at position 8: ('9')
+INFO:  Read tuple at position 9: ('10')
+INFO:  Read tuple at position 10: ('11')
+INFO:  Read tuple at position 11: ('12')
+INFO:  Read tuple at position 12: ('13')
+INFO:  Read tuple at position 13: ('14')
+INFO:  Read tuple at position 14: ('15')
+INFO:  Read tuple at position 15: ('16')
+INFO:  Read tuple at position 16: ('17')
+INFO:  Read tuple at position 17: ('18')
+INFO:  Read tuple at position 18: ('19')
+INFO:  Read tuple at position 19: ('20')
+INFO:  Read tuple at position 20: ('21')
+INFO:  Read tuple at position 21: ('22')
+INFO:  Read tuple at position 22: ('23')
+INFO:  Read tuple at position 23: ('24')
+INFO:  Read tuple at position 24: ('25')
+INFO:  Read tuple at position 25: ('26')
+INFO:  Read tuple at position 26: ('27')
+INFO:  Read tuple at position 27: ('28')
+INFO:  Read tuple at position 28: ('29')
+INFO:  Read tuple at position 29: ('30')
+INFO:  Read tuple at position 30: ('31')
+INFO:  Read tuple at position 31: ('32')
+INFO:  Read tuple at position 32: ('33')
+INFO:  Read tuple at position 33: ('34')
+INFO:  Read tuple at position 34: ('35')
+INFO:  Read tuple at position 35: ('36')
+INFO:  Read tuple at position 36: ('37')
+INFO:  Read tuple at position 37: ('38')
+INFO:  Compare tuple ('0') at position 0: -1
+INFO:  Compare tuple ('1') at position 1: -1
+INFO:  Compare tuple ('2') at position 2: -1
+INFO:  Compare tuple ('3') at position 3: -1
+INFO:  Compare tuple ('4') at position 4: -1
+INFO:  Compare tuple ('5') at position 5: -1
+INFO:  Compare tuple ('6') at position 6: -1
+INFO:  Compare tuple ('7') at position 7: -1
+INFO:  Compare tuple ('8') at position 8: -1
+INFO:  Compare tuple ('9') at position 9: -1
+INFO:  Compare tuple ('10') at position 10: -1
+INFO:  Compare tuple ('11') at position 11: -1
+INFO:  Compare tuple ('12') at position 12: -1
+INFO:  Compare tuple ('13') at position 13: -1
+INFO:  Compare tuple ('14') at position 14: -1
+INFO:  Compare tuple ('15') at position 15: -1
+INFO:  Compare tuple ('16') at position 16: -1
+INFO:  Compare tuple ('17') at position 17: -1
+INFO:  Compare tuple ('18') at position 18: -1
+INFO:  Compare tuple ('19') at position 19: -1
+INFO:  Compare tuple ('20') at position 20: -1
+INFO:  Compare tuple ('21') at position 21: -1
+INFO:  Compare tuple ('22') at position 22: -1
+INFO:  Compare tuple ('23') at position 23: -1
+INFO:  Compare tuple ('24') at position 24: -1
+INFO:  Compare tuple ('25') at position 25: -1
+INFO:  Compare tuple ('26') at position 26: -1
+INFO:  Compare tuple ('27') at position 27: -1
+INFO:  Compare tuple ('28') at position 28: -1
+INFO:  Compare tuple ('29') at position 29: -1
+INFO:  Compare tuple ('30') at position 30: -1
+INFO:  Compare tuple ('31') at position 31: -1
+INFO:  Compare tuple ('32') at position 32: -1
+INFO:  Compare tuple ('33') at position 33: -1
+INFO:  Compare tuple ('34') at position 34: -1
+INFO:  Compare tuple ('35') at position 35: -1
+INFO:  Compare tuple ('36') at position 36: -1
+INFO:  Compare tuple ('37') at position 37: -1
+INFO:  Compare tuple ('1') at position 0: 0
+INFO:  Compare tuple ('2') at position 1: 0
+INFO:  Compare tuple ('3') at position 2: 0
+INFO:  Compare tuple ('4') at position 3: 0
+INFO:  Compare tuple ('5') at position 4: 0
+INFO:  Compare tuple ('6') at position 5: 0
+INFO:  Compare tuple ('7') at position 6: 0
+INFO:  Compare tuple ('8') at position 7: 0
+INFO:  Compare tuple ('9') at position 8: 0
+INFO:  Compare tuple ('10') at position 9: 0
+INFO:  Compare tuple ('11') at position 10: 0
+INFO:  Compare tuple ('12') at position 11: 0
+INFO:  Compare tuple ('13') at position 12: 0
+INFO:  Compare tuple ('14') at position 13: 0
+INFO:  Compare tuple ('15') at position 14: 0
+INFO:  Compare tuple ('16') at position 15: 0
+INFO:  Compare tuple ('17') at position 16: 0
+INFO:  Compare tuple ('18') at position 17: 0
+INFO:  Compare tuple ('19') at position 18: 0
+INFO:  Compare tuple ('20') at position 19: 0
+INFO:  Compare tuple ('21') at position 20: 0
+INFO:  Compare tuple ('22') at position 21: 0
+INFO:  Compare tuple ('23') at position 22: 0
+INFO:  Compare tuple ('24') at position 23: 0
+INFO:  Compare tuple ('25') at position 24: 0
+INFO:  Compare tuple ('26') at position 25: 0
+INFO:  Compare tuple ('27') at position 26: 0
+INFO:  Compare tuple ('28') at position 27: 0
+INFO:  Compare tuple ('29') at position 28: 0
+INFO:  Compare tuple ('30') at position 29: 0
+INFO:  Compare tuple ('31') at position 30: 0
+INFO:  Compare tuple ('32') at position 31: 0
+INFO:  Compare tuple ('33') at position 32: 0
+INFO:  Compare tuple ('34') at position 33: 0
+INFO:  Compare tuple ('35') at position 34: 0
+INFO:  Compare tuple ('36') at position 35: 0
+INFO:  Compare tuple ('37') at position 36: 0
+INFO:  Compare tuple ('38') at position 37: 0
+INFO:  Search for tuple ('0'): 0
+INFO:  Search for tuple ('1'): 1
+INFO:  Search for tuple ('2'): 2
+INFO:  Search for tuple ('3'): 3
+INFO:  Search for tuple ('4'): 4
+INFO:  Search for tuple ('5'): 5
+INFO:  Search for tuple ('6'): 6
+INFO:  Search for tuple ('7'): 7
+INFO:  Search for tuple ('8'): 8
+INFO:  Search for tuple ('9'): 9
+INFO:  Search for tuple ('10'): 10
+INFO:  Search for tuple ('11'): 11
+INFO:  Search for tuple ('12'): 12
+INFO:  Search for tuple ('13'): 13
+INFO:  Search for tuple ('14'): 14
+INFO:  Search for tuple ('15'): 15
+INFO:  Search for tuple ('16'): 16
+INFO:  Search for tuple ('17'): 17
+INFO:  Search for tuple ('18'): 18
+INFO:  Search for tuple ('19'): 19
+INFO:  Search for tuple ('20'): 20
+INFO:  Search for tuple ('21'): 21
+INFO:  Search for tuple ('22'): 22
+INFO:  Search for tuple ('23'): 23
+INFO:  Search for tuple ('24'): 24
+INFO:  Search for tuple ('25'): 25
+INFO:  Search for tuple ('26'): 26
+INFO:  Search for tuple ('27'): 27
+INFO:  Search for tuple ('28'): 28
+INFO:  Search for tuple ('29'): 29
+INFO:  Search for tuple ('30'): 30
+INFO:  Search for tuple ('31'): 31
+INFO:  Search for tuple ('32'): 32
+INFO:  Search for tuple ('33'): 33
+INFO:  Search for tuple ('34'): 34
+INFO:  Search for tuple ('35'): 35
+INFO:  Search for tuple ('36'): 36
+INFO:  Search for tuple ('37'): 37
+INFO:  Search for tuple ('38'): 37
+INFO:  Search for tuple ('39'): 37
+INFO:  Estimate UPDATE operation ('1') at position 0: 0
+INFO:  Estimate DELETE operation at position 0: -8
+INFO:  Perform UPDATE operation ('100') at position 0
+INFO:  Perform UPDATE operation ('101') at position 1
+INFO:  Perform UPDATE operation ('102') at position 2
+INFO:  Perform UPDATE operation ('103') at position 3
+INFO:  Perform UPDATE operation ('104') at position 4
+INFO:  Perform UPDATE operation ('105') at position 5
+INFO:  Perform UPDATE operation ('106') at position 6
+INFO:  Perform UPDATE operation ('107') at position 7
+INFO:  Perform UPDATE operation ('108') at position 8
+INFO:  Perform UPDATE operation ('109') at position 9
+INFO:  Perform UPDATE operation ('110') at position 10
+INFO:  Perform UPDATE operation ('111') at position 11
+INFO:  Perform UPDATE operation ('112') at position 12
+INFO:  Perform UPDATE operation ('113') at position 13
+INFO:  Perform UPDATE operation ('114') at position 14
+INFO:  Perform UPDATE operation ('115') at position 15
+INFO:  Perform UPDATE operation ('116') at position 16
+INFO:  Perform UPDATE operation ('117') at position 17
+INFO:  Perform UPDATE operation ('118') at position 18
+INFO:  Perform UPDATE operation ('119') at position 19
+INFO:  Perform UPDATE operation ('120') at position 20
+INFO:  Perform UPDATE operation ('121') at position 21
+INFO:  Perform UPDATE operation ('122') at position 22
+INFO:  Perform UPDATE operation ('123') at position 23
+INFO:  Perform UPDATE operation ('124') at position 24
+INFO:  Perform UPDATE operation ('125') at position 25
+INFO:  Perform UPDATE operation ('126') at position 26
+INFO:  Perform UPDATE operation ('127') at position 27
+INFO:  Perform UPDATE operation ('128') at position 28
+INFO:  Perform UPDATE operation ('129') at position 29
+INFO:  Perform UPDATE operation ('130') at position 30
+INFO:  Perform UPDATE operation ('131') at position 31
+INFO:  Perform UPDATE operation ('132') at position 32
+INFO:  Perform UPDATE operation ('133') at position 33
+INFO:  Perform UPDATE operation ('134') at position 34
+INFO:  Perform UPDATE operation ('135') at position 35
+INFO:  Perform UPDATE operation ('136') at position 36
+INFO:  Perform UPDATE operation ('137') at position 37
+INFO:  Read tuple at position 0: ('100')
+INFO:  Read tuple at position 1: ('101')
+INFO:  Read tuple at position 2: ('102')
+INFO:  Read tuple at position 3: ('103')
+INFO:  Read tuple at position 4: ('104')
+INFO:  Read tuple at position 5: ('105')
+INFO:  Read tuple at position 6: ('106')
+INFO:  Read tuple at position 7: ('107')
+INFO:  Read tuple at position 8: ('108')
+INFO:  Read tuple at position 9: ('109')
+INFO:  Read tuple at position 10: ('110')
+INFO:  Read tuple at position 11: ('111')
+INFO:  Read tuple at position 12: ('112')
+INFO:  Read tuple at position 13: ('113')
+INFO:  Read tuple at position 14: ('114')
+INFO:  Read tuple at position 15: ('115')
+INFO:  Read tuple at position 16: ('116')
+INFO:  Read tuple at position 17: ('117')
+INFO:  Read tuple at position 18: ('118')
+INFO:  Read tuple at position 19: ('119')
+INFO:  Read tuple at position 20: ('120')
+INFO:  Read tuple at position 21: ('121')
+INFO:  Read tuple at position 22: ('122')
+INFO:  Read tuple at position 23: ('123')
+INFO:  Read tuple at position 24: ('124')
+INFO:  Read tuple at position 25: ('125')
+INFO:  Read tuple at position 26: ('126')
+INFO:  Read tuple at position 27: ('127')
+INFO:  Read tuple at position 28: ('128')
+INFO:  Read tuple at position 29: ('129')
+INFO:  Read tuple at position 30: ('130')
+INFO:  Read tuple at position 31: ('131')
+INFO:  Read tuple at position 32: ('132')
+INFO:  Read tuple at position 33: ('133')
+INFO:  Read tuple at position 34: ('134')
+INFO:  Read tuple at position 35: ('135')
+INFO:  Read tuple at position 36: ('136')
+INFO:  Read tuple at position 37: ('137')
+INFO:  Compare tuple ('100') at position 0: 0
+INFO:  Search for tuple ('100'): 1
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Perform DELETE operation at position 0
+INFO:  Read tuple at position 0: ('110')
+INFO:  Read tuple at position 1: ('111')
+INFO:  Read tuple at position 2: ('112')
+INFO:  Read tuple at position 3: ('113')
+INFO:  Read tuple at position 4: ('114')
+INFO:  Read tuple at position 5: ('115')
+INFO:  Read tuple at position 6: ('116')
+INFO:  Read tuple at position 7: ('117')
+INFO:  Read tuple at position 8: ('118')
+INFO:  Read tuple at position 9: ('119')
+INFO:  Read tuple at position 10: ('120')
+INFO:  Read tuple at position 11: ('121')
+INFO:  Read tuple at position 12: ('122')
+INFO:  Read tuple at position 13: ('123')
+INFO:  Read tuple at position 14: ('124')
+INFO:  Read tuple at position 15: ('125')
+INFO:  Read tuple at position 16: ('126')
+INFO:  Read tuple at position 17: ('127')
+INFO:  Read tuple at position 18: ('128')
+INFO:  Read tuple at position 19: ('129')
+INFO:  Read tuple at position 20: ('130')
+INFO:  Read tuple at position 21: ('131')
+INFO:  Read tuple at position 22: ('132')
+INFO:  Read tuple at position 23: ('133')
+INFO:  Read tuple at position 24: ('134')
+INFO:  Read tuple at position 25: ('135')
+INFO:  Read tuple at position 26: ('136')
+INFO:  Read tuple at position 27: ('137')
+INFO:  Compare tuple ('100') at position 0: -1
+INFO:  Search for tuple ('100'): 0
+ test_btree_hikey_chunk 
+------------------------
+ 
+(1 row)
+
+SELECT test_btree_hikey_chunk_builder('tuple_chunk_test'::regclass);
+INFO:  Estimate adding tuple ('1') to builder: 8
+INFO:  Perform adding tuple ('1') to builder
+INFO:  Perform adding tuple ('2') to builder
+INFO:  Perform adding tuple ('3') to builder
+INFO:  Perform adding tuple ('4') to builder
+INFO:  Perform adding tuple ('5') to builder
+INFO:  Perform adding tuple ('6') to builder
+INFO:  Perform adding tuple ('7') to builder
+INFO:  Perform adding tuple ('8') to builder
+INFO:  Perform adding tuple ('9') to builder
+INFO:  Perform adding tuple ('10') to builder
+INFO:  Perform adding tuple ('11') to builder
+INFO:  Perform adding tuple ('12') to builder
+INFO:  Perform adding tuple ('13') to builder
+INFO:  Perform adding tuple ('14') to builder
+INFO:  Perform adding tuple ('15') to builder
+INFO:  Perform adding tuple ('16') to builder
+INFO:  Perform adding tuple ('17') to builder
+INFO:  Perform adding tuple ('18') to builder
+INFO:  Perform adding tuple ('19') to builder
+INFO:  Perform adding tuple ('20') to builder
+INFO:  Perform adding tuple ('21') to builder
+INFO:  Perform adding tuple ('22') to builder
+INFO:  Perform adding tuple ('23') to builder
+INFO:  Perform adding tuple ('24') to builder
+INFO:  Perform adding tuple ('25') to builder
+INFO:  Perform adding tuple ('26') to builder
+INFO:  Perform adding tuple ('27') to builder
+INFO:  Perform adding tuple ('28') to builder
+INFO:  Perform adding tuple ('29') to builder
+INFO:  Perform adding tuple ('30') to builder
+INFO:  Perform adding tuple ('31') to builder
+INFO:  Perform adding tuple ('32') to builder
+INFO:  Perform adding tuple ('33') to builder
+INFO:  Perform adding tuple ('34') to builder
+INFO:  Perform adding tuple ('35') to builder
+INFO:  Perform adding tuple ('36') to builder
+INFO:  Perform adding tuple ('37') to builder
+INFO:  Perform adding tuple ('38') to builder
+INFO:  Finished building tuple chunk
+INFO:  Read tuple at position 0: ('1')
+INFO:  Read tuple at position 1: ('2')
+INFO:  Read tuple at position 2: ('3')
+INFO:  Read tuple at position 3: ('4')
+INFO:  Read tuple at position 4: ('5')
+INFO:  Read tuple at position 5: ('6')
+INFO:  Read tuple at position 6: ('7')
+INFO:  Read tuple at position 7: ('8')
+INFO:  Read tuple at position 8: ('9')
+INFO:  Read tuple at position 9: ('10')
+INFO:  Read tuple at position 10: ('11')
+INFO:  Read tuple at position 11: ('12')
+INFO:  Read tuple at position 12: ('13')
+INFO:  Read tuple at position 13: ('14')
+INFO:  Read tuple at position 14: ('15')
+INFO:  Read tuple at position 15: ('16')
+INFO:  Read tuple at position 16: ('17')
+INFO:  Read tuple at position 17: ('18')
+INFO:  Read tuple at position 18: ('19')
+INFO:  Read tuple at position 19: ('20')
+INFO:  Read tuple at position 20: ('21')
+INFO:  Read tuple at position 21: ('22')
+INFO:  Read tuple at position 22: ('23')
+INFO:  Read tuple at position 23: ('24')
+INFO:  Read tuple at position 24: ('25')
+INFO:  Read tuple at position 25: ('26')
+INFO:  Read tuple at position 26: ('27')
+INFO:  Read tuple at position 27: ('28')
+INFO:  Read tuple at position 28: ('29')
+INFO:  Read tuple at position 29: ('30')
+INFO:  Read tuple at position 30: ('31')
+INFO:  Read tuple at position 31: ('32')
+INFO:  Read tuple at position 32: ('33')
+INFO:  Read tuple at position 33: ('34')
+INFO:  Read tuple at position 34: ('35')
+INFO:  Read tuple at position 35: ('36')
+INFO:  Read tuple at position 36: ('37')
+INFO:  Read tuple at position 37: ('38')
+ test_btree_hikey_chunk_builder 
+--------------------------------
+ 
+(1 row)
+
+DROP SCHEMA tuple_chunk CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to extension orioledb
+drop cascades to table tuple_chunk_test
+RESET search_path;

--- a/test/sql/btree_chunk_ops.sql
+++ b/test/sql/btree_chunk_ops.sql
@@ -1,0 +1,20 @@
+CREATE SCHEMA tuple_chunk;
+SET SESSION search_path = 'tuple_chunk';
+CREATE EXTENSION orioledb;
+
+CREATE TABLE tuple_chunk_test
+(
+    id int PRIMARY KEY,
+    value text
+) USING orioledb;
+
+SELECT test_btree_leaf_tuple_chunk('tuple_chunk_test'::regclass);
+
+SELECT test_btree_leaf_tuple_chunk_builder('tuple_chunk_test'::regclass);
+
+SELECT test_btree_hikey_chunk('tuple_chunk_test'::regclass);
+
+SELECT test_btree_hikey_chunk_builder('tuple_chunk_test'::regclass);
+
+DROP SCHEMA tuple_chunk CASCADE;
+RESET search_path;


### PR DESCRIPTION
Add page chunk API to manipulate and read chunks, it allows to use different chunk implementations.

- `include/btree/chunk_ops.h` - defines abstract page chunk API
- `src/btree/tuple_chunk.c` - tuple chunks implementation of the chunk API for leaf, internal and hikey chunks
- `src/btree/tuple_chunk_test.c`, `test/sql/tuple_chunk.sql` - unit tests for tuple chunks implementation, needs https://github.com/orioledb/orioledb/pull/400 to be merged first