### PR TITLE
Update src/btree/io.c to use <fcntl.h> for Alpine compatibility

### DIFF
--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -12,7 +12,7 @@
  */
 #include "postgres.h"
 
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <sys/mman.h>


### PR DESCRIPTION
Replace <sys/fcntl.h> with the POSIX standard <fcntl.h> in src/btree/io.c to resolve build warnings on Alpine Linux.
This change follows a similar approach as seen in https://github.com/orioledb/orioledb/pull/397

-----------

fixing this warning in the alpine log:
* dockerTEST: docker 17-clang-alpine-3.20
    * https://github.com/orioledb/orioledb/actions/runs/13752409338/job/38455030392

```log
I/usr/include/libxml2  -flto=thin -emit-llvm -c -o src/btree/iterator.bc src/btree/iterator.c
2025-03-09T21:03:09.4966934Z #12 577.2 In file included from src/btree/io.c:15:
2025-03-09T21:03:09.4967876Z #12 577.2 /usr/include/sys/fcntl.h:1:2: warning: redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-W#warnings]
2025-03-09T21:03:09.6458192Z #12 577.2     1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
2025-03-09T21:03:09.6466262Z #12 577.2       |  ^
```

