### PR TITLE
Don't use Ubuntu 20.04 and Alpine pre-3.18 Docker images

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   config_build_push:
     name: Build config docker images and push to Antithesis repository
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout extension code into workspace directory
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
             PGTAG=${{ env.PGTAG }}
   app_build_push:
     name: Build app/workload docker images and push to Antithesis repository
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: true
       matrix:
@@ -128,7 +128,7 @@ jobs:
 
   regress_webhook:
     name: Run regression/isolation tests with fault injection to test system resiliency
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - config_build_push
       - app_build_push
@@ -149,7 +149,7 @@ jobs:
           curl -X POST https://orioledb.antithesis.com/api/v1/launch_experiment/${{ env.ENDPOINT }}${{ matrix.pg_version }}-latest -u '${{ secrets.ANTITHESIS_API_USER }}'
   testgres_webhook:
     name: Run randomized testgres tests without any test harness
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs:
       - config_build_push
       - app_build_push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,9 +19,9 @@ jobs:
         compiler: [clang]
         distr: [alpine, ubuntu]
         include:
-          - distr-version: 3.19
+          - distr-version: 3.21
             distr: alpine
-          - distr-version: focal
+          - distr-version: noble
             distr: ubuntu
 
     name: Push Docker image to Docker Hub

--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -17,9 +17,9 @@ jobs:
         compiler: [clang]
         distr: [alpine, ubuntu]
         include:
-          - distr-version: "3.20"
+          - distr-version: "3.21"
             distr: alpine
-          - distr-version: "focal"
+          - distr-version: "noble"
             distr: ubuntu
 
     name: docker ${{ matrix.postgres }}-${{ matrix.compiler }}-${{ matrix.distr }}-${{ matrix.distr-version }}

--- a/ci/docker_matrix.sh
+++ b/ci/docker_matrix.sh
@@ -10,16 +10,16 @@ DRY_RUN="false"
 
 # Define base lists
 declare -A base_lists
-base_lists[all-oldest]="ubuntu:22.04 alpine:3.14"
-base_lists[all-latest]="ubuntu:24.10 alpine:3.20"
+base_lists[all-oldest]="ubuntu:22.04 alpine:3.18"
+base_lists[all-latest]="ubuntu:25.04 alpine:3.21"
 base_lists[all-dev]="ubuntu:devel alpine:edge"
-base_lists[all-alpine]="alpine:edge alpine:3.20 alpine:3.19 alpine:3.18 alpine:3.17 alpine:3.16 alpine:3.15 alpine:3.14"
-base_lists[all-debian]="ubuntu:devel ubuntu:24.10 ubuntu:24.04 ubuntu:22.04 ubuntu:20.04 "
+base_lists[all-alpine]="alpine:edge alpine:3.21 alpine:3.20 alpine:3.19 alpine:3.18"
+base_lists[all-debian]="ubuntu:devel ubuntu:25.04 ubuntu:24.10 ubuntu:24.04 ubuntu:22.04"
 base_lists[all]="${base_lists[all-alpine]} ${base_lists[all-debian]}"
 
 # Valid Alpine, Ubuntu, PG and Compiler versions
-VALID_ALPINE_VERSIONS="edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14 latest"
-VALID_UBUNTU_VERSIONS="devel 24.10 24.04 22.04 20.04 oracular noble jammy focal latest rolling"
+VALID_ALPINE_VERSIONS="edge 3.21 3.20 3.19 3.18 latest"
+VALID_UBUNTU_VERSIONS="devel 25.04 24.10 24.04 22.04 plucky oracular noble jammy latest rolling"
 VALID_PG_MAJOR_VERSIONS="17 16"
 VALID_COMPILERS="clang gcc"
 
@@ -72,8 +72,8 @@ and you can check the build logs with:
 
 Examples:
   ./ci/docker_matrix.sh --base all-dev --pg-major all --compiler clang
-  ./ci/docker_matrix.sh --base alpine:3.20 --pg-major 17 --compiler gcc --debug true
-  ./ci/docker_matrix.sh --base ubuntu:oracular --pg-major 16 --compiler all --debug false
+  ./ci/docker_matrix.sh --base alpine:3.21 --pg-major 17 --compiler gcc --debug true
+  ./ci/docker_matrix.sh --base ubuntu:noble --pg-major 16 --compiler all --debug false
 
 Default behavior:
   ./ci/docker_matrix.sh --base $BASE_MATRIX --pg-major $PG_MAJOR --compiler $COMPILER --debug $DEBUG

--- a/ci/local_docker_matrix.sh
+++ b/ci/local_docker_matrix.sh
@@ -10,19 +10,16 @@ pg_major_list=( 16 17)
 compiler_list=( clang gcc )
 base_list=(
    # alpine versions
+   alpine:3.21
    alpine:3.20
    alpine:3.19
    alpine:3.18
-   alpine:3.17
-   alpine:3.16
-   alpine:3.15
-   alpine:3.14
 
    # ubuntu versions
+   ubuntu:25.04
    ubuntu:24.10
    ubuntu:24.04
    ubuntu:22.04
-   ubuntu:20.04
 
    # developer versions
    alpine:edge

--- a/doc/contributing/docker-builds.mdx
+++ b/doc/contributing/docker-builds.mdx
@@ -34,7 +34,7 @@ Connect to the server via psql:
 You should expect a similar psql message:
 
 ```
-psql (17.0 OrioleDB public beta 10 PGTAG=patches17_6 alpine:3.20+clang build:2024-10-25T19:54:25+00:00 17.0)
+psql (17.0 OrioleDB public beta 10 PGTAG=patches17_6 alpine:3.21+clang build:2024-10-25T19:54:25+00:00 17.0)
 Type "help" for help.
 postgres=#
 ```
@@ -203,10 +203,10 @@ Read more: https://github.com/docker-library/docs/blob/master/postgres/README.md
 
 Please check the Dockerfiles for the full list of build args!
 - Alpine Linux: `./Dockerfile`
-  - supported [ `edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14` ]
-  - example: `--build-arg ALPINE_VERSION="3.20" -f docker/Dockerfile `
+  - supported [ `edge 3.21 3.20 3.19 3.18` ]
+  - example: `--build-arg ALPINE_VERSION="3.21" -f docker/Dockerfile `
 - Ubuntu Linux: `./Dockerfile.ubuntu`
-  - supported [ `devel 24.10 24.04 22.04 20.04 oracular noble jammy focal` ]
+  - supported [ `devel 25.04 24.10 24.04 22.04 plucky oracular noble jammy` ]
   - example: `--build-arg UBUNTU_VERSION="24.04" -f docker/Dockerfile.ubuntu `
 
 Other important build args:
@@ -217,15 +217,15 @@ Other important build args:
   - Choose the C compiler. Default is `clang`.
   - You can choose either `clang` or `gcc`.
 
-For example, to build an image using Alpine version `3.20`, the `gcc` compiler and PostgreSQL version `16`, use the following command:
+For example, to build an image using Alpine version `3.21`, the `gcc` compiler and PostgreSQL version `16`, use the following command:
 
 ```bash
 docker build --pull --network=host --progress=plain \
-    --build-arg ALPINE_VERSION="3.20" \
+    --build-arg ALPINE_VERSION="3.21" \
     --build-arg BUILD_CC_COMPILER="gcc" \
     --build-arg PG_MAJOR="16" \
     -f docker/Dockerfile \
-    -t orioletest:16-gcc-alpine3.20 .
+    -t orioletest:16-gcc-alpine3.21 .
 ```
 
 To build an image using Ubuntu version `devel`, the `clang` compiler and PostgreSQL version `17`, use the following command:
@@ -245,15 +245,15 @@ The "devel" version is the latest development Ubuntu version, so it might not be
 Known limitations:
 - OrioleDB `gist`, `sp-gist`, and other related indexes are not yet supported.
 
-#### Step 1: create image: `orioletest:17-gcc-alpine3.20`
+#### Step 1: create image: `orioletest:17-gcc-alpine3.21`
 
 ```bash
 docker build --pull --network=host --progress=plain \
-    --build-arg ALPINE_VERSION="3.20" \
+    --build-arg ALPINE_VERSION="3.21" \
     --build-arg BUILD_CC_COMPILER="gcc" \
     --build-arg PG_MAJOR="17" \
     -f docker/Dockerfile \
-    -t orioletest:17-gcc-alpine3.20 .
+    -t orioletest:17-gcc-alpine3.21 .
 ```
 
 #### Step2: Build the `oriolegis:17-3.5-alpine` image.
@@ -264,7 +264,7 @@ in a new directory, run this commands:
 git clone --depth=1 https://github.com/postgis/docker-postgis.git
 cd ./docker-postgis/17-3.5/alpine
 docker build --network=host --progress=plain \
-     --build-arg BASE_IMAGE=orioletest:17-gcc-alpine3.20 \
+     --build-arg BASE_IMAGE=orioletest:17-gcc-alpine3.21 \
      -t oriolegis:17-3.5-alpine .
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # This is slightly adjusted Dockerfile from
 # https://github.com/docker-library/postgres
 
-# set ALPINE_VERSION= [ edge 3.20 3.19 3.18 3.17 3.16 3.15 3.14 ]
-ARG ALPINE_VERSION=3.20
+# set ALPINE_VERSION= [ edge 3.21 3.20 3.19 3.18 ]
+ARG ALPINE_VERSION=3.21
 FROM alpine:${ALPINE_VERSION}
 
 ARG ALPINE_VERSION

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,8 +1,8 @@
 # This is modified Dockerfile from 16/bookworm in
 # https://github.com/docker-library/postgres
 
-# Set UBUNTU_VERSION = [ devel 24.10    24.04 22.04 20.04 ]
-#                   or [ devel oracular noble jammy focal ]
+# Set UBUNTU_VERSION = [ devel 25.04 24.10 24.04 22.04 ]
+#                   or [ devel plucky oracular noble jammy ]
 
 ARG UBUNTU_VERSION=noble
 FROM ubuntu:${UBUNTU_VERSION}

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,13 +21,13 @@ git clone "$OFFIMG_REPO_URL" "$OFFIMG_LOCAL_CLONE"
 "${OFFIMG_LOCAL_CLONE}/test/run.sh" \
     -c "${OFFIMG_LOCAL_CLONE}/test/config.sh" \
     -c "docker/orioledb-config.sh" \
-    "orioletest:17-gcc-ubuntu-22.04"
+    "orioletest:17-gcc-ubuntu-24.04"
 ```
 
 If the test is ok, you can see:
 
 ```bash
-testing orioletest:17-gcc-ubuntu-22.04
+testing orioletest:17-gcc-ubuntu-24.04
 	'utc' [1/6]...passed
 	'no-hard-coded-passwords' [2/6]...passed
 	'override-cmd' [3/6]...passed


### PR DESCRIPTION
Github Actions deprecated usage of Ubuntu 20.04. It makes sense to stop using Ubuntu 20.04 Docker image. Same way stop using old Alpine pre-3.18 Docker images.
- Currently supported Alpine Docker images: https://hub.docker.com/_/alpine
- Currently supported Ubuntu Docker images: https://hub.docker.com/_/ubuntu