### PR TITLE
fix| python regex: Add raw string prefix to regex patterns

### DIFF
--- a/t/checkpointer_test.py
+++ b/t/checkpointer_test.py
@@ -106,6 +106,6 @@ class CheckpointerTest(BaseTest):
 			dbDir = os.path.join(orioledb_dir, f)
 			if os.path.isdir(dbDir):
 				for ff in os.listdir(dbDir):
-					if re.match(".*[1-9]\.map$", ff):
+					if re.match(r".*[1-9]\.map$", ff):
 						exist = True
 		return exist

--- a/t/files_test.py
+++ b/t/files_test.py
@@ -166,13 +166,13 @@ class FilesTest(BaseTest):
 		orioledb_dir = self.node.data_dir + "/orioledb_data"
 		for ff in os.listdir(orioledb_dir):
 			dbDir = os.path.join(orioledb_dir, ff)
-			if re.match(".*\.xid$", ff):
+			if re.match(r".*\.xid$", ff):
 				xid_files.append(ff)
 			elif os.path.isdir(dbDir):
 				for f in os.listdir(dbDir):
-					if re.match(".*\.map$", f):
+					if re.match(r".*\.map$", f):
 						map_files.append(ff + '_' + f)
-					if re.match(".*\.tmp$", f):
+					if re.match(r".*\.tmp$", f):
 						tmp_files.append(ff + '_' + f)
 
 		self.assertEqual(1, len(xid_files))
@@ -347,15 +347,15 @@ class FilesTest(BaseTest):
 		tmp_files = ""
 
 		for f in glob.glob(orioledb_dir + '/*/*'):
-			if re.match(".*\.map$", f):
+			if re.match(r".*\.map$", f):
 				map_files = map_files + " " + f
-			if re.match(".*\.tmp$", f):
+			if re.match(r".*\.tmp$", f):
 				tmp_files = tmp_files + " " + f
 
 		# all files should exists
-		self.assertTrue(bool(re.match(".*-1\.map.*", map_files)))
-		self.assertTrue(bool(re.match(".*-2\.map.*", map_files)))
-		self.assertTrue(bool(re.match(".*-2\.tmp.*", tmp_files)))
+		self.assertTrue(bool(re.match(r".*-1\.map.*", map_files)))
+		self.assertTrue(bool(re.match(r".*-2\.map.*", map_files)))
+		self.assertTrue(bool(re.match(r".*-2\.tmp.*", tmp_files)))
 
 	def test_drop_table_cleanup(self):
 		node = self.node
@@ -378,10 +378,10 @@ class FilesTest(BaseTest):
 				# do not check files of trees duplicating syscach
 				all_files = all_files + " " + f
 
-		self.assertFalse(bool(re.match(".*\.map", all_files)))
-		self.assertFalse(bool(re.match(".*\.tmp", all_files)))
-		self.assertFalse(bool(re.match(".*evt", all_files)))
-		self.assertFalse(bool(re.match("[0-9]*_[0-9]*_[0-9]*", all_files)))
+		self.assertFalse(bool(re.match(r".*\.map", all_files)))
+		self.assertFalse(bool(re.match(r".*\.tmp", all_files)))
+		self.assertFalse(bool(re.match(r".*evt", all_files)))
+		self.assertFalse(bool(re.match(r"[0-9]*_[0-9]*_[0-9]*", all_files)))
 
 	def test_drop_extension_cleanup(self):
 		node = self.node
@@ -404,10 +404,10 @@ class FilesTest(BaseTest):
 				# DROP EXTENSION saves o_tables BTree files, skip it
 				all_files = all_files + " " + f
 
-		self.assertFalse(bool(re.match(".*\.map", all_files)))
-		self.assertFalse(bool(re.match(".*\.tmp", all_files)))
-		self.assertFalse(bool(re.match(".*evt", all_files)))
-		self.assertFalse(bool(re.match("[0-9]*_[0-9]*_[0-9]*", all_files)))
+		self.assertFalse(bool(re.match(r".*\.map", all_files)))
+		self.assertFalse(bool(re.match(r".*\.tmp", all_files)))
+		self.assertFalse(bool(re.match(r".*evt", all_files)))
+		self.assertFalse(bool(re.match(r"[0-9]*_[0-9]*_[0-9]*", all_files)))
 
 	def test_drop_database_cleanup(self):
 		node = self.node
@@ -457,10 +457,10 @@ class FilesTest(BaseTest):
 				# DROP EXTENSION saves o_tables BTree files, skip it
 				all_files = all_files + " " + f
 
-		self.assertFalse(bool(re.match(".*\.map", all_files)))
-		self.assertFalse(bool(re.match(".*\.tmp", all_files)))
-		self.assertFalse(bool(re.match(".*evt", all_files)))
-		self.assertFalse(bool(re.match("[0-9]*_[0-9]*_[0-9]*", all_files)))
+		self.assertFalse(bool(re.match(r".*\.map", all_files)))
+		self.assertFalse(bool(re.match(r".*\.tmp", all_files)))
+		self.assertFalse(bool(re.match(r".*evt", all_files)))
+		self.assertFalse(bool(re.match(r"[0-9]*_[0-9]*_[0-9]*", all_files)))
 
 	def test_evt_cleanup(self):
 		node = self.node

--- a/t/indices_build_test.py
+++ b/t/indices_build_test.py
@@ -657,7 +657,7 @@ class IndicesBuildTest(BaseTest):
 			dbDir = os.path.join(orioledb_dir, ff)
 			if os.path.isdir(dbDir):
 				for f in os.listdir(dbDir):
-					if re.match(".*\.map$", f):
+					if re.match(r".*\.map$", f):
 						map_files.append(ff + '_' + f)
 
 		map_files = [re.split(r'\.|-|_', f) for f in map_files]


### PR DESCRIPTION
Fix python warning  in the test log  [ `SyntaxWarning: invalid escape sequence '\.' ` ] 
```
2024-12-09T22:19:54.8285358Z python3 -W ignore::DeprecationWarning -m unittest -v t/files_test.py
2024-12-09T22:19:54.8782019Z /temp_orioledb/t/files_test.py:169: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8782691Z   if re.match(".*\.xid$", ff):
2024-12-09T22:19:54.8787178Z /temp_orioledb/t/files_test.py:173: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8787805Z   if re.match(".*\.map$", f):
2024-12-09T22:19:54.8788397Z /temp_orioledb/t/files_test.py:175: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8789034Z   if re.match(".*\.tmp$", f):
2024-12-09T22:19:54.8798937Z /temp_orioledb/t/files_test.py:350: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8799564Z   if re.match(".*\.map$", f):
2024-12-09T22:19:54.8800139Z /temp_orioledb/t/files_test.py:352: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8800755Z   if re.match(".*\.tmp$", f):
2024-12-09T22:19:54.8805250Z /temp_orioledb/t/files_test.py:356: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8805978Z   self.assertTrue(bool(re.match(".*-1\.map.*", map_files)))
2024-12-09T22:19:54.8806671Z /temp_orioledb/t/files_test.py:357: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8807417Z   self.assertTrue(bool(re.match(".*-2\.map.*", map_files)))
2024-12-09T22:19:54.8808177Z /temp_orioledb/t/files_test.py:358: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8808974Z   self.assertTrue(bool(re.match(".*-2\.tmp.*", tmp_files)))
2024-12-09T22:19:54.8809710Z /temp_orioledb/t/files_test.py:381: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8810439Z   self.assertFalse(bool(re.match(".*\.map", all_files)))
2024-12-09T22:19:54.8815104Z /temp_orioledb/t/files_test.py:382: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8815817Z   self.assertFalse(bool(re.match(".*\.tmp", all_files)))
2024-12-09T22:19:54.8816710Z /temp_orioledb/t/files_test.py:407: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8817369Z   self.assertFalse(bool(re.match(".*\.map", all_files)))
2024-12-09T22:19:54.8818055Z /temp_orioledb/t/files_test.py:408: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8818744Z   self.assertFalse(bool(re.match(".*\.tmp", all_files)))
2024-12-09T22:19:54.8819429Z /temp_orioledb/t/files_test.py:460: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8820122Z   self.assertFalse(bool(re.match(".*\.map", all_files)))
2024-12-09T22:19:54.8821067Z /temp_orioledb/t/files_test.py:461: SyntaxWarning: invalid escape sequence '\.'
2024-12-09T22:19:54.8821823Z   self.assertFalse(bool(re.match(".*\.tmp", all_files)))
2024-12-09T22:19:54.9426231Z ok 15        - load_refind_page                          45
```