### PR TITLE
Make orioledb a default AM and install it by default

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /usr/src/postgresql/contrib/orioledb
 
 COPY . /usr/src/postgresql/contrib/orioledb
 
-RUN mkdir /docker-entrypoint-initdb.d
+RUN mkdir /docker-entrypoint-initdb.d /docker-default-initdb.d
 
 RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
@@ -240,10 +240,13 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 RUN mkdir -p /etc/postgresql && chown -R postgres:postgres /etc/postgresql && chmod 700 /etc/postgresql
-COPY --chown=postgres:postgres docker/postgresql.docker.conf /etc/postgresql/postgresql.conf
+COPY --chown=postgres:postgres docker/init/postgresql.docker.conf /etc/postgresql/postgresql.conf
 ENV PG_CONF=/etc/postgresql/postgresql.conf
 
-COPY docker/docker-entrypoint.sh /usr/local/bin/
+ENV POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=en"
+
+COPY docker/init/docker-entrypoint.sh /usr/local/bin/
+COPY docker/init/default-orioledb.sh /docker-default-initdb.d/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -89,7 +89,7 @@ RUN mkdir -p /usr/src/postgresql/contrib/orioledb
 
 COPY . /usr/src/postgresql/contrib/orioledb
 
-RUN mkdir /docker-entrypoint-initdb.d
+RUN mkdir /docker-entrypoint-initdb.d /docker-default-initdb.d
 
 RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
@@ -267,10 +267,13 @@ RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PG
 VOLUME /var/lib/postgresql/data
 
 RUN mkdir -p /etc/postgresql && chown -R postgres:postgres /etc/postgresql && chmod 700 /etc/postgresql
-COPY --chown=postgres:postgres docker/postgresql.docker.conf /etc/postgresql/postgresql.conf
+COPY --chown=postgres:postgres docker/init/postgresql.docker.conf /etc/postgresql/postgresql.conf
 ENV PG_CONF=/etc/postgresql/postgresql.conf
 
-COPY docker/docker-entrypoint.sh /usr/local/bin/
+ENV POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=en"
+
+COPY docker/init/docker-entrypoint.sh /usr/local/bin/
+COPY docker/init/default-orioledb.sh /docker-default-initdb.d/
 RUN sed -i -e 's/su-exec/gosu/g' "/usr/local/bin/docker-entrypoint.sh"
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/docker/init/default-orioledb.sh
+++ b/docker/init/default-orioledb.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "template1" <<-EOSQL
+CREATE EXTENSION orioledb;
+EOSQL
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+CREATE EXTENSION orioledb;
+EOSQL

--- a/docker/init/docker-entrypoint.sh
+++ b/docker/init/docker-entrypoint.sh
@@ -312,6 +312,7 @@ _main() {
 
 			# check dir permissions to reduce likelihood of half-initialized database
 			ls /docker-entrypoint-initdb.d/ > /dev/null
+			ls /docker-default-initdb.d/ > /dev/null
 
 			docker_init_database_dir
 			pg_setup_hba_conf "$@"
@@ -322,6 +323,7 @@ _main() {
 			docker_temp_server_start "$@"
 
 			docker_setup_db
+			docker_process_init_files /docker-default-initdb.d/*
 			docker_process_init_files /docker-entrypoint-initdb.d/*
 
 			docker_temp_server_stop

--- a/docker/init/postgresql.docker.conf
+++ b/docker/init/postgresql.docker.conf
@@ -2,6 +2,7 @@ data_directory = '/var/lib/postgresql/data'
 hba_file = '/var/lib/postgresql/data/pg_hba.conf'
 listen_addresses = '*'
 shared_preload_libraries = 'orioledb'
+default_table_access_method = 'orioledb'
 orioledb.main_buffers = 512MB
 orioledb.undo_buffers = 256MB
 max_wal_size = 8GB


### PR DESCRIPTION
Make orioledb available immediately on docker container startup by:
- setting config `default_table_access_method = 'orioledb'`
- creating the extension on databases `template1` and `postgres`
- default locale provider is `icu` and default ICU locale is `en`