### PR TITLE
Make test `rll_mix` output stable

### DIFF
--- a/test/specs/rll_mix.spec
+++ b/test/specs/rll_mix.spec
@@ -425,7 +425,7 @@ permutation "s1_begin" "s2_begin" "s1_deadlock_timeout" "s2_deadlock_timeout"
 "s1_savepoint"
 "s2_select_key_share"
 "s1_update"
-"s2_select_update"
+"s2_select_update" ("s1_delete")
 "s1_delete"
 "s1_rollbak_to_savepoint"
 "s1_commit" "s2_commit"


### PR DESCRIPTION
Sometimes `s1_delete` and `s2_select_update` steps output is printed in different order.

Define output dependency explicitely in the `rll_mix.spec`.