### PR TITLE
OIndex deserialize and serialize bugfix

### DIFF
--- a/include/catalog/o_indices.h
+++ b/include/catalog/o_indices.h
@@ -51,6 +51,17 @@ typedef struct
 	uint16		nPrimaryFields;
 	/* where primary key fields located in index tuple */
 	AttrNumber	primaryFieldsAttnums[INDEX_MAX_KEYS];
+
+	/*
+	 * Fields above are stored in SYS_TREES_O_INDICES and serialized/deserialized
+	 * by serialize_o_index()/deserialize_o_index().
+	 * Fields below are also storied in SYS_TREES_O_INDICES, but they are
+	 * palloc'ed by deserialize_o_index().
+	 *
+	 * Be careful while adding new fields in order to not break backward
+	 * compatibility.
+	 */
+
 	OTableField *leafTableFields;
 	OTableIndexField *leafFields;
 	List	   *predicate;		/* list of Expr */


### PR DESCRIPTION
The bug was introduced by efb3e2a, which changed fields of `OIndex`. Now `leafFields` is after `leafTableFields`. `deserialize_o_index()` and `serialize_o_index()` weren't adjusted accordingly.