### PR TITLE
Update contributing docs and add markdown-bash-check CI workflow

### DIFF
--- a/.github/workflows/markdown-bash-check.yml
+++ b/.github/workflows/markdown-bash-check.yml
@@ -1,0 +1,72 @@
+name: markdown-bash-check
+
+# This workflow checks markdown documentation for embedded bash scripts
+# by extracting and executing them in a controlled environment.
+#
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types: [published]
+  schedule:
+    # Runs every Monday at 6:00 AM UTC.
+    # Running the check weekly helps detect changes in external dependencies
+    # (such as Docker, PostGIS-Docker, Python, and Ubuntu) early,
+    # before they affect users.
+    - cron: '0 6 * * 1'
+  pull_request:
+    paths:
+      - 'docker/**'
+      - 'doc/contributing/docker-builds.mdx'
+      - 'doc/contributing/local-builds.mdx'
+      - '.github/workflows/markdown-bash-check.yml'
+      - '.pgtags'
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  check-markdown-bash:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 'local-builds.mdx'
+            type: 'local'
+            markdown_file: './doc/contributing/local-builds.mdx'
+            docker_image: 'orioledb.test.local-builds'
+            dockerfile: './docker/Dockerfile.test.local-builds'
+            output_script: '_local-builds.sh'
+          - name: 'docker-builds.mdx'
+            type: 'docker'
+            markdown_file: './doc/contributing/docker-builds.mdx'
+
+    name: "${{ matrix.name }} check"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check markdown file
+        run: ./ci/markdown-bash-checker.sh --dry-run ${{ matrix.markdown_file }}
+
+      - name: Run markdown bash check for local builds
+        if: ${{ matrix.type == 'local' }}
+        # if ./doc/contributing/local-builds.mdx
+        run: |
+          echo "Building a minimal Ubuntu Docker image for local builds with default 'yes' settings..."
+          docker build --pull -t ${{ matrix.docker_image }} -f ${{ matrix.dockerfile }} .
+
+          echo "Extracting and generating an output script from the markdown file: ${{ matrix.markdown_file }}..."
+          ./ci/markdown-bash-checker.sh --output ${{ matrix.output_script }} ${{ matrix.markdown_file }}
+
+          echo "Executing the generated script inside the Ubuntu Docker container to emulate a user's environment..."
+          docker run \
+            -v "$(pwd)/${{ matrix.output_script }}:/home/orioleuser/${{ matrix.output_script }}" \
+            ${{ matrix.docker_image }} \
+            /bin/bash -c "bash /home/orioleuser/${{ matrix.output_script }}"
+
+      - name: Run markdown bash check for docker builds
+        if: ${{ matrix.type == 'docker' }}
+        # if ./doc/contributing/docker-builds.mdx
+        run: ./ci/markdown-bash-checker.sh --run ${{ matrix.markdown_file }}

--- a/ci/markdown-bash-checker.sh
+++ b/ci/markdown-bash-checker.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Show help message
+function show_help() {
+    cat << EOF
+Usage: $(basename "$0") [options] <markdown-file>
+Extract and optionally run bash code blocks from a markdown file.
+
+Options:
+  -h, --help          Show this help message
+  -o, --output FILE   Specify the output file (default: auto-generated temporary file)
+  -r, --run          Run the extracted bash code blocks
+  --dry-run          Extract and show the blocks without executing them
+  --check-syntax     Only check the bash syntax without running
+
+Example:
+  $(basename "$0") myfile.md             # Extract only
+  $(basename "$0") -r myfile.md          # Extract and run
+  $(basename "$0") --check-syntax myfile.md  # Check syntax only
+EOF
+}
+
+# Function to check bash syntax
+check_syntax() {
+    local file="$1"
+    if ! bash -n "$file"; then
+        echo "Error: Syntax check failed for '$file'" >&2
+        return 1
+    fi
+    echo "Syntax check passed for '$file'"
+    return 0
+}
+
+# Parse command line arguments
+if [[ $# -eq 0 ]]; then
+    show_help
+    exit 1
+fi
+
+MARKDOWN_FILE=""
+OUTPUT_FILE=""
+RUN_BLOCKS=0
+DRY_RUN=0
+CHECK_SYNTAX=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -o|--output)
+            shift
+            if [[ $# -eq 0 ]]; then
+                echo "Error: Missing argument for output file" >&2
+                exit 1
+            fi
+            OUTPUT_FILE="$1"
+            shift
+            ;;
+        -r|--run)
+            RUN_BLOCKS=1
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --check-syntax)
+            CHECK_SYNTAX=1
+            shift
+            ;;
+        *)
+            MARKDOWN_FILE="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$MARKDOWN_FILE" ]]; then
+    echo "Error: Markdown file not specified." >&2
+    show_help
+    exit 1
+fi
+
+if [[ ! -f "$MARKDOWN_FILE" ]]; then
+    echo "Error: File '$MARKDOWN_FILE' not found." >&2
+    exit 1
+fi
+
+# If no output file is specified, use a temporary file
+if [[ -z "$OUTPUT_FILE" ]]; then
+    OUTPUT_FILE=$(mktemp --tmpdir _tempXXXX.sh)
+fi
+
+# Initialize the output file with the shebang and strict mode
+{
+    echo "#!/usr/bin/env bash"
+    echo "set -euxo pipefail"
+} > "$OUTPUT_FILE"
+
+BLOCK_COUNT=0
+in_bash_block=0
+
+# Process the markdown file line by line
+while IFS= read -r line; do
+    # Strip leading/trailing whitespace
+    trimmed_line=$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    
+    # Detect start of a bash code block
+    if [ "$trimmed_line" = '```bash' ]; then
+        in_bash_block=1
+        BLOCK_COUNT=$((BLOCK_COUNT + 1))
+        echo -e "\n# Block $BLOCK_COUNT" >> "$OUTPUT_FILE"
+        continue
+    fi
+    
+    # Detect end of code block
+    if [ "$trimmed_line" = '```' ] && [ $in_bash_block -eq 1 ]; then
+        in_bash_block=0
+        continue
+    fi
+    
+    # If inside a bash block, write the line to the output file
+    if [ $in_bash_block -eq 1 ]; then
+        echo "$line" >> "$OUTPUT_FILE"
+    fi
+done < "$MARKDOWN_FILE"
+
+# Make the output file executable
+chmod +x "$OUTPUT_FILE"
+
+# Provide feedback on the result
+if [[ $BLOCK_COUNT -eq 0 ]]; then
+    echo "Warning: No bash code blocks found in '$MARKDOWN_FILE'."
+    exit 0
+fi
+
+echo "Found $BLOCK_COUNT bash code block(s), output written to '$OUTPUT_FILE'."
+
+# Handle different execution modes
+if [[ $CHECK_SYNTAX -eq 1 ]]; then
+    check_syntax "$OUTPUT_FILE"
+    exit $?
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "Dry run - contents of extracted script:"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+if [[ $RUN_BLOCKS -eq 1 ]]; then
+    echo "Executing extracted bash blocks..."
+    if ! "$OUTPUT_FILE"; then
+        echo "Error: Execution failed" >&2
+        exit 1
+    fi
+    echo "Execution completed successfully"
+fi

--- a/doc/contributing/docker-builds.mdx
+++ b/doc/contributing/docker-builds.mdx
@@ -3,6 +3,13 @@ id: docker-builds
 sidebar_label: Docker Builds
 ---
 
+<!-- 
+WARNING: Code blocks marked with the ```bash language are automatically tested by GitHub CI 
+(as defined in .github/workflows/markdown-bash-check.yml). 
+If you want to display command examples that should not be tested, 
+please use the ```sh language marker instead.
+-->
+
 # Building Docker images
 
 This document provides instructions on how to build Docker images for OrioleDB, and how to test them.
@@ -21,15 +28,44 @@ Open a terminal and navigate to the OrioleDB project directory, if you are not a
 
 Build (Alpine) PostgreSQL 17 + OrioleDB extension:
 
-- `docker build -t orioletest:17 -f docker/Dockerfile --pull --network=host --progress=plain --build-arg PG_MAJOR="17" .`
+```bash
+docker build -t orioletest:17 -f docker/Dockerfile --pull --network=host --progress=plain --build-arg PG_MAJOR="17" .
+```
 
 Start server:
 
-- `docker run --name orioletest17 -v orioletest17data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=oriole123 -d orioletest:17`
+```bash
+docker run --name orioletest17 -v orioletest17data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=oriole123 -d orioletest:17
+```
+
+Enable orioledb extension via psql:
+
+```bash
+# Wait for the server to start
+docker exec orioletest17 bash -c "while ! pg_isready --host 127.0.0.1; do sleep 1; done ;"
+
+# Enable orioledb extension
+docker exec orioletest17 psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS orioledb;" -c "\dx"
+
+```
+
+You should expect a similar psql message:
+
+```sql
+CREATE EXTENSION
+                              List of installed extensions
+   Name   | Version |   Schema   |                     Description
+----------+---------+------------+------------------------------------------------------
+ orioledb | 1.3     | public     | OrioleDB -- the next generation transactional engine
+ plpgsql  | 1.0     | pg_catalog | PL/pgSQL procedural language
+(2 rows)
+```
 
 Connect to the server via psql:
 
-- `docker exec -ti orioletest17 psql -U postgres`
+```sh
+docker exec -ti orioletest17 psql -U postgres
+```
 
 You should expect a similar psql message:
 
@@ -39,13 +75,9 @@ Type "help" for help.
 postgres=#
 ```
 
-Enable orioledb extension:
-
-- `create extension if not exists orioledb;`
-
 Test some commands:
 
-```
+```sql
 postgres=# select orioledb_version();
     orioledb_version
 ------------------------
@@ -84,14 +116,6 @@ postgres=# \d+
  public | orioledb_table       | view  | postgres | permanent   |               | 0 bytes    |
  public | orioledb_table_descr | view  | postgres | permanent   |               | 0 bytes    |
 (5 rows)
-
-postgres=# \dx
-                              List of installed extensions
-   Name   | Version |   Schema   |                     Description
-----------+---------+------------+------------------------------------------------------
- orioledb | 1.2     | public     | OrioleDB -- the next generation transactional engine
- plpgsql  | 1.0     | pg_catalog | PL/pgSQL procedural language
-(2 rows)
 
 postgres=# \dx+ orioledb
                      Objects in extension "orioledb"
@@ -153,21 +177,22 @@ postgres=# \dx+ orioledb
 
 Quit from the database: `\q`
 
-Stop the server:
 
-- `docker stop orioletest17`
+Stop the server and clean up:
 
-Remove container:
+```bash
+# Stop the server
+docker stop orioletest17
 
-- `docker container rm orioletest17`
+# Remove container:
+docker container rm orioletest17
 
-Remove docker image:
+# Remove docker image:
+docker rmi orioletest:17
 
-- `docker rmi orioletest:17`
-
-Remove the data volume:
-
-- `docker volume rm orioletest17data`
+# Remove the data volume:
+docker volume rm orioletest17data
+```
 
 ## Building Docker Images
 
@@ -175,13 +200,13 @@ To build a Docker image, use one of the following commands:
 
 #### To build PostgreSQL 17 + OrieleDB extension
 
-```
+```bash
 docker build -t orioletest:17 -f docker/Dockerfile --pull --network=host --progress=plain --build-arg PG_MAJOR="17" .
 ```
 
 #### To build PostgreSQL 16 + OrieleDB extension
 
-```
+```bash
 docker build -t orioletest:16 -f docker/Dockerfile --pull --network=host --progress=plain --build-arg PG_MAJOR="16" .
 ```
 
@@ -228,17 +253,16 @@ docker build --pull --network=host --progress=plain \
     -t orioletest:16-gcc-alpine3.20 .
 ```
 
-To build an image using Ubuntu version `devel`, the `clang` compiler and PostgreSQL version `17`, use the following command:
+To build an image using Ubuntu version `24.10`, the `clang` compiler and PostgreSQL version `17`, use the following command:
 
 ```bash
 docker build --pull --network=host --progress=plain \
-    --build-arg UBUNTU_VERSION="devel" \
+    --build-arg UBUNTU_VERSION="24.10" \
     --build-arg BUILD_CC_COMPILER="clang" \
     --build-arg PG_MAJOR="17" \
     -f docker/Dockerfile.ubuntu \
-    -t orioletest:17-clang-ubuntu-devel .
+    -t orioletest:17-clang-ubuntu-24.10 .
 ```
-The "devel" version is the latest development Ubuntu version, so it might not be stable.
 
 ## Experimental OrioleDB + PostGIS Extension build
 
@@ -261,6 +285,7 @@ docker build --pull --network=host --progress=plain \
 in a new directory, run this commands:
 
 ```bash
+rm -rf docker-postgis 2>/dev/null || true
 git clone --depth=1 https://github.com/postgis/docker-postgis.git
 cd ./docker-postgis/17-3.5/alpine
 docker build --network=host --progress=plain \
@@ -289,19 +314,19 @@ To build all Docker image variations on a local machine, run the following comma
 #### macOS
 On macOS you might need to install `bash` and `gnu-getopt` from Homebrew. To install them run the command:
 
-```bash
+```sh
 brew install bash gnu-getopt
 ```
 
 Update your `/etc/shells`:
 
-```bash
+```sh
 echo /opt/homebrew/bin/bash >> /etc/shells
 ```
 
 You may need to update your `PATH` variable in the `.bashrc` or `.zshrc` file:
 
-```
+```sh
 PATH=/opt/homebrew/bin:/opt/homebrew/opt/gnu-getopt/bin:$PATH
 ```
 

--- a/doc/contributing/local-builds.mdx
+++ b/doc/contributing/local-builds.mdx
@@ -3,17 +3,56 @@ id: local-builds
 sidebar_label: Building from source
 ---
 
+<!--
+WARNING:
+Code blocks marked with the ```bash language are automatically tested by GitHub CI
+(as defined in .github/workflows/markdown-bash-check.yml).
+If you want to display command examples that should not be tested,
+please use the ```sh language marker instead.
+
+NOTE:
+In this markdown file, use the `bash` marker exclusively
+for Linux-related examples. ( Run in docker/Dockerfile.test.local-builds )
+For Windows and macOS examples, use the `sh` marker, as these sections are not currently tested.
+-->
+
 # OrioleDB development quickstart
 
 This guide will help you to build and run OrioleDB on your local machine from the source code.
 
 ## Linux
 
+**Prerequisites Checklist**
+
+Please ensure all requirements are met before proceeding:
+
+**Directory Creation**
+- The following directories, files will be created in your home folder (`$HOME`):
+  - `orioledb/` - Main OrioleDB source code repository (~200MB)
+  - `pg17/` - PostgreSQL 17 installation directory (~200MB)
+  - `pgdata/` - PostgreSQL data directory (~100MB initial size)
+  - `postgres-patches17/` - PostgreSQL 17 source with OrioleDB patches (~800MB)
+  - `log` - PostgreSQL log file
+
+**System Requirements**
+- None of the above directory names are currently in use
+- At least 2GB of free disk space in your home directory
+- 1-2 GB of additional disk space will be for the extra packages needed for building PostgreSQL
+- Sufficient memory (minimum 4GB RAM recommended)
+- 64bit Linux
+
+**User Requirements**
+- You are logged in as a non-root user
+- Your user has sudo privileges
+- Your user has write permissions in the home directory
+
+**Note**: Running this tutorial as root is not recommended and may cause security and permission issues.
+
 ### Install prerequisites
 
 ```bash
 sudo apt-get update
-sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind
+sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind libssl-dev libcurl4-openssl-dev wget
 ```
 
 ### Download and install PostgreSQL 17 with patches
@@ -44,14 +83,25 @@ PG_PREFIX=$HOME/pg17
 ./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix=$PG_PREFIX
 make -j$(nproc)
 make -j$(nproc) install
+cd contrib
+make -j$(nproc)
+make -j$(nproc) install
+cd ..
 echo "export PATH=\"$PG_PREFIX/bin:\$PATH\"" >> ~/.bashrc
 source ~/.bashrc
+# Fallback: Manually update PATH in case sourcing ~/.bashrc doesn't work as expected
+export PATH="$PG_PREFIX/bin:$PATH"
 ```
 
 ### Install python requirements
 
+Before proceeding, it is recommended to create a dedicated Python 3 virtual environment.
+This helps avoid conflicts with system packages and ensures a clean installation of the required modules.
+You can use tools like **conda**, **virtualenv**, or any other Python package manager you prefer.
+Please note that the steps for setting up a virtual environment are not covered in this tutorial.
+
 ```bash
-pip3 install psycopg2 six testgres
+pip3 install psycopg2 six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
 sudo pip3 install compiledb
 ```
 
@@ -61,13 +111,18 @@ sudo pip3 install compiledb
 cd ..
 git clone https://github.com/orioledb/orioledb.git
 cd orioledb
+# Check the required PostgreSQL patch version
+cat .pgtags
+# Verify the patch version in the .pgtags file.
+# If the patch version differs, go back to the previous steps and update the PostgreSQL patch version!
+grep -qFx '17: patches17_5' .pgtags || { echo "The .pgtags patch version is different; please update the tutorial accordingly!"; 1=2; }
 # Build with compiledb, because it creates compile_commands.json needed for VSCode C/C++ extension
 compiledb make USE_PGXS=1 IS_DEV=1
 # Exclude compile_commands.json from the Git tracking
 echo "compile_commands.json" >> .git/info/exclude
 ```
 
-### Download and install Visual Studio Code
+### Download and install Visual Studio Code ( optional )
 
 ```bash
 cd ..
@@ -91,12 +146,14 @@ make USE_PGXS=1 IS_DEV=1 installcheck
 #### Manual installation and running
 
 ```bash
+cd ..
 cd orioledb
 make USE_PGXS=1 IS_DEV=1 install
 initdb --no-locale -D $HOME/pgdata
 sed -i 's/#shared_preload_libraries = '\'''\''/shared_preload_libraries = '\''orioledb'\''/' $HOME/pgdata/postgresql.conf
 pg_ctl -D $HOME/pgdata/ start -l $HOME/log
 psql -c "CREATE EXTENSION IF NOT EXISTS orioledb; SELECT orioledb_commit_hash();" -d postgres
+psql -c "\dx" -d postgres
 ```
 
 # MacOS
@@ -107,13 +164,13 @@ Follow [the instruction to disable System Integrity Protection](http://osxdaily.
 
 ### Install Homebrew
 
-```
+```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 ### Install prerequisites
 
-```bash
+```sh
 brew install python zstd pkg-config icu4c openssl wget gnu-sed
 sudo cpan IPC::Run
 echo "export PKG_CONFIG_PATH=\"\$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig\"" >> ~/.zshrc
@@ -125,7 +182,7 @@ exec zsh -l
 
 ### Download and install PostgreSQL 17 with patches
 
-```bash
+```sh
 git clone https://github.com/orioledb/postgres.git --branch patches17 --single-branch postgres-patches17
 cd postgres-patches17/
 ```
@@ -134,34 +191,40 @@ cd postgres-patches17/
 
 Check required postgres patch version in [.pgtags](https://github.com/orioledb/orioledb/blob/main/.pgtags) or [README.md](https://github.com/orioledb/orioledb?tab=readme-ov-file#build-from-source) files. Because documentation can become outdated.
 
-```bash
+```sh
 git checkout patches17_5
 ```
 
 ### Configure and build
 
-```bash
+```sh
 PG_PREFIX=$HOME/pg17
 ./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix=$PG_PREFIX
 make -j$(nproc)
 make -j$(nproc) install
+cd contrib
+make -j$(nproc)
+make -j$(nproc) install
+cd ..
 echo "export PATH=\"$PG_PREFIX/bin:\$PATH\"" >> ~/.zshrc
 exec zsh -l
 ```
 
 ### Install python requirements
 
-```bash
-pip3 install psycopg2 six testgres
+```sh
+pip3 install psycopg2 six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
 sudo pip3 install compiledb
 ```
 
 ### Download and build the OrioleDB extension
 
-```bash
+```sh
 cd ..
 git clone https://github.com/orioledb/orioledb.git
 cd orioledb
+# Check the required PostgreSQL patch version
+cat .pgtags
 # Build with compiledb, because it creates compile_commands.json needed for VSCode C/C++ extension
 compiledb make USE_PGXS=1 IS_DEV=1
 # Exclude compile_commands.json from the Git tracking
@@ -170,7 +233,7 @@ echo "compile_commands.json" >> .git/info/exclude
 
 ### Download and install Visual Studio Code
 
-```bash
+```sh
 cd ..
 brew install --cask visual-studio-code
 exec zsh -l
@@ -184,14 +247,14 @@ code orioledb
 
 #### Run automated tests
 
-```bash
+```sh
 cd orioledb
 make USE_PGXS=1 IS_DEV=1 installcheck
 ```
 
 #### Manual installation and running
 
-```bash
+```sh
 cd orioledb
 make USE_PGXS=1 IS_DEV=1 install
 initdb --no-locale -D $HOME/pgdata
@@ -218,15 +281,15 @@ Start Ubuntu from start menu again.
 
 ### Install prerequisites
 
-```bash
+```sh
 sudo hwclock --hctosys
 sudo apt-get update
-sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind
+sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind libssl-dev libcurl4-openssl-dev wget
 ```
 
 ### Download and install PostgreSQL 17 with patches
 
-```bash
+```sh
 git clone https://github.com/orioledb/postgres.git --branch patches17 --single-branch postgres-patches17
 cd postgres-patches17/
 ```
@@ -235,40 +298,46 @@ cd postgres-patches17/
 
 Check required postgres patch version in [.pgtags](https://github.com/orioledb/orioledb/blob/main/.pgtags) or [README.md](https://github.com/orioledb/orioledb?tab=readme-ov-file#build-from-source) files. Because documentation can become outdated.
 
-```bash
+```sh
 git checkout patches17_5
 ```
 
 ### Enable Valgrind support in PostgreSQL code (optional)
 
-```bash
+```sh
 sed -i.bak "s/\/\* #define USE_VALGRIND \*\//#define USE_VALGRIND/g" src/include/pg_config_manual.h
 ```
 
 ### Configure and build
 
-```bash
+```sh
 PG_PREFIX=$HOME/pg17
 ./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix=$PG_PREFIX
 make -j$(nproc)
 make -j$(nproc) install
+cd contrib
+make -j$(nproc)
+make -j$(nproc) install
+cd ..
 echo "export PATH=\"$PG_PREFIX/bin:\$PATH\"" >> ~/.bashrc
 source ~/.bashrc
 ```
 
 ### Install python requirements
 
-```bash
-pip3 install psycopg2 six testgres
+```sh
+pip3 install psycopg2 six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
 sudo pip3 install compiledb
 ```
 
 ### Download and build the OrioleDB extension
 
-```bash
+```sh
 cd ..
 git clone https://github.com/orioledb/orioledb.git
 cd orioledb
+# Check the required PostgreSQL patch version
+cat .pgtags
 # Build with compiledb, because it creates compile_commands.json needed for VSCode C/C++ extension
 compiledb make USE_PGXS=1 IS_DEV=1
 # Exclude compile_commands.json from the Git tracking
@@ -288,7 +357,7 @@ code --remote wsl+ubuntu /home/USERNAME/orioledb
 
 In VSCode terminal:
 
-```bash
+```sh
 code --install-extension ms-python.python
 code --install-extension ms-vscode.cpptools
 ```
@@ -297,13 +366,13 @@ code --install-extension ms-vscode.cpptools
 
 #### Run automated tests
 
-```bash
+```sh
 make USE_PGXS=1 IS_DEV=1 installcheck
 ```
 
 #### Manual installation and running
 
-```bash
+```sh
 make USE_PGXS=1 IS_DEV=1 install
 initdb --no-locale -D $HOME/pgdata
 sed -i 's/#shared_preload_libraries = '\'''\''/shared_preload_libraries = '\''orioledb'\''/' $HOME/pgdata/postgresql.conf

--- a/docker/Dockerfile.test.local-builds
+++ b/docker/Dockerfile.test.local-builds
@@ -1,0 +1,49 @@
+FROM ubuntu:24.04
+
+# ----------------------------
+# Dockerfile.test.local-builds
+#
+# This Dockerfile builds a minimal Ubuntu image configured for local builds.
+# It sets a non-interactive environment with default "yes" settings for package
+# installations, applies system defaults for secure and unattended operations,
+# and creates a non-root user with sudo privileges.
+#
+# This image is essential for running bash scripts extracted from markdown
+# files in a controlled, reproducible environment before the scripts are used
+# by end users.
+#
+# Build command (from the root of the repository):
+#   docker build --pull -t orioledb.test.local-builds -f ./docker/Dockerfile.test.local-builds .
+#
+# Run command (from the root of the repository):
+#   ./ci/markdown-bash-checker.sh  --output _local-builds.sh ./doc/contributing/local-builds.mdx
+#   docker run -it -v $(pwd)/_local-builds.sh:/home/orioleuser/_local-builds.sh orioledb.test.local-builds /bin/bash -c "bash /home/orioleuser/_local-builds.sh"
+#
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV TZ=Etc/UTC
+
+# Install minimal system packages - expected in a user environment
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      sudo \
+      tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# System-wide configurations - for defaults and security
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90assumeyes && \
+    echo 'Dpkg::Options::="--force-confdef";' >> /etc/apt/apt.conf.d/90assumeyes && \
+    echo 'Dpkg::Options::="--force-confold";' >> /etc/apt/apt.conf.d/90assumeyes && \
+    echo 'Defaults env_keep += "PIP_BREAK_SYSTEM_PACKAGES"' >> /etc/sudoers && \
+    echo 'Defaults env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers
+
+# Create orioleuser, add to sudo group, and set up home directory
+RUN useradd -m -s /bin/bash orioleuser && \
+    usermod -aG sudo orioleuser && \
+    echo "orioleuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Set the default user
+USER orioleuser
+
+# Set working directory to orioleuser's home
+WORKDIR /home/orioleuser


### PR DESCRIPTION
This PR is the first part of my major Docker refactoring proposal  https://github.com/orioledb/orioledb/pull/381 . 
I hope breaking it down like this makes it easier to understand. 

-----------

This commit introduces a new GitHub CI workflow 
named "markdown-bash-check" that extracts and executes embedded bash scripts
in markdown documentation within a controlled environment.

The documentation has been updated, expanded, and refined to improve testability.

Files now being checked:
- `doc/contributing/docker-builds.mdx`
  - changes:  
      - UBUNTU_VERSION="devel"  example has some problem ;  now: 24.10 used 
      - added some extra steps ( ~  waiting for server )  - without this the checking is not working.
- `doc/contributing/local-builds.mdx` 
  - changes: 
     - added:  an extra warning for the $HOME directory,  disk space, ...
     - added:  3 new packages `libssl-dev libcurl4-openssl-dev wget`   ( now the build is working ) 
     - added:  the postgresql contrib build   ( for the test ) 
     - added:  other python packages   ( for the test ) 
     - added some `.pgtags` info and checks.
   - **IMPORTANT: The Windows and MacOS part need re-check !** 
  
Currently, markdown code blocks marked with \`\`\`bash are automatically tested by GitHub CI 
(as defined in `.github/workflows/markdown-bash-check.yml` ). 
If you want to include command examples that should not be tested, please use the \`\`\`sh language marker instead.

I added a large HTML comment to the .mdx files; 
however, I couldn’t test if it might cause any issues on the website. 
I hope it won't, but please keep an eye on it.

Context – The Rationale:
* I plan to introduce a few breaking changes to the Dockerfiles in the future. This automated check ensures that the necessary updates to the documentation are not overlooked.
* Additionally, the documentation must work flawlessly, as it creates the first impression for new contributors.


---------------------

# docker-builds.mdx 

now the test output of
* `./ci/markdown-bash-checker.sh --dry-run  ./doc/contributing/docker-builds.mdx`

```
$ ./ci/markdown-bash-checker.sh --dry-run  ./doc/contributing/docker-builds.mdx
Found 10 bash code block(s), output written to '/tmp/_tempba1J.sh'.
Dry run - contents of extracted script:
#!/usr/bin/env bash
set -euxo pipefail

# Block 1
docker build -t orioletest:17 -f docker/Dockerfile --pull --network=host --progress=plain --build-arg PG_MAJOR="17" .

# Block 2
docker run --name orioletest17 -v orioletest17data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=oriole123 -d orioletest:17

# Block 3
# Wait for the server to start
docker exec orioletest17 bash -c "while ! pg_isready --host 127.0.0.1; do sleep 1; done ;"

# Enable orioledb extension
docker exec orioletest17 psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS orioledb;" -c "\dx"


# Block 4
# Stop the server
docker stop orioletest17

# Remove container:
docker container rm orioletest17

# Remove docker image:
docker rmi orioletest:17

# Remove the data volume:
docker volume rm orioletest17data

# Block 5
docker build -t orioletest:17 -f docker/Dockerfile --pull --network=host --progress=plain --build-arg PG_MAJOR="17" .

# Block 6
docker build -t orioletest:16 -f docker/Dockerfile --pull --network=host --progress=plain --build-arg PG_MAJOR="16" .

# Block 7
docker build --pull --network=host --progress=plain \
    --build-arg ALPINE_VERSION="3.20" \
    --build-arg BUILD_CC_COMPILER="gcc" \
    --build-arg PG_MAJOR="16" \
    -f docker/Dockerfile \
    -t orioletest:16-gcc-alpine3.20 .

# Block 8
docker build --pull --network=host --progress=plain \
    --build-arg UBUNTU_VERSION="24.10" \
    --build-arg BUILD_CC_COMPILER="clang" \
    --build-arg PG_MAJOR="17" \
    -f docker/Dockerfile.ubuntu \
    -t orioletest:17-clang-ubuntu-24.10 .

# Block 9
docker build --pull --network=host --progress=plain \
    --build-arg ALPINE_VERSION="3.20" \
    --build-arg BUILD_CC_COMPILER="gcc" \
    --build-arg PG_MAJOR="17" \
    -f docker/Dockerfile \
    -t orioletest:17-gcc-alpine3.20 .

# Block 10
rm -rf docker-postgis 2>/dev/null || true
git clone --depth=1 https://github.com/postgis/docker-postgis.git
cd ./docker-postgis/17-3.5/alpine
docker build --network=host --progress=plain \
     --build-arg BASE_IMAGE=orioletest:17-gcc-alpine3.20 \
     -t oriolegis:17-3.5-alpine .
```

# local-builds.mdx 

now the test output of : 
* `./ci/markdown-bash-checker.sh --dry-run  ./doc/contributing/local-builds.mdx`
and this is running in the ./docker/Dockerfile.test.local-builds  Docker env.  ( ubuntu:24.04 ) 

```bash
$ ./ci/markdown-bash-checker.sh --dry-run  ./doc/contributing/local-builds.mdx
Found 10 bash code block(s), output written to '/tmp/_tempMbXB.sh'.
Dry run - contents of extracted script:
#!/usr/bin/env bash
set -euxo pipefail

# Block 1
sudo apt-get update
sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind libssl-dev libcurl4-openssl-dev wget

# Block 2
git clone https://github.com/orioledb/postgres.git --branch patches17 --single-branch postgres-patches17
cd postgres-patches17/

# Block 3
git checkout patches17_5

# Block 4
sed -i.bak "s/\/\* #define USE_VALGRIND \*\//#define USE_VALGRIND/g" src/include/pg_config_manual.h

# Block 5
PG_PREFIX=$HOME/pg17
./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix=$PG_PREFIX
make -j$(nproc)
make -j$(nproc) install
cd contrib
make -j$(nproc)
make -j$(nproc) install
cd ..
echo "export PATH=\"$PG_PREFIX/bin:\$PATH\"" >> ~/.bashrc
source ~/.bashrc
# Fallback: Manually update PATH in case sourcing ~/.bashrc doesn't work as expected
export PATH="$PG_PREFIX/bin:$PATH"

# Block 6
pip3 install psycopg2 six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
sudo pip3 install compiledb

# Block 7
cd ..
git clone https://github.com/orioledb/orioledb.git
cd orioledb
# Check the required PostgreSQL patch version
cat .pgtags
# Verify the patch version in the .pgtags file.
# If the patch version differs, go back to the previous steps and update the PostgreSQL patch version!
grep -qFx '17: patches17_5' .pgtags || { echo "The .pgtags patch version is different; please update the tutorial accordingly!"; 1=2; }
# Build with compiledb, because it creates compile_commands.json needed for VSCode C/C++ extension
compiledb make USE_PGXS=1 IS_DEV=1
# Exclude compile_commands.json from the Git tracking
echo "compile_commands.json" >> .git/info/exclude

# Block 8
cd ..
wget --content-disposition "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64"
sudo apt install ./code_*.deb
# Install Python and C++ extension
code --install-extension ms-python.python
code --install-extension ms-vscode.cpptools
code orioledb

# Block 9
cd orioledb
make USE_PGXS=1 IS_DEV=1 installcheck

# Block 10
cd ..
cd orioledb
make USE_PGXS=1 IS_DEV=1 install
initdb --no-locale -D $HOME/pgdata
sed -i 's/#shared_preload_libraries = '\'''\''/shared_preload_libraries = '\''orioledb'\''/' $HOME/pgdata/postgresql.conf
pg_ctl -D $HOME/pgdata/ start -l $HOME/log
psql -c "CREATE EXTENSION IF NOT EXISTS orioledb; SELECT orioledb_commit_hash();" -d postgres
psql -c "\dx" -d postgres
```