### PR TITLE
docs: Synchronize local-builds.mdx with latest development changes

### DIFF
--- a/doc/contributing/local-builds.mdx
+++ b/doc/contributing/local-builds.mdx
@@ -13,7 +13,7 @@ This guide will help you to build and run OrioleDB on your local machine from th
 
 ```bash
 sudo apt-get update
-sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind
+sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind libssl-dev libcurl4-openssl-dev wget
 ```
 
 ### Download and install PostgreSQL 17 with patches
@@ -28,7 +28,7 @@ cd postgres-patches17/
 Check required postgres patch version in [.pgtags](https://github.com/orioledb/orioledb/blob/main/.pgtags) or [README.md](https://github.com/orioledb/orioledb?tab=readme-ov-file#build-from-source) files. Because documentation can become outdated.
 
 ```bash
-git checkout patches17_5
+git checkout patches17_6
 ```
 
 ### Enable Valgrind support in PostgreSQL code (optional)
@@ -44,6 +44,8 @@ PG_PREFIX=$HOME/pg17
 ./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix=$PG_PREFIX
 make -j$(nproc)
 make -j$(nproc) install
+make -C contrib -j$(nproc)
+make -C contrib -j$(nproc) install
 echo "export PATH=\"$PG_PREFIX/bin:\$PATH\"" >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -51,7 +53,7 @@ source ~/.bashrc
 ### Install python requirements
 
 ```bash
-pip3 install psycopg2 six testgres
+pip3 install psycopg2 six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
 sudo pip3 install compiledb
 ```
 
@@ -135,7 +137,7 @@ cd postgres-patches17/
 Check required postgres patch version in [.pgtags](https://github.com/orioledb/orioledb/blob/main/.pgtags) or [README.md](https://github.com/orioledb/orioledb?tab=readme-ov-file#build-from-source) files. Because documentation can become outdated.
 
 ```bash
-git checkout patches17_5
+git checkout patches17_6
 ```
 
 ### Configure and build
@@ -145,6 +147,8 @@ PG_PREFIX=$HOME/pg17
 ./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix=$PG_PREFIX
 make -j$(nproc)
 make -j$(nproc) install
+make -C contrib -j$(nproc)
+make -C contrib -j$(nproc) install
 echo "export PATH=\"$PG_PREFIX/bin:\$PATH\"" >> ~/.zshrc
 exec zsh -l
 ```
@@ -152,7 +156,7 @@ exec zsh -l
 ### Install python requirements
 
 ```bash
-pip3 install psycopg2 six testgres
+pip3 install psycopg2 six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
 sudo pip3 install compiledb
 ```
 
@@ -221,7 +225,7 @@ Start Ubuntu from start menu again.
 ```bash
 sudo hwclock --hctosys
 sudo apt-get update
-sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind
+sudo apt install git build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3 python3-dev python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev valgrind libssl-dev libcurl4-openssl-dev wget
 ```
 
 ### Download and install PostgreSQL 17 with patches
@@ -236,7 +240,7 @@ cd postgres-patches17/
 Check required postgres patch version in [.pgtags](https://github.com/orioledb/orioledb/blob/main/.pgtags) or [README.md](https://github.com/orioledb/orioledb?tab=readme-ov-file#build-from-source) files. Because documentation can become outdated.
 
 ```bash
-git checkout patches17_5
+git checkout patches17_6
 ```
 
 ### Enable Valgrind support in PostgreSQL code (optional)
@@ -252,6 +256,8 @@ PG_PREFIX=$HOME/pg17
 ./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix=$PG_PREFIX
 make -j$(nproc)
 make -j$(nproc) install
+make -C contrib -j$(nproc)
+make -C contrib -j$(nproc) install
 echo "export PATH=\"$PG_PREFIX/bin:\$PATH\"" >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -259,7 +265,7 @@ source ~/.bashrc
 ### Install python requirements
 
 ```bash
-pip3 install psycopg2 six testgres
+pip3 install psycopg2 six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
 sudo pip3 install compiledb
 ```
 


### PR DESCRIPTION
local-builds.mdx was out of sync;

This update aligns the documentation with recent development changes:
- Add libssl-dev, libcurl4-openssl-dev, and wget to the Debian package list.
- Update `.pgtags` references from `patches17_5` to `patches17_6`.
- Compile and install PostgreSQL contrib modules during the build process. (for testing)
- Install additional Python packages for testing: moto[s3], flask, flask_cors, boto3, pyOpenSSL.

----

In my opinion, the changes above are necessary to prevent a new developer from encountering strange error messages during the build or test process.

These changes were adapted from the pull request at https://github.com/orioledb/orioledb/pull/432