### PR TITLE
'index_bridging' option improving

### DIFF
--- a/include/indexam/handler.h
+++ b/include/indexam/handler.h
@@ -17,7 +17,6 @@
 
 extern IndexAmRoutine *orioledb_indexam_routine_hook(Oid tamoid,
 													 Oid amhandler);
-extern void o_add_bridged_option_to_ams(void);
 
 extern Relation o_current_index;
 

--- a/include/indexam/handler.h
+++ b/include/indexam/handler.h
@@ -17,7 +17,7 @@
 
 extern IndexAmRoutine *orioledb_indexam_routine_hook(Oid tamoid,
 													 Oid amhandler);
-extern IndexAmRoutine *orioledb_hash_handler(void);
+extern void o_add_bridged_option_to_ams(void);
 
 extern Relation o_current_index;
 

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -386,7 +386,7 @@ typedef struct OBTOptions
 {
 	BTOptions	bt_options;
 	int			compress_offset;
-	bool		index_bridging;
+	bool		orioledb_index;
 } OBTOptions;
 
 extern int16 o_parse_compress(const char *value);

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -2591,8 +2591,10 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 
 								if (options && !options->orioledb_index)
 								{
-									ereport(WARNING, errmsg("Using bridged btree index for orioledb"),
-											errdetail("this feature is only for testing"));
+									ereport(WARNING,
+											errcode(ERRCODE_WARNING),
+											errmsg("using bridged btree index for orioledb"),
+											errdetail("This feature is intended for testing purposes and is not recommended for normal usage."));
 									add_bridging = true;
 								}
 								else
@@ -2612,8 +2614,10 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 								OBTOptions *options = (OBTOptions *) rel->rd_options;
 
 								if (options && !options->orioledb_index)
-									ereport(WARNING, errmsg("Using bridged btree index for orioledb"),
-											errdetail("this feature is only for testing"));
+									ereport(WARNING,
+											errcode(ERRCODE_WARNING),
+											errmsg("using bridged btree index for orioledb"),
+											errdetail("This feature is intended for testing purposes and is not recommended for normal usage."));
 							}
 						}
 
@@ -2635,8 +2639,10 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 							OTableDescr *descr;
 							OTableDescr *old_descr;
 
-							ereport(WARNING, errmsg("Enabling bridging for orioledb table '%s'",
-													RelationGetRelationName(tbl)));
+							ereport(NOTICE,
+									errmsg("enabling index bridging for orioledb table '%s'",
+										   RelationGetRelationName(tbl)),
+									errdetail("The required index access method is not natively supported, so index bridgind is automatically enabled."));
 
 							old_o_table = o_table;
 							o_table = o_tables_get(o_table->oids);

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -2251,8 +2251,8 @@ add_bridge_index(Relation tbl, OTable *o_table, bool manually, Oid amoid)
 
 	if (!manually)
 	{
-		HeapTuple       tuple;
-		Form_pg_am      amform;
+		HeapTuple	tuple;
+		Form_pg_am	amform;
 
 		tuple = SearchSysCache1(AMOID, ObjectIdGetDatum(amoid));
 		if (!HeapTupleIsValid(tuple))
@@ -2260,7 +2260,7 @@ add_bridge_index(Relation tbl, OTable *o_table, bool manually, Oid amoid)
 
 		amform = (Form_pg_am) GETSTRUCT(tuple);
 
-		if(amoid != BTREE_AM_OID)
+		if (amoid != BTREE_AM_OID)
 		{
 			ereport(NOTICE,
 					errmsg("index bridging is enabled for orioledb table '%s'",

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -21,6 +21,7 @@
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
 #include "tableam/operations.h"
+#include "catalog/pg_am.h"
 #include "tableam/toast.h"
 #include "transam/oxid.h"
 #include "transam/undo.h"
@@ -2239,7 +2240,7 @@ change_bridging_option(Relation rel, bool value, bool isReset)
 }
 
 static void
-add_bridge_index(Relation tbl, OTable *o_table, bool manually)
+add_bridge_index(Relation tbl, OTable *o_table, bool manually, Oid amoid)
 {
 	OSnapshot	oSnapshot;
 	OXid		oxid;
@@ -2249,10 +2250,33 @@ add_bridge_index(Relation tbl, OTable *o_table, bool manually)
 	int			ix_num = InvalidIndexNumber;
 
 	if (!manually)
-		ereport(NOTICE,
-				errmsg("enabling index bridging for orioledb table '%s'",
-					   RelationGetRelationName(tbl)),
-				errdetail("The required index access method is not natively supported, so index bridgind is automatically enabled."));
+	{
+		HeapTuple       tuple;
+		Form_pg_am      amform;
+
+		tuple = SearchSysCache1(AMOID, ObjectIdGetDatum(amoid));
+		if (!HeapTupleIsValid(tuple))
+			elog(ERROR, "cache lookup failed for access method %u", amoid);
+
+		amform = (Form_pg_am) GETSTRUCT(tuple);
+
+		if(amoid != BTREE_AM_OID)
+		{
+			ereport(NOTICE,
+					errmsg("index bridging is enabled for orioledb table '%s'",
+						   RelationGetRelationName(tbl)),
+					errdetail("index access method '%s' is supported only via index bridging for OrioleDB table", NameStr(amform->amname)));
+		}
+		else
+		{
+			ereport(NOTICE,
+					errmsg("index bridging is enabled for orioledb table '%s'",
+						   RelationGetRelationName(tbl)),
+					errdetail("index access method '%s' is requested with index bridging for OrioleDB table", NameStr(amform->amname)));
+		}
+
+		ReleaseSysCache(tuple);
+	}
 
 	old_o_table = o_table;
 	o_table = o_tables_get(o_table->oids);
@@ -2730,7 +2754,7 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 						}
 
 						if (add_bridging)
-							add_bridge_index(tbl, o_table, false);
+							add_bridge_index(tbl, o_table, false, rel->rd_rel->relam);
 						else
 							o_table_free(o_table);
 					}
@@ -3122,12 +3146,12 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 						if (!has_bridged)
 						{
 							if (new_index_bridging)
-								add_bridge_index(tbl, o_table, true);
+								add_bridge_index(tbl, o_table, true, InvalidOid);
 							else
 								drop_bridge_index(tbl, o_table);
 						}
 						else
-							elog(ERROR, "Cannot change 'index_bridging' manually when there are bridged indices");
+							elog(ERROR, "cannot disable 'index_bridging' for a table with bridged indices");
 					}
 					if (GET_PRIMARY(descr)->fillfactor != new_fillfactor)
 						set_toast_oids_and_options(tbl, rel, true, false);

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -28,13 +28,8 @@
 #include "utils/compress.h"
 #include "recovery/wal.h"
 
-#include "access/brin.h"
-#include "access/gin_private.h"
-#include "access/gist_private.h"
-#include "access/hash.h"
 #include "access/heapam.h"
 #include "access/reloptions.h"
-#include "access/spgist_private.h"
 #include "access/tableam.h"
 #include "access/toast_compression.h"
 #include "access/transam.h"

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -960,8 +960,10 @@ orioledb_utility_command(PlannedStmt *pstmt,
 						case AT_DropNotNull:
 						case AT_EnableRowSecurity:
 						case AT_GenericOptions:
+						case AT_ResetRelOptions:
 						case AT_SetIdentity:
 						case AT_SetNotNull:
+						case AT_SetRelOptions:
 							break;
 						default:
 							ereport(ERROR,

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -29,12 +29,7 @@
 #include "utils/stopevent.h"
 
 #include "access/amapi.h"
-#include "access/brin.h"
-#include "access/gin_private.h"
-#include "access/gist_private.h"
-#include "access/hash.h"
 #include "access/relation.h"
-#include "access/spgist_private.h"
 #include "commands/progress.h"
 #include "commands/vacuum.h"
 #include "nodes/pathnodes.h"

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -1945,174 +1945,111 @@ bridged_ambeginscan(Relation rel, int nkeys, int norderbys)
 	return amroutine->ambeginscan(rel, nkeys, norderbys);
 }
 
+void o_add_bridged_option_to_ams()
+{
+	static bool first_call = true;
+	static int last_assigned_relopt = RELOPT_KIND_LAST_DEFAULT;
+	if (first_call)
+	{
+		add_bool_reloption(RELOPT_KIND_HASH, "index_bridging",
+						   "Use postgresql index via index bridging. "
+						   "Set automatically if index_bridging enabled for table",
+						   false, AccessExclusiveLock);
+		add_bool_reloption(RELOPT_KIND_GIST, "index_bridging",
+						   "Use postgresql index via index bridging. "
+						   "Set automatically if index_bridging enabled for table",
+						   false, AccessExclusiveLock);
+		add_bool_reloption(RELOPT_KIND_GIN, "index_bridging",
+						   "Use postgresql index via index bridging. "
+						   "Set automatically if index_bridging enabled for table",
+						   false, AccessExclusiveLock);
+		add_bool_reloption(RELOPT_KIND_SPGIST, "index_bridging",
+						   "Use postgresql index via index bridging. "
+						   "Set automatically if index_bridging enabled for table",
+						   false, AccessExclusiveLock);
+		add_bool_reloption(RELOPT_KIND_BRIN, "index_bridging",
+						   "Use postgresql index via index bridging. "
+						   "Set automatically if index_bridging enabled for table",
+						   false, AccessExclusiveLock);
+		first_call = false;
+	}
+}
+
 /* Should be kept in sync with hashoptions */
 bytea *
 bridged_hashoptions(Datum reloptions, bool validate)
 {
-	static bool relopts_set = false;
-	static local_relopts relopts = {0};
+	static const relopt_parse_elt tab[] = {
+		{"fillfactor", RELOPT_TYPE_INT, offsetof(HashOptions, fillfactor)},
+		{"index_bridging", RELOPT_TYPE_BOOL, sizeof(HashOptions)},
+	};
 
-	if (!relopts_set)
-	{
-		MemoryContext oldcxt;
-
-		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-		init_local_reloptions(&relopts, sizeof(HashOptions) + sizeof(bool));
-
-		add_local_int_reloption(&relopts, "fillfactor",
-								"Packs hash index pages only to this percentage",
-								HASH_DEFAULT_FILLFACTOR, HASH_MIN_FILLFACTOR, 100,
-								offsetof(HashOptions, fillfactor));
-		add_local_bool_reloption(&relopts, "index_bridging",
-								 "Use postgresql index via index bridging. "
-								 "Set automatically if index_bridging enabled for table",
-								 false,
-								 sizeof(HashOptions));
-		MemoryContextSwitchTo(oldcxt);
-		relopts_set = true;
-	}
-
-	return (bytea *) build_local_reloptions(&relopts, reloptions, validate);
+	return (bytea *) build_reloptions(reloptions, validate,
+									  RELOPT_KIND_HASH,
+									  sizeof(HashOptions) + sizeof(bool),
+									  tab, lengthof(tab));
 }
-
-/* values from GistOptBufferingMode */
-static relopt_enum_elt_def gistBufferingOptValues[] =
-{
-	{"auto", GIST_OPTION_BUFFERING_AUTO},
-	{"on", GIST_OPTION_BUFFERING_ON},
-	{"off", GIST_OPTION_BUFFERING_OFF},
-	{(const char *) NULL}		/* list terminator */
-};
 
 /* Should be kept in sync with gistoptions */
 bytea *
 bridged_gistoptions(Datum reloptions, bool validate)
 {
-	static bool relopts_set = false;
-	static local_relopts relopts = {0};
+	static const relopt_parse_elt tab[] = {
+		{"fillfactor", RELOPT_TYPE_INT, offsetof(GiSTOptions, fillfactor)},
+		{"buffering", RELOPT_TYPE_ENUM, offsetof(GiSTOptions, buffering_mode)},
+		{"index_bridging", RELOPT_TYPE_BOOL, sizeof(GiSTOptions)},
+	};
 
-	if (!relopts_set)
-	{
-		MemoryContext oldcxt;
-
-		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-		init_local_reloptions(&relopts, sizeof(GiSTOptions) + sizeof(bool));
-
-		add_local_int_reloption(&relopts, "fillfactor",
-								"Packs gist index pages only to this percentage",
-								GIST_DEFAULT_FILLFACTOR, GIST_MIN_FILLFACTOR, 100,
-								offsetof(GiSTOptions, fillfactor));
-		add_local_enum_reloption(&relopts, "buffering",
-								 "Enables buffering build for this GiST index",
-								 gistBufferingOptValues, GIST_OPTION_BUFFERING_AUTO,
-								 gettext_noop("Valid values are \"on\", \"off\", and \"auto\"."),
-								 offsetof(GiSTOptions, buffering_mode));
-		add_local_bool_reloption(&relopts, "index_bridging",
-								 "Use postgresql index via index bridging. "
-								 "Set automatically if index_bridging enabled for table",
-								 false,
-								 sizeof(GiSTOptions));
-		MemoryContextSwitchTo(oldcxt);
-		relopts_set = true;
-	}
-
-	return (bytea *) build_local_reloptions(&relopts, reloptions, validate);
+	return (bytea *) build_reloptions(reloptions, validate,
+									  RELOPT_KIND_GIST,
+									  sizeof(GiSTOptions) + sizeof(bool),
+									  tab, lengthof(tab));
 }
 
 /* Should be kept in sync with ginoptions */
 bytea *
 bridged_ginoptions(Datum reloptions, bool validate)
 {
-	static bool relopts_set = false;
-	static local_relopts relopts = {0};
+	static const relopt_parse_elt tab[] = {
+		{"fastupdate", RELOPT_TYPE_BOOL, offsetof(GinOptions, useFastUpdate)},
+		{"gin_pending_list_limit", RELOPT_TYPE_INT, offsetof(GinOptions,
+															 pendingListCleanupSize)},
+		{"index_bridging", RELOPT_TYPE_BOOL, sizeof(GinOptions)},
+	};
 
-	if (!relopts_set)
-	{
-		MemoryContext oldcxt;
-
-		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-		init_local_reloptions(&relopts, sizeof(GinOptions) + sizeof(bool));
-
-		add_local_bool_reloption(&relopts, "fastupdate",
-								 "Enables \"fast update\" feature for this GIN index",
-								 true,
-								 offsetof(GinOptions, useFastUpdate));
-		add_local_int_reloption(&relopts, "gin_pending_list_limit",
-								"Maximum size of the pending list for this GIN index, in kilobytes.",
-								-1, 64, MAX_KILOBYTES,
-								offsetof(GinOptions, pendingListCleanupSize));
-		add_local_bool_reloption(&relopts, "index_bridging",
-								 "Use postgresql index via index bridging. "
-								 "Set automatically if index_bridging enabled for table",
-								 false,
-								 sizeof(GinOptions));
-		MemoryContextSwitchTo(oldcxt);
-		relopts_set = true;
-	}
-
-	return (bytea *) build_local_reloptions(&relopts, reloptions, validate);
+	return (bytea *) build_reloptions(reloptions, validate,
+									  RELOPT_KIND_GIN,
+									  sizeof(GinOptions) + sizeof(bool),
+									  tab, lengthof(tab));
 }
 
 /* Should be kept in sync with spgoptions */
 bytea *
 bridged_spgoptions(Datum reloptions, bool validate)
 {
-	static bool relopts_set = false;
-	static local_relopts relopts = {0};
+	static const relopt_parse_elt tab[] = {
+		{"fillfactor", RELOPT_TYPE_INT, offsetof(SpGistOptions, fillfactor)},
+		{"index_bridging", RELOPT_TYPE_BOOL, sizeof(SpGistOptions)},
+	};
 
-	if (!relopts_set)
-	{
-		MemoryContext oldcxt;
-
-		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-		init_local_reloptions(&relopts, sizeof(SpGistOptions) + sizeof(bool));
-
-		add_local_int_reloption(&relopts, "fillfactor",
-								"Packs spgist index pages only to this percentage",
-								SPGIST_DEFAULT_FILLFACTOR, SPGIST_MIN_FILLFACTOR, 100,
-								offsetof(SpGistOptions, fillfactor));
-		add_local_bool_reloption(&relopts, "index_bridging",
-								 "Use postgresql index via index bridging. "
-								 "Set automatically if index_bridging enabled for table",
-								 false,
-								 sizeof(SpGistOptions));
-		MemoryContextSwitchTo(oldcxt);
-		relopts_set = true;
-	}
-
-	return (bytea *) build_local_reloptions(&relopts, reloptions, validate);
+	return (bytea *) build_reloptions(reloptions, validate,
+									  RELOPT_KIND_SPGIST,
+									  sizeof(SpGistOptions) + sizeof(bool),
+									  tab, lengthof(tab));
 }
 
 /* Should be kept in sync with brinoptions */
 bytea *
 bridged_brinoptions(Datum reloptions, bool validate)
 {
-	static bool relopts_set = false;
-	static local_relopts relopts = {0};
+	static const relopt_parse_elt tab[] = {
+		{"pages_per_range", RELOPT_TYPE_INT, offsetof(BrinOptions, pagesPerRange)},
+		{"autosummarize", RELOPT_TYPE_BOOL, offsetof(BrinOptions, autosummarize)},
+		{"index_bridging", RELOPT_TYPE_BOOL, sizeof(BrinOptions)},
+	};
 
-	if (!relopts_set)
-	{
-		MemoryContext oldcxt;
-
-		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-		init_local_reloptions(&relopts, sizeof(BrinOptions) + sizeof(bool));
-
-		add_local_int_reloption(&relopts, "pages_per_range",
-								"Number of pages that each page range covers in a BRIN index",
-								128, 1, 131072,
-								offsetof(BrinOptions, pagesPerRange));
-		add_local_bool_reloption(&relopts, "autosummarize",
-								 "Enables automatic summarization on this BRIN index",
-								 false,
-								 offsetof(BrinOptions, autosummarize));
-		add_local_bool_reloption(&relopts, "index_bridging",
-								 "Use postgresql index via index bridging. "
-								 "Set automatically if index_bridging enabled for table",
-								 false,
-								 sizeof(BrinOptions));
-		MemoryContextSwitchTo(oldcxt);
-		relopts_set = true;
-	}
-
-	return (bytea *) build_local_reloptions(&relopts, reloptions, validate);
+	return (bytea *) build_reloptions(reloptions, validate,
+									  RELOPT_KIND_BRIN,
+									  sizeof(BrinOptions) + sizeof(bool),
+									  tab, lengthof(tab));
 }

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -1671,7 +1671,7 @@ orioledb_get_relation_info_hook(PlannerInfo *root,
 
 					options = (OBTOptions *) index->rd_options;
 
-					if ((options && options->index_bridging) || index->rd_rel->relam != BTREE_AM_OID)
+					if (index->rd_rel->relam != BTREE_AM_OID || (options && options->index_bridging))
 					{
 						index_close(index, AccessShareLock);
 						continue;

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -954,6 +954,7 @@ _PG_init(void)
 	base_init_startup_hook = o_base_init_startup_hook;
 	IndexAMRoutineHook = orioledb_indexam_routine_hook;
 	orioledb_setup_ddl_hooks();
+	o_add_bridged_option_to_ams();
 	stopevents_make_cxt();
 }
 

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -954,7 +954,6 @@ _PG_init(void)
 	base_init_startup_hook = o_base_init_startup_hook;
 	IndexAMRoutineHook = orioledb_indexam_routine_hook;
 	orioledb_setup_ddl_hooks();
-	o_add_bridged_option_to_ams();
 	stopevents_make_cxt();
 }
 
@@ -1672,7 +1671,7 @@ orioledb_get_relation_info_hook(PlannerInfo *root,
 
 					options = (OBTOptions *) index->rd_options;
 
-					if (index->rd_rel->relam != BTREE_AM_OID || (options && options->index_bridging))
+					if (index->rd_rel->relam != BTREE_AM_OID || (options && !options->orioledb_index))
 					{
 						index_close(index, AccessShareLock);
 						continue;

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -377,8 +377,8 @@ o_exec_bitmapqual(OBitmapHeapPlanState *bitmap_state, PlanState *planstate)
 					result = o_keybitmap_create();
 				}
 
-				if ((options && options->index_bridging) ||
-					node->biss_RelationDesc->rd_rel->relam != BTREE_AM_OID)
+				if (node->biss_RelationDesc->rd_rel->relam != BTREE_AM_OID ||
+					(options && options->index_bridging))
 				{
 					TIDBitmap  *bridged_bitmap = tbm_create(work_mem * 1024L, NULL);
 					TBMIterator *tbmiterator;

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -378,7 +378,7 @@ o_exec_bitmapqual(OBitmapHeapPlanState *bitmap_state, PlanState *planstate)
 				}
 
 				if (node->biss_RelationDesc->rd_rel->relam != BTREE_AM_OID ||
-					(options && options->index_bridging))
+					(options && !options->orioledb_index))
 				{
 					TIDBitmap  *bridged_bitmap = tbm_create(work_mem * 1024L, NULL);
 					TBMIterator *tbmiterator;

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -131,7 +131,7 @@ orioledb_index_fetch_begin(Relation rel)
 		OBTOptions *options = (OBTOptions *) o_current_index->rd_options;
 
 		o_scan->bridged_tuple = (o_current_index->rd_rel->relam != BTREE_AM_OID) ||
-			(options && options->index_bridging);
+			(options && !options->orioledb_index);
 		o_current_index = NULL;
 	}
 
@@ -816,7 +816,7 @@ drop_indices_for_rel(Relation rel, bool primary)
 		ind = relation_open(indexOid, AccessShareLock);
 		options = (OBTOptions *) ind->rd_options;
 
-		if (ind->rd_rel->relam == BTREE_AM_OID && !(options && options->index_bridging) &&
+		if (ind->rd_rel->relam == BTREE_AM_OID && !(options && !options->orioledb_index) &&
 			((primary && ind->rd_index->indisprimary) || (!primary && !ind->rd_index->indisprimary)))
 		{
 			OIndexNumber ix_num;
@@ -953,7 +953,7 @@ orioledb_index_build_range_scan(Relation heapRelation,
 {
 	OBTOptions *options = (OBTOptions *) indexRelation->rd_options;
 
-	if (indexRelation->rd_rel->relam != BTREE_AM_OID || (options && options->index_bridging))
+	if (indexRelation->rd_rel->relam != BTREE_AM_OID || (options && !options->orioledb_index))
 	{
 		OTableDescr *descr;
 		BTreeSeqScan *seq_scan;

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -130,8 +130,8 @@ orioledb_index_fetch_begin(Relation rel)
 	{
 		OBTOptions *options = (OBTOptions *) o_current_index->rd_options;
 
-		o_scan->bridged_tuple = (options && options->index_bridging) ||
-			(o_current_index->rd_rel->relam != BTREE_AM_OID);
+		o_scan->bridged_tuple = (o_current_index->rd_rel->relam != BTREE_AM_OID) ||
+			(options && options->index_bridging);
 		o_current_index = NULL;
 	}
 
@@ -953,7 +953,7 @@ orioledb_index_build_range_scan(Relation heapRelation,
 {
 	OBTOptions *options = (OBTOptions *) indexRelation->rd_options;
 
-	if ((options && options->index_bridging) || indexRelation->rd_rel->relam != BTREE_AM_OID)
+	if (indexRelation->rd_rel->relam != BTREE_AM_OID || (options && options->index_bridging))
 	{
 		OTableDescr *descr;
 		BTreeSeqScan *seq_scan;
@@ -1949,7 +1949,7 @@ orioledb_default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
 								   offsetof(ORelOptions,
 											toast_compress_offset));
 		add_local_bool_reloption(&relopts, "index_bridging",
-								 "Enables implicit ctid index and ctid column for all indices",
+								 "Enables implicit bridge ctid index and support of non-btree indices via bridging",
 								 false,
 								 offsetof(ORelOptions,
 										  index_bridging));

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -743,7 +743,7 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 			{
 				OBTOptions *options = (OBTOptions *) index_rel->rd_options;
 
-				intresting = options && options->index_bridging;
+				intresting = options && !options->orioledb_index;
 			}
 			if (intresting)
 			{

--- a/src/tableam/vacuum.c
+++ b/src/tableam/vacuum.c
@@ -262,7 +262,7 @@ vac_open_bridged_indexes(Relation relation, LOCKMODE lockmode,
 		{
 			OBTOptions *options = (OBTOptions *) indrel->rd_options;
 
-			if (!(options && options->index_bridging))
+			if (!(options && !options->orioledb_index))
 			{
 				index_close(indrel, lockmode);
 				continue;

--- a/src/tuple/slot.c
+++ b/src/tuple/slot.c
@@ -1056,7 +1056,7 @@ tts_orioledb_make_secondary_tuple(TupleTableSlot *slot, OIndexDescr *idx, bool l
 	{
 		bridge_data.bridge_iptr = &oslot->bridge_ctid;
 		bridge_data.is_pkey = false;
-		bridge_data.attnum = idx->desc.type == oIndexBridge ? 1 : ctid_off + 1;
+		bridge_data.attnum = 1;
 		bridge_data_arg = &bridge_data;
 	}
 

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -1185,7 +1185,7 @@ CREATE INDEX o_test_ix_ams_hash_ix ON o_test_ix_ams USING hash (k);
  pk2    | integer |           | not null |         | plain   |              | 
  k      | integer |           |          |         | plain   |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
     "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
 Options: index_bridging=true
 
@@ -1377,7 +1377,7 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
     "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
 Options: index_bridging=true
 
@@ -1448,7 +1448,7 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
     "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
 Options: index_bridging=true
 
@@ -1993,12 +1993,443 @@ SELECT * FROM o_test_bitmap_scans
 (6 rows)
 
 COMMIT;
+CREATE TABLE o_test_index_bridging_options (
+	i int NOT NULL,
+	j int4[],
+	p point
+) USING orioledb WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix1 ON o_test_index_bridging_options USING btree (i);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (index_bridging);
+WARNING:  Using bridged btree index for orioledb
+DETAIL:  this feature is only for testing
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING hash (i) WITH (index_bridging);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gist (p);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING gin (j);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING spgist (p);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix9 ON o_test_index_bridging_options USING brin (i);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing tables
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER TABLE o_test_index_bridging_options SET (index_bridging);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix5 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix2 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix1 SET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix6 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix7 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix8 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix9 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE TABLE o_test_non_index_bridging_options (
+	i int NOT NULL,
+	j int4[],
+	p point
+) USING orioledb;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing tables
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_options USING btree (i);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (index_bridging);
+ERROR:  Cannot use 'index_bridging' on table without 'index_bridging' option
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
+ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
+ALTER INDEX o_test_non_index_bridging_options_ix1 SET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
 drop cascades to table o_test_bitmap_scans
+drop cascades to table o_test_index_bridging_options
+drop cascades to table o_test_non_index_bridging_options
 DROP SCHEMA index_bridging CASCADE;
 RESET search_path;

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -95,8 +95,8 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
 CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (orioledb_index = off, deduplicate_items = off);
 WARNING:  using bridged btree index for orioledb
 DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
-NOTICE:  enabling index bridging for orioledb table 'o_test_ix_ams'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_test_ix_ams'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
 SELECT ctid, htid, tids FROM
 		 generate_series(1,
 						 (SELECT relpages - 1 FROM pg_class
@@ -1566,8 +1566,8 @@ SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
 (1 row)
 
 CREATE INDEX o_briging_vacuum_test_p_idx on o_briging_vacuum_test using gist(p);
-NOTICE:  enabling index bridging for orioledb table 'o_briging_vacuum_test'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_briging_vacuum_test'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
 DELETE FROM o_briging_vacuum_test;
 VACUUM o_briging_vacuum_test;
 SELECT * FROM o_briging_vacuum_test WHERE p <@ box(point(0,0), point(1,1));
@@ -2102,7 +2102,7 @@ Indexes:
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2433,7 +2433,7 @@ SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
 
 COMMIT;
 ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2591,8 +2591,8 @@ Indexes:
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  using bridged btree index for orioledb
 DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
-NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2673,7 +2673,7 @@ SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true)
 (1 row)
 
 ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -3201,8 +3201,8 @@ SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  using bridged btree index for orioledb
 DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
-NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -2102,7 +2102,7 @@ Indexes:
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change index_bridging option manually
+ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2185,6 +2185,71 @@ CREATE TABLE o_test_non_index_bridging_options (
 	j int4[],
 	p point
 ) USING orioledb;
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(1, 10) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                            orioledb_tbl_structure                             
+-------------------------------------------------------------------------------
+ Index ctid_primary contents                                                  +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                          +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty          +
+     Leftmost, Rightmost                                                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 64, hikey = ('(0,5)')+
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')         +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')         +
+     Item 2: offset = 440, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')         +
+     Item 3: offset = 528, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')         +
+   Chunk 1: offset = 4, location = 616, hikey location = 72                   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')       +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')       +
+     Item 6: offset = 808, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')       +
+     Item 7: offset = 896, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')       +
+     Item 8: offset = 984, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')       +
+     Item 9: offset = 1072, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')    +
+                                                                              +
+ Index toast: not loaded                                                      +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
 ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
@@ -2194,8 +2259,62 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
 
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                            orioledb_tbl_structure                             
+-------------------------------------------------------------------------------
+ Index ctid_primary contents                                                  +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                          +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty          +
+     Leftmost, Rightmost                                                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 64, hikey = ('(0,5)')+
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')         +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')         +
+     Item 2: offset = 440, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')         +
+     Item 3: offset = 528, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')         +
+   Chunk 1: offset = 4, location = 616, hikey location = 72                   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')       +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')       +
+     Item 6: offset = 808, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')       +
+     Item 7: offset = 896, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')       +
+     Item 8: offset = 984, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')       +
+     Item 9: offset = 1072, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')    +
+                                                                              +
+ Index toast: not loaded                                                      +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
 ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
-ERROR:  Cannot change index_bridging option manually
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2203,6 +2322,260 @@ ERROR:  Cannot change index_bridging option manually
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                               orioledb_tbl_structure                                
+-------------------------------------------------------------------------------------
+ Index ctid_primary contents                                                        +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                +
+     Leftmost, Rightmost                                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{18,34}', '(6,6)')      +
+   Chunk 1: offset = 1, location = 352, hikey location = 104, hikey = ('(0,3)')     +
+     Item 1: offset = 360, tuple = ('(0,2)', '(0,2)', '2', '{19,35}', '(7,7)')      +
+   Chunk 2: offset = 2, location = 448, hikey location = 112, hikey = ('(0,4)')     +
+     Item 2: offset = 456, tuple = ('(0,3)', '(0,3)', '3', '{20,36}', '(8,8)')      +
+   Chunk 3: offset = 3, location = 544, hikey location = 120, hikey = ('(0,5)')     +
+     Item 3: offset = 552, tuple = ('(0,4)', '(0,4)', '4', '{21,37}', '(9,9)')      +
+   Chunk 4: offset = 4, location = 640, hikey location = 128, hikey = ('(0,6)')     +
+     Item 4: offset = 648, tuple = ('(0,5)', '(0,5)', '5', '{22,38}', '(10,10)')    +
+   Chunk 5: offset = 5, location = 736, hikey location = 136, hikey = ('(0,7)')     +
+     Item 5: offset = 744, tuple = ('(0,6)', '(0,6)', '6', '{23,39}', '(11,11)')    +
+   Chunk 6: offset = 6, location = 832, hikey location = 144, hikey = ('(0,8)')     +
+     Item 6: offset = 840, tuple = ('(0,7)', '(0,7)', '7', '{24,40}', '(12,12)')    +
+   Chunk 7: offset = 7, location = 928, hikey location = 152, hikey = ('(0,9)')     +
+     Item 7: offset = 936, tuple = ('(0,8)', '(0,8)', '8', '{25,41}', '(13,13)')    +
+   Chunk 8: offset = 8, location = 1024, hikey location = 160, hikey = ('(0,10)')   +
+     Item 8: offset = 1032, tuple = ('(0,9)', '(0,9)', '9', '{26,42}', '(14,14)')   +
+   Chunk 9: offset = 9, location = 1120, hikey location = 168                       +
+     Item 9: offset = 1128, tuple = ('(0,10)', '(0,10)', '10', '{27,43}', '(15,15)')+
+                                                                                    +
+ Index index_bridge: not loaded                                                     +
+ Index toast: not loaded                                                            +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Index Scan using o_test_non_index_bridging_options_ix2 on o_test_non_index_bridging_options
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
+COMMIT;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+DROP INDEX o_test_non_index_bridging_options_ix2;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                              
+----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                     +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                             +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean             +
+     Leftmost, Rightmost                                                         +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')            +
+   Chunk 1: offset = 1, location = 352, hikey location = 104, hikey = ('(0,3)')  +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')            +
+   Chunk 2: offset = 2, location = 448, hikey location = 112, hikey = ('(0,4)')  +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')            +
+   Chunk 3: offset = 3, location = 544, hikey location = 120, hikey = ('(0,5)')  +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')            +
+   Chunk 4: offset = 4, location = 640, hikey location = 128, hikey = ('(0,6)')  +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')          +
+   Chunk 5: offset = 5, location = 736, hikey location = 136, hikey = ('(0,7)')  +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')          +
+   Chunk 6: offset = 6, location = 832, hikey location = 144, hikey = ('(0,8)')  +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')          +
+   Chunk 7: offset = 7, location = 928, hikey location = 152, hikey = ('(0,9)')  +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')          +
+   Chunk 8: offset = 8, location = 1024, hikey location = 160, hikey = ('(0,10)')+
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')         +
+   Chunk 9: offset = 9, location = 1120, hikey location = 168                    +
+     Item 9: offset = 1128, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')       +
+                                                                                 +
+ Index toast: not loaded                                                         +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(11, 15) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                              
+----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                     +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                             +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty             +
+     Leftmost, Rightmost                                                         +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')            +
+   Chunk 1: offset = 1, location = 352, hikey location = 104, hikey = ('(0,3)')  +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')            +
+   Chunk 2: offset = 2, location = 448, hikey location = 112, hikey = ('(0,4)')  +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')            +
+   Chunk 3: offset = 3, location = 544, hikey location = 120, hikey = ('(0,5)')  +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')            +
+   Chunk 4: offset = 4, location = 640, hikey location = 128, hikey = ('(0,6)')  +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')          +
+   Chunk 5: offset = 5, location = 736, hikey location = 136, hikey = ('(0,7)')  +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')          +
+   Chunk 6: offset = 6, location = 832, hikey location = 144, hikey = ('(0,8)')  +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')          +
+   Chunk 7: offset = 7, location = 928, hikey location = 152, hikey = ('(0,9)')  +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')          +
+   Chunk 8: offset = 8, location = 1024, hikey location = 160, hikey = ('(0,10)')+
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')         +
+   Chunk 9: offset = 9, location = 1120, hikey location = 168                    +
+     Item 9: offset = 1136, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')       +
+     Item 10: offset = 1224, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')      +
+     Item 11: offset = 1312, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')      +
+     Item 12: offset = 1400, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')      +
+     Item 13: offset = 1488, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')      +
+     Item 14: offset = 1576, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')      +
+                                                                                 +
+ Index toast: not loaded                                                         +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+(15 rows)
 
 CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_options USING btree (i);
 \d+ o_test_non_index_bridging_options
@@ -2260,6 +2633,648 @@ Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
 Options: index_bridging=true
 
+ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index o_test_non_index_bridging_options_ix1              +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 2           +
+     Non-leaf tuple fields: i, ctid                       +
+     Leaf tuple fields: i, ctid                           +
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index o_test_non_index_bridging_options_ix1              +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 2           +
+     Non-leaf tuple fields: i, ctid                       +
+     Leaf tuple fields: i, ctid                           +
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                                orioledb_tbl_structure                                
+--------------------------------------------------------------------------------------
+ Index ctid_primary contents                                                         +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                 +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                 +
+     Leftmost, Rightmost                                                             +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('(0,2)')      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{18,34}', '(6,6)')       +
+   Chunk 1: offset = 1, location = 352, hikey location = 128, hikey = ('(0,3)')      +
+     Item 1: offset = 360, tuple = ('(0,2)', '(0,2)', '2', '{19,35}', '(7,7)')       +
+   Chunk 2: offset = 2, location = 448, hikey location = 136, hikey = ('(0,4)')      +
+     Item 2: offset = 456, tuple = ('(0,3)', '(0,3)', '3', '{20,36}', '(8,8)')       +
+   Chunk 3: offset = 3, location = 544, hikey location = 144, hikey = ('(0,5)')      +
+     Item 3: offset = 552, tuple = ('(0,4)', '(0,4)', '4', '{21,37}', '(9,9)')       +
+   Chunk 4: offset = 4, location = 640, hikey location = 152, hikey = ('(0,6)')      +
+     Item 4: offset = 648, tuple = ('(0,5)', '(0,5)', '5', '{22,38}', '(10,10)')     +
+   Chunk 5: offset = 5, location = 736, hikey location = 160, hikey = ('(0,7)')      +
+     Item 5: offset = 744, tuple = ('(0,6)', '(0,6)', '6', '{23,39}', '(11,11)')     +
+   Chunk 6: offset = 6, location = 832, hikey location = 168, hikey = ('(0,8)')      +
+     Item 6: offset = 840, tuple = ('(0,7)', '(0,7)', '7', '{24,40}', '(12,12)')     +
+   Chunk 7: offset = 7, location = 928, hikey location = 176, hikey = ('(0,9)')      +
+     Item 7: offset = 936, tuple = ('(0,8)', '(0,8)', '8', '{25,41}', '(13,13)')     +
+   Chunk 8: offset = 8, location = 1024, hikey location = 184, hikey = ('(0,10)')    +
+     Item 8: offset = 1032, tuple = ('(0,9)', '(0,9)', '9', '{26,42}', '(14,14)')    +
+   Chunk 9: offset = 9, location = 1120, hikey location = 192, hikey = ('(0,11)')    +
+     Item 9: offset = 1128, tuple = ('(0,10)', '(0,10)', '10', '{27,43}', '(15,15)') +
+   Chunk 10: offset = 10, location = 1216, hikey location = 200, hikey = ('(0,12)')  +
+     Item 10: offset = 1224, tuple = ('(0,11)', '(0,11)', '11', '{28,44}', '(16,16)')+
+   Chunk 11: offset = 11, location = 1312, hikey location = 208, hikey = ('(0,13)')  +
+     Item 11: offset = 1320, tuple = ('(0,12)', '(0,12)', '12', '{29,45}', '(17,17)')+
+   Chunk 12: offset = 12, location = 1408, hikey location = 216, hikey = ('(0,14)')  +
+     Item 12: offset = 1416, tuple = ('(0,13)', '(0,13)', '13', '{30,46}', '(18,18)')+
+   Chunk 13: offset = 13, location = 1504, hikey location = 224, hikey = ('(0,15)')  +
+     Item 13: offset = 1512, tuple = ('(0,14)', '(0,14)', '14', '{31,47}', '(19,19)')+
+   Chunk 14: offset = 14, location = 1600, hikey location = 232                      +
+     Item 14: offset = 1608, tuple = ('(0,15)', '(0,15)', '15', '{32,48}', '(20,20)')+
+                                                                                     +
+ Index o_test_non_index_bridging_options_ix1: not loaded                             +
+ Index index_bridge: not loaded                                                      +
+ Index toast: not loaded                                                             +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+(15 rows)
+
+ALTER TABLE o_test_non_index_bridging_options ADD PRIMARY KEY (i);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
+    "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index o_test_non_index_bridging_options_pkey       +
+     Index type: primary, unique                    +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: i                       +
+     Leaf tuple fields: index_bridging_ctid, i, j, p+
+ Index o_test_non_index_bridging_options_ix1        +
+     Index type: secondary                          +
+     Leaf tuple size: 1, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: i                       +
+     Leaf tuple fields: i                           +
+ Index index_bridge                                 +
+     Index type: secondary                          +
+     Leaf tuple size: 2, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: index_bridging_ctid     +
+     Leaf tuple fields: index_bridging_ctid, i      +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: i, attnum, chunknum     +
+     Leaf tuple fields: i, attnum, chunknum, data   +
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                             orioledb_tbl_structure                             
+--------------------------------------------------------------------------------
+ Index o_test_non_index_bridging_options_pkey contents                         +
+ Page 0: level = 0, maxKeyLen = 4, nVacatedBytes = 0                           +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean           +
+     Leftmost, Rightmost                                                       +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('2')    +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')          +
+   Chunk 1: offset = 1, location = 352, hikey location = 128, hikey = ('3')    +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')          +
+   Chunk 2: offset = 2, location = 448, hikey location = 136, hikey = ('4')    +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')          +
+   Chunk 3: offset = 3, location = 544, hikey location = 144, hikey = ('5')    +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')          +
+   Chunk 4: offset = 4, location = 640, hikey location = 152, hikey = ('6')    +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')        +
+   Chunk 5: offset = 5, location = 736, hikey location = 160, hikey = ('7')    +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')        +
+   Chunk 6: offset = 6, location = 832, hikey location = 168, hikey = ('8')    +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')        +
+   Chunk 7: offset = 7, location = 928, hikey location = 176, hikey = ('9')    +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')        +
+   Chunk 8: offset = 8, location = 1024, hikey location = 184, hikey = ('10')  +
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')       +
+   Chunk 9: offset = 9, location = 1120, hikey location = 192, hikey = ('11')  +
+     Item 9: offset = 1128, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')     +
+   Chunk 10: offset = 10, location = 1216, hikey location = 200, hikey = ('12')+
+     Item 10: offset = 1224, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')    +
+   Chunk 11: offset = 11, location = 1312, hikey location = 208, hikey = ('13')+
+     Item 11: offset = 1320, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')    +
+   Chunk 12: offset = 12, location = 1408, hikey location = 216, hikey = ('14')+
+     Item 12: offset = 1416, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')    +
+   Chunk 13: offset = 13, location = 1504, hikey location = 224, hikey = ('15')+
+     Item 13: offset = 1512, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')    +
+   Chunk 14: offset = 14, location = 1600, hikey location = 232                +
+     Item 14: offset = 1608, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')    +
+                                                                               +
+ Index o_test_non_index_bridging_options_ix1: not loaded                       +
+ Index index_bridge: not loaded                                                +
+ Index toast: not loaded                                                       +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+(15 rows)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(16, 20) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                               
+-----------------------------------------------------------------------------------
+ Index o_test_non_index_bridging_options_pkey contents                            +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('2')       +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')             +
+   Chunk 1: offset = 1, location = 352, hikey location = 128, hikey = ('3')       +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')             +
+   Chunk 2: offset = 2, location = 448, hikey location = 136, hikey = ('4')       +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')             +
+   Chunk 3: offset = 3, location = 544, hikey location = 144, hikey = ('5')       +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')             +
+   Chunk 4: offset = 4, location = 640, hikey location = 152, hikey = ('6')       +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')           +
+   Chunk 5: offset = 5, location = 736, hikey location = 160, hikey = ('7')       +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')           +
+   Chunk 6: offset = 6, location = 832, hikey location = 168, hikey = ('8')       +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')           +
+   Chunk 7: offset = 7, location = 928, hikey location = 176, hikey = ('9')       +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')           +
+   Chunk 8: offset = 8, location = 1024, hikey location = 184, hikey = ('10')     +
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')          +
+   Chunk 9: offset = 9, location = 1120, hikey location = 192, hikey = ('11')     +
+     Item 9: offset = 1128, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')        +
+   Chunk 10: offset = 10, location = 1216, hikey location = 200, hikey = ('12')   +
+     Item 10: offset = 1224, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')       +
+   Chunk 11: offset = 11, location = 1312, hikey location = 208, hikey = ('13')   +
+     Item 11: offset = 1320, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')       +
+   Chunk 12: offset = 12, location = 1408, hikey location = 216, hikey = ('14')   +
+     Item 12: offset = 1416, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')       +
+   Chunk 13: offset = 13, location = 1504, hikey location = 224, hikey = ('15')   +
+     Item 13: offset = 1512, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')       +
+   Chunk 14: offset = 14, location = 1600, hikey location = 232                   +
+     Item 14: offset = 1616, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')       +
+     Item 15: offset = 1704, tuple = ('(0,16)', '16', '{33,49}', '(21,21)')       +
+     Item 16: offset = 1792, tuple = ('(0,17)', '17', '{34,50}', '(22,22)')       +
+     Item 17: offset = 1880, tuple = ('(0,18)', '18', '{35,51}', '(23,23)')       +
+     Item 18: offset = 1968, tuple = ('(0,19)', '19', '{36,52}', '(24,24)')       +
+     Item 19: offset = 2056, tuple = ('(0,20)', '20', '{37,53}', '(25,25)')       +
+                                                                                  +
+ Index o_test_non_index_bridging_options_ix1 contents                             +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = regular, dirty              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('2')       +
+     Item 0: offset = 264, tuple = ('1')                                          +
+   Chunk 1: offset = 1, location = 288, hikey location = 128, hikey = ('3')       +
+     Item 1: offset = 296, tuple = ('2')                                          +
+   Chunk 2: offset = 2, location = 320, hikey location = 136, hikey = ('4')       +
+     Item 2: offset = 328, tuple = ('3')                                          +
+   Chunk 3: offset = 3, location = 352, hikey location = 144, hikey = ('5')       +
+     Item 3: offset = 360, tuple = ('4')                                          +
+   Chunk 4: offset = 4, location = 384, hikey location = 152, hikey = ('6')       +
+     Item 4: offset = 392, tuple = ('5')                                          +
+   Chunk 5: offset = 5, location = 416, hikey location = 160, hikey = ('7')       +
+     Item 5: offset = 424, tuple = ('6')                                          +
+   Chunk 6: offset = 6, location = 448, hikey location = 168, hikey = ('8')       +
+     Item 6: offset = 456, tuple = ('7')                                          +
+   Chunk 7: offset = 7, location = 480, hikey location = 176, hikey = ('9')       +
+     Item 7: offset = 488, tuple = ('8')                                          +
+   Chunk 8: offset = 8, location = 512, hikey location = 184, hikey = ('10')      +
+     Item 8: offset = 520, tuple = ('9')                                          +
+   Chunk 9: offset = 9, location = 544, hikey location = 192, hikey = ('11')      +
+     Item 9: offset = 552, tuple = ('10')                                         +
+   Chunk 10: offset = 10, location = 576, hikey location = 200, hikey = ('12')    +
+     Item 10: offset = 584, tuple = ('11')                                        +
+   Chunk 11: offset = 11, location = 608, hikey location = 208, hikey = ('13')    +
+     Item 11: offset = 616, tuple = ('12')                                        +
+   Chunk 12: offset = 12, location = 640, hikey location = 216, hikey = ('14')    +
+     Item 12: offset = 648, tuple = ('13')                                        +
+   Chunk 13: offset = 13, location = 672, hikey location = 224, hikey = ('15')    +
+     Item 13: offset = 680, tuple = ('14')                                        +
+   Chunk 14: offset = 14, location = 704, hikey location = 232                    +
+     Item 14: offset = 720, tuple = ('15')                                        +
+     Item 15: offset = 744, tuple = ('16')                                        +
+     Item 16: offset = 768, tuple = ('17')                                        +
+     Item 17: offset = 792, tuple = ('18')                                        +
+     Item 18: offset = 816, tuple = ('19')                                        +
+     Item 19: offset = 840, tuple = ('20')                                        +
+                                                                                  +
+ Index index_bridge contents                                                      +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = bridge, dirty               +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('(0,2)')   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1')                                 +
+   Chunk 1: offset = 1, location = 296, hikey location = 128, hikey = ('(0,3)')   +
+     Item 1: offset = 304, tuple = ('(0,2)', '2')                                 +
+   Chunk 2: offset = 2, location = 336, hikey location = 136, hikey = ('(0,4)')   +
+     Item 2: offset = 344, tuple = ('(0,3)', '3')                                 +
+   Chunk 3: offset = 3, location = 376, hikey location = 144, hikey = ('(0,5)')   +
+     Item 3: offset = 384, tuple = ('(0,4)', '4')                                 +
+   Chunk 4: offset = 4, location = 416, hikey location = 152, hikey = ('(0,6)')   +
+     Item 4: offset = 424, tuple = ('(0,5)', '5')                                 +
+   Chunk 5: offset = 5, location = 456, hikey location = 160, hikey = ('(0,7)')   +
+     Item 5: offset = 464, tuple = ('(0,6)', '6')                                 +
+   Chunk 6: offset = 6, location = 496, hikey location = 168, hikey = ('(0,8)')   +
+     Item 6: offset = 504, tuple = ('(0,7)', '7')                                 +
+   Chunk 7: offset = 7, location = 536, hikey location = 176, hikey = ('(0,9)')   +
+     Item 7: offset = 544, tuple = ('(0,8)', '8')                                 +
+   Chunk 8: offset = 8, location = 576, hikey location = 184, hikey = ('(0,10)')  +
+     Item 8: offset = 584, tuple = ('(0,9)', '9')                                 +
+   Chunk 9: offset = 9, location = 616, hikey location = 192, hikey = ('(0,11)')  +
+     Item 9: offset = 624, tuple = ('(0,10)', '10')                               +
+   Chunk 10: offset = 10, location = 656, hikey location = 200, hikey = ('(0,12)')+
+     Item 10: offset = 664, tuple = ('(0,11)', '11')                              +
+   Chunk 11: offset = 11, location = 696, hikey location = 208, hikey = ('(0,13)')+
+     Item 11: offset = 704, tuple = ('(0,12)', '12')                              +
+   Chunk 12: offset = 12, location = 736, hikey location = 216, hikey = ('(0,14)')+
+     Item 12: offset = 744, tuple = ('(0,13)', '13')                              +
+   Chunk 13: offset = 13, location = 776, hikey location = 224, hikey = ('(0,15)')+
+     Item 13: offset = 784, tuple = ('(0,14)', '14')                              +
+   Chunk 14: offset = 14, location = 816, hikey location = 232                    +
+     Item 14: offset = 832, tuple = ('(0,15)', '15')                              +
+     Item 15: offset = 864, tuple = ('(0,16)', '16')                              +
+     Item 16: offset = 896, tuple = ('(0,17)', '17')                              +
+     Item 17: offset = 928, tuple = ('(0,18)', '18')                              +
+     Item 18: offset = 960, tuple = ('(0,19)', '19')                              +
+     Item 19: offset = 992, tuple = ('(0,20)', '20')                              +
+                                                                                  +
+ Index toast: not loaded                                                          +
+ 
+(1 row)
+
+DROP INDEX o_test_non_index_bridging_options_ix1;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Index Scan using o_test_non_index_bridging_options_ix2 on o_test_non_index_bridging_options
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+ 16 | {33,49} | (21,21)
+ 17 | {34,50} | (22,22)
+ 18 | {35,51} | (23,23)
+ 19 | {36,52} | (24,24)
+ 20 | {37,53} | (25,25)
+(20 rows)
+
+COMMIT;
+DROP INDEX o_test_non_index_bridging_options_ix2;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
+
+ALTER TABLE o_test_non_index_bridging_options DROP CONSTRAINT o_test_non_index_bridging_options_pkey;
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                               
+-----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                      +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,3)')    +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')             +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')             +
+   Chunk 1: offset = 2, location = 440, hikey location = 104, hikey = ('(0,5)')   +
+     Item 2: offset = 448, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')             +
+     Item 3: offset = 536, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')             +
+   Chunk 2: offset = 4, location = 624, hikey location = 112, hikey = ('(0,7)')   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')           +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')           +
+   Chunk 3: offset = 6, location = 808, hikey location = 120, hikey = ('(0,9)')   +
+     Item 6: offset = 816, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')           +
+     Item 7: offset = 904, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')           +
+   Chunk 4: offset = 8, location = 992, hikey location = 128, hikey = ('(0,11)')  +
+     Item 8: offset = 1000, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')          +
+     Item 9: offset = 1088, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')        +
+   Chunk 5: offset = 10, location = 1176, hikey location = 136, hikey = ('(0,13)')+
+     Item 10: offset = 1184, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')       +
+     Item 11: offset = 1272, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')       +
+   Chunk 6: offset = 12, location = 1360, hikey location = 144, hikey = ('(0,15)')+
+     Item 12: offset = 1368, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')       +
+     Item 13: offset = 1456, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')       +
+   Chunk 7: offset = 14, location = 1544, hikey location = 152, hikey = ('(0,17)')+
+     Item 14: offset = 1552, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')       +
+     Item 15: offset = 1640, tuple = ('(0,16)', '16', '{33,49}', '(21,21)')       +
+   Chunk 8: offset = 16, location = 1728, hikey location = 160, hikey = ('(0,19)')+
+     Item 16: offset = 1736, tuple = ('(0,17)', '17', '{34,50}', '(22,22)')       +
+     Item 17: offset = 1824, tuple = ('(0,18)', '18', '{35,51}', '(23,23)')       +
+   Chunk 9: offset = 18, location = 1912, hikey location = 168                    +
+     Item 18: offset = 1920, tuple = ('(0,19)', '19', '{36,52}', '(24,24)')       +
+     Item 19: offset = 2008, tuple = ('(0,20)', '20', '{37,53}', '(25,25)')       +
+                                                                                  +
+ Index toast: not loaded                                                          +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+ 16 | {33,49} | (21,21)
+ 17 | {34,50} | (22,22)
+ 18 | {35,51} | (23,23)
+ 19 | {36,52} | (24,24)
+ 20 | {37,53} | (25,25)
+(20 rows)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(21, 25) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                               
+-----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                      +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,3)')    +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')             +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')             +
+   Chunk 1: offset = 2, location = 440, hikey location = 104, hikey = ('(0,5)')   +
+     Item 2: offset = 448, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')             +
+     Item 3: offset = 536, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')             +
+   Chunk 2: offset = 4, location = 624, hikey location = 112, hikey = ('(0,7)')   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')           +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')           +
+   Chunk 3: offset = 6, location = 808, hikey location = 120, hikey = ('(0,9)')   +
+     Item 6: offset = 816, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')           +
+     Item 7: offset = 904, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')           +
+   Chunk 4: offset = 8, location = 992, hikey location = 128, hikey = ('(0,11)')  +
+     Item 8: offset = 1000, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')          +
+     Item 9: offset = 1088, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')        +
+   Chunk 5: offset = 10, location = 1176, hikey location = 136, hikey = ('(0,13)')+
+     Item 10: offset = 1184, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')       +
+     Item 11: offset = 1272, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')       +
+   Chunk 6: offset = 12, location = 1360, hikey location = 144, hikey = ('(0,15)')+
+     Item 12: offset = 1368, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')       +
+     Item 13: offset = 1456, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')       +
+   Chunk 7: offset = 14, location = 1544, hikey location = 152, hikey = ('(0,17)')+
+     Item 14: offset = 1552, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')       +
+     Item 15: offset = 1640, tuple = ('(0,16)', '16', '{33,49}', '(21,21)')       +
+   Chunk 8: offset = 16, location = 1728, hikey location = 160, hikey = ('(0,19)')+
+     Item 16: offset = 1736, tuple = ('(0,17)', '17', '{34,50}', '(22,22)')       +
+     Item 17: offset = 1824, tuple = ('(0,18)', '18', '{35,51}', '(23,23)')       +
+   Chunk 9: offset = 18, location = 1912, hikey location = 168                    +
+     Item 18: offset = 1928, tuple = ('(0,19)', '19', '{36,52}', '(24,24)')       +
+     Item 19: offset = 2016, tuple = ('(0,20)', '20', '{37,53}', '(25,25)')       +
+     Item 20: offset = 2104, tuple = ('(0,21)', '21', '{38,54}', '(26,26)')       +
+     Item 21: offset = 2192, tuple = ('(0,22)', '22', '{39,55}', '(27,27)')       +
+     Item 22: offset = 2280, tuple = ('(0,23)', '23', '{40,56}', '(28,28)')       +
+     Item 23: offset = 2368, tuple = ('(0,24)', '24', '{41,57}', '(29,29)')       +
+     Item 24: offset = 2456, tuple = ('(0,25)', '25', '{42,58}', '(30,30)')       +
+                                                                                  +
+ Index toast: not loaded                                                          +
+ 
+(1 row)
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Index Scan using o_test_non_index_bridging_options_ix2 on o_test_non_index_bridging_options
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+ 16 | {33,49} | (21,21)
+ 17 | {34,50} | (22,22)
+ 18 | {35,51} | (23,23)
+ 19 | {36,52} | (24,24)
+ 20 | {37,53} | (25,25)
+ 21 | {38,54} | (26,26)
+ 22 | {39,55} | (27,27)
+ 23 | {40,56} | (28,28)
+ 24 | {41,57} | (29,29)
+ 25 | {42,58} | (30,30)
+(25 rows)
+
+COMMIT;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 6 other objects

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -93,9 +93,10 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
 (1 row)
 
 CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (orioledb_index = off, deduplicate_items = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
-WARNING:  Enabling bridging for orioledb table 'o_test_ix_ams'
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  enabling index bridging for orioledb table 'o_test_ix_ams'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
 SELECT ctid, htid, tids FROM
 		 generate_series(1,
 						 (SELECT relpages - 1 FROM pg_class
@@ -1005,8 +1006,8 @@ SELECT * FROM o_test_ix_ams ORDER BY j;
 
 COMMIT;
 CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (orioledb_index = off, deduplicate_items = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
                           orioledb_tbl_indices                          
 ------------------------------------------------------------------------
@@ -1565,7 +1566,8 @@ SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
 (1 row)
 
 CREATE INDEX o_briging_vacuum_test_p_idx on o_briging_vacuum_test using gist(p);
-WARNING:  Enabling bridging for orioledb table 'o_briging_vacuum_test'
+NOTICE:  enabling index bridging for orioledb table 'o_briging_vacuum_test'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
 DELETE FROM o_briging_vacuum_test;
 VACUUM o_briging_vacuum_test;
 SELECT * FROM o_briging_vacuum_test WHERE p <@ box(point(0,0), point(1,1));
@@ -1613,8 +1615,8 @@ CREATE TABLE o_test_bridging_with_regular_no_pkey (
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix1 on
 	o_test_bridging_with_regular_no_pkey using btree (j) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix2 on
 	o_test_bridging_with_regular_no_pkey using btree (j);
 INSERT INTO o_test_bridging_with_regular_no_pkey
@@ -1759,8 +1761,8 @@ CREATE TABLE o_test_bridging_with_regular_pkey (
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_pkey_ix1 on
 	o_test_bridging_with_regular_pkey using btree (j) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 CREATE INDEX o_test_bridging_with_regular_pkey_ix2 on
 	o_test_bridging_with_regular_pkey using btree (k);
 INSERT INTO o_test_bridging_with_regular_pkey
@@ -1879,8 +1881,8 @@ CREATE INDEX o_test_bitmap_scans_ix2 on o_test_bitmap_scans using btree (j);
 CREATE INDEX o_test_bitmap_scans_ix3 on o_test_bitmap_scans using gin (j);
 CREATE INDEX o_test_bitmap_scans_ix4 on o_test_bitmap_scans using gist (p);
 CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 BEGIN;
 SET LOCAL enable_seqscan = off;
 SET LOCAL enable_indexscan = off;
@@ -1986,8 +1988,8 @@ Indexes:
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2214,9 +2216,10 @@ Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
 
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
-WARNING:  Enabling bridging for orioledb table 'o_test_non_index_bridging_options'
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -10,7 +10,7 @@ CREATE TABLE o_test_ix_ams (
 	p point,
 	pk1 int,
 	pk2 int
-) USING orioledb WITH (index_bridging);
+) USING orioledb;
 SELECT orioledb_table_description('o_test_ix_ams'::regclass);
                 orioledb_table_description                 
 -----------------------------------------------------------
@@ -33,48 +33,35 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  p      | point     |           |          |         | plain    |              | 
  pk1    | integer   |           |          |         | plain    |              | 
  pk2    | integer   |           |          |         | plain    |              | 
-Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
-                        orioledb_tbl_indices                         
----------------------------------------------------------------------
- Index ctid_primary                                                 +
-     Index type: primary, unique, ctid                              +
-     Leaf tuple size: 7, non-leaf tuple size: 1                     +
-     Non-leaf tuple fields: ctid                                    +
-     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p, pk1, pk2+
- Index index_bridge                                                 +
-     Index type: secondary                                          +
-     Leaf tuple size: 2, non-leaf tuple size: 1                     +
-     Non-leaf tuple fields: index_bridging_ctid                     +
-     Leaf tuple fields: index_bridging_ctid, ctid                   +
- Index toast                                                        +
-     Index type: secondary                                          +
-     Leaf tuple size: 4, non-leaf tuple size: 3                     +
-     Non-leaf tuple fields: ctid, attnum, chunknum                  +
-     Leaf tuple fields: ctid, attnum, chunknum, data                +
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 6, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p, pk1, pk2     +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
  
 (1 row)
 
 INSERT INTO o_test_ix_ams VALUES (1, ARRAY[2,3], point(4, 5), 6, 7);
 SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
-                                orioledb_tbl_structure                                 
----------------------------------------------------------------------------------------
- Index ctid_primary contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty                  +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
-                                                                                      +
- Index index_bridge contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty                   +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                 +
-                                                                                      +
- Index toast: not loaded                                                              +
+                            orioledb_tbl_structure                            
+------------------------------------------------------------------------------
+ Index ctid_primary contents                                                 +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                         +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty         +
+     Leftmost, Rightmost                                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                  +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
+                                                                             +
+ Index toast: not loaded                                                     +
  
 (1 row)
 
@@ -92,29 +79,23 @@ SELECT * FROM o_test_ix_ams;
 (1 row)
 
 SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
-                                orioledb_tbl_structure                                 
----------------------------------------------------------------------------------------
- Index ctid_primary contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty                  +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
-                                                                                      +
- Index index_bridge contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty                   +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                 +
-                                                                                      +
- Index toast: not loaded                                                              +
+                            orioledb_tbl_structure                            
+------------------------------------------------------------------------------
+ Index ctid_primary contents                                                 +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                         +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty         +
+     Leftmost, Rightmost                                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                  +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
+                                                                             +
+ Index toast: not loaded                                                     +
  
 (1 row)
 
-CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (index_bridging, deduplicate_items = off);
+CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (orioledb_index = off, deduplicate_items = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
+WARNING:  Enabling bridging for orioledb table 'o_test_ix_ams'
 SELECT ctid, htid, tids FROM
 		 generate_series(1,
 						 (SELECT relpages - 1 FROM pg_class
@@ -136,7 +117,7 @@ SELECT ctid, htid, tids FROM
  pk1    | integer   |           |          |         | plain    |              | 
  pk2    | integer   |           |          |         | plain    |              | 
 Indexes:
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -191,15 +172,15 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
                                 orioledb_tbl_structure                                 
 ---------------------------------------------------------------------------------------
  Index ctid_primary contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty                  +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                  +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                  +
      Leftmost, Rightmost                                                              +
    Chunk 0: offset = 0, location = 256, hikey location = 64                           +
      Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
                                                                                       +
  Index index_bridge contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty                   +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                  +
+ state = free, datoid equal, relnode equal, ix_type = bridge, clean                   +
      Leftmost, Rightmost                                                              +
    Chunk 0: offset = 0, location = 256, hikey location = 64                           +
      Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                 +
@@ -569,12 +550,12 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
      Leftmost, Rightmost                                                                            +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,1)')                      +
-     Item 0: offset = 264, tuple = ('(0,0)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
-   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,2)')                      +
-     Item 1: offset = 368, tuple = ('(0,1)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,2)')                      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
+   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,3)')                      +
+     Item 1: offset = 368, tuple = ('(0,2)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
    Chunk 2: offset = 2, location = 464, hikey location = 88                                         +
-     Item 2: offset = 472, tuple = ('(0,2)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
+     Item 2: offset = 472, tuple = ('(0,3)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
                                                                                                     +
  Index index_bridge: not loaded                                                                     +
  Index toast: not loaded                                                                            +
@@ -619,23 +600,23 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
      Leftmost, Rightmost                                                                            +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,1)')                      +
-     Item 0: offset = 264, tuple = ('(0,0)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
-   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,2)')                      +
-     Item 1: offset = 368, tuple = ('(0,1)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,2)')                      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
+   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,3)')                      +
+     Item 1: offset = 368, tuple = ('(0,2)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
    Chunk 2: offset = 2, location = 464, hikey location = 88                                         +
-     Item 2: offset = 472, tuple = ('(0,2)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
+     Item 2: offset = 472, tuple = ('(0,3)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
                                                                                                     +
  Index index_bridge contents                                                                        +
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                +
  state = free, datoid equal, relnode equal, ix_type = bridge, clean                                 +
      Leftmost, Rightmost                                                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,2)')                      +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,0)')                                               +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                               +
    Chunk 1: offset = 1, location = 296, hikey location = 80, hikey = ('(0,3)')                      +
-     Item 1: offset = 304, tuple = ('(0,2)', '(0,1)')                                               +
+     Item 1: offset = 304, tuple = ('(0,2)', '(0,2)')                                               +
    Chunk 2: offset = 2, location = 336, hikey location = 88                                         +
-     Item 2: offset = 344, tuple = ('(0,3)', '(0,2)')                                               +
+     Item 2: offset = 344, tuple = ('(0,3)', '(0,3)')                                               +
                                                                                                     +
  Index toast: not loaded                                                                            +
  
@@ -870,7 +851,7 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  pk2    | integer |           | not null |         | plain   |              | 
  k      | integer |           |          |         | plain   |              | 
 Indexes:
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 -- Don't update bridge_index when updated column not indexed by any bridged index
@@ -1023,7 +1004,7 @@ SELECT * FROM o_test_ix_ams ORDER BY j;
 (3 rows)
 
 COMMIT;
-CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (index_bridging, deduplicate_items = off);
+CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (orioledb_index = off, deduplicate_items = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1185,8 +1166,8 @@ CREATE INDEX o_test_ix_ams_hash_ix ON o_test_ix_ams USING hash (k);
  pk2    | integer |           | not null |         | plain   |              | 
  k      | integer |           |          |         | plain   |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1377,8 +1358,8 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT *, r IS NULL FROM o_test_ix_ams;
@@ -1448,8 +1429,8 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1563,38 +1544,28 @@ SELECT p FROM o_test_ix_ams WHERE p <@ box(point(0,0), point(4000, 5000));
 (3 rows)
 
 COMMIT;
-CREATE TABLE o_briging_vacuum_test (id serial primary key, val float, p point) USING orioledb WITH (index_bridging);
+CREATE TABLE o_briging_vacuum_test (id serial primary key, val float, p point) USING orioledb;
 INSERT INTO o_briging_vacuum_test (p) (SELECT point(0.01 * i, 0.02 * i) FROM generate_series(1,5) i);
 SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
-                        orioledb_tbl_structure                         
------------------------------------------------------------------------
- Index o_briging_vacuum_test_pkey contents                            +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty  +
-     Leftmost, Rightmost                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64           +
-     Item 0: offset = 272, tuple = ('(0,1)', '1', null, '(0.01,0.02)')+
-     Item 1: offset = 336, tuple = ('(0,2)', '2', null, '(0.02,0.04)')+
-     Item 2: offset = 400, tuple = ('(0,3)', '3', null, '(0.03,0.06)')+
-     Item 3: offset = 464, tuple = ('(0,4)', '4', null, '(0.04,0.08)')+
-     Item 4: offset = 528, tuple = ('(0,5)', '5', null, '(0.05,0.1)') +
-                                                                      +
- Index index_bridge contents                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty   +
-     Leftmost, Rightmost                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64           +
-     Item 0: offset = 272, tuple = ('(0,1)', '1')                     +
-     Item 1: offset = 304, tuple = ('(0,2)', '2')                     +
-     Item 2: offset = 336, tuple = ('(0,3)', '3')                     +
-     Item 3: offset = 368, tuple = ('(0,4)', '4')                     +
-     Item 4: offset = 400, tuple = ('(0,5)', '5')                     +
-                                                                      +
- Index toast: not loaded                                              +
+                       orioledb_tbl_structure                        
+---------------------------------------------------------------------
+ Index o_briging_vacuum_test_pkey contents                          +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty+
+     Leftmost, Rightmost                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 64         +
+     Item 0: offset = 272, tuple = ('1', null, '(0.01,0.02)')       +
+     Item 1: offset = 328, tuple = ('2', null, '(0.02,0.04)')       +
+     Item 2: offset = 384, tuple = ('3', null, '(0.03,0.06)')       +
+     Item 3: offset = 440, tuple = ('4', null, '(0.04,0.08)')       +
+     Item 4: offset = 496, tuple = ('5', null, '(0.05,0.1)')        +
+                                                                    +
+ Index toast: not loaded                                            +
  
 (1 row)
 
 CREATE INDEX o_briging_vacuum_test_p_idx on o_briging_vacuum_test using gist(p);
+WARNING:  Enabling bridging for orioledb table 'o_briging_vacuum_test'
 DELETE FROM o_briging_vacuum_test;
 VACUUM o_briging_vacuum_test;
 SELECT * FROM o_briging_vacuum_test WHERE p <@ box(point(0,0), point(1,1));
@@ -1606,18 +1577,22 @@ SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
                              orioledb_tbl_structure                             
 --------------------------------------------------------------------------------
  Index o_briging_vacuum_test_pkey contents                                     +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 320                         +
+ Page 0: level = 0, maxKeyLen = 4, nVacatedBytes = 320                         +
  state = free, datoid equal, relnode equal, ix_type = primary, dirty           +
      Leftmost, Rightmost                                                       +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                    +
-     Item 0: deleted, offset = 272, tuple = ('(0,1)', '1', null, '(0.01,0.02)')+
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('2')     +
+     Item 0: deleted, offset = 264, tuple = ('(0,1)', '1', null, '(0.01,0.02)')+
+   Chunk 1: offset = 1, location = 328, hikey location = 88, hikey = ('3')     +
      Item 1: deleted, offset = 336, tuple = ('(0,2)', '2', null, '(0.02,0.04)')+
-     Item 2: deleted, offset = 400, tuple = ('(0,3)', '3', null, '(0.03,0.06)')+
-     Item 3: deleted, offset = 464, tuple = ('(0,4)', '4', null, '(0.04,0.08)')+
-     Item 4: deleted, offset = 528, tuple = ('(0,5)', '5', null, '(0.05,0.1)') +
+   Chunk 2: offset = 2, location = 400, hikey location = 96, hikey = ('4')     +
+     Item 2: deleted, offset = 408, tuple = ('(0,3)', '3', null, '(0.03,0.06)')+
+   Chunk 3: offset = 3, location = 472, hikey location = 104, hikey = ('5')    +
+     Item 3: deleted, offset = 480, tuple = ('(0,4)', '4', null, '(0.04,0.08)')+
+   Chunk 4: offset = 4, location = 544, hikey location = 112                   +
+     Item 4: deleted, offset = 552, tuple = ('(0,5)', '5', null, '(0.05,0.1)') +
                                                                                +
  Index index_bridge contents                                                   +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                           +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                           +
  state = free, datoid equal, relnode equal, ix_type = bridge, dirty            +
      Leftmost, Rightmost                                                       +
    Chunk 0: offset = 0, location = 256, hikey location = 64                    +
@@ -1637,7 +1612,7 @@ CREATE TABLE o_test_bridging_with_regular_no_pkey (
 	j int
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix1 on
-	o_test_bridging_with_regular_no_pkey using btree (j) WITH (index_bridging);
+	o_test_bridging_with_regular_no_pkey using btree (j) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix2 on
@@ -1783,7 +1758,7 @@ CREATE TABLE o_test_bridging_with_regular_pkey (
 	k int
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_pkey_ix1 on
-	o_test_bridging_with_regular_pkey using btree (j) WITH (index_bridging);
+	o_test_bridging_with_regular_pkey using btree (j) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 CREATE INDEX o_test_bridging_with_regular_pkey_ix2 on
@@ -1903,7 +1878,7 @@ CREATE INDEX o_test_bitmap_scans_ix1 on o_test_bitmap_scans using hash (j);
 CREATE INDEX o_test_bitmap_scans_ix2 on o_test_bitmap_scans using btree (j);
 CREATE INDEX o_test_bitmap_scans_ix3 on o_test_bitmap_scans using gin (j);
 CREATE INDEX o_test_bitmap_scans_ix4 on o_test_bitmap_scans using gist (p);
-CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (index_bridging);
+CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 BEGIN;
@@ -2010,7 +1985,7 @@ Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 \d+ o_test_index_bridging_options
@@ -2022,7 +1997,7 @@ DETAIL:  this feature is only for testing
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
@@ -2035,8 +2010,8 @@ CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
@@ -2049,12 +2024,12 @@ CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING hash (i) WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING gist (p);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2064,13 +2039,13 @@ CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gist (p);
+CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gin (j);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2080,14 +2055,14 @@ CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING gin (j);
+CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING spgist (p);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2097,15 +2072,15 @@ CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING spgist (p);
+CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING brin (i);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2115,37 +2090,17 @@ CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-Options: index_bridging=true
-
-CREATE INDEX o_test_index_bridging_options_ix9 ON o_test_index_bridging_options USING brin (i);
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing tables
+ERROR:  Cannot change index_bridging option manually
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2155,14 +2110,13 @@ ERROR:  Cannot change index_bridging option for existing tables
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options SET (index_bridging);
@@ -2175,17 +2129,17 @@ ALTER TABLE o_test_index_bridging_options SET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
-ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
+ALTER INDEX o_test_index_bridging_options_ix2 RESET (orioledb_index);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2195,18 +2149,17 @@ ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
-ALTER INDEX o_test_index_bridging_options_ix5 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
+ALTER INDEX o_test_index_bridging_options_ix1 SET (orioledb_index = off);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2216,140 +2169,13 @@ ERROR:  Cannot change index_bridging option for existing indices
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix2 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix1 SET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix6 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix7 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix8 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix9 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
 CREATE TABLE o_test_non_index_bridging_options (
@@ -2367,7 +2193,7 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 
 ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing tables
+ERROR:  Cannot change index_bridging option manually
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2387,8 +2213,10 @@ CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
 
-CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (index_bridging);
-ERROR:  Cannot use 'index_bridging' on table without 'index_bridging' option
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+WARNING:  Using bridged btree index for orioledb
+DETAIL:  this feature is only for testing
+WARNING:  Enabling bridging for orioledb table 'o_test_non_index_bridging_options'
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2398,8 +2226,11 @@ ERROR:  Cannot use 'index_bridging' on table without 'index_bridging' option
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
 
-ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
+ALTER INDEX o_test_non_index_bridging_options_ix2 RESET (orioledb_index);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2409,9 +2240,11 @@ ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
 
-ALTER INDEX o_test_non_index_bridging_options_ix1 SET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
+ALTER INDEX o_test_non_index_bridging_options_ix1 SET (orioledb_index = off);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2421,6 +2254,8 @@ ERROR:  Cannot change index_bridging option for existing indices
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
 
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -11,7 +11,7 @@ CREATE TABLE o_test_ix_ams (
 	p point,
 	pk1 int,
 	pk2 int
-) USING orioledb WITH (index_bridging);
+) USING orioledb;
 SELECT orioledb_table_description('o_test_ix_ams'::regclass);
                 orioledb_table_description                 
 -----------------------------------------------------------
@@ -34,48 +34,35 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  p      | point     |           |          |         | plain    |              | 
  pk1    | integer   |           |          |         | plain    |              | 
  pk2    | integer   |           |          |         | plain    |              | 
-Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
-                        orioledb_tbl_indices                         
----------------------------------------------------------------------
- Index ctid_primary                                                 +
-     Index type: primary, unique, ctid                              +
-     Leaf tuple size: 7, non-leaf tuple size: 1                     +
-     Non-leaf tuple fields: ctid                                    +
-     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p, pk1, pk2+
- Index index_bridge                                                 +
-     Index type: secondary                                          +
-     Leaf tuple size: 2, non-leaf tuple size: 1                     +
-     Non-leaf tuple fields: index_bridging_ctid                     +
-     Leaf tuple fields: index_bridging_ctid, ctid                   +
- Index toast                                                        +
-     Index type: secondary                                          +
-     Leaf tuple size: 4, non-leaf tuple size: 3                     +
-     Non-leaf tuple fields: ctid, attnum, chunknum                  +
-     Leaf tuple fields: ctid, attnum, chunknum, data                +
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 6, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p, pk1, pk2     +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
  
 (1 row)
 
 INSERT INTO o_test_ix_ams VALUES (1, ARRAY[2,3], point(4, 5), 6, 7);
 SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
-                                orioledb_tbl_structure                                 
----------------------------------------------------------------------------------------
- Index ctid_primary contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty                  +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
-                                                                                      +
- Index index_bridge contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty                   +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                 +
-                                                                                      +
- Index toast: not loaded                                                              +
+                            orioledb_tbl_structure                            
+------------------------------------------------------------------------------
+ Index ctid_primary contents                                                 +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                         +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty         +
+     Leftmost, Rightmost                                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                  +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
+                                                                             +
+ Index toast: not loaded                                                     +
  
 (1 row)
 
@@ -93,29 +80,23 @@ SELECT * FROM o_test_ix_ams;
 (1 row)
 
 SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
-                                orioledb_tbl_structure                                 
----------------------------------------------------------------------------------------
- Index ctid_primary contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty                  +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
-                                                                                      +
- Index index_bridge contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty                   +
-     Leftmost, Rightmost                                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                           +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                 +
-                                                                                      +
- Index toast: not loaded                                                              +
+                            orioledb_tbl_structure                            
+------------------------------------------------------------------------------
+ Index ctid_primary contents                                                 +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                         +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty         +
+     Leftmost, Rightmost                                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                  +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
+                                                                             +
+ Index toast: not loaded                                                     +
  
 (1 row)
 
-CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (index_bridging, deduplicate_items = off);
+CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (orioledb_index = off, deduplicate_items = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
+WARNING:  Enabling bridging for orioledb table 'o_test_ix_ams'
 SELECT ctid, htid, tids FROM
 		 generate_series(1,
 						 (SELECT relpages - 1 FROM pg_class
@@ -136,7 +117,7 @@ HINT:  No function matches the given name and argument types. You might need to 
  pk1    | integer   |           |          |         | plain    |              | 
  pk2    | integer   |           |          |         | plain    |              | 
 Indexes:
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -190,15 +171,15 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
                                 orioledb_tbl_structure                                 
 ---------------------------------------------------------------------------------------
  Index ctid_primary contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty                  +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                  +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                  +
      Leftmost, Rightmost                                                              +
    Chunk 0: offset = 0, location = 256, hikey location = 64                           +
      Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')+
                                                                                       +
  Index index_bridge contents                                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty                   +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                  +
+ state = free, datoid equal, relnode equal, ix_type = bridge, clean                   +
      Leftmost, Rightmost                                                              +
    Chunk 0: offset = 0, location = 256, hikey location = 64                           +
      Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                 +
@@ -561,12 +542,12 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
      Leftmost, Rightmost                                                                            +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,1)')                      +
-     Item 0: offset = 264, tuple = ('(0,0)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
-   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,2)')                      +
-     Item 1: offset = 368, tuple = ('(0,1)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,2)')                      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
+   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,3)')                      +
+     Item 1: offset = 368, tuple = ('(0,2)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
    Chunk 2: offset = 2, location = 464, hikey location = 88                                         +
-     Item 2: offset = 472, tuple = ('(0,2)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
+     Item 2: offset = 472, tuple = ('(0,3)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
                                                                                                     +
  Index index_bridge: not loaded                                                                     +
  Index toast: not loaded                                                                            +
@@ -608,23 +589,23 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
      Leftmost, Rightmost                                                                            +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,1)')                      +
-     Item 0: offset = 264, tuple = ('(0,0)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
-   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,2)')                      +
-     Item 1: offset = 368, tuple = ('(0,1)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,2)')                      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{2,3}', '(4,5)', '6', '7')              +
+   Chunk 1: offset = 1, location = 360, hikey location = 80, hikey = ('(0,3)')                      +
+     Item 1: offset = 368, tuple = ('(0,2)', '(0,2)', '10', '{20,30}', '(40,50)', '60', '70')       +
    Chunk 2: offset = 2, location = 464, hikey location = 88                                         +
-     Item 2: offset = 472, tuple = ('(0,2)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
+     Item 2: offset = 472, tuple = ('(0,3)', '(0,3)', '100', '{200,300}', '(400,500)', '600', '700')+
                                                                                                     +
  Index index_bridge contents                                                                        +
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                +
  state = free, datoid equal, relnode equal, ix_type = bridge, clean                                 +
      Leftmost, Rightmost                                                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('(0,2)')                      +
-     Item 0: offset = 264, tuple = ('(0,1)', '(0,0)')                                               +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)')                                               +
    Chunk 1: offset = 1, location = 296, hikey location = 80, hikey = ('(0,3)')                      +
-     Item 1: offset = 304, tuple = ('(0,2)', '(0,1)')                                               +
+     Item 1: offset = 304, tuple = ('(0,2)', '(0,2)')                                               +
    Chunk 2: offset = 2, location = 336, hikey location = 88                                         +
-     Item 2: offset = 344, tuple = ('(0,3)', '(0,2)')                                               +
+     Item 2: offset = 344, tuple = ('(0,3)', '(0,3)')                                               +
                                                                                                     +
  Index toast: not loaded                                                                            +
  
@@ -853,7 +834,7 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  pk2    | integer |           | not null |         | plain   |              | 
  k      | integer |           |          |         | plain   |              | 
 Indexes:
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 -- Don't update bridge_index when updated column not indexed by any bridged index
@@ -997,7 +978,7 @@ SELECT * FROM o_test_ix_ams ORDER BY j;
 (3 rows)
 
 COMMIT;
-CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (index_bridging, deduplicate_items = off);
+CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (orioledb_index = off, deduplicate_items = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1152,8 +1133,8 @@ CREATE INDEX o_test_ix_ams_hash_ix ON o_test_ix_ams USING hash (k);
  pk2    | integer |           | not null |         | plain   |              | 
  k      | integer |           |          |         | plain   |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1342,8 +1323,8 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT *, r IS NULL FROM o_test_ix_ams;
@@ -1413,8 +1394,8 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
-    "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
+    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1524,38 +1505,28 @@ SELECT p FROM o_test_ix_ams WHERE p <@ box(point(0,0), point(4000, 5000));
 (3 rows)
 
 COMMIT;
-CREATE TABLE o_briging_vacuum_test (id serial primary key, val float, p point) USING orioledb WITH (index_bridging);
+CREATE TABLE o_briging_vacuum_test (id serial primary key, val float, p point) USING orioledb;
 INSERT INTO o_briging_vacuum_test (p) (SELECT point(0.01 * i, 0.02 * i) FROM generate_series(1,5) i);
 SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
-                        orioledb_tbl_structure                         
------------------------------------------------------------------------
- Index o_briging_vacuum_test_pkey contents                            +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                  +
- state = free, datoid equal, relnode equal, ix_type = primary, dirty  +
-     Leftmost, Rightmost                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64           +
-     Item 0: offset = 272, tuple = ('(0,1)', '1', null, '(0.01,0.02)')+
-     Item 1: offset = 336, tuple = ('(0,2)', '2', null, '(0.02,0.04)')+
-     Item 2: offset = 400, tuple = ('(0,3)', '3', null, '(0.03,0.06)')+
-     Item 3: offset = 464, tuple = ('(0,4)', '4', null, '(0.04,0.08)')+
-     Item 4: offset = 528, tuple = ('(0,5)', '5', null, '(0.05,0.1)') +
-                                                                      +
- Index index_bridge contents                                          +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                  +
- state = free, datoid equal, relnode equal, ix_type = bridge, dirty   +
-     Leftmost, Rightmost                                              +
-   Chunk 0: offset = 0, location = 256, hikey location = 64           +
-     Item 0: offset = 272, tuple = ('(0,1)', '1')                     +
-     Item 1: offset = 304, tuple = ('(0,2)', '2')                     +
-     Item 2: offset = 336, tuple = ('(0,3)', '3')                     +
-     Item 3: offset = 368, tuple = ('(0,4)', '4')                     +
-     Item 4: offset = 400, tuple = ('(0,5)', '5')                     +
-                                                                      +
- Index toast: not loaded                                              +
+                       orioledb_tbl_structure                        
+---------------------------------------------------------------------
+ Index o_briging_vacuum_test_pkey contents                          +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty+
+     Leftmost, Rightmost                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 64         +
+     Item 0: offset = 272, tuple = ('1', null, '(0.01,0.02)')       +
+     Item 1: offset = 328, tuple = ('2', null, '(0.02,0.04)')       +
+     Item 2: offset = 384, tuple = ('3', null, '(0.03,0.06)')       +
+     Item 3: offset = 440, tuple = ('4', null, '(0.04,0.08)')       +
+     Item 4: offset = 496, tuple = ('5', null, '(0.05,0.1)')        +
+                                                                    +
+ Index toast: not loaded                                            +
  
 (1 row)
 
 CREATE INDEX o_briging_vacuum_test_p_idx on o_briging_vacuum_test using gist(p);
+WARNING:  Enabling bridging for orioledb table 'o_briging_vacuum_test'
 DELETE FROM o_briging_vacuum_test;
 VACUUM o_briging_vacuum_test;
 SELECT * FROM o_briging_vacuum_test WHERE p <@ box(point(0,0), point(1,1));
@@ -1567,18 +1538,22 @@ SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
                              orioledb_tbl_structure                             
 --------------------------------------------------------------------------------
  Index o_briging_vacuum_test_pkey contents                                     +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 320                         +
+ Page 0: level = 0, maxKeyLen = 4, nVacatedBytes = 320                         +
  state = free, datoid equal, relnode equal, ix_type = primary, dirty           +
      Leftmost, Rightmost                                                       +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                    +
-     Item 0: deleted, offset = 272, tuple = ('(0,1)', '1', null, '(0.01,0.02)')+
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('2')     +
+     Item 0: deleted, offset = 264, tuple = ('(0,1)', '1', null, '(0.01,0.02)')+
+   Chunk 1: offset = 1, location = 328, hikey location = 88, hikey = ('3')     +
      Item 1: deleted, offset = 336, tuple = ('(0,2)', '2', null, '(0.02,0.04)')+
-     Item 2: deleted, offset = 400, tuple = ('(0,3)', '3', null, '(0.03,0.06)')+
-     Item 3: deleted, offset = 464, tuple = ('(0,4)', '4', null, '(0.04,0.08)')+
-     Item 4: deleted, offset = 528, tuple = ('(0,5)', '5', null, '(0.05,0.1)') +
+   Chunk 2: offset = 2, location = 400, hikey location = 96, hikey = ('4')     +
+     Item 2: deleted, offset = 408, tuple = ('(0,3)', '3', null, '(0.03,0.06)')+
+   Chunk 3: offset = 3, location = 472, hikey location = 104, hikey = ('5')    +
+     Item 3: deleted, offset = 480, tuple = ('(0,4)', '4', null, '(0.04,0.08)')+
+   Chunk 4: offset = 4, location = 544, hikey location = 112                   +
+     Item 4: deleted, offset = 552, tuple = ('(0,5)', '5', null, '(0.05,0.1)') +
                                                                                +
  Index index_bridge contents                                                   +
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                           +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                           +
  state = free, datoid equal, relnode equal, ix_type = bridge, dirty            +
      Leftmost, Rightmost                                                       +
    Chunk 0: offset = 0, location = 256, hikey location = 64                    +
@@ -1598,7 +1573,7 @@ CREATE TABLE o_test_bridging_with_regular_no_pkey (
 	j int
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix1 on
-	o_test_bridging_with_regular_no_pkey using btree (j) WITH (index_bridging);
+	o_test_bridging_with_regular_no_pkey using btree (j) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix2 on
@@ -1744,7 +1719,7 @@ CREATE TABLE o_test_bridging_with_regular_pkey (
 	k int
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_pkey_ix1 on
-	o_test_bridging_with_regular_pkey using btree (j) WITH (index_bridging);
+	o_test_bridging_with_regular_pkey using btree (j) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 CREATE INDEX o_test_bridging_with_regular_pkey_ix2 on
@@ -1864,7 +1839,7 @@ CREATE INDEX o_test_bitmap_scans_ix1 on o_test_bitmap_scans using hash (j);
 CREATE INDEX o_test_bitmap_scans_ix2 on o_test_bitmap_scans using btree (j);
 CREATE INDEX o_test_bitmap_scans_ix3 on o_test_bitmap_scans using gin (j);
 CREATE INDEX o_test_bitmap_scans_ix4 on o_test_bitmap_scans using gist (p);
-CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (index_bridging);
+CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 BEGIN;
@@ -1971,7 +1946,7 @@ Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  Using bridged btree index for orioledb
 DETAIL:  this feature is only for testing
 \d+ o_test_index_bridging_options
@@ -1983,7 +1958,7 @@ DETAIL:  this feature is only for testing
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
@@ -1996,8 +1971,8 @@ CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
@@ -2010,12 +1985,12 @@ CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING hash (i) WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING gist (p);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2025,13 +2000,13 @@ CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gist (p);
+CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gin (j);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2041,14 +2016,14 @@ CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING gin (j);
+CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING spgist (p);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2058,15 +2033,15 @@ CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
 Options: index_bridging=true
 
-CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING spgist (p);
+CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING brin (i);
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2076,37 +2051,17 @@ CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-Options: index_bridging=true
-
-CREATE INDEX o_test_index_bridging_options_ix9 ON o_test_index_bridging_options USING brin (i);
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing tables
+ERROR:  Cannot change index_bridging option manually
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2116,14 +2071,13 @@ ERROR:  Cannot change index_bridging option for existing tables
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options SET (index_bridging);
@@ -2136,17 +2090,17 @@ ALTER TABLE o_test_index_bridging_options SET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
-ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
+ALTER INDEX o_test_index_bridging_options_ix2 RESET (orioledb_index);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2156,18 +2110,17 @@ ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
-ALTER INDEX o_test_index_bridging_options_ix5 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
+ALTER INDEX o_test_index_bridging_options_ix1 SET (orioledb_index = off);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2177,140 +2130,13 @@ ERROR:  Cannot change index_bridging option for existing indices
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix2 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix1 SET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix6 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix7 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix8 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
-Options: index_bridging=true
-
-ALTER INDEX o_test_index_bridging_options_ix9 RESET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
-\d+ o_test_index_bridging_options
-                    Table "index_bridging.o_test_index_bridging_options"
- Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
---------+-----------+-----------+----------+---------+----------+--------------+-------------
- i      | integer   |           | not null |         | plain    |              | 
- j      | integer[] |           |          |         | extended |              | 
- p      | point     |           |          |         | plain    |              | 
-Indexes:
-    "o_test_index_bridging_options_ix1" btree (i)
-    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
-    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
-    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+    "o_test_index_bridging_options_ix3" hash (i)
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+    "o_test_index_bridging_options_ix5" gist (p)
+    "o_test_index_bridging_options_ix6" gin (j)
+    "o_test_index_bridging_options_ix7" spgist (p)
+    "o_test_index_bridging_options_ix8" brin (i)
 Options: index_bridging=true
 
 CREATE TABLE o_test_non_index_bridging_options (
@@ -2328,7 +2154,7 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 
 ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing tables
+ERROR:  Cannot change index_bridging option manually
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2348,8 +2174,10 @@ CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
 
-CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (index_bridging);
-ERROR:  Cannot use 'index_bridging' on table without 'index_bridging' option
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+WARNING:  Using bridged btree index for orioledb
+DETAIL:  this feature is only for testing
+WARNING:  Enabling bridging for orioledb table 'o_test_non_index_bridging_options'
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2359,8 +2187,11 @@ ERROR:  Cannot use 'index_bridging' on table without 'index_bridging' option
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
 
-ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
+ALTER INDEX o_test_non_index_bridging_options_ix2 RESET (orioledb_index);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2370,9 +2201,11 @@ ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
 
-ALTER INDEX o_test_non_index_bridging_options_ix1 SET (index_bridging);
-ERROR:  Cannot change index_bridging option for existing indices
+ALTER INDEX o_test_non_index_bridging_options_ix1 SET (orioledb_index = off);
+ERROR:  Cannot change 'orioledb_index' option for existing indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2382,6 +2215,8 @@ ERROR:  Cannot change index_bridging option for existing indices
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
 
 DROP EXTENSION pageinspect;
 ERROR:  extension "pageinspect" does not exist

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -94,9 +94,10 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
 (1 row)
 
 CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (orioledb_index = off, deduplicate_items = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
-WARNING:  Enabling bridging for orioledb table 'o_test_ix_ams'
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  enabling index bridging for orioledb table 'o_test_ix_ams'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
 SELECT ctid, htid, tids FROM
 		 generate_series(1,
 						 (SELECT relpages - 1 FROM pg_class
@@ -1526,7 +1527,8 @@ SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
 (1 row)
 
 CREATE INDEX o_briging_vacuum_test_p_idx on o_briging_vacuum_test using gist(p);
-WARNING:  Enabling bridging for orioledb table 'o_briging_vacuum_test'
+NOTICE:  enabling index bridging for orioledb table 'o_briging_vacuum_test'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
 DELETE FROM o_briging_vacuum_test;
 VACUUM o_briging_vacuum_test;
 SELECT * FROM o_briging_vacuum_test WHERE p <@ box(point(0,0), point(1,1));
@@ -1574,8 +1576,8 @@ CREATE TABLE o_test_bridging_with_regular_no_pkey (
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix1 on
 	o_test_bridging_with_regular_no_pkey using btree (j) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix2 on
 	o_test_bridging_with_regular_no_pkey using btree (j);
 INSERT INTO o_test_bridging_with_regular_no_pkey
@@ -1720,8 +1722,8 @@ CREATE TABLE o_test_bridging_with_regular_pkey (
 ) USING orioledb WITH (index_bridging);
 CREATE INDEX o_test_bridging_with_regular_pkey_ix1 on
 	o_test_bridging_with_regular_pkey using btree (j) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 CREATE INDEX o_test_bridging_with_regular_pkey_ix2 on
 	o_test_bridging_with_regular_pkey using btree (k);
 INSERT INTO o_test_bridging_with_regular_pkey
@@ -1840,8 +1842,8 @@ CREATE INDEX o_test_bitmap_scans_ix2 on o_test_bitmap_scans using btree (j);
 CREATE INDEX o_test_bitmap_scans_ix3 on o_test_bitmap_scans using gin (j);
 CREATE INDEX o_test_bitmap_scans_ix4 on o_test_bitmap_scans using gist (p);
 CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 BEGIN;
 SET LOCAL enable_seqscan = off;
 SET LOCAL enable_indexscan = off;
@@ -1947,8 +1949,8 @@ Indexes:
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2061,7 +2063,7 @@ Indexes:
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change index_bridging option manually
+ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2144,6 +2146,71 @@ CREATE TABLE o_test_non_index_bridging_options (
 	j int4[],
 	p point
 ) USING orioledb;
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(1, 10) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                            orioledb_tbl_structure                             
+-------------------------------------------------------------------------------
+ Index ctid_primary contents                                                  +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                          +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty          +
+     Leftmost, Rightmost                                                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 64, hikey = ('(0,5)')+
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')         +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')         +
+     Item 2: offset = 440, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')         +
+     Item 3: offset = 528, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')         +
+   Chunk 1: offset = 4, location = 616, hikey location = 72                   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')       +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')       +
+     Item 6: offset = 808, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')       +
+     Item 7: offset = 896, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')       +
+     Item 8: offset = 984, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')       +
+     Item 9: offset = 1072, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')    +
+                                                                              +
+ Index toast: not loaded                                                      +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
 ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
@@ -2153,8 +2220,62 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
 
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                            orioledb_tbl_structure                             
+-------------------------------------------------------------------------------
+ Index ctid_primary contents                                                  +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                          +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty          +
+     Leftmost, Rightmost                                                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 64, hikey = ('(0,5)')+
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')         +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')         +
+     Item 2: offset = 440, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')         +
+     Item 3: offset = 528, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')         +
+   Chunk 1: offset = 4, location = 616, hikey location = 72                   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')       +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')       +
+     Item 6: offset = 808, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')       +
+     Item 7: offset = 896, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')       +
+     Item 8: offset = 984, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')       +
+     Item 9: offset = 1072, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')    +
+                                                                              +
+ Index toast: not loaded                                                      +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
 ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
-ERROR:  Cannot change index_bridging option manually
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2162,6 +2283,260 @@ ERROR:  Cannot change index_bridging option manually
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                               orioledb_tbl_structure                                
+-------------------------------------------------------------------------------------
+ Index ctid_primary contents                                                        +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                +
+     Leftmost, Rightmost                                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{18,34}', '(6,6)')      +
+   Chunk 1: offset = 1, location = 352, hikey location = 104, hikey = ('(0,3)')     +
+     Item 1: offset = 360, tuple = ('(0,2)', '(0,2)', '2', '{19,35}', '(7,7)')      +
+   Chunk 2: offset = 2, location = 448, hikey location = 112, hikey = ('(0,4)')     +
+     Item 2: offset = 456, tuple = ('(0,3)', '(0,3)', '3', '{20,36}', '(8,8)')      +
+   Chunk 3: offset = 3, location = 544, hikey location = 120, hikey = ('(0,5)')     +
+     Item 3: offset = 552, tuple = ('(0,4)', '(0,4)', '4', '{21,37}', '(9,9)')      +
+   Chunk 4: offset = 4, location = 640, hikey location = 128, hikey = ('(0,6)')     +
+     Item 4: offset = 648, tuple = ('(0,5)', '(0,5)', '5', '{22,38}', '(10,10)')    +
+   Chunk 5: offset = 5, location = 736, hikey location = 136, hikey = ('(0,7)')     +
+     Item 5: offset = 744, tuple = ('(0,6)', '(0,6)', '6', '{23,39}', '(11,11)')    +
+   Chunk 6: offset = 6, location = 832, hikey location = 144, hikey = ('(0,8)')     +
+     Item 6: offset = 840, tuple = ('(0,7)', '(0,7)', '7', '{24,40}', '(12,12)')    +
+   Chunk 7: offset = 7, location = 928, hikey location = 152, hikey = ('(0,9)')     +
+     Item 7: offset = 936, tuple = ('(0,8)', '(0,8)', '8', '{25,41}', '(13,13)')    +
+   Chunk 8: offset = 8, location = 1024, hikey location = 160, hikey = ('(0,10)')   +
+     Item 8: offset = 1032, tuple = ('(0,9)', '(0,9)', '9', '{26,42}', '(14,14)')   +
+   Chunk 9: offset = 9, location = 1120, hikey location = 168                       +
+     Item 9: offset = 1128, tuple = ('(0,10)', '(0,10)', '10', '{27,43}', '(15,15)')+
+                                                                                    +
+ Index index_bridge: not loaded                                                     +
+ Index toast: not loaded                                                            +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Index Scan using o_test_non_index_bridging_options_ix2 on o_test_non_index_bridging_options
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
+COMMIT;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+DROP INDEX o_test_non_index_bridging_options_ix2;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                              
+----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                     +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                             +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean             +
+     Leftmost, Rightmost                                                         +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')            +
+   Chunk 1: offset = 1, location = 352, hikey location = 104, hikey = ('(0,3)')  +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')            +
+   Chunk 2: offset = 2, location = 448, hikey location = 112, hikey = ('(0,4)')  +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')            +
+   Chunk 3: offset = 3, location = 544, hikey location = 120, hikey = ('(0,5)')  +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')            +
+   Chunk 4: offset = 4, location = 640, hikey location = 128, hikey = ('(0,6)')  +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')          +
+   Chunk 5: offset = 5, location = 736, hikey location = 136, hikey = ('(0,7)')  +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')          +
+   Chunk 6: offset = 6, location = 832, hikey location = 144, hikey = ('(0,8)')  +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')          +
+   Chunk 7: offset = 7, location = 928, hikey location = 152, hikey = ('(0,9)')  +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')          +
+   Chunk 8: offset = 8, location = 1024, hikey location = 160, hikey = ('(0,10)')+
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')         +
+   Chunk 9: offset = 9, location = 1120, hikey location = 168                    +
+     Item 9: offset = 1128, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')       +
+                                                                                 +
+ Index toast: not loaded                                                         +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+(10 rows)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(11, 15) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                              
+----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                     +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                             +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty             +
+     Leftmost, Rightmost                                                         +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')            +
+   Chunk 1: offset = 1, location = 352, hikey location = 104, hikey = ('(0,3)')  +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')            +
+   Chunk 2: offset = 2, location = 448, hikey location = 112, hikey = ('(0,4)')  +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')            +
+   Chunk 3: offset = 3, location = 544, hikey location = 120, hikey = ('(0,5)')  +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')            +
+   Chunk 4: offset = 4, location = 640, hikey location = 128, hikey = ('(0,6)')  +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')          +
+   Chunk 5: offset = 5, location = 736, hikey location = 136, hikey = ('(0,7)')  +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')          +
+   Chunk 6: offset = 6, location = 832, hikey location = 144, hikey = ('(0,8)')  +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')          +
+   Chunk 7: offset = 7, location = 928, hikey location = 152, hikey = ('(0,9)')  +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')          +
+   Chunk 8: offset = 8, location = 1024, hikey location = 160, hikey = ('(0,10)')+
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')         +
+   Chunk 9: offset = 9, location = 1120, hikey location = 168                    +
+     Item 9: offset = 1136, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')       +
+     Item 10: offset = 1224, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')      +
+     Item 11: offset = 1312, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')      +
+     Item 12: offset = 1400, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')      +
+     Item 13: offset = 1488, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')      +
+     Item 14: offset = 1576, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')      +
+                                                                                 +
+ Index toast: not loaded                                                         +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+(15 rows)
 
 CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_options USING btree (i);
 \d+ o_test_non_index_bridging_options
@@ -2175,9 +2550,10 @@ Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
 
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
-WARNING:  Enabling bridging for orioledb table 'o_test_non_index_bridging_options'
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2218,6 +2594,648 @@ Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
 Options: index_bridging=true
 
+ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index o_test_non_index_bridging_options_ix1              +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 2           +
+     Non-leaf tuple fields: i, ctid                       +
+     Leaf tuple fields: i, ctid                           +
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index o_test_non_index_bridging_options_ix1              +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 2           +
+     Non-leaf tuple fields: i, ctid                       +
+     Leaf tuple fields: i, ctid                           +
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                                orioledb_tbl_structure                                
+--------------------------------------------------------------------------------------
+ Index ctid_primary contents                                                         +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                 +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                 +
+     Leftmost, Rightmost                                                             +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('(0,2)')      +
+     Item 0: offset = 264, tuple = ('(0,1)', '(0,1)', '1', '{18,34}', '(6,6)')       +
+   Chunk 1: offset = 1, location = 352, hikey location = 128, hikey = ('(0,3)')      +
+     Item 1: offset = 360, tuple = ('(0,2)', '(0,2)', '2', '{19,35}', '(7,7)')       +
+   Chunk 2: offset = 2, location = 448, hikey location = 136, hikey = ('(0,4)')      +
+     Item 2: offset = 456, tuple = ('(0,3)', '(0,3)', '3', '{20,36}', '(8,8)')       +
+   Chunk 3: offset = 3, location = 544, hikey location = 144, hikey = ('(0,5)')      +
+     Item 3: offset = 552, tuple = ('(0,4)', '(0,4)', '4', '{21,37}', '(9,9)')       +
+   Chunk 4: offset = 4, location = 640, hikey location = 152, hikey = ('(0,6)')      +
+     Item 4: offset = 648, tuple = ('(0,5)', '(0,5)', '5', '{22,38}', '(10,10)')     +
+   Chunk 5: offset = 5, location = 736, hikey location = 160, hikey = ('(0,7)')      +
+     Item 5: offset = 744, tuple = ('(0,6)', '(0,6)', '6', '{23,39}', '(11,11)')     +
+   Chunk 6: offset = 6, location = 832, hikey location = 168, hikey = ('(0,8)')      +
+     Item 6: offset = 840, tuple = ('(0,7)', '(0,7)', '7', '{24,40}', '(12,12)')     +
+   Chunk 7: offset = 7, location = 928, hikey location = 176, hikey = ('(0,9)')      +
+     Item 7: offset = 936, tuple = ('(0,8)', '(0,8)', '8', '{25,41}', '(13,13)')     +
+   Chunk 8: offset = 8, location = 1024, hikey location = 184, hikey = ('(0,10)')    +
+     Item 8: offset = 1032, tuple = ('(0,9)', '(0,9)', '9', '{26,42}', '(14,14)')    +
+   Chunk 9: offset = 9, location = 1120, hikey location = 192, hikey = ('(0,11)')    +
+     Item 9: offset = 1128, tuple = ('(0,10)', '(0,10)', '10', '{27,43}', '(15,15)') +
+   Chunk 10: offset = 10, location = 1216, hikey location = 200, hikey = ('(0,12)')  +
+     Item 10: offset = 1224, tuple = ('(0,11)', '(0,11)', '11', '{28,44}', '(16,16)')+
+   Chunk 11: offset = 11, location = 1312, hikey location = 208, hikey = ('(0,13)')  +
+     Item 11: offset = 1320, tuple = ('(0,12)', '(0,12)', '12', '{29,45}', '(17,17)')+
+   Chunk 12: offset = 12, location = 1408, hikey location = 216, hikey = ('(0,14)')  +
+     Item 12: offset = 1416, tuple = ('(0,13)', '(0,13)', '13', '{30,46}', '(18,18)')+
+   Chunk 13: offset = 13, location = 1504, hikey location = 224, hikey = ('(0,15)')  +
+     Item 13: offset = 1512, tuple = ('(0,14)', '(0,14)', '14', '{31,47}', '(19,19)')+
+   Chunk 14: offset = 14, location = 1600, hikey location = 232                      +
+     Item 14: offset = 1608, tuple = ('(0,15)', '(0,15)', '15', '{32,48}', '(20,20)')+
+                                                                                     +
+ Index o_test_non_index_bridging_options_ix1: not loaded                             +
+ Index index_bridge: not loaded                                                      +
+ Index toast: not loaded                                                             +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+(15 rows)
+
+ALTER TABLE o_test_non_index_bridging_options ADD PRIMARY KEY (i);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
+    "o_test_non_index_bridging_options_ix1" btree (i)
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index o_test_non_index_bridging_options_pkey       +
+     Index type: primary, unique                    +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: i                       +
+     Leaf tuple fields: index_bridging_ctid, i, j, p+
+ Index o_test_non_index_bridging_options_ix1        +
+     Index type: secondary                          +
+     Leaf tuple size: 1, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: i                       +
+     Leaf tuple fields: i                           +
+ Index index_bridge                                 +
+     Index type: secondary                          +
+     Leaf tuple size: 2, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: index_bridging_ctid     +
+     Leaf tuple fields: index_bridging_ctid, i      +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: i, attnum, chunknum     +
+     Leaf tuple fields: i, attnum, chunknum, data   +
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                             orioledb_tbl_structure                             
+--------------------------------------------------------------------------------
+ Index o_test_non_index_bridging_options_pkey contents                         +
+ Page 0: level = 0, maxKeyLen = 4, nVacatedBytes = 0                           +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean           +
+     Leftmost, Rightmost                                                       +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('2')    +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')          +
+   Chunk 1: offset = 1, location = 352, hikey location = 128, hikey = ('3')    +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')          +
+   Chunk 2: offset = 2, location = 448, hikey location = 136, hikey = ('4')    +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')          +
+   Chunk 3: offset = 3, location = 544, hikey location = 144, hikey = ('5')    +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')          +
+   Chunk 4: offset = 4, location = 640, hikey location = 152, hikey = ('6')    +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')        +
+   Chunk 5: offset = 5, location = 736, hikey location = 160, hikey = ('7')    +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')        +
+   Chunk 6: offset = 6, location = 832, hikey location = 168, hikey = ('8')    +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')        +
+   Chunk 7: offset = 7, location = 928, hikey location = 176, hikey = ('9')    +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')        +
+   Chunk 8: offset = 8, location = 1024, hikey location = 184, hikey = ('10')  +
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')       +
+   Chunk 9: offset = 9, location = 1120, hikey location = 192, hikey = ('11')  +
+     Item 9: offset = 1128, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')     +
+   Chunk 10: offset = 10, location = 1216, hikey location = 200, hikey = ('12')+
+     Item 10: offset = 1224, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')    +
+   Chunk 11: offset = 11, location = 1312, hikey location = 208, hikey = ('13')+
+     Item 11: offset = 1320, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')    +
+   Chunk 12: offset = 12, location = 1408, hikey location = 216, hikey = ('14')+
+     Item 12: offset = 1416, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')    +
+   Chunk 13: offset = 13, location = 1504, hikey location = 224, hikey = ('15')+
+     Item 13: offset = 1512, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')    +
+   Chunk 14: offset = 14, location = 1600, hikey location = 232                +
+     Item 14: offset = 1608, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')    +
+                                                                               +
+ Index o_test_non_index_bridging_options_ix1: not loaded                       +
+ Index index_bridge: not loaded                                                +
+ Index toast: not loaded                                                       +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+(15 rows)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(16, 20) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                               
+-----------------------------------------------------------------------------------
+ Index o_test_non_index_bridging_options_pkey contents                            +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('2')       +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')             +
+   Chunk 1: offset = 1, location = 352, hikey location = 128, hikey = ('3')       +
+     Item 1: offset = 360, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')             +
+   Chunk 2: offset = 2, location = 448, hikey location = 136, hikey = ('4')       +
+     Item 2: offset = 456, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')             +
+   Chunk 3: offset = 3, location = 544, hikey location = 144, hikey = ('5')       +
+     Item 3: offset = 552, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')             +
+   Chunk 4: offset = 4, location = 640, hikey location = 152, hikey = ('6')       +
+     Item 4: offset = 648, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')           +
+   Chunk 5: offset = 5, location = 736, hikey location = 160, hikey = ('7')       +
+     Item 5: offset = 744, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')           +
+   Chunk 6: offset = 6, location = 832, hikey location = 168, hikey = ('8')       +
+     Item 6: offset = 840, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')           +
+   Chunk 7: offset = 7, location = 928, hikey location = 176, hikey = ('9')       +
+     Item 7: offset = 936, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')           +
+   Chunk 8: offset = 8, location = 1024, hikey location = 184, hikey = ('10')     +
+     Item 8: offset = 1032, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')          +
+   Chunk 9: offset = 9, location = 1120, hikey location = 192, hikey = ('11')     +
+     Item 9: offset = 1128, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')        +
+   Chunk 10: offset = 10, location = 1216, hikey location = 200, hikey = ('12')   +
+     Item 10: offset = 1224, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')       +
+   Chunk 11: offset = 11, location = 1312, hikey location = 208, hikey = ('13')   +
+     Item 11: offset = 1320, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')       +
+   Chunk 12: offset = 12, location = 1408, hikey location = 216, hikey = ('14')   +
+     Item 12: offset = 1416, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')       +
+   Chunk 13: offset = 13, location = 1504, hikey location = 224, hikey = ('15')   +
+     Item 13: offset = 1512, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')       +
+   Chunk 14: offset = 14, location = 1600, hikey location = 232                   +
+     Item 14: offset = 1616, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')       +
+     Item 15: offset = 1704, tuple = ('(0,16)', '16', '{33,49}', '(21,21)')       +
+     Item 16: offset = 1792, tuple = ('(0,17)', '17', '{34,50}', '(22,22)')       +
+     Item 17: offset = 1880, tuple = ('(0,18)', '18', '{35,51}', '(23,23)')       +
+     Item 18: offset = 1968, tuple = ('(0,19)', '19', '{36,52}', '(24,24)')       +
+     Item 19: offset = 2056, tuple = ('(0,20)', '20', '{37,53}', '(25,25)')       +
+                                                                                  +
+ Index o_test_non_index_bridging_options_ix1 contents                             +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = regular, dirty              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('2')       +
+     Item 0: offset = 264, tuple = ('1')                                          +
+   Chunk 1: offset = 1, location = 288, hikey location = 128, hikey = ('3')       +
+     Item 1: offset = 296, tuple = ('2')                                          +
+   Chunk 2: offset = 2, location = 320, hikey location = 136, hikey = ('4')       +
+     Item 2: offset = 328, tuple = ('3')                                          +
+   Chunk 3: offset = 3, location = 352, hikey location = 144, hikey = ('5')       +
+     Item 3: offset = 360, tuple = ('4')                                          +
+   Chunk 4: offset = 4, location = 384, hikey location = 152, hikey = ('6')       +
+     Item 4: offset = 392, tuple = ('5')                                          +
+   Chunk 5: offset = 5, location = 416, hikey location = 160, hikey = ('7')       +
+     Item 5: offset = 424, tuple = ('6')                                          +
+   Chunk 6: offset = 6, location = 448, hikey location = 168, hikey = ('8')       +
+     Item 6: offset = 456, tuple = ('7')                                          +
+   Chunk 7: offset = 7, location = 480, hikey location = 176, hikey = ('9')       +
+     Item 7: offset = 488, tuple = ('8')                                          +
+   Chunk 8: offset = 8, location = 512, hikey location = 184, hikey = ('10')      +
+     Item 8: offset = 520, tuple = ('9')                                          +
+   Chunk 9: offset = 9, location = 544, hikey location = 192, hikey = ('11')      +
+     Item 9: offset = 552, tuple = ('10')                                         +
+   Chunk 10: offset = 10, location = 576, hikey location = 200, hikey = ('12')    +
+     Item 10: offset = 584, tuple = ('11')                                        +
+   Chunk 11: offset = 11, location = 608, hikey location = 208, hikey = ('13')    +
+     Item 11: offset = 616, tuple = ('12')                                        +
+   Chunk 12: offset = 12, location = 640, hikey location = 216, hikey = ('14')    +
+     Item 12: offset = 648, tuple = ('13')                                        +
+   Chunk 13: offset = 13, location = 672, hikey location = 224, hikey = ('15')    +
+     Item 13: offset = 680, tuple = ('14')                                        +
+   Chunk 14: offset = 14, location = 704, hikey location = 232                    +
+     Item 14: offset = 720, tuple = ('15')                                        +
+     Item 15: offset = 744, tuple = ('16')                                        +
+     Item 16: offset = 768, tuple = ('17')                                        +
+     Item 17: offset = 792, tuple = ('18')                                        +
+     Item 18: offset = 816, tuple = ('19')                                        +
+     Item 19: offset = 840, tuple = ('20')                                        +
+                                                                                  +
+ Index index_bridge contents                                                      +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = bridge, dirty               +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 120, hikey = ('(0,2)')   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1')                                 +
+   Chunk 1: offset = 1, location = 296, hikey location = 128, hikey = ('(0,3)')   +
+     Item 1: offset = 304, tuple = ('(0,2)', '2')                                 +
+   Chunk 2: offset = 2, location = 336, hikey location = 136, hikey = ('(0,4)')   +
+     Item 2: offset = 344, tuple = ('(0,3)', '3')                                 +
+   Chunk 3: offset = 3, location = 376, hikey location = 144, hikey = ('(0,5)')   +
+     Item 3: offset = 384, tuple = ('(0,4)', '4')                                 +
+   Chunk 4: offset = 4, location = 416, hikey location = 152, hikey = ('(0,6)')   +
+     Item 4: offset = 424, tuple = ('(0,5)', '5')                                 +
+   Chunk 5: offset = 5, location = 456, hikey location = 160, hikey = ('(0,7)')   +
+     Item 5: offset = 464, tuple = ('(0,6)', '6')                                 +
+   Chunk 6: offset = 6, location = 496, hikey location = 168, hikey = ('(0,8)')   +
+     Item 6: offset = 504, tuple = ('(0,7)', '7')                                 +
+   Chunk 7: offset = 7, location = 536, hikey location = 176, hikey = ('(0,9)')   +
+     Item 7: offset = 544, tuple = ('(0,8)', '8')                                 +
+   Chunk 8: offset = 8, location = 576, hikey location = 184, hikey = ('(0,10)')  +
+     Item 8: offset = 584, tuple = ('(0,9)', '9')                                 +
+   Chunk 9: offset = 9, location = 616, hikey location = 192, hikey = ('(0,11)')  +
+     Item 9: offset = 624, tuple = ('(0,10)', '10')                               +
+   Chunk 10: offset = 10, location = 656, hikey location = 200, hikey = ('(0,12)')+
+     Item 10: offset = 664, tuple = ('(0,11)', '11')                              +
+   Chunk 11: offset = 11, location = 696, hikey location = 208, hikey = ('(0,13)')+
+     Item 11: offset = 704, tuple = ('(0,12)', '12')                              +
+   Chunk 12: offset = 12, location = 736, hikey location = 216, hikey = ('(0,14)')+
+     Item 12: offset = 744, tuple = ('(0,13)', '13')                              +
+   Chunk 13: offset = 13, location = 776, hikey location = 224, hikey = ('(0,15)')+
+     Item 13: offset = 784, tuple = ('(0,14)', '14')                              +
+   Chunk 14: offset = 14, location = 816, hikey location = 232                    +
+     Item 14: offset = 832, tuple = ('(0,15)', '15')                              +
+     Item 15: offset = 864, tuple = ('(0,16)', '16')                              +
+     Item 16: offset = 896, tuple = ('(0,17)', '17')                              +
+     Item 17: offset = 928, tuple = ('(0,18)', '18')                              +
+     Item 18: offset = 960, tuple = ('(0,19)', '19')                              +
+     Item 19: offset = 992, tuple = ('(0,20)', '20')                              +
+                                                                                  +
+ Index toast: not loaded                                                          +
+ 
+(1 row)
+
+DROP INDEX o_test_non_index_bridging_options_ix1;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Index Scan using o_test_non_index_bridging_options_ix2 on o_test_non_index_bridging_options
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+ 16 | {33,49} | (21,21)
+ 17 | {34,50} | (22,22)
+ 18 | {35,51} | (23,23)
+ 19 | {36,52} | (24,24)
+ 20 | {37,53} | (25,25)
+(20 rows)
+
+COMMIT;
+DROP INDEX o_test_non_index_bridging_options_ix2;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
+
+ALTER TABLE o_test_non_index_bridging_options DROP CONSTRAINT o_test_non_index_bridging_options_pkey;
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, i, j, p               +
+ Index toast                                        +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                               
+-----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                      +
+ Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,3)')    +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')             +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')             +
+   Chunk 1: offset = 2, location = 440, hikey location = 104, hikey = ('(0,5)')   +
+     Item 2: offset = 448, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')             +
+     Item 3: offset = 536, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')             +
+   Chunk 2: offset = 4, location = 624, hikey location = 112, hikey = ('(0,7)')   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')           +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')           +
+   Chunk 3: offset = 6, location = 808, hikey location = 120, hikey = ('(0,9)')   +
+     Item 6: offset = 816, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')           +
+     Item 7: offset = 904, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')           +
+   Chunk 4: offset = 8, location = 992, hikey location = 128, hikey = ('(0,11)')  +
+     Item 8: offset = 1000, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')          +
+     Item 9: offset = 1088, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')        +
+   Chunk 5: offset = 10, location = 1176, hikey location = 136, hikey = ('(0,13)')+
+     Item 10: offset = 1184, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')       +
+     Item 11: offset = 1272, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')       +
+   Chunk 6: offset = 12, location = 1360, hikey location = 144, hikey = ('(0,15)')+
+     Item 12: offset = 1368, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')       +
+     Item 13: offset = 1456, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')       +
+   Chunk 7: offset = 14, location = 1544, hikey location = 152, hikey = ('(0,17)')+
+     Item 14: offset = 1552, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')       +
+     Item 15: offset = 1640, tuple = ('(0,16)', '16', '{33,49}', '(21,21)')       +
+   Chunk 8: offset = 16, location = 1728, hikey location = 160, hikey = ('(0,19)')+
+     Item 16: offset = 1736, tuple = ('(0,17)', '17', '{34,50}', '(22,22)')       +
+     Item 17: offset = 1824, tuple = ('(0,18)', '18', '{35,51}', '(23,23)')       +
+   Chunk 9: offset = 18, location = 1912, hikey location = 168                    +
+     Item 18: offset = 1920, tuple = ('(0,19)', '19', '{36,52}', '(24,24)')       +
+     Item 19: offset = 2008, tuple = ('(0,20)', '20', '{37,53}', '(25,25)')       +
+                                                                                  +
+ Index toast: not loaded                                                          +
+ 
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+ 16 | {33,49} | (21,21)
+ 17 | {34,50} | (22,22)
+ 18 | {35,51} | (23,23)
+ 19 | {36,52} | (24,24)
+ 20 | {37,53} | (25,25)
+(20 rows)
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(21, 25) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+                              orioledb_tbl_structure                               
+-----------------------------------------------------------------------------------
+ Index ctid_primary contents                                                      +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                              +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty              +
+     Leftmost, Rightmost                                                          +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,3)')    +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', '{18,34}', '(6,6)')             +
+     Item 1: offset = 352, tuple = ('(0,2)', '2', '{19,35}', '(7,7)')             +
+   Chunk 1: offset = 2, location = 440, hikey location = 104, hikey = ('(0,5)')   +
+     Item 2: offset = 448, tuple = ('(0,3)', '3', '{20,36}', '(8,8)')             +
+     Item 3: offset = 536, tuple = ('(0,4)', '4', '{21,37}', '(9,9)')             +
+   Chunk 2: offset = 4, location = 624, hikey location = 112, hikey = ('(0,7)')   +
+     Item 4: offset = 632, tuple = ('(0,5)', '5', '{22,38}', '(10,10)')           +
+     Item 5: offset = 720, tuple = ('(0,6)', '6', '{23,39}', '(11,11)')           +
+   Chunk 3: offset = 6, location = 808, hikey location = 120, hikey = ('(0,9)')   +
+     Item 6: offset = 816, tuple = ('(0,7)', '7', '{24,40}', '(12,12)')           +
+     Item 7: offset = 904, tuple = ('(0,8)', '8', '{25,41}', '(13,13)')           +
+   Chunk 4: offset = 8, location = 992, hikey location = 128, hikey = ('(0,11)')  +
+     Item 8: offset = 1000, tuple = ('(0,9)', '9', '{26,42}', '(14,14)')          +
+     Item 9: offset = 1088, tuple = ('(0,10)', '10', '{27,43}', '(15,15)')        +
+   Chunk 5: offset = 10, location = 1176, hikey location = 136, hikey = ('(0,13)')+
+     Item 10: offset = 1184, tuple = ('(0,11)', '11', '{28,44}', '(16,16)')       +
+     Item 11: offset = 1272, tuple = ('(0,12)', '12', '{29,45}', '(17,17)')       +
+   Chunk 6: offset = 12, location = 1360, hikey location = 144, hikey = ('(0,15)')+
+     Item 12: offset = 1368, tuple = ('(0,13)', '13', '{30,46}', '(18,18)')       +
+     Item 13: offset = 1456, tuple = ('(0,14)', '14', '{31,47}', '(19,19)')       +
+   Chunk 7: offset = 14, location = 1544, hikey location = 152, hikey = ('(0,17)')+
+     Item 14: offset = 1552, tuple = ('(0,15)', '15', '{32,48}', '(20,20)')       +
+     Item 15: offset = 1640, tuple = ('(0,16)', '16', '{33,49}', '(21,21)')       +
+   Chunk 8: offset = 16, location = 1728, hikey location = 160, hikey = ('(0,19)')+
+     Item 16: offset = 1736, tuple = ('(0,17)', '17', '{34,50}', '(22,22)')       +
+     Item 17: offset = 1824, tuple = ('(0,18)', '18', '{35,51}', '(23,23)')       +
+   Chunk 9: offset = 18, location = 1912, hikey location = 168                    +
+     Item 18: offset = 1928, tuple = ('(0,19)', '19', '{36,52}', '(24,24)')       +
+     Item 19: offset = 2016, tuple = ('(0,20)', '20', '{37,53}', '(25,25)')       +
+     Item 20: offset = 2104, tuple = ('(0,21)', '21', '{38,54}', '(26,26)')       +
+     Item 21: offset = 2192, tuple = ('(0,22)', '22', '{39,55}', '(27,27)')       +
+     Item 22: offset = 2280, tuple = ('(0,23)', '23', '{40,56}', '(28,28)')       +
+     Item 23: offset = 2368, tuple = ('(0,24)', '24', '{41,57}', '(29,29)')       +
+     Item 24: offset = 2456, tuple = ('(0,25)', '25', '{42,58}', '(30,30)')       +
+                                                                                  +
+ Index toast: not loaded                                                          +
+ 
+(1 row)
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Options: index_bridging=true
+
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+                   orioledb_tbl_indices                    
+-----------------------------------------------------------
+ Index ctid_primary                                       +
+     Index type: primary, unique, ctid                    +
+     Leaf tuple size: 5, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: ctid                          +
+     Leaf tuple fields: ctid, index_bridging_ctid, i, j, p+
+ Index index_bridge                                       +
+     Index type: secondary                                +
+     Leaf tuple size: 2, non-leaf tuple size: 1           +
+     Non-leaf tuple fields: index_bridging_ctid           +
+     Leaf tuple fields: index_bridging_ctid, ctid         +
+ Index toast                                              +
+     Index type: secondary                                +
+     Leaf tuple size: 4, non-leaf tuple size: 3           +
+     Non-leaf tuple fields: ctid, attnum, chunknum        +
+     Leaf tuple fields: ctid, attnum, chunknum, data      +
+ 
+(1 row)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Index Scan using o_test_non_index_bridging_options_ix2 on o_test_non_index_bridging_options
+(1 row)
+
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+ i  |    j    |    p    
+----+---------+---------
+  1 | {18,34} | (6,6)
+  2 | {19,35} | (7,7)
+  3 | {20,36} | (8,8)
+  4 | {21,37} | (9,9)
+  5 | {22,38} | (10,10)
+  6 | {23,39} | (11,11)
+  7 | {24,40} | (12,12)
+  8 | {25,41} | (13,13)
+  9 | {26,42} | (14,14)
+ 10 | {27,43} | (15,15)
+ 11 | {28,44} | (16,16)
+ 12 | {29,45} | (17,17)
+ 13 | {30,46} | (18,18)
+ 14 | {31,47} | (19,19)
+ 15 | {32,48} | (20,20)
+ 16 | {33,49} | (21,21)
+ 17 | {34,50} | (22,22)
+ 18 | {35,51} | (23,23)
+ 19 | {36,52} | (24,24)
+ 20 | {37,53} | (25,25)
+ 21 | {38,54} | (26,26)
+ 22 | {39,55} | (27,27)
+ 23 | {40,56} | (28,28)
+ 24 | {41,57} | (29,29)
+ 25 | {42,58} | (30,30)
+(25 rows)
+
+COMMIT;
 DROP EXTENSION pageinspect;
 ERROR:  extension "pageinspect" does not exist
 DROP EXTENSION orioledb CASCADE;

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -1152,7 +1152,7 @@ CREATE INDEX o_test_ix_ams_hash_ix ON o_test_ix_ams USING hash (k);
  pk2    | integer |           | not null |         | plain   |              | 
  k      | integer |           |          |         | plain   |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
     "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
 Options: index_bridging=true
 
@@ -1342,7 +1342,7 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
     "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
 Options: index_bridging=true
 
@@ -1413,7 +1413,7 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  k      | integer   |           |          |         | plain    |              | 
  r      | integer[] |           |          |         | extended |              | 
 Indexes:
-    "o_test_ix_ams_hash_ix" hash (k)
+    "o_test_ix_ams_hash_ix" hash (k) WITH (index_bridging='true')
     "o_test_ix_ams_ix1" btree (j) WITH (index_bridging='true', deduplicate_items=off)
 Options: index_bridging=true
 
@@ -1954,13 +1954,444 @@ SELECT * FROM o_test_bitmap_scans
 (6 rows)
 
 COMMIT;
+CREATE TABLE o_test_index_bridging_options (
+	i int NOT NULL,
+	j int4[],
+	p point
+) USING orioledb WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix1 ON o_test_index_bridging_options USING btree (i);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (index_bridging);
+WARNING:  Using bridged btree index for orioledb
+DETAIL:  this feature is only for testing
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING hash (i) WITH (index_bridging);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gist (p);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING gin (j);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING spgist (p);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE INDEX o_test_index_bridging_options_ix9 ON o_test_index_bridging_options USING brin (i);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing tables
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER TABLE o_test_index_bridging_options SET (index_bridging);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix5 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix2 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix1 SET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix6 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix7 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix8 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+ALTER INDEX o_test_index_bridging_options_ix9 RESET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_index_bridging_options
+                    Table "index_bridging.o_test_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_index_bridging_options_ix1" btree (i)
+    "o_test_index_bridging_options_ix2" btree (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix3" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65', index_bridging='true')
+    "o_test_index_bridging_options_ix5" hash (i) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix6" gist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix7" gin (j) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix8" spgist (p) WITH (index_bridging='true')
+    "o_test_index_bridging_options_ix9" brin (i) WITH (index_bridging='true')
+Options: index_bridging=true
+
+CREATE TABLE o_test_non_index_bridging_options (
+	i int NOT NULL,
+	j int4[],
+	p point
+) USING orioledb;
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing tables
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+
+CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_options USING btree (i);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (index_bridging);
+ERROR:  Cannot use 'index_bridging' on table without 'index_bridging' option
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
+ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
+ALTER INDEX o_test_non_index_bridging_options_ix1 SET (index_bridging);
+ERROR:  Cannot change index_bridging option for existing indices
+\d+ o_test_non_index_bridging_options
+                  Table "index_bridging.o_test_non_index_bridging_options"
+ Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-----------+-----------+----------+---------+----------+--------------+-------------
+ i      | integer   |           | not null |         | plain    |              | 
+ j      | integer[] |           |          |         | extended |              | 
+ p      | point     |           |          |         | plain    |              | 
+Indexes:
+    "o_test_non_index_bridging_options_ix1" btree (i)
+
 DROP EXTENSION pageinspect;
 ERROR:  extension "pageinspect" does not exist
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
 drop cascades to table o_test_bitmap_scans
+drop cascades to table o_test_index_bridging_options
+drop cascades to table o_test_non_index_bridging_options
 DROP SCHEMA index_bridging CASCADE;
 RESET search_path;

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -96,8 +96,8 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
 CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (orioledb_index = off, deduplicate_items = off);
 WARNING:  using bridged btree index for orioledb
 DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
-NOTICE:  enabling index bridging for orioledb table 'o_test_ix_ams'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_test_ix_ams'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
 SELECT ctid, htid, tids FROM
 		 generate_series(1,
 						 (SELECT relpages - 1 FROM pg_class
@@ -980,8 +980,8 @@ SELECT * FROM o_test_ix_ams ORDER BY j;
 
 COMMIT;
 CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (orioledb_index = off, deduplicate_items = off);
-WARNING:  Using bridged btree index for orioledb
-DETAIL:  this feature is only for testing
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
                           orioledb_tbl_indices                          
 ------------------------------------------------------------------------
@@ -1527,8 +1527,8 @@ SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
 (1 row)
 
 CREATE INDEX o_briging_vacuum_test_p_idx on o_briging_vacuum_test using gist(p);
-NOTICE:  enabling index bridging for orioledb table 'o_briging_vacuum_test'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_briging_vacuum_test'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
 DELETE FROM o_briging_vacuum_test;
 VACUUM o_briging_vacuum_test;
 SELECT * FROM o_briging_vacuum_test WHERE p <@ box(point(0,0), point(1,1));
@@ -2063,7 +2063,7 @@ Indexes:
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 \d+ o_test_index_bridging_options
                     Table "index_bridging.o_test_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2394,7 +2394,7 @@ SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
 
 COMMIT;
 ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2552,8 +2552,8 @@ Indexes:
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  using bridged btree index for orioledb
 DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
-NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -2634,7 +2634,7 @@ SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true)
 (1 row)
 
 ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
-ERROR:  Cannot change 'index_bridging' manually when there are bridged indices
+ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -3162,8 +3162,8 @@ SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  using bridged btree index for orioledb
 DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
-NOTICE:  enabling index bridging for orioledb table 'o_test_non_index_bridging_options'
-DETAIL:  The required index access method is not natively supported, so index bridgind is automatically enabled.
+NOTICE:  index bridging is enabled for orioledb table 'o_test_non_index_bridging_options'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
 \d+ o_test_non_index_bridging_options
                   Table "index_bridging.o_test_non_index_bridging_options"
  Column |   Type    | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -6727,76 +6727,76 @@ SELECT orioledb_tbl_structure('o_test_reuse_multiple_indices'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                             +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')                   +
-     Item 0: offset = 264, tuple = ('(0,0)', '1', 'XXX1', '10', '100', 'b')                      +
-   Chunk 1: offset = 1, location = 320, hikey location = 88, hikey = ('(0,2)')                   +
-     Item 1: offset = 328, tuple = ('(0,1)', '2', 'XXX2', '20', '200', 'c')                      +
-   Chunk 2: offset = 2, location = 384, hikey location = 96, hikey = ('(0,3)')                   +
-     Item 2: offset = 392, tuple = ('(0,2)', '3', 'XXX3', '30', '300', 'd')                      +
-   Chunk 3: offset = 3, location = 448, hikey location = 104, hikey = ('(0,4)')                  +
-     Item 3: offset = 456, tuple = ('(0,3)', '4', 'XXX4', '40', '400', 'e')                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')                   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', 'XXX1', '10', '100', 'b')                      +
+   Chunk 1: offset = 1, location = 320, hikey location = 88, hikey = ('(0,3)')                   +
+     Item 1: offset = 328, tuple = ('(0,2)', '2', 'XXX2', '20', '200', 'c')                      +
+   Chunk 2: offset = 2, location = 384, hikey location = 96, hikey = ('(0,4)')                   +
+     Item 2: offset = 392, tuple = ('(0,3)', '3', 'XXX3', '30', '300', 'd')                      +
+   Chunk 3: offset = 3, location = 448, hikey location = 104, hikey = ('(0,5)')                  +
+     Item 3: offset = 456, tuple = ('(0,4)', '4', 'XXX4', '40', '400', 'e')                      +
    Chunk 4: offset = 4, location = 512, hikey location = 112                                     +
-     Item 4: offset = 520, tuple = ('(0,4)', '5', 'XXX5', '50', '500', 'f')                      +
+     Item 4: offset = 520, tuple = ('(0,5)', '5', 'XXX5', '50', '500', 'f')                      +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix1 contents                                                +
  Page 0: level = 0, maxKeyLen = 20, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('XXX2', '(0,1)')           +
-     Item 0: offset = 264, tuple = ('XXX1', '(0,0)')                                             +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('XXX3', '(0,2)')          +
-     Item 1: offset = 312, tuple = ('XXX2', '(0,1)')                                             +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('XXX4', '(0,3)')          +
-     Item 2: offset = 360, tuple = ('XXX3', '(0,2)')                                             +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('XXX5', '(0,4)')          +
-     Item 3: offset = 408, tuple = ('XXX4', '(0,3)')                                             +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('XXX2', '(0,2)')           +
+     Item 0: offset = 264, tuple = ('XXX1', '(0,1)')                                             +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('XXX3', '(0,3)')          +
+     Item 1: offset = 312, tuple = ('XXX2', '(0,2)')                                             +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('XXX4', '(0,4)')          +
+     Item 2: offset = 360, tuple = ('XXX3', '(0,3)')                                             +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('XXX5', '(0,5)')          +
+     Item 3: offset = 408, tuple = ('XXX4', '(0,4)')                                             +
    Chunk 4: offset = 4, location = 448, hikey location = 176                                     +
-     Item 4: offset = 456, tuple = ('XXX5', '(0,4)')                                             +
+     Item 4: offset = 456, tuple = ('XXX5', '(0,5)')                                             +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix2 contents                                                +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', 'XXX4', '(0,3)')     +
-     Item 0: offset = 264, tuple = ('50', 'XXX5', '(0,4)')                                       +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('30', 'XXX3', '(0,2)')    +
-     Item 1: offset = 312, tuple = ('40', 'XXX4', '(0,3)')                                       +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('20', 'XXX2', '(0,1)')    +
-     Item 2: offset = 360, tuple = ('30', 'XXX3', '(0,2)')                                       +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('10', 'XXX1', '(0,0)')    +
-     Item 3: offset = 408, tuple = ('20', 'XXX2', '(0,1)')                                       +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', 'XXX4', '(0,4)')     +
+     Item 0: offset = 264, tuple = ('50', 'XXX5', '(0,5)')                                       +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('30', 'XXX3', '(0,3)')    +
+     Item 1: offset = 312, tuple = ('40', 'XXX4', '(0,4)')                                       +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('20', 'XXX2', '(0,2)')    +
+     Item 2: offset = 360, tuple = ('30', 'XXX3', '(0,3)')                                       +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('10', 'XXX1', '(0,1)')    +
+     Item 3: offset = 408, tuple = ('20', 'XXX2', '(0,2)')                                       +
    Chunk 4: offset = 4, location = 448, hikey location = 176                                     +
-     Item 4: offset = 456, tuple = ('10', 'XXX1', '(0,0)')                                       +
+     Item 4: offset = 456, tuple = ('10', 'XXX1', '(0,1)')                                       +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix3 contents                                                +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', 'XXX2', '(0,1)')    +
-     Item 0: offset = 264, tuple = ('100', 'XXX1', '(0,0)')                                      +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', 'XXX3', '(0,2)')   +
-     Item 1: offset = 312, tuple = ('200', 'XXX2', '(0,1)')                                      +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', 'XXX4', '(0,3)')   +
-     Item 2: offset = 360, tuple = ('300', 'XXX3', '(0,2)')                                      +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', 'XXX5', '(0,4)')   +
-     Item 3: offset = 408, tuple = ('400', 'XXX4', '(0,3)')                                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', 'XXX2', '(0,2)')    +
+     Item 0: offset = 264, tuple = ('100', 'XXX1', '(0,1)')                                      +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', 'XXX3', '(0,3)')   +
+     Item 1: offset = 312, tuple = ('200', 'XXX2', '(0,2)')                                      +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', 'XXX4', '(0,4)')   +
+     Item 2: offset = 360, tuple = ('300', 'XXX3', '(0,3)')                                      +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', 'XXX5', '(0,5)')   +
+     Item 3: offset = 408, tuple = ('400', 'XXX4', '(0,4)')                                      +
    Chunk 4: offset = 4, location = 448, hikey location = 176                                     +
-     Item 4: offset = 456, tuple = ('500', 'XXX5', '(0,4)')                                      +
+     Item 4: offset = 456, tuple = ('500', 'XXX5', '(0,5)')                                      +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix4 contents                                                +
  Page 0: level = 0, maxKeyLen = 28, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('c', '2', 'XXX2', '(0,1)') +
-     Item 0: offset = 264, tuple = ('b', '1', 'XXX1', '(0,0)')                                   +
-   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('d', '3', 'XXX3', '(0,2)')+
-     Item 1: offset = 320, tuple = ('c', '2', 'XXX2', '(0,1)')                                   +
-   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e', '4', 'XXX4', '(0,3)')+
-     Item 2: offset = 376, tuple = ('d', '3', 'XXX3', '(0,2)')                                   +
-   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('f', '5', 'XXX5', '(0,4)')+
-     Item 3: offset = 432, tuple = ('e', '4', 'XXX4', '(0,3)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('c', '2', 'XXX2', '(0,2)') +
+     Item 0: offset = 264, tuple = ('b', '1', 'XXX1', '(0,1)')                                   +
+   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('d', '3', 'XXX3', '(0,3)')+
+     Item 1: offset = 320, tuple = ('c', '2', 'XXX2', '(0,2)')                                   +
+   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e', '4', 'XXX4', '(0,4)')+
+     Item 2: offset = 376, tuple = ('d', '3', 'XXX3', '(0,3)')                                   +
+   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('f', '5', 'XXX5', '(0,5)')+
+     Item 3: offset = 432, tuple = ('e', '4', 'XXX4', '(0,4)')                                   +
    Chunk 4: offset = 4, location = 480, hikey location = 208                                     +
-     Item 4: offset = 488, tuple = ('f', '5', 'XXX5', '(0,4)')                                   +
+     Item 4: offset = 488, tuple = ('f', '5', 'XXX5', '(0,5)')                                   +
                                                                                                  +
  Index toast: not loaded                                                                         +
  

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -6716,76 +6716,76 @@ SELECT orioledb_tbl_structure('o_test_reuse_multiple_indices'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                             +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')                   +
-     Item 0: offset = 264, tuple = ('(0,0)', '1', 'XXX1', '10', '100', 'b')                      +
-   Chunk 1: offset = 1, location = 320, hikey location = 88, hikey = ('(0,2)')                   +
-     Item 1: offset = 328, tuple = ('(0,1)', '2', 'XXX2', '20', '200', 'c')                      +
-   Chunk 2: offset = 2, location = 384, hikey location = 96, hikey = ('(0,3)')                   +
-     Item 2: offset = 392, tuple = ('(0,2)', '3', 'XXX3', '30', '300', 'd')                      +
-   Chunk 3: offset = 3, location = 448, hikey location = 104, hikey = ('(0,4)')                  +
-     Item 3: offset = 456, tuple = ('(0,3)', '4', 'XXX4', '40', '400', 'e')                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')                   +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', 'XXX1', '10', '100', 'b')                      +
+   Chunk 1: offset = 1, location = 320, hikey location = 88, hikey = ('(0,3)')                   +
+     Item 1: offset = 328, tuple = ('(0,2)', '2', 'XXX2', '20', '200', 'c')                      +
+   Chunk 2: offset = 2, location = 384, hikey location = 96, hikey = ('(0,4)')                   +
+     Item 2: offset = 392, tuple = ('(0,3)', '3', 'XXX3', '30', '300', 'd')                      +
+   Chunk 3: offset = 3, location = 448, hikey location = 104, hikey = ('(0,5)')                  +
+     Item 3: offset = 456, tuple = ('(0,4)', '4', 'XXX4', '40', '400', 'e')                      +
    Chunk 4: offset = 4, location = 512, hikey location = 112                                     +
-     Item 4: offset = 520, tuple = ('(0,4)', '5', 'XXX5', '50', '500', 'f')                      +
+     Item 4: offset = 520, tuple = ('(0,5)', '5', 'XXX5', '50', '500', 'f')                      +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix1 contents                                                +
  Page 0: level = 0, maxKeyLen = 20, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('XXX2', '(0,1)')           +
-     Item 0: offset = 264, tuple = ('XXX1', '(0,0)')                                             +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('XXX3', '(0,2)')          +
-     Item 1: offset = 312, tuple = ('XXX2', '(0,1)')                                             +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('XXX4', '(0,3)')          +
-     Item 2: offset = 360, tuple = ('XXX3', '(0,2)')                                             +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('XXX5', '(0,4)')          +
-     Item 3: offset = 408, tuple = ('XXX4', '(0,3)')                                             +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('XXX2', '(0,2)')           +
+     Item 0: offset = 264, tuple = ('XXX1', '(0,1)')                                             +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('XXX3', '(0,3)')          +
+     Item 1: offset = 312, tuple = ('XXX2', '(0,2)')                                             +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('XXX4', '(0,4)')          +
+     Item 2: offset = 360, tuple = ('XXX3', '(0,3)')                                             +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('XXX5', '(0,5)')          +
+     Item 3: offset = 408, tuple = ('XXX4', '(0,4)')                                             +
    Chunk 4: offset = 4, location = 448, hikey location = 176                                     +
-     Item 4: offset = 456, tuple = ('XXX5', '(0,4)')                                             +
+     Item 4: offset = 456, tuple = ('XXX5', '(0,5)')                                             +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix2 contents                                                +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', 'XXX4', '(0,3)')     +
-     Item 0: offset = 264, tuple = ('50', 'XXX5', '(0,4)')                                       +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('30', 'XXX3', '(0,2)')    +
-     Item 1: offset = 312, tuple = ('40', 'XXX4', '(0,3)')                                       +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('20', 'XXX2', '(0,1)')    +
-     Item 2: offset = 360, tuple = ('30', 'XXX3', '(0,2)')                                       +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('10', 'XXX1', '(0,0)')    +
-     Item 3: offset = 408, tuple = ('20', 'XXX2', '(0,1)')                                       +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', 'XXX4', '(0,4)')     +
+     Item 0: offset = 264, tuple = ('50', 'XXX5', '(0,5)')                                       +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('30', 'XXX3', '(0,3)')    +
+     Item 1: offset = 312, tuple = ('40', 'XXX4', '(0,4)')                                       +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('20', 'XXX2', '(0,2)')    +
+     Item 2: offset = 360, tuple = ('30', 'XXX3', '(0,3)')                                       +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('10', 'XXX1', '(0,1)')    +
+     Item 3: offset = 408, tuple = ('20', 'XXX2', '(0,2)')                                       +
    Chunk 4: offset = 4, location = 448, hikey location = 176                                     +
-     Item 4: offset = 456, tuple = ('10', 'XXX1', '(0,0)')                                       +
+     Item 4: offset = 456, tuple = ('10', 'XXX1', '(0,1)')                                       +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix3 contents                                                +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', 'XXX2', '(0,1)')    +
-     Item 0: offset = 264, tuple = ('100', 'XXX1', '(0,0)')                                      +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', 'XXX3', '(0,2)')   +
-     Item 1: offset = 312, tuple = ('200', 'XXX2', '(0,1)')                                      +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', 'XXX4', '(0,3)')   +
-     Item 2: offset = 360, tuple = ('300', 'XXX3', '(0,2)')                                      +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', 'XXX5', '(0,4)')   +
-     Item 3: offset = 408, tuple = ('400', 'XXX4', '(0,3)')                                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', 'XXX2', '(0,2)')    +
+     Item 0: offset = 264, tuple = ('100', 'XXX1', '(0,1)')                                      +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', 'XXX3', '(0,3)')   +
+     Item 1: offset = 312, tuple = ('200', 'XXX2', '(0,2)')                                      +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', 'XXX4', '(0,4)')   +
+     Item 2: offset = 360, tuple = ('300', 'XXX3', '(0,3)')                                      +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', 'XXX5', '(0,5)')   +
+     Item 3: offset = 408, tuple = ('400', 'XXX4', '(0,4)')                                      +
    Chunk 4: offset = 4, location = 448, hikey location = 176                                     +
-     Item 4: offset = 456, tuple = ('500', 'XXX5', '(0,4)')                                      +
+     Item 4: offset = 456, tuple = ('500', 'XXX5', '(0,5)')                                      +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix4 contents                                                +
  Page 0: level = 0, maxKeyLen = 28, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('c', '2', 'XXX2', '(0,1)') +
-     Item 0: offset = 264, tuple = ('b', '1', 'XXX1', '(0,0)')                                   +
-   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('d', '3', 'XXX3', '(0,2)')+
-     Item 1: offset = 320, tuple = ('c', '2', 'XXX2', '(0,1)')                                   +
-   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e', '4', 'XXX4', '(0,3)')+
-     Item 2: offset = 376, tuple = ('d', '3', 'XXX3', '(0,2)')                                   +
-   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('f', '5', 'XXX5', '(0,4)')+
-     Item 3: offset = 432, tuple = ('e', '4', 'XXX4', '(0,3)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('c', '2', 'XXX2', '(0,2)') +
+     Item 0: offset = 264, tuple = ('b', '1', 'XXX1', '(0,1)')                                   +
+   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('d', '3', 'XXX3', '(0,3)')+
+     Item 1: offset = 320, tuple = ('c', '2', 'XXX2', '(0,2)')                                   +
+   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e', '4', 'XXX4', '(0,4)')+
+     Item 2: offset = 376, tuple = ('d', '3', 'XXX3', '(0,3)')                                   +
+   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('f', '5', 'XXX5', '(0,5)')+
+     Item 3: offset = 432, tuple = ('e', '4', 'XXX4', '(0,4)')                                   +
    Chunk 4: offset = 4, location = 480, hikey location = 208                                     +
-     Item 4: offset = 488, tuple = ('f', '5', 'XXX5', '(0,4)')                                   +
+     Item 4: offset = 488, tuple = ('f', '5', 'XXX5', '(0,5)')                                   +
                                                                                                  +
  Index toast: not loaded                                                                         +
  

--- a/test/expected/indices_build.out
+++ b/test/expected/indices_build.out
@@ -23008,31 +23008,31 @@ SELECT orioledb_tbl_structure('o_indices8'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                         +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                         +
      Leftmost, Rightmost                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')               +
-     Item 0: offset = 264, tuple = ('(0,0)', '1', 'e2af2ac479', '551e8b15be547418fbf5')      +
-   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,2)')               +
-     Item 1: offset = 344, tuple = ('(0,1)', '2', 'a9a8d7170b', TOASTed)                     +
-   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,3)')               +
-     Item 2: offset = 416, tuple = ('(0,2)', '3', 'a9a8d7170b', TOASTed)                     +
-   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,4)')              +
-     Item 3: offset = 488, tuple = ('(0,3)', '4', '6714eedbf4', TOASTed)                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')               +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', 'e2af2ac479', '551e8b15be547418fbf5')      +
+   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,3)')               +
+     Item 1: offset = 344, tuple = ('(0,2)', '2', 'a9a8d7170b', TOASTed)                     +
+   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,4)')               +
+     Item 2: offset = 416, tuple = ('(0,3)', '3', 'a9a8d7170b', TOASTed)                     +
+   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,5)')              +
+     Item 3: offset = 488, tuple = ('(0,4)', '4', '6714eedbf4', TOASTed)                     +
    Chunk 4: offset = 4, location = 552, hikey location = 112                                 +
-     Item 4: offset = 560, tuple = ('(0,4)', '5', 'e2af2ac479', TOASTed)                     +
+     Item 4: offset = 560, tuple = ('(0,5)', '5', 'e2af2ac479', TOASTed)                     +
                                                                                              +
  Index o_indices8_idx1 contents                                                              +
  Page 0: level = 0, maxKeyLen = 26, nVacatedBytes = 0                                        +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                         +
      Leftmost, Rightmost                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,1)') +
-     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,3)')                                   +
-   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,2)')+
-     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,1)')                                   +
-   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,0)')+
-     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,2)')                                   +
-   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,4)')+
-     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,0)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,2)') +
+     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,4)')                                   +
+   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,3)')+
+     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,2)')                                   +
+   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,1)')+
+     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,3)')                                   +
+   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,5)')+
+     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,1)')                                   +
    Chunk 4: offset = 4, location = 480, hikey location = 208                                 +
-     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,4)')                                   +
+     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,5)')                                   +
                                                                                              +
  Index toast: not loaded                                                                     +
  
@@ -23064,64 +23064,64 @@ SELECT orioledb_tbl_structure('o_indices8'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                         +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                         +
      Leftmost, Rightmost                                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')                               +
-     Item 0: offset = 264, tuple = ('(0,0)', '1', 'e2af2ac479', '551e8b15be547418fbf5')                      +
-   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,2)')                               +
-     Item 1: offset = 344, tuple = ('(0,1)', '2', 'a9a8d7170b', TOASTed)                                     +
-   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,3)')                               +
-     Item 2: offset = 416, tuple = ('(0,2)', '3', 'a9a8d7170b', TOASTed)                                     +
-   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,4)')                              +
-     Item 3: offset = 488, tuple = ('(0,3)', '4', '6714eedbf4', TOASTed)                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')                               +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', 'e2af2ac479', '551e8b15be547418fbf5')                      +
+   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,3)')                               +
+     Item 1: offset = 344, tuple = ('(0,2)', '2', 'a9a8d7170b', TOASTed)                                     +
+   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,4)')                               +
+     Item 2: offset = 416, tuple = ('(0,3)', '3', 'a9a8d7170b', TOASTed)                                     +
+   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,5)')                              +
+     Item 3: offset = 488, tuple = ('(0,4)', '4', '6714eedbf4', TOASTed)                                     +
    Chunk 4: offset = 4, location = 552, hikey location = 112                                                 +
-     Item 4: offset = 560, tuple = ('(0,4)', '5', 'e2af2ac479', TOASTed)                                     +
+     Item 4: offset = 560, tuple = ('(0,5)', '5', 'e2af2ac479', TOASTed)                                     +
                                                                                                              +
  Index o_indices8_idx1 contents                                                                              +
  Page 0: level = 0, maxKeyLen = 26, nVacatedBytes = 0                                                        +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                         +
      Leftmost, Rightmost                                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,1)')                 +
-     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,3)')                                                   +
-   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,2)')                +
-     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,1)')                                                   +
-   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,0)')                +
-     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,2)')                                                   +
-   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,4)')                +
-     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,0)')                                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,2)')                 +
+     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,4)')                                                   +
+   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,3)')                +
+     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,2)')                                                   +
+   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,1)')                +
+     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,3)')                                                   +
+   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,5)')                +
+     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,1)')                                                   +
    Chunk 4: offset = 4, location = 480, hikey location = 208                                                 +
-     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,4)')                                                   +
+     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,5)')                                                   +
                                                                                                              +
  Index toast contents                                                                                        +
  Page 0: level = 1, maxKeyLen = 16                                                                           +
  state = free, datoid equal, relnode equal, ix_type = toast, clean                                           +
      Leftmost, Rightmost                                                                                     +
-   Chunk 0: offset = 0, location = 512, hikey location = 64, hikey = (PK: ('(0,3)'), attnum 4, chunknum 0)   +
+   Chunk 0: offset = 0, location = 512, hikey location = 64, hikey = (PK: ('(0,4)'), attnum 4, chunknum 0)   +
      Item 0: offset = 520, downlink = 1                                                                      +
    Chunk 1: offset = 1, location = 528, hikey location = 80                                                  +
-     Item 1: offset = 536, downlink = 2, key = (PK: ('(0,3)'), attnum 4, chunknum 0)                         +
+     Item 1: offset = 536, downlink = 2, key = (PK: ('(0,4)'), attnum 4, chunknum 0)                         +
                                                                                                              +
  Page 1: level = 0, maxKeyLen = 16, nVacatedBytes = 0                                                        +
  state = free, datoid equal, relnode equal, ix_type = toast, clean                                           +
      Leftmost, Rightlink is invalid                                                                          +
-     Hikey: offset = 120, key = (PK: ('(0,3)'), attnum 4, chunknum 0)                                        +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,1)'), attnum 4, chunknum 1)   +
-     Item 0: offset = 264, tuple = (PK: ('(0,1)'), attnum 4, chunknum 0, data_length 2657)                   +
-   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,2)'), attnum 4, chunknum 0)  +
-     Item 1: offset = 2976, tuple = (PK: ('(0,1)'), attnum 4, chunknum 1, data_length 1347)                  +
-   Chunk 2: offset = 2, location = 4368, hikey location = 104, hikey = (PK: ('(0,2)'), attnum 4, chunknum 1) +
-     Item 2: offset = 4376, tuple = (PK: ('(0,2)'), attnum 4, chunknum 0, data_length 2657)                  +
-   Chunk 3: offset = 3, location = 7080, hikey location = 120, hikey = (PK: ('(0,3)'), attnum 4, chunknum 0) +
-     Item 3: offset = 7088, tuple = (PK: ('(0,2)'), attnum 4, chunknum 1, data_length 347)                   +
+     Hikey: offset = 120, key = (PK: ('(0,4)'), attnum 4, chunknum 0)                                        +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,2)'), attnum 4, chunknum 1)   +
+     Item 0: offset = 264, tuple = (PK: ('(0,2)'), attnum 4, chunknum 0, data_length 2657)                   +
+   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,3)'), attnum 4, chunknum 0)  +
+     Item 1: offset = 2976, tuple = (PK: ('(0,2)'), attnum 4, chunknum 1, data_length 1347)                  +
+   Chunk 2: offset = 2, location = 4368, hikey location = 104, hikey = (PK: ('(0,3)'), attnum 4, chunknum 1) +
+     Item 2: offset = 4376, tuple = (PK: ('(0,3)'), attnum 4, chunknum 0, data_length 2657)                  +
+   Chunk 3: offset = 3, location = 7080, hikey location = 120, hikey = (PK: ('(0,4)'), attnum 4, chunknum 0) +
+     Item 3: offset = 7088, tuple = (PK: ('(0,3)'), attnum 4, chunknum 1, data_length 347)                   +
                                                                                                              +
  Page 2: level = 0, maxKeyLen = 12, nVacatedBytes = 0                                                        +
  state = free, datoid equal, relnode equal, ix_type = toast, clean                                           +
      Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,3)'), attnum 4, chunknum 1)   +
-     Item 0: offset = 264, tuple = (PK: ('(0,3)'), attnum 4, chunknum 0, data_length 2657)                   +
-   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,4)'), attnum 4, chunknum 1)  +
-     Item 1: offset = 2976, tuple = (PK: ('(0,3)'), attnum 4, chunknum 1, data_length 347)                   +
-     Item 2: offset = 3368, tuple = (PK: ('(0,4)'), attnum 4, chunknum 0, data_length 2657)                  +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,4)'), attnum 4, chunknum 1)   +
+     Item 0: offset = 264, tuple = (PK: ('(0,4)'), attnum 4, chunknum 0, data_length 2657)                   +
+   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,5)'), attnum 4, chunknum 1)  +
+     Item 1: offset = 2976, tuple = (PK: ('(0,4)'), attnum 4, chunknum 1, data_length 347)                   +
+     Item 2: offset = 3368, tuple = (PK: ('(0,5)'), attnum 4, chunknum 0, data_length 2657)                  +
    Chunk 2: offset = 3, location = 6072, hikey location = 104                                                +
-     Item 3: offset = 6080, tuple = (PK: ('(0,4)'), attnum 4, chunknum 1, data_length 347)                   +
+     Item 3: offset = 6080, tuple = (PK: ('(0,5)'), attnum 4, chunknum 1, data_length 347)                   +
                                                                                                              +
  
 (1 row)
@@ -23488,31 +23488,31 @@ SELECT orioledb_tbl_structure('o_indices8_ctid'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                         +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                         +
      Leftmost, Rightmost                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')               +
-     Item 0: offset = 264, tuple = ('(0,0)', '1', 'e2af2ac479', '551e8b15be547418fbf5')      +
-   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,2)')               +
-     Item 1: offset = 344, tuple = ('(0,1)', '2', 'a9a8d7170b', TOASTed)                     +
-   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,3)')               +
-     Item 2: offset = 416, tuple = ('(0,2)', '3', 'a9a8d7170b', TOASTed)                     +
-   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,4)')              +
-     Item 3: offset = 488, tuple = ('(0,3)', '4', '6714eedbf4', TOASTed)                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')               +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', 'e2af2ac479', '551e8b15be547418fbf5')      +
+   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,3)')               +
+     Item 1: offset = 344, tuple = ('(0,2)', '2', 'a9a8d7170b', TOASTed)                     +
+   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,4)')               +
+     Item 2: offset = 416, tuple = ('(0,3)', '3', 'a9a8d7170b', TOASTed)                     +
+   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,5)')              +
+     Item 3: offset = 488, tuple = ('(0,4)', '4', '6714eedbf4', TOASTed)                     +
    Chunk 4: offset = 4, location = 552, hikey location = 112                                 +
-     Item 4: offset = 560, tuple = ('(0,4)', '5', 'e2af2ac479', TOASTed)                     +
+     Item 4: offset = 560, tuple = ('(0,5)', '5', 'e2af2ac479', TOASTed)                     +
                                                                                              +
  Index o_indices8_ctid_idx1 contents                                                         +
  Page 0: level = 0, maxKeyLen = 26, nVacatedBytes = 0                                        +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                         +
      Leftmost, Rightmost                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,1)') +
-     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,3)')                                   +
-   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,2)')+
-     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,1)')                                   +
-   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,0)')+
-     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,2)')                                   +
-   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,4)')+
-     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,0)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,2)') +
+     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,4)')                                   +
+   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,3)')+
+     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,2)')                                   +
+   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,1)')+
+     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,3)')                                   +
+   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,5)')+
+     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,1)')                                   +
    Chunk 4: offset = 4, location = 480, hikey location = 208                                 +
-     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,4)')                                   +
+     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,5)')                                   +
                                                                                              +
  Index toast: not loaded                                                                     +
  
@@ -23544,64 +23544,64 @@ SELECT orioledb_tbl_structure('o_indices8_ctid'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                         +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                         +
      Leftmost, Rightmost                                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')                               +
-     Item 0: offset = 264, tuple = ('(0,0)', '1', 'e2af2ac479', '551e8b15be547418fbf5')                      +
-   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,2)')                               +
-     Item 1: offset = 344, tuple = ('(0,1)', '2', 'a9a8d7170b', TOASTed)                                     +
-   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,3)')                               +
-     Item 2: offset = 416, tuple = ('(0,2)', '3', 'a9a8d7170b', TOASTed)                                     +
-   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,4)')                              +
-     Item 3: offset = 488, tuple = ('(0,3)', '4', '6714eedbf4', TOASTed)                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')                               +
+     Item 0: offset = 264, tuple = ('(0,1)', '1', 'e2af2ac479', '551e8b15be547418fbf5')                      +
+   Chunk 1: offset = 1, location = 336, hikey location = 88, hikey = ('(0,3)')                               +
+     Item 1: offset = 344, tuple = ('(0,2)', '2', 'a9a8d7170b', TOASTed)                                     +
+   Chunk 2: offset = 2, location = 408, hikey location = 96, hikey = ('(0,4)')                               +
+     Item 2: offset = 416, tuple = ('(0,3)', '3', 'a9a8d7170b', TOASTed)                                     +
+   Chunk 3: offset = 3, location = 480, hikey location = 104, hikey = ('(0,5)')                              +
+     Item 3: offset = 488, tuple = ('(0,4)', '4', '6714eedbf4', TOASTed)                                     +
    Chunk 4: offset = 4, location = 552, hikey location = 112                                                 +
-     Item 4: offset = 560, tuple = ('(0,4)', '5', 'e2af2ac479', TOASTed)                                     +
+     Item 4: offset = 560, tuple = ('(0,5)', '5', 'e2af2ac479', TOASTed)                                     +
                                                                                                              +
  Index o_indices8_ctid_idx1 contents                                                                         +
  Page 0: level = 0, maxKeyLen = 26, nVacatedBytes = 0                                                        +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                         +
      Leftmost, Rightmost                                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,1)')                 +
-     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,3)')                                                   +
-   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,2)')                +
-     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,1)')                                                   +
-   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,0)')                +
-     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,2)')                                                   +
-   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,4)')                +
-     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,0)')                                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('a9a8d7170b', '(0,2)')                 +
+     Item 0: offset = 264, tuple = ('6714eedbf4', '(0,4)')                                                   +
+   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('a9a8d7170b', '(0,3)')                +
+     Item 1: offset = 320, tuple = ('a9a8d7170b', '(0,2)')                                                   +
+   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e2af2ac479', '(0,1)')                +
+     Item 2: offset = 376, tuple = ('a9a8d7170b', '(0,3)')                                                   +
+   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('e2af2ac479', '(0,5)')                +
+     Item 3: offset = 432, tuple = ('e2af2ac479', '(0,1)')                                                   +
    Chunk 4: offset = 4, location = 480, hikey location = 208                                                 +
-     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,4)')                                                   +
+     Item 4: offset = 488, tuple = ('e2af2ac479', '(0,5)')                                                   +
                                                                                                              +
  Index toast contents                                                                                        +
  Page 0: level = 1, maxKeyLen = 16                                                                           +
  state = free, datoid equal, relnode equal, ix_type = toast, clean                                           +
      Leftmost, Rightmost                                                                                     +
-   Chunk 0: offset = 0, location = 512, hikey location = 64, hikey = (PK: ('(0,3)'), attnum 4, chunknum 0)   +
+   Chunk 0: offset = 0, location = 512, hikey location = 64, hikey = (PK: ('(0,4)'), attnum 4, chunknum 0)   +
      Item 0: offset = 520, downlink = 1                                                                      +
    Chunk 1: offset = 1, location = 528, hikey location = 80                                                  +
-     Item 1: offset = 536, downlink = 2, key = (PK: ('(0,3)'), attnum 4, chunknum 0)                         +
+     Item 1: offset = 536, downlink = 2, key = (PK: ('(0,4)'), attnum 4, chunknum 0)                         +
                                                                                                              +
  Page 1: level = 0, maxKeyLen = 16, nVacatedBytes = 0                                                        +
  state = free, datoid equal, relnode equal, ix_type = toast, clean                                           +
      Leftmost, Rightlink is invalid                                                                          +
-     Hikey: offset = 120, key = (PK: ('(0,3)'), attnum 4, chunknum 0)                                        +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,1)'), attnum 4, chunknum 1)   +
-     Item 0: offset = 264, tuple = (PK: ('(0,1)'), attnum 4, chunknum 0, data_length 2657)                   +
-   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,2)'), attnum 4, chunknum 0)  +
-     Item 1: offset = 2976, tuple = (PK: ('(0,1)'), attnum 4, chunknum 1, data_length 1347)                  +
-   Chunk 2: offset = 2, location = 4368, hikey location = 104, hikey = (PK: ('(0,2)'), attnum 4, chunknum 1) +
-     Item 2: offset = 4376, tuple = (PK: ('(0,2)'), attnum 4, chunknum 0, data_length 2657)                  +
-   Chunk 3: offset = 3, location = 7080, hikey location = 120, hikey = (PK: ('(0,3)'), attnum 4, chunknum 0) +
-     Item 3: offset = 7088, tuple = (PK: ('(0,2)'), attnum 4, chunknum 1, data_length 347)                   +
+     Hikey: offset = 120, key = (PK: ('(0,4)'), attnum 4, chunknum 0)                                        +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,2)'), attnum 4, chunknum 1)   +
+     Item 0: offset = 264, tuple = (PK: ('(0,2)'), attnum 4, chunknum 0, data_length 2657)                   +
+   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,3)'), attnum 4, chunknum 0)  +
+     Item 1: offset = 2976, tuple = (PK: ('(0,2)'), attnum 4, chunknum 1, data_length 1347)                  +
+   Chunk 2: offset = 2, location = 4368, hikey location = 104, hikey = (PK: ('(0,3)'), attnum 4, chunknum 1) +
+     Item 2: offset = 4376, tuple = (PK: ('(0,3)'), attnum 4, chunknum 0, data_length 2657)                  +
+   Chunk 3: offset = 3, location = 7080, hikey location = 120, hikey = (PK: ('(0,4)'), attnum 4, chunknum 0) +
+     Item 3: offset = 7088, tuple = (PK: ('(0,3)'), attnum 4, chunknum 1, data_length 347)                   +
                                                                                                              +
  Page 2: level = 0, maxKeyLen = 12, nVacatedBytes = 0                                                        +
  state = free, datoid equal, relnode equal, ix_type = toast, clean                                           +
      Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,3)'), attnum 4, chunknum 1)   +
-     Item 0: offset = 264, tuple = (PK: ('(0,3)'), attnum 4, chunknum 0, data_length 2657)                   +
-   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,4)'), attnum 4, chunknum 1)  +
-     Item 1: offset = 2976, tuple = (PK: ('(0,3)'), attnum 4, chunknum 1, data_length 347)                   +
-     Item 2: offset = 3368, tuple = (PK: ('(0,4)'), attnum 4, chunknum 0, data_length 2657)                  +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (PK: ('(0,4)'), attnum 4, chunknum 1)   +
+     Item 0: offset = 264, tuple = (PK: ('(0,4)'), attnum 4, chunknum 0, data_length 2657)                   +
+   Chunk 1: offset = 1, location = 2968, hikey location = 88, hikey = (PK: ('(0,5)'), attnum 4, chunknum 1)  +
+     Item 1: offset = 2976, tuple = (PK: ('(0,4)'), attnum 4, chunknum 1, data_length 347)                   +
+     Item 2: offset = 3368, tuple = (PK: ('(0,5)'), attnum 4, chunknum 0, data_length 2657)                  +
    Chunk 2: offset = 3, location = 6072, hikey location = 104                                                +
-     Item 3: offset = 6080, tuple = (PK: ('(0,4)'), attnum 4, chunknum 1, data_length 347)                   +
+     Item 3: offset = 6080, tuple = (PK: ('(0,5)'), attnum 4, chunknum 1, data_length 347)                   +
                                                                                                              +
  
 (1 row)

--- a/test/expected/tableam.out
+++ b/test/expected/tableam.out
@@ -36,9 +36,6 @@ CREATE INDEX o_tableam1_ix_options ON o_tableam1 (value) WITH (compression = on)
 ERROR:  unrecognized parameter "compression"
 ALTER TABLE o_tableam1 ADD EXCLUDE USING btree (value WITH =);
 ERROR:  exclusion indices are not supported.
-CREATE INDEX o_tableam1_ix_hash on o_tableam1 using hash(key);
-ERROR:  'hash' access method is not supported
-HINT:  For other index access methods use 'index_bridging' option.
 SELECT orioledb_tbl_indices('o_tableam1'::regclass);
               orioledb_tbl_indices              
 ------------------------------------------------
@@ -857,189 +854,189 @@ SELECT orioledb_tbl_structure('o_test_partial'::regclass, 'ne');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                     +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')           +
-     Item 0: offset = 264, tuple = ('(0,0)', '0', '0text')                               +
-     Item 1: offset = 312, tuple = ('(0,1)', '2', '2text')                               +
-   Chunk 1: offset = 2, location = 360, hikey location = 104, hikey = ('(0,4)')          +
-     Item 2: offset = 368, tuple = ('(0,2)', '3', '3text')                               +
-     Item 3: offset = 416, tuple = ('(0,3)', '4', '4text')                               +
-   Chunk 2: offset = 4, location = 464, hikey location = 112, hikey = ('(0,6)')          +
-     Item 4: offset = 472, tuple = ('(0,4)', '16', '16text')                             +
-     Item 5: offset = 520, tuple = ('(0,5)', '17', '17text')                             +
-   Chunk 3: offset = 6, location = 568, hikey location = 120, hikey = ('(0,8)')          +
-     Item 6: offset = 576, tuple = ('(0,6)', '18', '18text')                             +
-     Item 7: offset = 624, tuple = ('(0,7)', '19', '19text')                             +
-   Chunk 4: offset = 8, location = 672, hikey location = 128, hikey = ('(0,10)')         +
-     Item 8: offset = 680, tuple = ('(0,8)', '20', '20text')                             +
-     Item 9: offset = 728, tuple = ('(0,9)', '105', '5text')                             +
-   Chunk 5: offset = 10, location = 776, hikey location = 136, hikey = ('(0,12)')        +
-     Item 10: offset = 784, tuple = ('(0,10)', '106', '6text')                           +
-     Item 11: offset = 832, tuple = ('(0,11)', '107', '7text')                           +
-   Chunk 6: offset = 12, location = 880, hikey location = 144, hikey = ('(0,14)')        +
-     Item 12: offset = 888, tuple = ('(0,12)', '108', '8text')                           +
-     Item 13: offset = 936, tuple = ('(0,13)', '109', '9text')                           +
-   Chunk 7: offset = 14, location = 984, hikey location = 152, hikey = ('(0,16)')        +
-     Item 14: offset = 992, tuple = ('(0,14)', '110', '10text')                          +
-     Item 15: offset = 1040, tuple = ('(0,15)', '111', '11text')                         +
-   Chunk 8: offset = 16, location = 1088, hikey location = 160, hikey = ('(0,18)')       +
-     Item 16: offset = 1096, tuple = ('(0,16)', '112', '12text')                         +
-     Item 17: offset = 1144, tuple = ('(0,17)', '113', '13text')                         +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,3)')           +
+     Item 0: offset = 264, tuple = ('(0,1)', '0', '0text')                               +
+     Item 1: offset = 312, tuple = ('(0,2)', '2', '2text')                               +
+   Chunk 1: offset = 2, location = 360, hikey location = 104, hikey = ('(0,5)')          +
+     Item 2: offset = 368, tuple = ('(0,3)', '3', '3text')                               +
+     Item 3: offset = 416, tuple = ('(0,4)', '4', '4text')                               +
+   Chunk 2: offset = 4, location = 464, hikey location = 112, hikey = ('(0,7)')          +
+     Item 4: offset = 472, tuple = ('(0,5)', '16', '16text')                             +
+     Item 5: offset = 520, tuple = ('(0,6)', '17', '17text')                             +
+   Chunk 3: offset = 6, location = 568, hikey location = 120, hikey = ('(0,9)')          +
+     Item 6: offset = 576, tuple = ('(0,7)', '18', '18text')                             +
+     Item 7: offset = 624, tuple = ('(0,8)', '19', '19text')                             +
+   Chunk 4: offset = 8, location = 672, hikey location = 128, hikey = ('(0,11)')         +
+     Item 8: offset = 680, tuple = ('(0,9)', '20', '20text')                             +
+     Item 9: offset = 728, tuple = ('(0,10)', '105', '5text')                            +
+   Chunk 5: offset = 10, location = 776, hikey location = 136, hikey = ('(0,13)')        +
+     Item 10: offset = 784, tuple = ('(0,11)', '106', '6text')                           +
+     Item 11: offset = 832, tuple = ('(0,12)', '107', '7text')                           +
+   Chunk 6: offset = 12, location = 880, hikey location = 144, hikey = ('(0,15)')        +
+     Item 12: offset = 888, tuple = ('(0,13)', '108', '8text')                           +
+     Item 13: offset = 936, tuple = ('(0,14)', '109', '9text')                           +
+   Chunk 7: offset = 14, location = 984, hikey location = 152, hikey = ('(0,17)')        +
+     Item 14: offset = 992, tuple = ('(0,15)', '110', '10text')                          +
+     Item 15: offset = 1040, tuple = ('(0,16)', '111', '11text')                         +
+   Chunk 8: offset = 16, location = 1088, hikey location = 160, hikey = ('(0,19)')       +
+     Item 16: offset = 1096, tuple = ('(0,17)', '112', '12text')                         +
+     Item 17: offset = 1144, tuple = ('(0,18)', '113', '13text')                         +
    Chunk 9: offset = 18, location = 1192, hikey location = 168                           +
-     Item 18: offset = 1200, tuple = ('(0,18)', '114', '14text')                         +
-     Item 19: offset = 1248, tuple = ('(0,19)', '115', '15text')                         +
+     Item 18: offset = 1200, tuple = ('(0,19)', '114', '14text')                         +
+     Item 19: offset = 1248, tuple = ('(0,20)', '115', '15text')                         +
                                                                                          +
  Index o_test_partial_ix1 contents                                                       +
  Page 0: level = 0, maxKeyLen = 14, nVacatedBytes = 0                                    +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('18', '(0,6)')     +
-     Item 0: offset = 264, tuple = ('16', '(0,4)')                                       +
-     Item 1: offset = 296, tuple = ('17', '(0,5)')                                       +
-   Chunk 1: offset = 2, location = 328, hikey location = 104, hikey = ('20', '(0,8)')    +
-     Item 2: offset = 336, tuple = ('18', '(0,6)')                                       +
-     Item 3: offset = 368, tuple = ('19', '(0,7)')                                       +
-   Chunk 2: offset = 4, location = 400, hikey location = 120, hikey = ('106', '(0,10)')  +
-     Item 4: offset = 408, tuple = ('20', '(0,8)')                                       +
-     Item 5: offset = 440, tuple = ('105', '(0,9)')                                      +
-   Chunk 3: offset = 6, location = 472, hikey location = 136, hikey = ('108', '(0,12)')  +
-     Item 6: offset = 480, tuple = ('106', '(0,10)')                                     +
-     Item 7: offset = 512, tuple = ('107', '(0,11)')                                     +
-   Chunk 4: offset = 8, location = 544, hikey location = 152, hikey = ('110', '(0,14)')  +
-     Item 8: offset = 552, tuple = ('108', '(0,12)')                                     +
-     Item 9: offset = 584, tuple = ('109', '(0,13)')                                     +
-   Chunk 5: offset = 10, location = 616, hikey location = 168, hikey = ('112', '(0,16)') +
-     Item 10: offset = 624, tuple = ('110', '(0,14)')                                    +
-     Item 11: offset = 656, tuple = ('111', '(0,15)')                                    +
-   Chunk 6: offset = 12, location = 688, hikey location = 184, hikey = ('114', '(0,18)') +
-     Item 12: offset = 696, tuple = ('112', '(0,16)')                                    +
-     Item 13: offset = 728, tuple = ('113', '(0,17)')                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('18', '(0,7)')     +
+     Item 0: offset = 264, tuple = ('16', '(0,5)')                                       +
+     Item 1: offset = 296, tuple = ('17', '(0,6)')                                       +
+   Chunk 1: offset = 2, location = 328, hikey location = 104, hikey = ('20', '(0,9)')    +
+     Item 2: offset = 336, tuple = ('18', '(0,7)')                                       +
+     Item 3: offset = 368, tuple = ('19', '(0,8)')                                       +
+   Chunk 2: offset = 4, location = 400, hikey location = 120, hikey = ('106', '(0,11)')  +
+     Item 4: offset = 408, tuple = ('20', '(0,9)')                                       +
+     Item 5: offset = 440, tuple = ('105', '(0,10)')                                     +
+   Chunk 3: offset = 6, location = 472, hikey location = 136, hikey = ('108', '(0,13)')  +
+     Item 6: offset = 480, tuple = ('106', '(0,11)')                                     +
+     Item 7: offset = 512, tuple = ('107', '(0,12)')                                     +
+   Chunk 4: offset = 8, location = 544, hikey location = 152, hikey = ('110', '(0,15)')  +
+     Item 8: offset = 552, tuple = ('108', '(0,13)')                                     +
+     Item 9: offset = 584, tuple = ('109', '(0,14)')                                     +
+   Chunk 5: offset = 10, location = 616, hikey location = 168, hikey = ('112', '(0,17)') +
+     Item 10: offset = 624, tuple = ('110', '(0,15)')                                    +
+     Item 11: offset = 656, tuple = ('111', '(0,16)')                                    +
+   Chunk 6: offset = 12, location = 688, hikey location = 184, hikey = ('114', '(0,19)') +
+     Item 12: offset = 696, tuple = ('112', '(0,17)')                                    +
+     Item 13: offset = 728, tuple = ('113', '(0,18)')                                    +
    Chunk 7: offset = 14, location = 760, hikey location = 200                            +
-     Item 14: offset = 768, tuple = ('114', '(0,18)')                                    +
-     Item 15: offset = 800, tuple = ('115', '(0,19)')                                    +
+     Item 14: offset = 768, tuple = ('114', '(0,19)')                                    +
+     Item 15: offset = 800, tuple = ('115', '(0,20)')                                    +
                                                                                          +
  Index o_test_partial_ix2 contents                                                       +
  Page 0: level = 0, maxKeyLen = 14, nVacatedBytes = 0                                    +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('18', '(0,6)')     +
-     Item 0: offset = 264, tuple = ('16', '(0,4)')                                       +
-     Item 1: offset = 296, tuple = ('17', '(0,5)')                                       +
-   Chunk 1: offset = 2, location = 328, hikey location = 104, hikey = ('20', '(0,8)')    +
-     Item 2: offset = 336, tuple = ('18', '(0,6)')                                       +
-     Item 3: offset = 368, tuple = ('19', '(0,7)')                                       +
-   Chunk 2: offset = 4, location = 400, hikey location = 120, hikey = ('106', '(0,10)')  +
-     Item 4: offset = 408, tuple = ('20', '(0,8)')                                       +
-     Item 5: offset = 440, tuple = ('105', '(0,9)')                                      +
-   Chunk 3: offset = 6, location = 472, hikey location = 136, hikey = ('108', '(0,12)')  +
-     Item 6: offset = 480, tuple = ('106', '(0,10)')                                     +
-     Item 7: offset = 512, tuple = ('107', '(0,11)')                                     +
-   Chunk 4: offset = 8, location = 544, hikey location = 152, hikey = ('110', '(0,14)')  +
-     Item 8: offset = 552, tuple = ('108', '(0,12)')                                     +
-     Item 9: offset = 584, tuple = ('109', '(0,13)')                                     +
-   Chunk 5: offset = 10, location = 616, hikey location = 168, hikey = ('112', '(0,16)') +
-     Item 10: offset = 624, tuple = ('110', '(0,14)')                                    +
-     Item 11: offset = 656, tuple = ('111', '(0,15)')                                    +
-   Chunk 6: offset = 12, location = 688, hikey location = 184, hikey = ('114', '(0,18)') +
-     Item 12: offset = 696, tuple = ('112', '(0,16)')                                    +
-     Item 13: offset = 728, tuple = ('113', '(0,17)')                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('18', '(0,7)')     +
+     Item 0: offset = 264, tuple = ('16', '(0,5)')                                       +
+     Item 1: offset = 296, tuple = ('17', '(0,6)')                                       +
+   Chunk 1: offset = 2, location = 328, hikey location = 104, hikey = ('20', '(0,9)')    +
+     Item 2: offset = 336, tuple = ('18', '(0,7)')                                       +
+     Item 3: offset = 368, tuple = ('19', '(0,8)')                                       +
+   Chunk 2: offset = 4, location = 400, hikey location = 120, hikey = ('106', '(0,11)')  +
+     Item 4: offset = 408, tuple = ('20', '(0,9)')                                       +
+     Item 5: offset = 440, tuple = ('105', '(0,10)')                                     +
+   Chunk 3: offset = 6, location = 472, hikey location = 136, hikey = ('108', '(0,13)')  +
+     Item 6: offset = 480, tuple = ('106', '(0,11)')                                     +
+     Item 7: offset = 512, tuple = ('107', '(0,12)')                                     +
+   Chunk 4: offset = 8, location = 544, hikey location = 152, hikey = ('110', '(0,15)')  +
+     Item 8: offset = 552, tuple = ('108', '(0,13)')                                     +
+     Item 9: offset = 584, tuple = ('109', '(0,14)')                                     +
+   Chunk 5: offset = 10, location = 616, hikey location = 168, hikey = ('112', '(0,17)') +
+     Item 10: offset = 624, tuple = ('110', '(0,15)')                                    +
+     Item 11: offset = 656, tuple = ('111', '(0,16)')                                    +
+   Chunk 6: offset = 12, location = 688, hikey location = 184, hikey = ('114', '(0,19)') +
+     Item 12: offset = 696, tuple = ('112', '(0,17)')                                    +
+     Item 13: offset = 728, tuple = ('113', '(0,18)')                                    +
    Chunk 7: offset = 14, location = 760, hikey location = 200                            +
-     Item 14: offset = 768, tuple = ('114', '(0,18)')                                    +
-     Item 15: offset = 800, tuple = ('115', '(0,19)')                                    +
+     Item 14: offset = 768, tuple = ('114', '(0,19)')                                    +
+     Item 15: offset = 800, tuple = ('115', '(0,20)')                                    +
                                                                                          +
  Index o_test_partial_ix3 contents                                                       +
  Page 0: level = 0, maxKeyLen = 14, nVacatedBytes = 0                                    +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('4', '(0,3)')      +
-     Item 0: offset = 264, tuple = ('2', '(0,1)')                                        +
-     Item 1: offset = 296, tuple = ('3', '(0,2)')                                        +
-   Chunk 1: offset = 2, location = 328, hikey location = 112, hikey = ('17', '(0,5)')    +
-     Item 2: offset = 336, tuple = ('4', '(0,3)')                                        +
-     Item 3: offset = 368, tuple = ('16', '(0,4)')                                       +
-   Chunk 2: offset = 4, location = 400, hikey location = 128, hikey = ('19', '(0,7)')    +
-     Item 4: offset = 408, tuple = ('17', '(0,5)')                                       +
-     Item 5: offset = 440, tuple = ('18', '(0,6)')                                       +
-   Chunk 3: offset = 6, location = 472, hikey location = 144, hikey = ('105', '(0,9)')   +
-     Item 6: offset = 480, tuple = ('19', '(0,7)')                                       +
-     Item 7: offset = 512, tuple = ('20', '(0,8)')                                       +
-   Chunk 4: offset = 8, location = 544, hikey location = 160, hikey = ('107', '(0,11)')  +
-     Item 8: offset = 552, tuple = ('105', '(0,9)')                                      +
-     Item 9: offset = 584, tuple = ('106', '(0,10)')                                     +
-   Chunk 5: offset = 10, location = 616, hikey location = 176, hikey = ('109', '(0,13)') +
-     Item 10: offset = 624, tuple = ('107', '(0,11)')                                    +
-     Item 11: offset = 656, tuple = ('108', '(0,12)')                                    +
-   Chunk 6: offset = 12, location = 688, hikey location = 192, hikey = ('111', '(0,15)') +
-     Item 12: offset = 696, tuple = ('109', '(0,13)')                                    +
-     Item 13: offset = 728, tuple = ('110', '(0,14)')                                    +
-   Chunk 7: offset = 14, location = 760, hikey location = 208, hikey = ('113', '(0,17)') +
-     Item 14: offset = 768, tuple = ('111', '(0,15)')                                    +
-     Item 15: offset = 800, tuple = ('112', '(0,16)')                                    +
-   Chunk 8: offset = 16, location = 832, hikey location = 224, hikey = ('115', '(0,19)') +
-     Item 16: offset = 840, tuple = ('113', '(0,17)')                                    +
-     Item 17: offset = 872, tuple = ('114', '(0,18)')                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('4', '(0,4)')      +
+     Item 0: offset = 264, tuple = ('2', '(0,2)')                                        +
+     Item 1: offset = 296, tuple = ('3', '(0,3)')                                        +
+   Chunk 1: offset = 2, location = 328, hikey location = 112, hikey = ('17', '(0,6)')    +
+     Item 2: offset = 336, tuple = ('4', '(0,4)')                                        +
+     Item 3: offset = 368, tuple = ('16', '(0,5)')                                       +
+   Chunk 2: offset = 4, location = 400, hikey location = 128, hikey = ('19', '(0,8)')    +
+     Item 4: offset = 408, tuple = ('17', '(0,6)')                                       +
+     Item 5: offset = 440, tuple = ('18', '(0,7)')                                       +
+   Chunk 3: offset = 6, location = 472, hikey location = 144, hikey = ('105', '(0,10)')  +
+     Item 6: offset = 480, tuple = ('19', '(0,8)')                                       +
+     Item 7: offset = 512, tuple = ('20', '(0,9)')                                       +
+   Chunk 4: offset = 8, location = 544, hikey location = 160, hikey = ('107', '(0,12)')  +
+     Item 8: offset = 552, tuple = ('105', '(0,10)')                                     +
+     Item 9: offset = 584, tuple = ('106', '(0,11)')                                     +
+   Chunk 5: offset = 10, location = 616, hikey location = 176, hikey = ('109', '(0,14)') +
+     Item 10: offset = 624, tuple = ('107', '(0,12)')                                    +
+     Item 11: offset = 656, tuple = ('108', '(0,13)')                                    +
+   Chunk 6: offset = 12, location = 688, hikey location = 192, hikey = ('111', '(0,16)') +
+     Item 12: offset = 696, tuple = ('109', '(0,14)')                                    +
+     Item 13: offset = 728, tuple = ('110', '(0,15)')                                    +
+   Chunk 7: offset = 14, location = 760, hikey location = 208, hikey = ('113', '(0,18)') +
+     Item 14: offset = 768, tuple = ('111', '(0,16)')                                    +
+     Item 15: offset = 800, tuple = ('112', '(0,17)')                                    +
+   Chunk 8: offset = 16, location = 832, hikey location = 224, hikey = ('115', '(0,20)') +
+     Item 16: offset = 840, tuple = ('113', '(0,18)')                                    +
+     Item 17: offset = 872, tuple = ('114', '(0,19)')                                    +
    Chunk 9: offset = 18, location = 904, hikey location = 240                            +
-     Item 18: offset = 912, tuple = ('115', '(0,19)')                                    +
+     Item 18: offset = 912, tuple = ('115', '(0,20)')                                    +
                                                                                          +
  Index o_test_partial_ix4 contents                                                       +
  Page 0: level = 0, maxKeyLen = 14, nVacatedBytes = 0                                    +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('4', '(0,3)')      +
-     Item 0: offset = 264, tuple = ('0', '(0,0)')                                        +
-     Item 1: offset = 296, tuple = ('2', '(0,1)')                                        +
-     Item 2: offset = 328, tuple = ('3', '(0,2)')                                        +
-   Chunk 1: offset = 3, location = 360, hikey location = 104, hikey = ('18', '(0,6)')    +
-     Item 3: offset = 368, tuple = ('4', '(0,3)')                                        +
-     Item 4: offset = 400, tuple = ('16', '(0,4)')                                       +
-     Item 5: offset = 432, tuple = ('17', '(0,5)')                                       +
-   Chunk 2: offset = 6, location = 464, hikey location = 120, hikey = ('105', '(0,9)')   +
-     Item 6: offset = 472, tuple = ('18', '(0,6)')                                       +
-     Item 7: offset = 504, tuple = ('19', '(0,7)')                                       +
-     Item 8: offset = 536, tuple = ('20', '(0,8)')                                       +
-   Chunk 3: offset = 9, location = 568, hikey location = 136, hikey = ('108', '(0,12)')  +
-     Item 9: offset = 576, tuple = ('105', '(0,9)')                                      +
-     Item 10: offset = 608, tuple = ('106', '(0,10)')                                    +
-     Item 11: offset = 640, tuple = ('107', '(0,11)')                                    +
-   Chunk 4: offset = 12, location = 672, hikey location = 152, hikey = ('111', '(0,15)') +
-     Item 12: offset = 680, tuple = ('108', '(0,12)')                                    +
-     Item 13: offset = 712, tuple = ('109', '(0,13)')                                    +
-     Item 14: offset = 744, tuple = ('110', '(0,14)')                                    +
-   Chunk 5: offset = 15, location = 776, hikey location = 168, hikey = ('114', '(0,18)') +
-     Item 15: offset = 784, tuple = ('111', '(0,15)')                                    +
-     Item 16: offset = 816, tuple = ('112', '(0,16)')                                    +
-     Item 17: offset = 848, tuple = ('113', '(0,17)')                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('4', '(0,4)')      +
+     Item 0: offset = 264, tuple = ('0', '(0,1)')                                        +
+     Item 1: offset = 296, tuple = ('2', '(0,2)')                                        +
+     Item 2: offset = 328, tuple = ('3', '(0,3)')                                        +
+   Chunk 1: offset = 3, location = 360, hikey location = 104, hikey = ('18', '(0,7)')    +
+     Item 3: offset = 368, tuple = ('4', '(0,4)')                                        +
+     Item 4: offset = 400, tuple = ('16', '(0,5)')                                       +
+     Item 5: offset = 432, tuple = ('17', '(0,6)')                                       +
+   Chunk 2: offset = 6, location = 464, hikey location = 120, hikey = ('105', '(0,10)')  +
+     Item 6: offset = 472, tuple = ('18', '(0,7)')                                       +
+     Item 7: offset = 504, tuple = ('19', '(0,8)')                                       +
+     Item 8: offset = 536, tuple = ('20', '(0,9)')                                       +
+   Chunk 3: offset = 9, location = 568, hikey location = 136, hikey = ('108', '(0,13)')  +
+     Item 9: offset = 576, tuple = ('105', '(0,10)')                                     +
+     Item 10: offset = 608, tuple = ('106', '(0,11)')                                    +
+     Item 11: offset = 640, tuple = ('107', '(0,12)')                                    +
+   Chunk 4: offset = 12, location = 672, hikey location = 152, hikey = ('111', '(0,16)') +
+     Item 12: offset = 680, tuple = ('108', '(0,13)')                                    +
+     Item 13: offset = 712, tuple = ('109', '(0,14)')                                    +
+     Item 14: offset = 744, tuple = ('110', '(0,15)')                                    +
+   Chunk 5: offset = 15, location = 776, hikey location = 168, hikey = ('114', '(0,19)') +
+     Item 15: offset = 784, tuple = ('111', '(0,16)')                                    +
+     Item 16: offset = 816, tuple = ('112', '(0,17)')                                    +
+     Item 17: offset = 848, tuple = ('113', '(0,18)')                                    +
    Chunk 6: offset = 18, location = 880, hikey location = 184                            +
-     Item 18: offset = 888, tuple = ('114', '(0,18)')                                    +
-     Item 19: offset = 920, tuple = ('115', '(0,19)')                                    +
+     Item 18: offset = 888, tuple = ('114', '(0,19)')                                    +
+     Item 19: offset = 920, tuple = ('115', '(0,20)')                                    +
                                                                                          +
  Index o_test_partial_ix5 contents                                                       +
  Page 0: level = 0, maxKeyLen = 14, nVacatedBytes = 0                                    +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('18', '(0,6)')     +
-     Item 0: offset = 264, tuple = ('16', '(0,4)')                                       +
-     Item 1: offset = 296, tuple = ('17', '(0,5)')                                       +
-   Chunk 1: offset = 2, location = 328, hikey location = 104, hikey = ('20', '(0,8)')    +
-     Item 2: offset = 336, tuple = ('18', '(0,6)')                                       +
-     Item 3: offset = 368, tuple = ('19', '(0,7)')                                       +
-   Chunk 2: offset = 4, location = 400, hikey location = 120, hikey = ('106', '(0,10)')  +
-     Item 4: offset = 408, tuple = ('20', '(0,8)')                                       +
-     Item 5: offset = 440, tuple = ('105', '(0,9)')                                      +
-   Chunk 3: offset = 6, location = 472, hikey location = 136, hikey = ('108', '(0,12)')  +
-     Item 6: offset = 480, tuple = ('106', '(0,10)')                                     +
-     Item 7: offset = 512, tuple = ('107', '(0,11)')                                     +
-   Chunk 4: offset = 8, location = 544, hikey location = 152, hikey = ('110', '(0,14)')  +
-     Item 8: offset = 552, tuple = ('108', '(0,12)')                                     +
-     Item 9: offset = 584, tuple = ('109', '(0,13)')                                     +
-   Chunk 5: offset = 10, location = 616, hikey location = 168, hikey = ('112', '(0,16)') +
-     Item 10: offset = 624, tuple = ('110', '(0,14)')                                    +
-     Item 11: offset = 656, tuple = ('111', '(0,15)')                                    +
-   Chunk 6: offset = 12, location = 688, hikey location = 184, hikey = ('114', '(0,18)') +
-     Item 12: offset = 696, tuple = ('112', '(0,16)')                                    +
-     Item 13: offset = 728, tuple = ('113', '(0,17)')                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('18', '(0,7)')     +
+     Item 0: offset = 264, tuple = ('16', '(0,5)')                                       +
+     Item 1: offset = 296, tuple = ('17', '(0,6)')                                       +
+   Chunk 1: offset = 2, location = 328, hikey location = 104, hikey = ('20', '(0,9)')    +
+     Item 2: offset = 336, tuple = ('18', '(0,7)')                                       +
+     Item 3: offset = 368, tuple = ('19', '(0,8)')                                       +
+   Chunk 2: offset = 4, location = 400, hikey location = 120, hikey = ('106', '(0,11)')  +
+     Item 4: offset = 408, tuple = ('20', '(0,9)')                                       +
+     Item 5: offset = 440, tuple = ('105', '(0,10)')                                     +
+   Chunk 3: offset = 6, location = 472, hikey location = 136, hikey = ('108', '(0,13)')  +
+     Item 6: offset = 480, tuple = ('106', '(0,11)')                                     +
+     Item 7: offset = 512, tuple = ('107', '(0,12)')                                     +
+   Chunk 4: offset = 8, location = 544, hikey location = 152, hikey = ('110', '(0,15)')  +
+     Item 8: offset = 552, tuple = ('108', '(0,13)')                                     +
+     Item 9: offset = 584, tuple = ('109', '(0,14)')                                     +
+   Chunk 5: offset = 10, location = 616, hikey location = 168, hikey = ('112', '(0,17)') +
+     Item 10: offset = 624, tuple = ('110', '(0,15)')                                    +
+     Item 11: offset = 656, tuple = ('111', '(0,16)')                                    +
+   Chunk 6: offset = 12, location = 688, hikey location = 184, hikey = ('114', '(0,19)') +
+     Item 12: offset = 696, tuple = ('112', '(0,17)')                                    +
+     Item 13: offset = 728, tuple = ('113', '(0,18)')                                    +
    Chunk 7: offset = 14, location = 760, hikey location = 200                            +
-     Item 14: offset = 768, tuple = ('114', '(0,18)')                                    +
-     Item 15: offset = 800, tuple = ('115', '(0,19)')                                    +
+     Item 14: offset = 768, tuple = ('114', '(0,19)')                                    +
+     Item 15: offset = 800, tuple = ('115', '(0,20)')                                    +
                                                                                          +
  Index o_test_partial_ix7 contents                                                       +
  Page 0: level = 0, maxKeyLen = 0, nVacatedBytes = 0                                     +
@@ -1051,31 +1048,31 @@ SELECT orioledb_tbl_structure('o_test_partial'::regclass, 'ne');
  Page 0: level = 0, maxKeyLen = 20, nVacatedBytes = 0                                    +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('6text', '(0,10)') +
-     Item 0: offset = 264, tuple = ('5text', '(0,9)')                                    +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('7text', '(0,11)')+
-     Item 1: offset = 312, tuple = ('6text', '(0,10)')                                   +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('8text', '(0,12)')+
-     Item 2: offset = 360, tuple = ('7text', '(0,11)')                                   +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('9text', '(0,13)')+
-     Item 3: offset = 408, tuple = ('8text', '(0,12)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('6text', '(0,11)') +
+     Item 0: offset = 264, tuple = ('5text', '(0,10)')                                   +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('7text', '(0,12)')+
+     Item 1: offset = 312, tuple = ('6text', '(0,11)')                                   +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('8text', '(0,13)')+
+     Item 2: offset = 360, tuple = ('7text', '(0,12)')                                   +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('9text', '(0,14)')+
+     Item 3: offset = 408, tuple = ('8text', '(0,13)')                                   +
    Chunk 4: offset = 4, location = 448, hikey location = 176                             +
-     Item 4: offset = 456, tuple = ('9text', '(0,13)')                                   +
+     Item 4: offset = 456, tuple = ('9text', '(0,14)')                                   +
                                                                                          +
  Index o_test_partial_ix9 contents                                                       +
  Page 0: level = 0, maxKeyLen = 20, nVacatedBytes = 0                                    +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                     +
      Leftmost, Rightmost                                                                 +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('6text', '(0,10)') +
-     Item 0: offset = 264, tuple = ('5text', '(0,9)')                                    +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('7text', '(0,11)')+
-     Item 1: offset = 312, tuple = ('6text', '(0,10)')                                   +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('8text', '(0,12)')+
-     Item 2: offset = 360, tuple = ('7text', '(0,11)')                                   +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('9text', '(0,13)')+
-     Item 3: offset = 408, tuple = ('8text', '(0,12)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('6text', '(0,11)') +
+     Item 0: offset = 264, tuple = ('5text', '(0,10)')                                   +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('7text', '(0,12)')+
+     Item 1: offset = 312, tuple = ('6text', '(0,11)')                                   +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('8text', '(0,13)')+
+     Item 2: offset = 360, tuple = ('7text', '(0,12)')                                   +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('9text', '(0,14)')+
+     Item 3: offset = 408, tuple = ('8text', '(0,13)')                                   +
    Chunk 4: offset = 4, location = 448, hikey location = 176                             +
-     Item 4: offset = 456, tuple = ('9text', '(0,13)')                                   +
+     Item 4: offset = 456, tuple = ('9text', '(0,14)')                                   +
                                                                                          +
  Index toast: not loaded                                                                 +
  
@@ -1614,251 +1611,251 @@ SELECT orioledb_tbl_structure('o_test_expression'::regclass, 'ne');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                                                   +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,2)')                                         +
-     Item 0: offset = 264, tuple = ('(0,0)', '0', '0text')                                                             +
-     Item 1: offset = 312, tuple = ('(0,1)', '2', '2text')                                                             +
-   Chunk 1: offset = 2, location = 360, hikey location = 104, hikey = ('(0,4)')                                        +
-     Item 2: offset = 368, tuple = ('(0,2)', '3', '3text')                                                             +
-     Item 3: offset = 416, tuple = ('(0,3)', '4', '4text')                                                             +
-   Chunk 2: offset = 4, location = 464, hikey location = 112, hikey = ('(0,6)')                                        +
-     Item 4: offset = 472, tuple = ('(0,4)', '16', '16text')                                                           +
-     Item 5: offset = 520, tuple = ('(0,5)', '17', '17text')                                                           +
-   Chunk 3: offset = 6, location = 568, hikey location = 120, hikey = ('(0,8)')                                        +
-     Item 6: offset = 576, tuple = ('(0,6)', '18', '18text')                                                           +
-     Item 7: offset = 624, tuple = ('(0,7)', '19', '19text')                                                           +
-   Chunk 4: offset = 8, location = 672, hikey location = 128, hikey = ('(0,10)')                                       +
-     Item 8: offset = 680, tuple = ('(0,8)', '20', '20text')                                                           +
-     Item 9: offset = 728, tuple = ('(0,9)', '105', '5text')                                                           +
-   Chunk 5: offset = 10, location = 776, hikey location = 136, hikey = ('(0,12)')                                      +
-     Item 10: offset = 784, tuple = ('(0,10)', '106', '6text')                                                         +
-     Item 11: offset = 832, tuple = ('(0,11)', '107', '7text')                                                         +
-   Chunk 6: offset = 12, location = 880, hikey location = 144, hikey = ('(0,14)')                                      +
-     Item 12: offset = 888, tuple = ('(0,12)', '108', '8text')                                                         +
-     Item 13: offset = 936, tuple = ('(0,13)', '109', '9text')                                                         +
-   Chunk 7: offset = 14, location = 984, hikey location = 152, hikey = ('(0,16)')                                      +
-     Item 14: offset = 992, tuple = ('(0,14)', '110', '10text')                                                        +
-     Item 15: offset = 1040, tuple = ('(0,15)', '111', '11text')                                                       +
-   Chunk 8: offset = 16, location = 1088, hikey location = 160, hikey = ('(0,18)')                                     +
-     Item 16: offset = 1096, tuple = ('(0,16)', '112', '12text')                                                       +
-     Item 17: offset = 1144, tuple = ('(0,17)', '113', '13text')                                                       +
+   Chunk 0: offset = 0, location = 256, hikey location = 96, hikey = ('(0,3)')                                         +
+     Item 0: offset = 264, tuple = ('(0,1)', '0', '0text')                                                             +
+     Item 1: offset = 312, tuple = ('(0,2)', '2', '2text')                                                             +
+   Chunk 1: offset = 2, location = 360, hikey location = 104, hikey = ('(0,5)')                                        +
+     Item 2: offset = 368, tuple = ('(0,3)', '3', '3text')                                                             +
+     Item 3: offset = 416, tuple = ('(0,4)', '4', '4text')                                                             +
+   Chunk 2: offset = 4, location = 464, hikey location = 112, hikey = ('(0,7)')                                        +
+     Item 4: offset = 472, tuple = ('(0,5)', '16', '16text')                                                           +
+     Item 5: offset = 520, tuple = ('(0,6)', '17', '17text')                                                           +
+   Chunk 3: offset = 6, location = 568, hikey location = 120, hikey = ('(0,9)')                                        +
+     Item 6: offset = 576, tuple = ('(0,7)', '18', '18text')                                                           +
+     Item 7: offset = 624, tuple = ('(0,8)', '19', '19text')                                                           +
+   Chunk 4: offset = 8, location = 672, hikey location = 128, hikey = ('(0,11)')                                       +
+     Item 8: offset = 680, tuple = ('(0,9)', '20', '20text')                                                           +
+     Item 9: offset = 728, tuple = ('(0,10)', '105', '5text')                                                          +
+   Chunk 5: offset = 10, location = 776, hikey location = 136, hikey = ('(0,13)')                                      +
+     Item 10: offset = 784, tuple = ('(0,11)', '106', '6text')                                                         +
+     Item 11: offset = 832, tuple = ('(0,12)', '107', '7text')                                                         +
+   Chunk 6: offset = 12, location = 880, hikey location = 144, hikey = ('(0,15)')                                      +
+     Item 12: offset = 888, tuple = ('(0,13)', '108', '8text')                                                         +
+     Item 13: offset = 936, tuple = ('(0,14)', '109', '9text')                                                         +
+   Chunk 7: offset = 14, location = 984, hikey location = 152, hikey = ('(0,17)')                                      +
+     Item 14: offset = 992, tuple = ('(0,15)', '110', '10text')                                                        +
+     Item 15: offset = 1040, tuple = ('(0,16)', '111', '11text')                                                       +
+   Chunk 8: offset = 16, location = 1088, hikey location = 160, hikey = ('(0,19)')                                     +
+     Item 16: offset = 1096, tuple = ('(0,17)', '112', '12text')                                                       +
+     Item 17: offset = 1144, tuple = ('(0,18)', '113', '13text')                                                       +
    Chunk 9: offset = 18, location = 1192, hikey location = 168                                                         +
-     Item 18: offset = 1200, tuple = ('(0,18)', '114', '14text')                                                       +
-     Item 19: offset = 1248, tuple = ('(0,19)', '115', '15text')                                                       +
+     Item 18: offset = 1200, tuple = ('(0,19)', '114', '14text')                                                       +
+     Item 19: offset = 1248, tuple = ('(0,20)', '115', '15text')                                                       +
                                                                                                                        +
  Index o_test_expression_ix1 contents                                                                                  +
  Page 0: level = 0, maxKeyLen = 14, nVacatedBytes = 0                                                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('400', '(0,3)')                                  +
-     Item 0: offset = 264, tuple = ('0', '(0,0)')                                                                      +
-     Item 1: offset = 296, tuple = ('200', '(0,1)')                                                                    +
-     Item 2: offset = 328, tuple = ('300', '(0,2)')                                                                    +
-   Chunk 1: offset = 3, location = 360, hikey location = 104, hikey = ('1800', '(0,6)')                                +
-     Item 3: offset = 368, tuple = ('400', '(0,3)')                                                                    +
-     Item 4: offset = 400, tuple = ('1600', '(0,4)')                                                                   +
-     Item 5: offset = 432, tuple = ('1700', '(0,5)')                                                                   +
-   Chunk 2: offset = 6, location = 464, hikey location = 120, hikey = ('10500', '(0,9)')                               +
-     Item 6: offset = 472, tuple = ('1800', '(0,6)')                                                                   +
-     Item 7: offset = 504, tuple = ('1900', '(0,7)')                                                                   +
-     Item 8: offset = 536, tuple = ('2000', '(0,8)')                                                                   +
-   Chunk 3: offset = 9, location = 568, hikey location = 136, hikey = ('10800', '(0,12)')                              +
-     Item 9: offset = 576, tuple = ('10500', '(0,9)')                                                                  +
-     Item 10: offset = 608, tuple = ('10600', '(0,10)')                                                                +
-     Item 11: offset = 640, tuple = ('10700', '(0,11)')                                                                +
-   Chunk 4: offset = 12, location = 672, hikey location = 152, hikey = ('11100', '(0,15)')                             +
-     Item 12: offset = 680, tuple = ('10800', '(0,12)')                                                                +
-     Item 13: offset = 712, tuple = ('10900', '(0,13)')                                                                +
-     Item 14: offset = 744, tuple = ('11000', '(0,14)')                                                                +
-   Chunk 5: offset = 15, location = 776, hikey location = 168, hikey = ('11400', '(0,18)')                             +
-     Item 15: offset = 784, tuple = ('11100', '(0,15)')                                                                +
-     Item 16: offset = 816, tuple = ('11200', '(0,16)')                                                                +
-     Item 17: offset = 848, tuple = ('11300', '(0,17)')                                                                +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('400', '(0,4)')                                  +
+     Item 0: offset = 264, tuple = ('0', '(0,1)')                                                                      +
+     Item 1: offset = 296, tuple = ('200', '(0,2)')                                                                    +
+     Item 2: offset = 328, tuple = ('300', '(0,3)')                                                                    +
+   Chunk 1: offset = 3, location = 360, hikey location = 104, hikey = ('1800', '(0,7)')                                +
+     Item 3: offset = 368, tuple = ('400', '(0,4)')                                                                    +
+     Item 4: offset = 400, tuple = ('1600', '(0,5)')                                                                   +
+     Item 5: offset = 432, tuple = ('1700', '(0,6)')                                                                   +
+   Chunk 2: offset = 6, location = 464, hikey location = 120, hikey = ('10500', '(0,10)')                              +
+     Item 6: offset = 472, tuple = ('1800', '(0,7)')                                                                   +
+     Item 7: offset = 504, tuple = ('1900', '(0,8)')                                                                   +
+     Item 8: offset = 536, tuple = ('2000', '(0,9)')                                                                   +
+   Chunk 3: offset = 9, location = 568, hikey location = 136, hikey = ('10800', '(0,13)')                              +
+     Item 9: offset = 576, tuple = ('10500', '(0,10)')                                                                 +
+     Item 10: offset = 608, tuple = ('10600', '(0,11)')                                                                +
+     Item 11: offset = 640, tuple = ('10700', '(0,12)')                                                                +
+   Chunk 4: offset = 12, location = 672, hikey location = 152, hikey = ('11100', '(0,16)')                             +
+     Item 12: offset = 680, tuple = ('10800', '(0,13)')                                                                +
+     Item 13: offset = 712, tuple = ('10900', '(0,14)')                                                                +
+     Item 14: offset = 744, tuple = ('11000', '(0,15)')                                                                +
+   Chunk 5: offset = 15, location = 776, hikey location = 168, hikey = ('11400', '(0,19)')                             +
+     Item 15: offset = 784, tuple = ('11100', '(0,16)')                                                                +
+     Item 16: offset = 816, tuple = ('11200', '(0,17)')                                                                +
+     Item 17: offset = 848, tuple = ('11300', '(0,18)')                                                                +
    Chunk 6: offset = 18, location = 880, hikey location = 184                                                          +
-     Item 18: offset = 888, tuple = ('11400', '(0,18)')                                                                +
-     Item 19: offset = 920, tuple = ('11500', '(0,19)')                                                                +
+     Item 18: offset = 888, tuple = ('11400', '(0,19)')                                                                +
+     Item 19: offset = 920, tuple = ('11500', '(0,20)')                                                                +
                                                                                                                        +
  Index o_test_expression_ix2 contents                                                                                  +
  Page 0: level = 0, maxKeyLen = 22, nVacatedBytes = 0                                                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('4', '400', '(0,3)')                             +
-     Item 0: offset = 264, tuple = ('0', '0', '(0,0)')                                                                 +
-     Item 1: offset = 304, tuple = ('2', '200', '(0,1)')                                                               +
-     Item 2: offset = 344, tuple = ('3', '300', '(0,2)')                                                               +
-   Chunk 1: offset = 3, location = 384, hikey location = 112, hikey = ('18', '1800', '(0,6)')                          +
-     Item 3: offset = 392, tuple = ('4', '400', '(0,3)')                                                               +
-     Item 4: offset = 432, tuple = ('16', '1600', '(0,4)')                                                             +
-     Item 5: offset = 472, tuple = ('17', '1700', '(0,5)')                                                             +
-   Chunk 2: offset = 6, location = 512, hikey location = 136, hikey = ('105', '10500', '(0,9)')                        +
-     Item 6: offset = 520, tuple = ('18', '1800', '(0,6)')                                                             +
-     Item 7: offset = 560, tuple = ('19', '1900', '(0,7)')                                                             +
-     Item 8: offset = 600, tuple = ('20', '2000', '(0,8)')                                                             +
-   Chunk 3: offset = 9, location = 640, hikey location = 160, hikey = ('108', '10800', '(0,12)')                       +
-     Item 9: offset = 648, tuple = ('105', '10500', '(0,9)')                                                           +
-     Item 10: offset = 688, tuple = ('106', '10600', '(0,10)')                                                         +
-     Item 11: offset = 728, tuple = ('107', '10700', '(0,11)')                                                         +
-   Chunk 4: offset = 12, location = 768, hikey location = 184, hikey = ('111', '11100', '(0,15)')                      +
-     Item 12: offset = 776, tuple = ('108', '10800', '(0,12)')                                                         +
-     Item 13: offset = 816, tuple = ('109', '10900', '(0,13)')                                                         +
-     Item 14: offset = 856, tuple = ('110', '11000', '(0,14)')                                                         +
-   Chunk 5: offset = 15, location = 896, hikey location = 208, hikey = ('114', '11400', '(0,18)')                      +
-     Item 15: offset = 904, tuple = ('111', '11100', '(0,15)')                                                         +
-     Item 16: offset = 944, tuple = ('112', '11200', '(0,16)')                                                         +
-     Item 17: offset = 984, tuple = ('113', '11300', '(0,17)')                                                         +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('4', '400', '(0,4)')                             +
+     Item 0: offset = 264, tuple = ('0', '0', '(0,1)')                                                                 +
+     Item 1: offset = 304, tuple = ('2', '200', '(0,2)')                                                               +
+     Item 2: offset = 344, tuple = ('3', '300', '(0,3)')                                                               +
+   Chunk 1: offset = 3, location = 384, hikey location = 112, hikey = ('18', '1800', '(0,7)')                          +
+     Item 3: offset = 392, tuple = ('4', '400', '(0,4)')                                                               +
+     Item 4: offset = 432, tuple = ('16', '1600', '(0,5)')                                                             +
+     Item 5: offset = 472, tuple = ('17', '1700', '(0,6)')                                                             +
+   Chunk 2: offset = 6, location = 512, hikey location = 136, hikey = ('105', '10500', '(0,10)')                       +
+     Item 6: offset = 520, tuple = ('18', '1800', '(0,7)')                                                             +
+     Item 7: offset = 560, tuple = ('19', '1900', '(0,8)')                                                             +
+     Item 8: offset = 600, tuple = ('20', '2000', '(0,9)')                                                             +
+   Chunk 3: offset = 9, location = 640, hikey location = 160, hikey = ('108', '10800', '(0,13)')                       +
+     Item 9: offset = 648, tuple = ('105', '10500', '(0,10)')                                                          +
+     Item 10: offset = 688, tuple = ('106', '10600', '(0,11)')                                                         +
+     Item 11: offset = 728, tuple = ('107', '10700', '(0,12)')                                                         +
+   Chunk 4: offset = 12, location = 768, hikey location = 184, hikey = ('111', '11100', '(0,16)')                      +
+     Item 12: offset = 776, tuple = ('108', '10800', '(0,13)')                                                         +
+     Item 13: offset = 816, tuple = ('109', '10900', '(0,14)')                                                         +
+     Item 14: offset = 856, tuple = ('110', '11000', '(0,15)')                                                         +
+   Chunk 5: offset = 15, location = 896, hikey location = 208, hikey = ('114', '11400', '(0,19)')                      +
+     Item 15: offset = 904, tuple = ('111', '11100', '(0,16)')                                                         +
+     Item 16: offset = 944, tuple = ('112', '11200', '(0,17)')                                                         +
+     Item 17: offset = 984, tuple = ('113', '11300', '(0,18)')                                                         +
    Chunk 6: offset = 18, location = 1024, hikey location = 232                                                         +
-     Item 18: offset = 1032, tuple = ('114', '11400', '(0,18)')                                                        +
-     Item 19: offset = 1072, tuple = ('115', '11500', '(0,19)')                                                        +
+     Item 18: offset = 1032, tuple = ('114', '11400', '(0,19)')                                                        +
+     Item 19: offset = 1072, tuple = ('115', '11500', '(0,20)')                                                        +
                                                                                                                        +
  Index o_test_expression_ix3 contents                                                                                  +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('12textWOW', '(0,16)')                           +
-     Item 0: offset = 264, tuple = ('0textWOW', '(0,0)')                                                               +
-     Item 1: offset = 304, tuple = ('10textWOW', '(0,14)')                                                             +
-     Item 2: offset = 344, tuple = ('11textWOW', '(0,15)')                                                             +
-   Chunk 1: offset = 3, location = 384, hikey location = 112, hikey = ('15textWOW', '(0,19)')                          +
-     Item 3: offset = 392, tuple = ('12textWOW', '(0,16)')                                                             +
-     Item 4: offset = 432, tuple = ('13textWOW', '(0,17)')                                                             +
-     Item 5: offset = 472, tuple = ('14textWOW', '(0,18)')                                                             +
-   Chunk 2: offset = 6, location = 512, hikey location = 136, hikey = ('18textWOW', '(0,6)')                           +
-     Item 6: offset = 520, tuple = ('15textWOW', '(0,19)')                                                             +
-     Item 7: offset = 560, tuple = ('16textWOW', '(0,4)')                                                              +
-     Item 8: offset = 600, tuple = ('17textWOW', '(0,5)')                                                              +
-   Chunk 3: offset = 9, location = 640, hikey location = 160, hikey = ('2textWOW', '(0,1)')                            +
-     Item 9: offset = 648, tuple = ('18textWOW', '(0,6)')                                                              +
-     Item 10: offset = 688, tuple = ('19textWOW', '(0,7)')                                                             +
-     Item 11: offset = 728, tuple = ('20textWOW', '(0,8)')                                                             +
-   Chunk 4: offset = 12, location = 768, hikey location = 184, hikey = ('5textWOW', '(0,9)')                           +
-     Item 12: offset = 776, tuple = ('2textWOW', '(0,1)')                                                              +
-     Item 13: offset = 816, tuple = ('3textWOW', '(0,2)')                                                              +
-     Item 14: offset = 856, tuple = ('4textWOW', '(0,3)')                                                              +
-   Chunk 5: offset = 15, location = 896, hikey location = 208, hikey = ('8textWOW', '(0,12)')                          +
-     Item 15: offset = 904, tuple = ('5textWOW', '(0,9)')                                                              +
-     Item 16: offset = 944, tuple = ('6textWOW', '(0,10)')                                                             +
-     Item 17: offset = 984, tuple = ('7textWOW', '(0,11)')                                                             +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('12textWOW', '(0,17)')                           +
+     Item 0: offset = 264, tuple = ('0textWOW', '(0,1)')                                                               +
+     Item 1: offset = 304, tuple = ('10textWOW', '(0,15)')                                                             +
+     Item 2: offset = 344, tuple = ('11textWOW', '(0,16)')                                                             +
+   Chunk 1: offset = 3, location = 384, hikey location = 112, hikey = ('15textWOW', '(0,20)')                          +
+     Item 3: offset = 392, tuple = ('12textWOW', '(0,17)')                                                             +
+     Item 4: offset = 432, tuple = ('13textWOW', '(0,18)')                                                             +
+     Item 5: offset = 472, tuple = ('14textWOW', '(0,19)')                                                             +
+   Chunk 2: offset = 6, location = 512, hikey location = 136, hikey = ('18textWOW', '(0,7)')                           +
+     Item 6: offset = 520, tuple = ('15textWOW', '(0,20)')                                                             +
+     Item 7: offset = 560, tuple = ('16textWOW', '(0,5)')                                                              +
+     Item 8: offset = 600, tuple = ('17textWOW', '(0,6)')                                                              +
+   Chunk 3: offset = 9, location = 640, hikey location = 160, hikey = ('2textWOW', '(0,2)')                            +
+     Item 9: offset = 648, tuple = ('18textWOW', '(0,7)')                                                              +
+     Item 10: offset = 688, tuple = ('19textWOW', '(0,8)')                                                             +
+     Item 11: offset = 728, tuple = ('20textWOW', '(0,9)')                                                             +
+   Chunk 4: offset = 12, location = 768, hikey location = 184, hikey = ('5textWOW', '(0,10)')                          +
+     Item 12: offset = 776, tuple = ('2textWOW', '(0,2)')                                                              +
+     Item 13: offset = 816, tuple = ('3textWOW', '(0,3)')                                                              +
+     Item 14: offset = 856, tuple = ('4textWOW', '(0,4)')                                                              +
+   Chunk 5: offset = 15, location = 896, hikey location = 208, hikey = ('8textWOW', '(0,13)')                          +
+     Item 15: offset = 904, tuple = ('5textWOW', '(0,10)')                                                             +
+     Item 16: offset = 944, tuple = ('6textWOW', '(0,11)')                                                             +
+     Item 17: offset = 984, tuple = ('7textWOW', '(0,12)')                                                             +
    Chunk 6: offset = 18, location = 1024, hikey location = 232                                                         +
-     Item 18: offset = 1032, tuple = ('8textWOW', '(0,12)')                                                            +
-     Item 19: offset = 1072, tuple = ('9textWOW', '(0,13)')                                                            +
+     Item 18: offset = 1032, tuple = ('8textWOW', '(0,13)')                                                            +
+     Item 19: offset = 1072, tuple = ('9textWOW', '(0,14)')                                                            +
                                                                                                                        +
  Index o_test_expression_ix4 contents                                                                                  +
  Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('13text', '13textWOW', '(0,17)')                 +
-     Item 0: offset = 264, tuple = ('0text', '0textWOW', '(0,0)')                                                      +
-     Item 1: offset = 312, tuple = ('10text', '10textWOW', '(0,14)')                                                   +
-     Item 2: offset = 360, tuple = ('11text', '11textWOW', '(0,15)')                                                   +
-     Item 3: offset = 408, tuple = ('12text', '12textWOW', '(0,16)')                                                   +
-   Chunk 1: offset = 4, location = 456, hikey location = 112, hikey = ('17text', '17textWOW', '(0,5)')                 +
-     Item 4: offset = 464, tuple = ('13text', '13textWOW', '(0,17)')                                                   +
-     Item 5: offset = 512, tuple = ('14text', '14textWOW', '(0,18)')                                                   +
-     Item 6: offset = 560, tuple = ('15text', '15textWOW', '(0,19)')                                                   +
-     Item 7: offset = 608, tuple = ('16text', '16textWOW', '(0,4)')                                                    +
-   Chunk 2: offset = 8, location = 656, hikey location = 144, hikey = ('2text', '2textWOW', '(0,1)')                   +
-     Item 8: offset = 664, tuple = ('17text', '17textWOW', '(0,5)')                                                    +
-     Item 9: offset = 712, tuple = ('18text', '18textWOW', '(0,6)')                                                    +
-     Item 10: offset = 760, tuple = ('19text', '19textWOW', '(0,7)')                                                   +
-     Item 11: offset = 808, tuple = ('20text', '20textWOW', '(0,8)')                                                   +
-   Chunk 3: offset = 12, location = 856, hikey location = 176, hikey = ('6text', '6textWOW', '(0,10)')                 +
-     Item 12: offset = 864, tuple = ('2text', '2textWOW', '(0,1)')                                                     +
-     Item 13: offset = 912, tuple = ('3text', '3textWOW', '(0,2)')                                                     +
-     Item 14: offset = 960, tuple = ('4text', '4textWOW', '(0,3)')                                                     +
-     Item 15: offset = 1008, tuple = ('5text', '5textWOW', '(0,9)')                                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('13text', '13textWOW', '(0,18)')                 +
+     Item 0: offset = 264, tuple = ('0text', '0textWOW', '(0,1)')                                                      +
+     Item 1: offset = 312, tuple = ('10text', '10textWOW', '(0,15)')                                                   +
+     Item 2: offset = 360, tuple = ('11text', '11textWOW', '(0,16)')                                                   +
+     Item 3: offset = 408, tuple = ('12text', '12textWOW', '(0,17)')                                                   +
+   Chunk 1: offset = 4, location = 456, hikey location = 112, hikey = ('17text', '17textWOW', '(0,6)')                 +
+     Item 4: offset = 464, tuple = ('13text', '13textWOW', '(0,18)')                                                   +
+     Item 5: offset = 512, tuple = ('14text', '14textWOW', '(0,19)')                                                   +
+     Item 6: offset = 560, tuple = ('15text', '15textWOW', '(0,20)')                                                   +
+     Item 7: offset = 608, tuple = ('16text', '16textWOW', '(0,5)')                                                    +
+   Chunk 2: offset = 8, location = 656, hikey location = 144, hikey = ('2text', '2textWOW', '(0,2)')                   +
+     Item 8: offset = 664, tuple = ('17text', '17textWOW', '(0,6)')                                                    +
+     Item 9: offset = 712, tuple = ('18text', '18textWOW', '(0,7)')                                                    +
+     Item 10: offset = 760, tuple = ('19text', '19textWOW', '(0,8)')                                                   +
+     Item 11: offset = 808, tuple = ('20text', '20textWOW', '(0,9)')                                                   +
+   Chunk 3: offset = 12, location = 856, hikey location = 176, hikey = ('6text', '6textWOW', '(0,11)')                 +
+     Item 12: offset = 864, tuple = ('2text', '2textWOW', '(0,2)')                                                     +
+     Item 13: offset = 912, tuple = ('3text', '3textWOW', '(0,3)')                                                     +
+     Item 14: offset = 960, tuple = ('4text', '4textWOW', '(0,4)')                                                     +
+     Item 15: offset = 1008, tuple = ('5text', '5textWOW', '(0,10)')                                                   +
    Chunk 4: offset = 16, location = 1056, hikey location = 208                                                         +
-     Item 16: offset = 1064, tuple = ('6text', '6textWOW', '(0,10)')                                                   +
-     Item 17: offset = 1112, tuple = ('7text', '7textWOW', '(0,11)')                                                   +
-     Item 18: offset = 1160, tuple = ('8text', '8textWOW', '(0,12)')                                                   +
-     Item 19: offset = 1208, tuple = ('9text', '9textWOW', '(0,13)')                                                   +
+     Item 16: offset = 1064, tuple = ('6text', '6textWOW', '(0,11)')                                                   +
+     Item 17: offset = 1112, tuple = ('7text', '7textWOW', '(0,12)')                                                   +
+     Item 18: offset = 1160, tuple = ('8text', '8textWOW', '(0,13)')                                                   +
+     Item 19: offset = 1208, tuple = ('9text', '9textWOW', '(0,14)')                                                   +
                                                                                                                        +
  Index o_test_expression_ix5 contents                                                                                  +
  Page 0: level = 0, maxKeyLen = 50, nVacatedBytes = 0                                                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('19000', '19text', '19', '19textWOW2', '(0,7)')  +
-     Item 0: offset = 272, tuple = ('0', '0text', '0', '0textWOW2', '(0,0)')                                           +
-     Item 1: offset = 336, tuple = ('2000', '2text', '2', '2textWOW2', '(0,1)')                                        +
-     Item 2: offset = 400, tuple = ('3000', '3text', '3', '3textWOW2', '(0,2)')                                        +
-     Item 3: offset = 464, tuple = ('4000', '4text', '4', '4textWOW2', '(0,3)')                                        +
-     Item 4: offset = 528, tuple = ('16000', '16text', '16', '16textWOW2', '(0,4)')                                    +
-     Item 5: offset = 600, tuple = ('17000', '17text', '17', '17textWOW2', '(0,5)')                                    +
-     Item 6: offset = 672, tuple = ('18000', '18text', '18', '18textWOW2', '(0,6)')                                    +
-   Chunk 1: offset = 7, location = 744, hikey location = 128, hikey = ('109000', '9text', '109', '9textWOW2', '(0,13)')+
-     Item 7: offset = 760, tuple = ('19000', '19text', '19', '19textWOW2', '(0,7)')                                    +
-     Item 8: offset = 832, tuple = ('20000', '20text', '20', '20textWOW2', '(0,8)')                                    +
-     Item 9: offset = 904, tuple = ('105000', '5text', '105', '5textWOW2', '(0,9)')                                    +
-     Item 10: offset = 968, tuple = ('106000', '6text', '106', '6textWOW2', '(0,10)')                                  +
-     Item 11: offset = 1032, tuple = ('107000', '7text', '107', '7textWOW2', '(0,11)')                                 +
-     Item 12: offset = 1096, tuple = ('108000', '8text', '108', '8textWOW2', '(0,12)')                                 +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('19000', '19text', '19', '19textWOW2', '(0,8)')  +
+     Item 0: offset = 272, tuple = ('0', '0text', '0', '0textWOW2', '(0,1)')                                           +
+     Item 1: offset = 336, tuple = ('2000', '2text', '2', '2textWOW2', '(0,2)')                                        +
+     Item 2: offset = 400, tuple = ('3000', '3text', '3', '3textWOW2', '(0,3)')                                        +
+     Item 3: offset = 464, tuple = ('4000', '4text', '4', '4textWOW2', '(0,4)')                                        +
+     Item 4: offset = 528, tuple = ('16000', '16text', '16', '16textWOW2', '(0,5)')                                    +
+     Item 5: offset = 600, tuple = ('17000', '17text', '17', '17textWOW2', '(0,6)')                                    +
+     Item 6: offset = 672, tuple = ('18000', '18text', '18', '18textWOW2', '(0,7)')                                    +
+   Chunk 1: offset = 7, location = 744, hikey location = 128, hikey = ('109000', '9text', '109', '9textWOW2', '(0,14)')+
+     Item 7: offset = 760, tuple = ('19000', '19text', '19', '19textWOW2', '(0,8)')                                    +
+     Item 8: offset = 832, tuple = ('20000', '20text', '20', '20textWOW2', '(0,9)')                                    +
+     Item 9: offset = 904, tuple = ('105000', '5text', '105', '5textWOW2', '(0,10)')                                   +
+     Item 10: offset = 968, tuple = ('106000', '6text', '106', '6textWOW2', '(0,11)')                                  +
+     Item 11: offset = 1032, tuple = ('107000', '7text', '107', '7textWOW2', '(0,12)')                                 +
+     Item 12: offset = 1096, tuple = ('108000', '8text', '108', '8textWOW2', '(0,13)')                                 +
    Chunk 2: offset = 13, location = 1160, hikey location = 176                                                         +
-     Item 13: offset = 1176, tuple = ('109000', '9text', '109', '9textWOW2', '(0,13)')                                 +
-     Item 14: offset = 1240, tuple = ('110000', '10text', '110', '10textWOW2', '(0,14)')                               +
-     Item 15: offset = 1312, tuple = ('111000', '11text', '111', '11textWOW2', '(0,15)')                               +
-     Item 16: offset = 1384, tuple = ('112000', '12text', '112', '12textWOW2', '(0,16)')                               +
-     Item 17: offset = 1456, tuple = ('113000', '13text', '113', '13textWOW2', '(0,17)')                               +
-     Item 18: offset = 1528, tuple = ('114000', '14text', '114', '14textWOW2', '(0,18)')                               +
-     Item 19: offset = 1600, tuple = ('115000', '15text', '115', '15textWOW2', '(0,19)')                               +
+     Item 13: offset = 1176, tuple = ('109000', '9text', '109', '9textWOW2', '(0,14)')                                 +
+     Item 14: offset = 1240, tuple = ('110000', '10text', '110', '10textWOW2', '(0,15)')                               +
+     Item 15: offset = 1312, tuple = ('111000', '11text', '111', '11textWOW2', '(0,16)')                               +
+     Item 16: offset = 1384, tuple = ('112000', '12text', '112', '12textWOW2', '(0,17)')                               +
+     Item 17: offset = 1456, tuple = ('113000', '13text', '113', '13textWOW2', '(0,18)')                               +
+     Item 18: offset = 1528, tuple = ('114000', '14text', '114', '14textWOW2', '(0,19)')                               +
+     Item 19: offset = 1600, tuple = ('115000', '15text', '115', '15textWOW2', '(0,20)')                               +
                                                                                                                        +
  Index o_test_expression_ix6 contents                                                                                  +
  Page 0: level = 0, maxKeyLen = 38, nVacatedBytes = 0                                                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('14TEXT', '114', '14text', '(0,18)')             +
-     Item 0: offset = 272, tuple = ('0TEXT', '0', '0text', '(0,0)')                                                    +
-     Item 1: offset = 328, tuple = ('10TEXT', '110', '10text', '(0,14)')                                               +
-     Item 2: offset = 384, tuple = ('11TEXT', '111', '11text', '(0,15)')                                               +
-     Item 3: offset = 440, tuple = ('12TEXT', '112', '12text', '(0,16)')                                               +
-     Item 4: offset = 496, tuple = ('13TEXT', '113', '13text', '(0,17)')                                               +
-   Chunk 1: offset = 5, location = 552, hikey location = 112, hikey = ('19TEXT', '19', '19text', '(0,7)')              +
-     Item 5: offset = 568, tuple = ('14TEXT', '114', '14text', '(0,18)')                                               +
-     Item 6: offset = 624, tuple = ('15TEXT', '115', '15text', '(0,19)')                                               +
-     Item 7: offset = 680, tuple = ('16TEXT', '16', '16text', '(0,4)')                                                 +
-     Item 8: offset = 736, tuple = ('17TEXT', '17', '17text', '(0,5)')                                                 +
-     Item 9: offset = 792, tuple = ('18TEXT', '18', '18text', '(0,6)')                                                 +
-   Chunk 2: offset = 10, location = 848, hikey location = 152, hikey = ('5TEXT', '105', '5text', '(0,9)')              +
-     Item 10: offset = 864, tuple = ('19TEXT', '19', '19text', '(0,7)')                                                +
-     Item 11: offset = 920, tuple = ('20TEXT', '20', '20text', '(0,8)')                                                +
-     Item 12: offset = 976, tuple = ('2TEXT', '2', '2text', '(0,1)')                                                   +
-     Item 13: offset = 1032, tuple = ('3TEXT', '3', '3text', '(0,2)')                                                  +
-     Item 14: offset = 1088, tuple = ('4TEXT', '4', '4text', '(0,3)')                                                  +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('14TEXT', '114', '14text', '(0,19)')             +
+     Item 0: offset = 272, tuple = ('0TEXT', '0', '0text', '(0,1)')                                                    +
+     Item 1: offset = 328, tuple = ('10TEXT', '110', '10text', '(0,15)')                                               +
+     Item 2: offset = 384, tuple = ('11TEXT', '111', '11text', '(0,16)')                                               +
+     Item 3: offset = 440, tuple = ('12TEXT', '112', '12text', '(0,17)')                                               +
+     Item 4: offset = 496, tuple = ('13TEXT', '113', '13text', '(0,18)')                                               +
+   Chunk 1: offset = 5, location = 552, hikey location = 112, hikey = ('19TEXT', '19', '19text', '(0,8)')              +
+     Item 5: offset = 568, tuple = ('14TEXT', '114', '14text', '(0,19)')                                               +
+     Item 6: offset = 624, tuple = ('15TEXT', '115', '15text', '(0,20)')                                               +
+     Item 7: offset = 680, tuple = ('16TEXT', '16', '16text', '(0,5)')                                                 +
+     Item 8: offset = 736, tuple = ('17TEXT', '17', '17text', '(0,6)')                                                 +
+     Item 9: offset = 792, tuple = ('18TEXT', '18', '18text', '(0,7)')                                                 +
+   Chunk 2: offset = 10, location = 848, hikey location = 152, hikey = ('5TEXT', '105', '5text', '(0,10)')             +
+     Item 10: offset = 864, tuple = ('19TEXT', '19', '19text', '(0,8)')                                                +
+     Item 11: offset = 920, tuple = ('20TEXT', '20', '20text', '(0,9)')                                                +
+     Item 12: offset = 976, tuple = ('2TEXT', '2', '2text', '(0,2)')                                                   +
+     Item 13: offset = 1032, tuple = ('3TEXT', '3', '3text', '(0,3)')                                                  +
+     Item 14: offset = 1088, tuple = ('4TEXT', '4', '4text', '(0,4)')                                                  +
    Chunk 3: offset = 15, location = 1144, hikey location = 192                                                         +
-     Item 15: offset = 1160, tuple = ('5TEXT', '105', '5text', '(0,9)')                                                +
-     Item 16: offset = 1216, tuple = ('6TEXT', '106', '6text', '(0,10)')                                               +
-     Item 17: offset = 1272, tuple = ('7TEXT', '107', '7text', '(0,11)')                                               +
-     Item 18: offset = 1328, tuple = ('8TEXT', '108', '8text', '(0,12)')                                               +
-     Item 19: offset = 1384, tuple = ('9TEXT', '109', '9text', '(0,13)')                                               +
+     Item 15: offset = 1160, tuple = ('5TEXT', '105', '5text', '(0,10)')                                               +
+     Item 16: offset = 1216, tuple = ('6TEXT', '106', '6text', '(0,11)')                                               +
+     Item 17: offset = 1272, tuple = ('7TEXT', '107', '7text', '(0,12)')                                               +
+     Item 18: offset = 1328, tuple = ('8TEXT', '108', '8text', '(0,13)')                                               +
+     Item 19: offset = 1384, tuple = ('9TEXT', '109', '9text', '(0,14)')                                               +
                                                                                                                        +
  Index o_test_expression_ix7 contents                                                                                  +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                   +
      Leftmost, Rightmost                                                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('t', '4', 't', '(0,3)')                          +
-     Item 0: offset = 264, tuple = ('t', '0', 't', '(0,0)')                                                            +
-     Item 1: offset = 304, tuple = ('t', '2', 't', '(0,1)')                                                            +
-     Item 2: offset = 344, tuple = ('t', '3', 't', '(0,2)')                                                            +
-   Chunk 1: offset = 3, location = 384, hikey location = 112, hikey = ('t', '18', 't', '(0,6)')                        +
-     Item 3: offset = 392, tuple = ('t', '4', 't', '(0,3)')                                                            +
-     Item 4: offset = 432, tuple = ('t', '16', 't', '(0,4)')                                                           +
-     Item 5: offset = 472, tuple = ('t', '17', 't', '(0,5)')                                                           +
-   Chunk 2: offset = 6, location = 512, hikey location = 136, hikey = ('t', '105', 't', '(0,9)')                       +
-     Item 6: offset = 520, tuple = ('t', '18', 't', '(0,6)')                                                           +
-     Item 7: offset = 560, tuple = ('t', '19', 't', '(0,7)')                                                           +
-     Item 8: offset = 600, tuple = ('t', '20', 't', '(0,8)')                                                           +
-   Chunk 3: offset = 9, location = 640, hikey location = 160, hikey = ('t', '108', 't', '(0,12)')                      +
-     Item 9: offset = 648, tuple = ('t', '105', 't', '(0,9)')                                                          +
-     Item 10: offset = 688, tuple = ('t', '106', 't', '(0,10)')                                                        +
-     Item 11: offset = 728, tuple = ('t', '107', 't', '(0,11)')                                                        +
-   Chunk 4: offset = 12, location = 768, hikey location = 184, hikey = ('t', '111', 't', '(0,15)')                     +
-     Item 12: offset = 776, tuple = ('t', '108', 't', '(0,12)')                                                        +
-     Item 13: offset = 816, tuple = ('t', '109', 't', '(0,13)')                                                        +
-     Item 14: offset = 856, tuple = ('t', '110', 't', '(0,14)')                                                        +
-   Chunk 5: offset = 15, location = 896, hikey location = 208, hikey = ('t', '114', 't', '(0,18)')                     +
-     Item 15: offset = 904, tuple = ('t', '111', 't', '(0,15)')                                                        +
-     Item 16: offset = 944, tuple = ('t', '112', 't', '(0,16)')                                                        +
-     Item 17: offset = 984, tuple = ('t', '113', 't', '(0,17)')                                                        +
+   Chunk 0: offset = 0, location = 256, hikey location = 88, hikey = ('t', '4', 't', '(0,4)')                          +
+     Item 0: offset = 264, tuple = ('t', '0', 't', '(0,1)')                                                            +
+     Item 1: offset = 304, tuple = ('t', '2', 't', '(0,2)')                                                            +
+     Item 2: offset = 344, tuple = ('t', '3', 't', '(0,3)')                                                            +
+   Chunk 1: offset = 3, location = 384, hikey location = 112, hikey = ('t', '18', 't', '(0,7)')                        +
+     Item 3: offset = 392, tuple = ('t', '4', 't', '(0,4)')                                                            +
+     Item 4: offset = 432, tuple = ('t', '16', 't', '(0,5)')                                                           +
+     Item 5: offset = 472, tuple = ('t', '17', 't', '(0,6)')                                                           +
+   Chunk 2: offset = 6, location = 512, hikey location = 136, hikey = ('t', '105', 't', '(0,10)')                      +
+     Item 6: offset = 520, tuple = ('t', '18', 't', '(0,7)')                                                           +
+     Item 7: offset = 560, tuple = ('t', '19', 't', '(0,8)')                                                           +
+     Item 8: offset = 600, tuple = ('t', '20', 't', '(0,9)')                                                           +
+   Chunk 3: offset = 9, location = 640, hikey location = 160, hikey = ('t', '108', 't', '(0,13)')                      +
+     Item 9: offset = 648, tuple = ('t', '105', 't', '(0,10)')                                                         +
+     Item 10: offset = 688, tuple = ('t', '106', 't', '(0,11)')                                                        +
+     Item 11: offset = 728, tuple = ('t', '107', 't', '(0,12)')                                                        +
+   Chunk 4: offset = 12, location = 768, hikey location = 184, hikey = ('t', '111', 't', '(0,16)')                     +
+     Item 12: offset = 776, tuple = ('t', '108', 't', '(0,13)')                                                        +
+     Item 13: offset = 816, tuple = ('t', '109', 't', '(0,14)')                                                        +
+     Item 14: offset = 856, tuple = ('t', '110', 't', '(0,15)')                                                        +
+   Chunk 5: offset = 15, location = 896, hikey location = 208, hikey = ('t', '114', 't', '(0,19)')                     +
+     Item 15: offset = 904, tuple = ('t', '111', 't', '(0,16)')                                                        +
+     Item 16: offset = 944, tuple = ('t', '112', 't', '(0,17)')                                                        +
+     Item 17: offset = 984, tuple = ('t', '113', 't', '(0,18)')                                                        +
    Chunk 6: offset = 18, location = 1024, hikey location = 232                                                         +
-     Item 18: offset = 1032, tuple = ('t', '114', 't', '(0,18)')                                                       +
-     Item 19: offset = 1072, tuple = ('t', '115', 't', '(0,19)')                                                       +
+     Item 18: offset = 1032, tuple = ('t', '114', 't', '(0,19)')                                                       +
+     Item 19: offset = 1072, tuple = ('t', '115', 't', '(0,20)')                                                       +
                                                                                                                        +
  Index toast: not loaded                                                                                               +
  

--- a/test/expected/temp.out
+++ b/test/expected/temp.out
@@ -379,46 +379,46 @@ SELECT orioledb_tbl_structure('o_test_temp_indices'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                   +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                   +
      Leftmost, Rightmost                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')         +
-     Item 0: offset = 264, tuple = ('(0,0)', '6', '20', '300')                         +
-   Chunk 1: offset = 1, location = 304, hikey location = 88, hikey = ('(0,2)')         +
-     Item 1: offset = 312, tuple = ('(0,1)', '12', '40', '600')                        +
-   Chunk 2: offset = 2, location = 352, hikey location = 96, hikey = ('(0,3)')         +
-     Item 2: offset = 360, tuple = ('(0,2)', '18', '60', '900')                        +
-   Chunk 3: offset = 3, location = 400, hikey location = 104, hikey = ('(0,4)')        +
-     Item 3: offset = 408, tuple = ('(0,3)', '24', '80', '1200')                       +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')         +
+     Item 0: offset = 264, tuple = ('(0,1)', '6', '20', '300')                         +
+   Chunk 1: offset = 1, location = 304, hikey location = 88, hikey = ('(0,3)')         +
+     Item 1: offset = 312, tuple = ('(0,2)', '12', '40', '600')                        +
+   Chunk 2: offset = 2, location = 352, hikey location = 96, hikey = ('(0,4)')         +
+     Item 2: offset = 360, tuple = ('(0,3)', '18', '60', '900')                        +
+   Chunk 3: offset = 3, location = 400, hikey location = 104, hikey = ('(0,5)')        +
+     Item 3: offset = 408, tuple = ('(0,4)', '24', '80', '1200')                       +
    Chunk 4: offset = 4, location = 448, hikey location = 112                           +
-     Item 4: offset = 456, tuple = ('(0,4)', '30', '100', '1500')                      +
+     Item 4: offset = 456, tuple = ('(0,5)', '30', '100', '1500')                      +
                                                                                        +
  Index o_test_temp_indices_ix1 contents                                                +
  Page 0: level = 0, maxKeyLen = 10, nVacatedBytes = 0                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                   +
      Leftmost, Rightmost                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', '(0,1)')   +
-     Item 0: offset = 264, tuple = ('20', '(0,0)')                                     +
-   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('60', '(0,2)')   +
-     Item 1: offset = 304, tuple = ('40', '(0,1)')                                     +
-   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('80', '(0,3)')  +
-     Item 2: offset = 344, tuple = ('60', '(0,2)')                                     +
-   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('100', '(0,4)') +
-     Item 3: offset = 384, tuple = ('80', '(0,3)')                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', '(0,2)')   +
+     Item 0: offset = 264, tuple = ('20', '(0,1)')                                     +
+   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('60', '(0,3)')   +
+     Item 1: offset = 304, tuple = ('40', '(0,2)')                                     +
+   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('80', '(0,4)')  +
+     Item 2: offset = 344, tuple = ('60', '(0,3)')                                     +
+   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('100', '(0,5)') +
+     Item 3: offset = 384, tuple = ('80', '(0,4)')                                     +
    Chunk 4: offset = 4, location = 416, hikey location = 144                           +
-     Item 4: offset = 424, tuple = ('100', '(0,4)')                                    +
+     Item 4: offset = 424, tuple = ('100', '(0,5)')                                    +
                                                                                        +
  Index o_test_temp_indices_ix2 contents                                                +
  Page 0: level = 0, maxKeyLen = 10, nVacatedBytes = 0                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                   +
      Leftmost, Rightmost                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('600', '(0,1)')  +
-     Item 0: offset = 264, tuple = ('300', '(0,0)')                                    +
-   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('900', '(0,2)')  +
-     Item 1: offset = 304, tuple = ('600', '(0,1)')                                    +
-   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('1200', '(0,3)')+
-     Item 2: offset = 344, tuple = ('900', '(0,2)')                                    +
-   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('1500', '(0,4)')+
-     Item 3: offset = 384, tuple = ('1200', '(0,3)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('600', '(0,2)')  +
+     Item 0: offset = 264, tuple = ('300', '(0,1)')                                    +
+   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('900', '(0,3)')  +
+     Item 1: offset = 304, tuple = ('600', '(0,2)')                                    +
+   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('1200', '(0,4)')+
+     Item 2: offset = 344, tuple = ('900', '(0,3)')                                    +
+   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('1500', '(0,5)')+
+     Item 3: offset = 384, tuple = ('1200', '(0,4)')                                   +
    Chunk 4: offset = 4, location = 416, hikey location = 144                           +
-     Item 4: offset = 424, tuple = ('1500', '(0,4)')                                   +
+     Item 4: offset = 424, tuple = ('1500', '(0,5)')                                   +
                                                                                        +
  Index toast: not loaded                                                               +
  
@@ -432,46 +432,46 @@ SELECT orioledb_tbl_structure('o_test_temp_indices'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 6, nVacatedBytes = 0                                   +
  state = free, datoid equal, relnode equal, ix_type = primary, dirty                   +
      Leftmost, Rightmost                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,1)')         +
-     Item 0: offset = 264, tuple = ('(0,0)', '36', '20', '300')                        +
-   Chunk 1: offset = 1, location = 304, hikey location = 88, hikey = ('(0,2)')         +
-     Item 1: offset = 312, tuple = ('(0,1)', '72', '40', '600')                        +
-   Chunk 2: offset = 2, location = 352, hikey location = 96, hikey = ('(0,3)')         +
-     Item 2: offset = 360, tuple = ('(0,2)', '108', '60', '900')                       +
-   Chunk 3: offset = 3, location = 400, hikey location = 104, hikey = ('(0,4)')        +
-     Item 3: offset = 408, tuple = ('(0,3)', '144', '80', '1200')                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('(0,2)')         +
+     Item 0: offset = 264, tuple = ('(0,1)', '36', '20', '300')                        +
+   Chunk 1: offset = 1, location = 304, hikey location = 88, hikey = ('(0,3)')         +
+     Item 1: offset = 312, tuple = ('(0,2)', '72', '40', '600')                        +
+   Chunk 2: offset = 2, location = 352, hikey location = 96, hikey = ('(0,4)')         +
+     Item 2: offset = 360, tuple = ('(0,3)', '108', '60', '900')                       +
+   Chunk 3: offset = 3, location = 400, hikey location = 104, hikey = ('(0,5)')        +
+     Item 3: offset = 408, tuple = ('(0,4)', '144', '80', '1200')                      +
    Chunk 4: offset = 4, location = 448, hikey location = 112                           +
-     Item 4: offset = 456, tuple = ('(0,4)', '180', '100', '1500')                     +
+     Item 4: offset = 456, tuple = ('(0,5)', '180', '100', '1500')                     +
                                                                                        +
  Index o_test_temp_indices_ix1 contents                                                +
  Page 0: level = 0, maxKeyLen = 10, nVacatedBytes = 0                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                   +
      Leftmost, Rightmost                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', '(0,1)')   +
-     Item 0: offset = 264, tuple = ('20', '(0,0)')                                     +
-   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('60', '(0,2)')   +
-     Item 1: offset = 304, tuple = ('40', '(0,1)')                                     +
-   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('80', '(0,3)')  +
-     Item 2: offset = 344, tuple = ('60', '(0,2)')                                     +
-   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('100', '(0,4)') +
-     Item 3: offset = 384, tuple = ('80', '(0,3)')                                     +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('40', '(0,2)')   +
+     Item 0: offset = 264, tuple = ('20', '(0,1)')                                     +
+   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('60', '(0,3)')   +
+     Item 1: offset = 304, tuple = ('40', '(0,2)')                                     +
+   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('80', '(0,4)')  +
+     Item 2: offset = 344, tuple = ('60', '(0,3)')                                     +
+   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('100', '(0,5)') +
+     Item 3: offset = 384, tuple = ('80', '(0,4)')                                     +
    Chunk 4: offset = 4, location = 416, hikey location = 144                           +
-     Item 4: offset = 424, tuple = ('100', '(0,4)')                                    +
+     Item 4: offset = 424, tuple = ('100', '(0,5)')                                    +
                                                                                        +
  Index o_test_temp_indices_ix2 contents                                                +
  Page 0: level = 0, maxKeyLen = 10, nVacatedBytes = 0                                  +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                   +
      Leftmost, Rightmost                                                               +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('600', '(0,1)')  +
-     Item 0: offset = 264, tuple = ('300', '(0,0)')                                    +
-   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('900', '(0,2)')  +
-     Item 1: offset = 304, tuple = ('600', '(0,1)')                                    +
-   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('1200', '(0,3)')+
-     Item 2: offset = 344, tuple = ('900', '(0,2)')                                    +
-   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('1500', '(0,4)')+
-     Item 3: offset = 384, tuple = ('1200', '(0,3)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('600', '(0,2)')  +
+     Item 0: offset = 264, tuple = ('300', '(0,1)')                                    +
+   Chunk 1: offset = 1, location = 296, hikey location = 96, hikey = ('900', '(0,3)')  +
+     Item 1: offset = 304, tuple = ('600', '(0,2)')                                    +
+   Chunk 2: offset = 2, location = 336, hikey location = 112, hikey = ('1200', '(0,4)')+
+     Item 2: offset = 344, tuple = ('900', '(0,3)')                                    +
+   Chunk 3: offset = 3, location = 376, hikey location = 128, hikey = ('1500', '(0,5)')+
+     Item 3: offset = 384, tuple = ('1200', '(0,4)')                                   +
    Chunk 4: offset = 4, location = 416, hikey location = 144                           +
-     Item 4: offset = 424, tuple = ('1500', '(0,4)')                                   +
+     Item 4: offset = 424, tuple = ('1500', '(0,5)')                                   +
                                                                                        +
  Index toast: not loaded                                                               +
  

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -436,6 +436,73 @@ SELECT * FROM o_test_bitmap_scans
 
 COMMIT;
 
+CREATE TABLE o_test_index_bridging_options (
+	i int NOT NULL,
+	j int4[],
+	p point
+) USING orioledb WITH (index_bridging);
+
+CREATE INDEX o_test_index_bridging_options_ix1 ON o_test_index_bridging_options USING btree (i);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (index_bridging);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING hash (i) WITH (index_bridging);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gist (p);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING gin (j);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING spgist (p);
+\d+ o_test_index_bridging_options
+CREATE INDEX o_test_index_bridging_options_ix9 ON o_test_index_bridging_options USING brin (i);
+\d+ o_test_index_bridging_options
+
+ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER TABLE o_test_index_bridging_options SET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix5 RESET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix2 RESET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix1 SET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix6 RESET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix7 RESET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix8 RESET (index_bridging);
+\d+ o_test_index_bridging_options
+ALTER INDEX o_test_index_bridging_options_ix9 RESET (index_bridging);
+\d+ o_test_index_bridging_options
+
+CREATE TABLE o_test_non_index_bridging_options (
+	i int NOT NULL,
+	j int4[],
+	p point
+) USING orioledb;
+
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
+\d+ o_test_non_index_bridging_options
+
+CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_options USING btree (i);
+\d+ o_test_non_index_bridging_options
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (index_bridging);
+\d+ o_test_non_index_bridging_options
+
+ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+ALTER INDEX o_test_non_index_bridging_options_ix1 SET (index_bridging);
+\d+ o_test_non_index_bridging_options
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -11,7 +11,7 @@ CREATE TABLE o_test_ix_ams (
 	p point,
 	pk1 int,
 	pk2 int
-) USING orioledb WITH (index_bridging);
+) USING orioledb;
 
 SELECT orioledb_table_description('o_test_ix_ams'::regclass);
 \d+ o_test_ix_ams
@@ -26,7 +26,7 @@ SELECT * FROM o_test_ix_ams;
 
 SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
 
-CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (index_bridging, deduplicate_items = off);
+CREATE INDEX o_test_ix_ams_ix1 on o_test_ix_ams using btree (j) WITH (orioledb_index = off, deduplicate_items = off);
 SELECT ctid, htid, tids FROM
 		 generate_series(1,
 						 (SELECT relpages - 1 FROM pg_class
@@ -234,7 +234,7 @@ EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_ix_ams ORDER BY j;
 COMMIT;
 
-CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (index_bridging, deduplicate_items = off);
+CREATE INDEX o_test_ix_ams_ix2 on o_test_ix_ams using btree (k) WITH (orioledb_index = off, deduplicate_items = off);
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
 
@@ -338,7 +338,7 @@ EXPLAIN (COSTS OFF)
 SELECT p FROM o_test_ix_ams WHERE p <@ box(point(0,0), point(4000, 5000));
 COMMIT;
 
-CREATE TABLE o_briging_vacuum_test (id serial primary key, val float, p point) USING orioledb WITH (index_bridging);
+CREATE TABLE o_briging_vacuum_test (id serial primary key, val float, p point) USING orioledb;
 INSERT INTO o_briging_vacuum_test (p) (SELECT point(0.01 * i, 0.02 * i) FROM generate_series(1,5) i);
 SELECT orioledb_tbl_structure('o_briging_vacuum_test'::regclass, 'ne');
 CREATE INDEX o_briging_vacuum_test_p_idx on o_briging_vacuum_test using gist(p);
@@ -356,7 +356,7 @@ CREATE TABLE o_test_bridging_with_regular_no_pkey (
 ) USING orioledb WITH (index_bridging);
 
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix1 on
-	o_test_bridging_with_regular_no_pkey using btree (j) WITH (index_bridging);
+	o_test_bridging_with_regular_no_pkey using btree (j) WITH (orioledb_index = off);
 CREATE INDEX o_test_bridging_with_regular_no_pkey_ix2 on
 	o_test_bridging_with_regular_no_pkey using btree (j);
 
@@ -380,7 +380,7 @@ CREATE TABLE o_test_bridging_with_regular_pkey (
 ) USING orioledb WITH (index_bridging);
 
 CREATE INDEX o_test_bridging_with_regular_pkey_ix1 on
-	o_test_bridging_with_regular_pkey using btree (j) WITH (index_bridging);
+	o_test_bridging_with_regular_pkey using btree (j) WITH (orioledb_index = off);
 CREATE INDEX o_test_bridging_with_regular_pkey_ix2 on
 	o_test_bridging_with_regular_pkey using btree (k);
 INSERT INTO o_test_bridging_with_regular_pkey
@@ -411,7 +411,7 @@ CREATE INDEX o_test_bitmap_scans_ix1 on o_test_bitmap_scans using hash (j);
 CREATE INDEX o_test_bitmap_scans_ix2 on o_test_bitmap_scans using btree (j);
 CREATE INDEX o_test_bitmap_scans_ix3 on o_test_bitmap_scans using gin (j);
 CREATE INDEX o_test_bitmap_scans_ix4 on o_test_bitmap_scans using gist (p);
-CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (index_bridging);
+CREATE INDEX o_test_bitmap_scans_ix5 on o_test_bitmap_scans using btree (j2) WITH (orioledb_index = off);
 
 BEGIN;
 SET LOCAL enable_seqscan = off;
@@ -444,42 +444,28 @@ CREATE TABLE o_test_index_bridging_options (
 
 CREATE INDEX o_test_index_bridging_options_ix1 ON o_test_index_bridging_options USING btree (i);
 \d+ o_test_index_bridging_options
-CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 \d+ o_test_index_bridging_options
 CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
 \d+ o_test_index_bridging_options
 CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
 \d+ o_test_index_bridging_options
-CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING hash (i) WITH (index_bridging);
+CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING gist (p);
 \d+ o_test_index_bridging_options
-CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gist (p);
+CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gin (j);
 \d+ o_test_index_bridging_options
-CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING gin (j);
+CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING spgist (p);
 \d+ o_test_index_bridging_options
-CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING spgist (p);
-\d+ o_test_index_bridging_options
-CREATE INDEX o_test_index_bridging_options_ix9 ON o_test_index_bridging_options USING brin (i);
+CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING brin (i);
 \d+ o_test_index_bridging_options
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
 \d+ o_test_index_bridging_options
 ALTER TABLE o_test_index_bridging_options SET (index_bridging);
 \d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix3 SET (index_bridging);
+ALTER INDEX o_test_index_bridging_options_ix2 RESET (orioledb_index);
 \d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix5 RESET (index_bridging);
-\d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix2 RESET (index_bridging);
-\d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix1 SET (index_bridging);
-\d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix6 RESET (index_bridging);
-\d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix7 RESET (index_bridging);
-\d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix8 RESET (index_bridging);
-\d+ o_test_index_bridging_options
-ALTER INDEX o_test_index_bridging_options_ix9 RESET (index_bridging);
+ALTER INDEX o_test_index_bridging_options_ix1 SET (orioledb_index = off);
 \d+ o_test_index_bridging_options
 
 CREATE TABLE o_test_non_index_bridging_options (
@@ -495,12 +481,12 @@ ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
 
 CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_options USING btree (i);
 \d+ o_test_non_index_bridging_options
-CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (index_bridging);
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 \d+ o_test_non_index_bridging_options
 
-ALTER INDEX o_test_non_index_bridging_options_ix1 RESET (index_bridging);
+ALTER INDEX o_test_non_index_bridging_options_ix2 RESET (orioledb_index);
 \d+ o_test_non_index_bridging_options
-ALTER INDEX o_test_non_index_bridging_options_ix1 SET (index_bridging);
+ALTER INDEX o_test_non_index_bridging_options_ix1 SET (orioledb_index = off);
 \d+ o_test_non_index_bridging_options
 
 DROP EXTENSION pageinspect;

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -473,11 +473,49 @@ CREATE TABLE o_test_non_index_bridging_options (
 	j int4[],
 	p point
 ) USING orioledb;
+\d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(1, 10) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
 
 ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
 \d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
+
 ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
 \d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+\d+ o_test_non_index_bridging_options
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+COMMIT;
+
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+DROP INDEX o_test_non_index_bridging_options_ix2;
+
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(11, 15) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
 
 CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_options USING btree (i);
 \d+ o_test_non_index_bridging_options
@@ -488,6 +526,58 @@ ALTER INDEX o_test_non_index_bridging_options_ix2 RESET (orioledb_index);
 \d+ o_test_non_index_bridging_options
 ALTER INDEX o_test_non_index_bridging_options_ix1 SET (orioledb_index = off);
 \d+ o_test_non_index_bridging_options
+
+ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
+\d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
+
+ALTER TABLE o_test_non_index_bridging_options ADD PRIMARY KEY (i);
+\d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(16, 20) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+
+DROP INDEX o_test_non_index_bridging_options_ix1;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+COMMIT;
+
+DROP INDEX o_test_non_index_bridging_options_ix2;
+
+ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
+\d+ o_test_non_index_bridging_options
+ALTER TABLE o_test_non_index_bridging_options DROP CONSTRAINT o_test_non_index_bridging_options_pkey;
+\d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+SELECT * FROM o_test_non_index_bridging_options;
+
+INSERT INTO o_test_non_index_bridging_options
+	SELECT v, ARRAY[v+17,v+33], point(v + 5, v + 5) FROM generate_series(21, 25) v;
+SELECT orioledb_tbl_structure('o_test_non_index_bridging_options'::regclass, 'ne');
+
+CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
+\d+ o_test_non_index_bridging_options
+SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
+COMMIT;
 
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;

--- a/test/sql/tableam.sql
+++ b/test/sql/tableam.sql
@@ -28,7 +28,6 @@ CREATE TABLE o_tableam1
 CREATE INDEX CONCURRENTLY o_tableam1_ix_concurrently ON o_tableam1 (key);
 CREATE INDEX o_tableam1_ix_options ON o_tableam1 (value) WITH (compression = on);
 ALTER TABLE o_tableam1 ADD EXCLUDE USING btree (value WITH =);
-CREATE INDEX o_tableam1_ix_hash on o_tableam1 using hash(key);
 
 SELECT orioledb_tbl_indices('o_tableam1'::regclass);
 

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -221,7 +221,6 @@ class BaseTest(unittest.TestCase):
 		path = os.path.join(pkg_lib_dir, f'{name}.{dlsuffix}')
 		return os.path.isfile(path)
 
-
 	def catchup_orioledb(self, replica):
 		# wait for synchronization
 		replica.catchup()

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -209,6 +209,19 @@ class BaseTest(unittest.TestCase):
 					return True
 		return False
 
+	@staticmethod
+	def extension_installed(name: str) -> bool:
+		if sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
+			dlsuffix = 'dll'
+		elif sys.platform.startswith("darwin"):
+			dlsuffix = 'dylib'
+		else:
+			dlsuffix = 'so'
+		pkg_lib_dir = get_pg_config()["PKGLIBDIR"]
+		path = os.path.join(pkg_lib_dir, f'{name}.{dlsuffix}')
+		return os.path.isfile(path)
+
+
 	def catchup_orioledb(self, replica):
 		# wait for synchronization
 		replica.catchup()

--- a/test/t/index_bridging_test.py
+++ b/test/t/index_bridging_test.py
@@ -36,9 +36,9 @@ class IndexBridgingTest(BaseTest):
 			CREATE TABLE o_test (
 				i int NOT NULL,
 				j int
-			) USING orioledb WITH (index_bridging);
+			) USING orioledb;
 
-			CREATE INDEX o_test_ix1 on o_test using btree (j) WITH (index_bridging);
+			CREATE INDEX o_test_ix1 on o_test using btree (j) WITH (orioledb_index=off);
 			CREATE INDEX o_test_ix2 on o_test using btree (j);
 		""")
 
@@ -114,9 +114,9 @@ class IndexBridgingTest(BaseTest):
 				i int NOT NULL,
 				j int,
 				k int
-			) USING orioledb WITH (index_bridging);
+			) USING orioledb;
 
-			CREATE INDEX o_test_ix1 on o_test using btree (j) WITH (index_bridging);
+			CREATE INDEX o_test_ix1 on o_test using btree (j) WITH (orioledb_index=off);
 			CREATE INDEX o_test_ix2 on o_test using btree (k);
 		""")
 
@@ -207,9 +207,9 @@ class IndexBridgingTest(BaseTest):
 				i int NOT NULL,
 				j int,
 				k int
-			) USING orioledb WITH (index_bridging);
+			) USING orioledb;
 
-			CREATE INDEX o_test_ix1 on o_test using btree (j) WITH (index_bridging);
+			CREATE INDEX o_test_ix1 on o_test using btree (j) WITH (orioledb_index=off);
 			CREATE INDEX o_test_ix2 on o_test using btree (k);
 		""")
 

--- a/test/t/index_bridging_test.py
+++ b/test/t/index_bridging_test.py
@@ -2,12 +2,15 @@
 # coding: utf-8
 
 import re
+import unittest
 
 from .base_test import BaseTest
 
 
 class IndexBridgingTest(BaseTest):
 
+	@unittest.skipIf(not BaseTest.extension_installed("pageinspect"),
+	                 "'pageinspect' is not installed")
 	def test_ctid_overflow(self):
 		node = self.node
 		node.append_conf("orioledb.debug_max_bridge_ctid_blkno=1")
@@ -83,6 +86,8 @@ class IndexBridgingTest(BaseTest):
 		    expected_ctids, key=lambda ctid: int(ctid[0][1:-1].split(',')[1]))
 		check(expected_ctids)
 
+	@unittest.skipIf(not BaseTest.extension_installed("pageinspect"),
+	                 "'pageinspect' is not installed")
 	def test_ctid_overflow_two_times(self):
 		node = self.node
 		node.append_conf("orioledb.debug_max_bridge_ctid_blkno=1")
@@ -195,7 +200,6 @@ class IndexBridgingTest(BaseTest):
 
 		node.safe_psql("""
 			CREATE EXTENSION orioledb;
-			CREATE EXTENSION pageinspect;
 		""")
 
 		node.safe_psql("""

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -12,6 +12,7 @@ from testgres.utils import get_pg_config
 
 from .base_test import BaseTest
 
+
 class LogicalTest(BaseTest):
 
 	def setUp(self):

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -12,19 +12,6 @@ from testgres.utils import get_pg_config
 
 from .base_test import BaseTest
 
-
-def extension_installed(name: str) -> bool:
-	if sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
-		dlsuffix = 'dll'
-	elif sys.platform.startswith("darwin"):
-		dlsuffix = 'dylib'
-	else:
-		dlsuffix = 'so'
-	pkg_lib_dir = get_pg_config()["PKGLIBDIR"]
-	path = os.path.join(pkg_lib_dir, f'{name}.{dlsuffix}')
-	return os.path.isfile(path)
-
-
 class LogicalTest(BaseTest):
 
 	def setUp(self):
@@ -40,7 +27,7 @@ class LogicalTest(BaseTest):
 			result = result + line + "\n"
 		return result
 
-	@unittest.skipIf(not extension_installed("test_decoding"),
+	@unittest.skipIf(not BaseTest.extension_installed("test_decoding"),
 	                 "'test_decoding' is not installed")
 	def test_simple(self):
 		node = self.node
@@ -70,7 +57,7 @@ class LogicalTest(BaseTest):
 		    "BEGIN\ntable public.data: INSERT: id[integer]:1 data[text]:'1'\ntable public.data: INSERT: id[integer]:2 data[text]:'2'\nCOMMIT\n"
 		)
 
-	@unittest.skipIf(not extension_installed("wal2json"),
+	@unittest.skipIf(not BaseTest.extension_installed("wal2json"),
 	                 "'wal2json' is not installed")
 	def test_wal2json(self):
 		node = self.node


### PR DESCRIPTION
- Added 'index_bridging' option to non-btree indices
- Not allowing changing 'index_bridging' option on the fly
- fixed order in all checks "(index->rd_rel->relam != BTREE_AM_OID || (options && options->index_bridging))"