### PR TITLE
Fix "Only C, POSIX and ICU collations supported for orioledb tables" error in pgbench.py

### DIFF
--- a/ci/pgbench.py
+++ b/ci/pgbench.py
@@ -576,7 +576,7 @@ class PgBenchTest:
 			self.results_dir = tempfile.mkdtemp(prefix='benchmark_')
 
 		if args.initdb:
-			node.init() # run initdb
+			node.init(["--no-locale", "--encoding=UTF8"]) # run initdb
 
 			if args.wal_dir:
 				shutil.move(os.path.join(node.data_dir, 'pg_wal'),


### PR DESCRIPTION
When running `./ci/pgbench.py` the following error occurred:
```
testgres.exceptions.QueryException: Utility exited with non-zero code. Error: `ERROR:  Only C, POSIX and ICU collations supported for orioledb tables`
Query: CREATE TABLE orioledb.pgbench_accounts (
 aid integer NOT NULL PRIMARY KEY,
 bid integer,
 abalance integer,
 filler character(84)
) USING orioledb;
CREATE TABLE orioledb.pgbench_branches (
 bid integer NOT NULL PRIMARY KEY,
 bbalance integer,
 filler character(88)
) USING orioledb;
CREATE TABLE orioledb.pgbench_tellers (
 tid integer NOT NULL PRIMARY KEY,
 bid integer,
 tbalance integer,
 filler character(84)
) USING orioledb;
CREATE TABLE orioledb.pgbench_history
(
 tid integer NOT NULL,
 bid integer NOT NULL,
 aid integer NOT NULL,
 delta integer NOT NULL,
 mtime timestamp NOT NULL,
 filler character(22),
 PRIMARY KEY(bid, mtime, tid, aid, delta)
) USING orioledb;
```

This patch fixes the error.