### PR TITLE
Fix calculating sizeof(BTreeIterator)

### DIFF
--- a/include/btree/iterator.h
+++ b/include/btree/iterator.h
@@ -45,7 +45,7 @@ extern OTuple o_btree_find_tuple_by_key(BTreeDescr *desc, void *key,
 extern BTreeIterator *o_btree_iterator_create(BTreeDescr *desc, void *key,
 											  BTreeKeyType kind,
 											  OSnapshot *o_snapshot,
-											  ScanDirection scan);
+											  ScanDirection scanDir);
 extern void o_btree_iterator_set_tuple_ctx(BTreeIterator *it,
 										   MemoryContext tupleCxt);
 extern void o_btree_iterator_set_callback(BTreeIterator *it,

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -404,7 +404,6 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 	uint16		findFlags = BTREE_PAGE_FIND_IMAGE;
 
 	it = (BTreeIterator *) palloc(sizeof(BTreeIterator));
-	ASAN_UNPOISON_MEMORY_REGION(&it, sizeof(*it));
 	it->combinedResult = !have_current_undo(desc->undoType) && COMMITSEQNO_IS_NORMAL(o_snapshot->csn);
 	it->oSnapshot = *o_snapshot;
 	it->scanDir = scanDir;

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -404,7 +404,7 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 	uint16		findFlags = BTREE_PAGE_FIND_IMAGE;
 
 	it = (BTreeIterator *) palloc(sizeof(BTreeIterator));
-	ASAN_UNPOISON_MEMORY_REGION(&it, sizeof(it));
+	ASAN_UNPOISON_MEMORY_REGION(&it, sizeof(*it));
 	it->combinedResult = !have_current_undo(desc->undoType) && COMMITSEQNO_IS_NORMAL(o_snapshot->csn);
 	it->oSnapshot = *o_snapshot;
 	it->scanDir = scanDir;


### PR DESCRIPTION
- Fix calculating `sizeof(BTreeIterator)`: `o_btree_iterator_create()` mistakenly calculates sizeof of a pointer to `BTreeIterator` instead of sizeof of the struct
- Fix name of the `o_btree_iterator_create()`: the definition and the implementation have different argument for `ScanDirection`