### PR TITLE
fix: use POSIX <fcntl.h> instead of <sys/fcntl.h> 

### DIFF
--- a/src/s3/control.c
+++ b/src/s3/control.c
@@ -13,7 +13,7 @@
 
 #include "postgres.h"
 
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #include <unistd.h>
 

--- a/src/s3/worker.c
+++ b/src/s3/worker.c
@@ -39,7 +39,7 @@
 #include "pgstat.h"
 
 #include "openssl/sha.h"
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 
 


### PR DESCRIPTION
fix alpine warning ...  https://github.com/orioledb/orioledb/issues/395
