### PR TITLE
Improve errmsg of file access calls

### DIFF
--- a/src/btree/build.c
+++ b/src/btree/build.c
@@ -480,7 +480,7 @@ btree_write_file_header(BTreeDescr *desc, CheckpointFileHeader *file_header)
 			pfree(filename);
 			ereport(FATAL,
 					(errcode_for_file_access(),
-					 errmsg("Could not write checkpoint header to file: %s",
+					 errmsg("Could not write checkpoint header to file %s: %m",
 							filename)));
 		}
 		FileClose(file);

--- a/src/btree/check.c
+++ b/src/btree/check.c
@@ -307,7 +307,7 @@ get_free_extents_from_file(SeqBufTag *tag, off_t offset,
 	{
 		if (should_exists)
 			ereport(NOTICE, (errcode_for_file_access(),
-							 errmsg("could not open map file %s.", filename)));
+							 errmsg("could not open map file %s: %m", filename)));
 		pfree(filename);
 		return;
 	}

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -286,7 +286,7 @@ btree_open_smgr_file(BTreeDescr *desc, uint32 num, uint32 chkpNum,
 		if (hashElem->file <= 0)
 			ereport(FATAL,
 					(errcode_for_file_access(),
-					 errmsg("could not open data file %s", filename)));
+					 errmsg("could not open data file %s: %m", filename)));
 		pfree(filename);
 		return hashElem->file;
 	}
@@ -317,7 +317,7 @@ btree_open_smgr_file(BTreeDescr *desc, uint32 num, uint32 chkpNum,
 		if (desc->smgr.array.files[num] <= 0)
 			ereport(FATAL,
 					(errcode_for_file_access(),
-					 errmsg("could not open data file %s", filename)));
+					 errmsg("could not open data file %s: %m", filename)));
 		pfree(filename);
 		return desc->smgr.array.files[num];
 	}
@@ -1412,7 +1412,7 @@ load_page(OBTreeFindPageContext *context)
 
 		ereport(ERROR, (errcode_for_file_access(),
 		/* cppcheck-suppress unknownMacro */
-						errmsg("could not read page with file offset " UINT64_FORMAT " from %s",
+						errmsg("could not read page with file offset " UINT64_FORMAT " from %s: %m",
 							   DOWNLINK_GET_DISK_OFF(downlink),
 							   btree_smgr_filename(desc, DOWNLINK_GET_DISK_OFF(downlink), chkpNum))));
 	}
@@ -1776,7 +1776,7 @@ perform_page_io(BTreeDescr *desc, OInMemoryBlkno blkno,
 	if (err)
 	{
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not (re) allocate file blocks for page %d to file %s",
+						errmsg("could not (re) allocate file blocks for page %d to file %s: %m",
 							   blkno, btree_smgr_filename(desc, 0, checkpoint_number))));
 	}
 
@@ -1785,7 +1785,7 @@ perform_page_io(BTreeDescr *desc, OInMemoryBlkno blkno,
 	if (!write_page_to_disk(desc, &page_desc->fileExtent, checkpoint_number, write_img, write_size))
 	{
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not write page %d to file %s with offset %lu",
+						errmsg("could not write page %d to file %s with offset %lu: %m",
 							   blkno,
 							   btree_smgr_filename(desc, page_desc->fileExtent.off, checkpoint_number),
 							   (unsigned long) page_desc->fileExtent.off)));
@@ -1816,7 +1816,7 @@ perform_page_io_autonomous(BTreeDescr *desc, uint32 chkpNum, Page img, FileExten
 	if (!get_free_disk_extent(desc, chkpNum, write_size, extent))
 	{
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not get free file offset for write page to file %s",
+						errmsg("could not get free file offset for write page to file %s: %m",
 							   btree_smgr_filename(desc, 0, 0))));
 
 		return InvalidDiskDownlink;
@@ -1840,7 +1840,7 @@ perform_page_io_autonomous(BTreeDescr *desc, uint32 chkpNum, Page img, FileExten
 		}
 
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not write autonomous page to file %s with offset %lu",
+						errmsg("could not write autonomous page to file %s with offset %lu: %m",
 							   btree_smgr_filename(desc, offset, chkpNum),
 							   (unsigned long) offset)));
 
@@ -1927,7 +1927,7 @@ perform_page_io_build(BTreeDescr *desc, Page img,
 	if (!write_page_to_disk(desc, extent, 0, write_img, write_size))
 	{
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not write autonomous page to file %s with offset %lu",
+						errmsg("could not write autonomous page to file %s with offset %lu: %m",
 							   btree_smgr_filename(desc, extent[0].off, chkpNum),
 							   (unsigned long) extent[0].off)));
 
@@ -2104,7 +2104,7 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 				page_desc->ionum = -1;
 				unlock_io(ionum);
 				ereport(ERROR, (errcode_for_file_access(),
-								errmsg("could not evict page %d to disk", blkno)));
+								errmsg("could not evict page %d to disk: %m", blkno)));
 			}
 			else if (!dirty_parent)
 			{
@@ -2154,7 +2154,7 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 				unlock_io(ionum);
 				unlock_page(parent_blkno);
 				ereport(ERROR, (errcode_for_file_access(),
-								errmsg("could not evict page %d to disk", blkno)));
+								errmsg("could not evict page %d to disk: %m", blkno)));
 			}
 			else
 			{
@@ -3149,7 +3149,7 @@ try_to_punch_holes(BTreeDescr *desc)
 		file = PathNameOpenFile(filename, O_RDONLY | PG_BINARY);
 		if (file < 0)
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not open file %s", filename)));
+							errmsg("could not open file %s: %m", filename)));
 		file_size = FileSize(file);
 
 		while (true)
@@ -3172,7 +3172,7 @@ try_to_punch_holes(BTreeDescr *desc)
 		}
 		if (file_size != len)
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not read data from checkpoint tmp file: %s %lu %lu",
+							errmsg("could not read data from checkpoint tmp file: %s %lu %lu: %m",
 								   filename, len, file_size)));
 
 		pfree(filename);

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -646,7 +646,7 @@ add_pending_truncate(ORelOids relOids, int numTrees, ORelOids *treeOids)
 											O_RDWR | O_CREAT | PG_BINARY);
 	if (pendingTruncatesFile < 0)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not open pending truncates file %s",
+						errmsg("could not open pending truncates file %s: %m",
 							   PENDING_TRUNCATES_FILENAME)));
 
 	offset = pending_truncates_meta->pendingTruncatesLocation;
@@ -655,7 +655,7 @@ add_pending_truncate(ORelOids relOids, int numTrees, ORelOids *treeOids)
 	if (FileWrite(pendingTruncatesFile, (Pointer) &relOids, length, offset,
 				  WAIT_EVENT_BUFFILE_WRITE) != length)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not write pending truncates file %s",
+						errmsg("could not write pending truncates file %s: %m",
 							   PENDING_TRUNCATES_FILENAME)));
 
 	offset += length;
@@ -664,7 +664,7 @@ add_pending_truncate(ORelOids relOids, int numTrees, ORelOids *treeOids)
 	if (FileWrite(pendingTruncatesFile, (Pointer) &numTrees, length, 0,
 				  WAIT_EVENT_BUFFILE_WRITE) != length)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not write pending truncates file %s",
+						errmsg("could not write pending truncates file %s: %m",
 							   PENDING_TRUNCATES_FILENAME)));
 
 	offset += length;
@@ -673,7 +673,7 @@ add_pending_truncate(ORelOids relOids, int numTrees, ORelOids *treeOids)
 	if (FileWrite(pendingTruncatesFile, (Pointer) &treeOids, length, 0,
 				  WAIT_EVENT_BUFFILE_WRITE) != length)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not write pending truncates file %s",
+						errmsg("could not write pending truncates file %s: %m",
 							   PENDING_TRUNCATES_FILENAME)));
 
 	offset += length;
@@ -715,7 +715,7 @@ check_pending_truncates(void)
 											O_RDONLY | PG_BINARY);
 	if (pendingTruncatesFile < 0)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not open pending truncates file %s",
+						errmsg("could not open pending truncates file %s: %m",
 							   PENDING_TRUNCATES_FILENAME)));
 
 	offset = 0;
@@ -728,7 +728,7 @@ check_pending_truncates(void)
 		if (FileRead(pendingTruncatesFile, (Pointer) &relOids, length, offset,
 					 WAIT_EVENT_BUFFILE_READ) != length)
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not read pending truncates file %s",
+							errmsg("could not read pending truncates file %s: %m",
 								   PENDING_TRUNCATES_FILENAME)));
 
 		offset += length;
@@ -737,7 +737,7 @@ check_pending_truncates(void)
 		if (FileRead(pendingTruncatesFile, (Pointer) &numTrees, length, offset,
 					 WAIT_EVENT_BUFFILE_READ) != length)
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not read pending truncates file %s",
+							errmsg("could not read pending truncates file %s: %m",
 								   PENDING_TRUNCATES_FILENAME)));
 
 		if (numTrees > relNodesAllocated)
@@ -755,7 +755,7 @@ check_pending_truncates(void)
 		if (FileRead(pendingTruncatesFile, (Pointer) relNodes, length, offset,
 					 WAIT_EVENT_BUFFILE_READ) != length)
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not read pending truncates file %s",
+							errmsg("could not read pending truncates file %s: %m",
 								   PENDING_TRUNCATES_FILENAME)));
 
 		for (i = 0; i < numTrees; i++)

--- a/src/catalog/free_extents.c
+++ b/src/catalog/free_extents.c
@@ -584,7 +584,7 @@ add_free_extents_from_tmp(BTreeDescr *desc, bool remove)
 		file = PathNameOpenFile(filename, O_RDONLY | PG_BINARY);
 		if (file < 0)
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not open file %s", filename)));
+							errmsg("could not open file %s: %m", filename)));
 		file_size = FileSize(file);
 
 		while (true)
@@ -616,7 +616,7 @@ add_free_extents_from_tmp(BTreeDescr *desc, bool remove)
 		}
 		if (file_size != len)
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not read data from checkpoint tmp file: %s %lu %lu",
+							errmsg("could not read data from checkpoint tmp file: %s %lu %lu: %m",
 								   filename, len, file_size)));
 
 		pfree(filename);

--- a/src/checkpoint/control.c
+++ b/src/checkpoint/control.c
@@ -48,7 +48,7 @@ get_checkpoint_control_data(CheckpointControl *control)
 			 sizeof(CheckpointControl)) != sizeof(CheckpointControl))
 		ereport(ERROR,
 				(errcode_for_file_access(),
-				 errmsg("could not read data from control file \"%s\"",
+				 errmsg("could not read data from control file \"%s\": %m",
 						CONTROL_FILENAME)));
 
 	close(controlFile);
@@ -111,13 +111,13 @@ write_checkpoint_control(CheckpointControl *control)
 	controlFile = PathNameOpenFile(CONTROL_FILENAME, O_RDWR | O_CREAT | PG_BINARY);
 	if (controlFile < 0)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not open checkpoint control file %s", CONTROL_FILENAME)));
+						errmsg("could not open checkpoint control file %s: %m", CONTROL_FILENAME)));
 
 	if (OFileWrite(controlFile, buffer, CHECKPOINT_CONTROL_FILE_SIZE, 0,
 				   WAIT_EVENT_SLRU_WRITE) != CHECKPOINT_CONTROL_FILE_SIZE ||
 		FileSync(controlFile, WAIT_EVENT_SLRU_SYNC) != 0)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not write checkpoint control to file %s", CONTROL_FILENAME)));
+						errmsg("could not write checkpoint control to file %s: %m", CONTROL_FILENAME)));
 
 	FileClose(controlFile);
 }

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -451,13 +451,13 @@ read_xids(int checkpointnum, bool recovery_single, int worker_id)
 	xidFile = PathNameOpenFile(xidFilename, O_RDONLY | PG_BINARY);
 	if (xidFile < 0)
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not open xid file %s", xidFilename)));
+						errmsg("could not open xid file %s: %m", xidFilename)));
 
 	if (OFileRead(xidFile, (Pointer) &count,
 				  sizeof(count), offset,
 				  WAIT_EVENT_SLRU_READ) != sizeof(count))
 		ereport(FATAL, (errcode_for_file_access(),
-						errmsg("could not read xid record from file %s", xidFilename)));
+						errmsg("could not read xid record from file %s: %m", xidFilename)));
 	offset += sizeof(count);
 
 	for (i = 0; i < count; i++)
@@ -470,7 +470,7 @@ read_xids(int checkpointnum, bool recovery_single, int worker_id)
 					  sizeof(xidRec), offset,
 					  WAIT_EVENT_SLRU_READ) != sizeof(xidRec))
 			ereport(FATAL, (errcode_for_file_access(),
-							errmsg("could not read xid record from file %s", xidFilename)));
+							errmsg("could not read xid record from file %s: %m", xidFilename)));
 
 		advance_oxids(xidRec.oxid);
 		state = (RecoveryXidState *) hash_search(recovery_xid_state_hash,
@@ -2185,7 +2185,7 @@ recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 	if (errno != 0)
 	{
 		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("unable to clean up temporary files")));
+						errmsg("unable to clean up temporary files: %m")));
 	}
 
 	closedir(dir);

--- a/src/s3/control.c
+++ b/src/s3/control.c
@@ -156,7 +156,7 @@ s3_put_lock_file(void)
 				 sizeof(lock_identifier)) != sizeof(lock_identifier))
 			ereport(FATAL,
 					(errcode_for_file_access(),
-					 errmsg("could not read data from lock file \"%s\"",
+					 errmsg("could not read data from lock file \"%s\": %m",
 							LOCK_FILENAME)));
 
 		close(lock_file);

--- a/src/s3/headers.c
+++ b/src/s3/headers.c
@@ -244,7 +244,7 @@ read_from_file(S3HeaderTag tag, uint32 values[S3_HEADER_NUM_VALUES],
 	if (fd <= 0)
 		ereport(FATAL,
 				(errcode_for_file_access(),
-				 errmsg("could not open data file %s", filename)));
+				 errmsg("could not open data file %s: %m", filename)));
 
 	pgstat_report_wait_start(WAIT_EVENT_DATA_FILE_READ);
 	rc = pg_pread(fd, (char *) values, headerSize, 0);
@@ -269,7 +269,7 @@ read_from_file(S3HeaderTag tag, uint32 values[S3_HEADER_NUM_VALUES],
 	else if (rc != headerSize)
 		ereport(FATAL,
 				(errcode_for_file_access(),
-				 errmsg("could not read header from data file %s", filename)));
+				 errmsg("could not read header from data file %s: %m", filename)));
 
 	close(fd);
 }
@@ -289,7 +289,7 @@ write_to_file(S3HeaderTag tag, uint32 values[S3_HEADER_NUM_VALUES])
 	if (fd <= 0)
 		ereport(FATAL,
 				(errcode_for_file_access(),
-				 errmsg("could not open data file %s", filename)));
+				 errmsg("could not open data file %s: %m", filename)));
 
 	pgstat_report_wait_start(WAIT_EVENT_DATA_FILE_WRITE);
 	if (pg_pwrite(fd, (char *) values, headerSize, 0) != headerSize)
@@ -1032,7 +1032,7 @@ iterate_files(IterateFilesCallback callback)
 	dir = opendir(ORIOLEDB_DATA_DIR);
 	if (dir == NULL)
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not open the orioledb data directory")));
+						errmsg("could not open the orioledb data directory: %m")));
 
 	while (errno = 0, (file = readdir(dir)) != NULL)
 	{
@@ -1106,7 +1106,7 @@ initial_parts_counting_callback(S3HeaderTag tag)
 	if (fd <= 0)
 		ereport(FATAL,
 				(errcode_for_file_access(),
-				 errmsg("could not open data file %s", filename)));
+				 errmsg("could not open data file %s: %m", filename)));
 	pfree(filename);
 
 	fileSize = lseek(fd, 0, SEEK_END);

--- a/src/utils/o_buffers.c
+++ b/src/utils/o_buffers.c
@@ -119,7 +119,7 @@ open_file(OBuffersDesc *desc, uint64 fileNum)
 	desc->curFileNum = fileNum;
 	if (desc->curFile < 0)
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not open undo log file %s", desc->curFileName)));
+						errmsg("could not open undo log file %s: %m", desc->curFileName)));
 }
 
 static void
@@ -146,7 +146,7 @@ write_buffer_data(OBuffersDesc *desc, char *data, uint64 blockNum)
 						WAIT_EVENT_SLRU_WRITE);
 	if (result != ORIOLEDB_BLCKSZ)
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not write buffer to file %s", desc->curFileName)));
+						errmsg("could not write buffer to file %s: %m", desc->curFileName)));
 }
 
 static void
@@ -168,7 +168,7 @@ read_buffer(OBuffersDesc *desc, OBuffer *buffer)
 	/* we may not read all the bytes due to read past EOF */
 	if (result < 0)
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not read buffer from file %s", desc->curFileName)));
+						errmsg("could not read buffer from file %s: %m", desc->curFileName)));
 
 	if (result < ORIOLEDB_BLCKSZ)
 		memset(&buffer->data[result], 0, ORIOLEDB_BLCKSZ - result);

--- a/src/utils/seq_buf.c
+++ b/src/utils/seq_buf.c
@@ -205,7 +205,7 @@ seq_buf_check_open_file(SeqBufDescPrivate *seqBufPrivate)
 		{
 			SpinLockRelease(&shared->lock);
 			ereport(PANIC, (errcode_for_file_access(),
-							errmsg("could not open seq buf file %s for %s",
+							errmsg("could not open seq buf file %s for %s: %m",
 								   get_seq_buf_filename(&shared->tag),
 								   (seqBufPrivate->write ? "write" : "read"))));
 			seqBufPrivate->tag = old_tag;
@@ -261,7 +261,7 @@ seq_buf_finish_prev_page(SeqBufDescPrivate *seqBufPrivate)
 		{
 			SpinLockRelease(&shared->lock);
 			ereport(PANIC, (errcode_for_file_access(),
-							errmsg("Error write seq buf %s at offset %u",
+							errmsg("Error write seq buf %s at offset %u: %m",
 								   FilePathName(seqBufPrivate->file),
 								   (uint32) offset)));
 			return false;
@@ -287,7 +287,7 @@ seq_buf_finish_prev_page(SeqBufDescPrivate *seqBufPrivate)
 			{
 				SpinLockRelease(&shared->lock);
 				ereport(PANIC, (errcode_for_file_access(),
-								errmsg("Error read seq buf %s at offset %u",
+								errmsg("Error read seq buf %s at offset %u: %m",
 									   FilePathName(seqBufPrivate->file),
 									   (uint32) offset)));
 				return false;
@@ -484,7 +484,7 @@ seq_buf_finalize(SeqBufDescPrivate *seqBufPrivate)
 		{
 			SpinLockRelease(&shared->lock);
 			ereport(PANIC, (errcode_for_file_access(),
-							errmsg("could not finalize previous sequence buffer page to file %s",
+							errmsg("could not finalize previous sequence buffer page to file %s: %m",
 								   get_seq_buf_filename(&seqBufPrivate->tag))));
 		}
 		shared->prevPageState = SeqBufPrevPageDone;
@@ -496,7 +496,7 @@ seq_buf_finalize(SeqBufDescPrivate *seqBufPrivate)
 		{
 			SpinLockRelease(&shared->lock);
 			ereport(PANIC, (errcode_for_file_access(),
-							errmsg("could not open sequence buffer file %s",
+							errmsg("could not open sequence buffer file %s: %m",
 								   get_seq_buf_filename(&seqBufPrivate->tag))));
 		}
 
@@ -509,7 +509,7 @@ seq_buf_finalize(SeqBufDescPrivate *seqBufPrivate)
 			{
 				SpinLockRelease(&shared->lock);
 				ereport(PANIC, (errcode_for_file_access(),
-								errmsg("could not finalize sequence buffer into file %s",
+								errmsg("could not finalize sequence buffer into file %s: %m",
 									   FilePathName(seqBufPrivate->file))));
 			}
 		}
@@ -590,7 +590,7 @@ seq_buf_try_replace(SeqBufDescPrivate *seqBufPrivate, SeqBufTag *tag,
 			shared->tag = old_tag;
 			SpinLockRelease(&shared->lock);
 			ereport(PANIC, (errcode_for_file_access(),
-							errmsg("could not seek to the end of file %s",
+							errmsg("could not seek to the end of file %s: %m",
 								   FilePathName(seqBufPrivate->file))));
 			return SeqBufReplaceError;
 		}
@@ -634,7 +634,7 @@ seq_buf_read_pages(SeqBufDescPrivate *seqBufPrivate, SeqBufDescShared *shared,
 	{
 		SpinLockRelease(&shared->lock);
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("length %d of file %s is less than header %d",
+						errmsg("length %d of file %s is less than header %d: %m",
 							   len, FilePathName(seqBufPrivate->file), header_off)));
 		return false;
 	}
@@ -659,7 +659,7 @@ seq_buf_read_pages(SeqBufDescPrivate *seqBufPrivate, SeqBufDescShared *shared,
 	{
 		SpinLockRelease(&shared->lock);
 		ereport(PANIC, (errcode_for_file_access(),
-						errmsg("could not to read first page from file %s, read = %d, expected = %d",
+						errmsg("could not to read first page from file %s, read = %d, expected = %d: %m",
 							   FilePathName(seqBufPrivate->file), nbytes, should_read)));
 		return false;
 	}
@@ -676,7 +676,7 @@ seq_buf_read_pages(SeqBufDescPrivate *seqBufPrivate, SeqBufDescShared *shared,
 		{
 			SpinLockRelease(&shared->lock);
 			ereport(PANIC, (errcode_for_file_access(),
-							errmsg("could not to read second page from file %s, read = %d, expected = %d",
+							errmsg("could not to read second page from file %s, read = %d, expected = %d: %m",
 								   FilePathName(seqBufPrivate->file), nbytes, should_read)));
 			return false;
 		}


### PR DESCRIPTION
Few `errmsg()` miss `%m` in the format string. This commit adds it.