### PR TITLE
do not limit index fields with INDEX_MAX_KEYS

### DIFF
--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -146,7 +146,7 @@ struct OIndexDescr
 	int			nFields;
 	int			nKeyFields;
 	int			nIncludedFields;
-	OIndexField fields[INDEX_MAX_KEYS];
+	OIndexField *fields;
 
 	/*
 	 * Attnums for primary key values in the secondary index tuples. We may

--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -165,6 +165,9 @@ struct OIndexDescr
 	/* Used in getsomeattrs to reorder fields during index only scan of pkey  */
 	AttrNumberMap *pk_tbl_field_map;
 
+	/* Cached comparators used to fill key for pkey tuple search */
+	OComparator **pk_comparators;
+
 	/* tupdesc and slots needed for indexam operations */
 	TupleDesc	itupdesc;
 	TupleTableSlot *index_slot;

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -1905,7 +1905,6 @@ drop_primary_index(Relation rel, OTable *o_table)
 
 	old_o_table = o_table;
 	o_table = o_tables_get(o_table->oids);
-	elog(WARNING, "assign_new_oids CALL 1");
 	assign_new_oids(o_table, rel, true);
 
 	memmove(&o_table->indices[0],

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -846,6 +846,7 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, OTable *oTable)
 	ListCell   *lc;
 	MemoryContext mcxt,
 				old_mcxt;
+	int			n_max_fields;
 
 	memset(descr, 0, sizeof(*descr));
 	descr->oids = oIndex->indexOids;
@@ -932,6 +933,11 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, OTable *oTable)
 	descr->nUniqueFields = oIndex->nUniqueFields;
 	descr->nFields = oIndex->nNonLeafFields;
 
+	n_max_fields = Max(oIndex->nLeafFields, oIndex->nNonLeafFields);
+	mcxt = OGetIndexContext(descr);
+	descr->fields = (OIndexField *) MemoryContextAllocZero(mcxt,
+														   sizeof(OIndexField) * n_max_fields);
+
 	descr->nKeyFields = oIndex->nKeyFields;
 	descr->nIncludedFields = oIndex->nIncludedFields;
 	for (i = 0; i < oIndex->nLeafFields; i++)
@@ -986,7 +992,6 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, OTable *oTable)
 										   iField->opclass);
 	}
 
-	mcxt = OGetIndexContext(descr);
 	old_mcxt = MemoryContextSwitchTo(mcxt);
 	descr->predicate = list_copy_deep(oIndex->predicate);
 	if (descr->predicate)

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -54,7 +54,7 @@ tts_copy_identity(TupleTableSlot *srcSlot, TupleTableSlot *dstSlot,
 	{
 		int			attnum;
 
-		attnum = idx->fields[i].tableAttnum - 1;
+		attnum = idx->tableAttnums[i] - 1;
 		if (attnum >= 0)
 		{
 			dstSlot->tts_values[i] = srcSlot->tts_values[i];

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -1077,7 +1077,7 @@ is_pk_attnum(OTableDescr *tableDescr, AttrNumber attnum)
 
 	for (i = 0; i < pk->nFields; i++)
 	{
-		if (attnum == pk->fields[i].tableAttnum)
+		if (attnum == pk->tableAttnums[i])
 			return true;
 	}
 	return false;

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -188,7 +188,7 @@ apply_new_bridge_index_ctid(OTableDescr *descr, Relation relation,
 
 		for (i = 0; i < GET_PRIMARY(descr)->nKeyFields; i++)
 		{
-			AttrNumber	attnum = GET_PRIMARY(descr)->fields[i].tableAttnum - 1;
+			AttrNumber	attnum = GET_PRIMARY(descr)->tableAttnums[i] - 1;
 
 			values[i + 1] = slot->tts_values[attnum];
 			isnull[i + 1] = slot->tts_isnull[attnum];

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -547,7 +547,7 @@ o_fill_pindex_tuple_key_bound(BTreeDescr *desc,
 		bound->keys[i].flags = O_VALUE_BOUND_PLAIN_VALUE;
 		if (isnull)
 			bound->keys[i].flags |= O_VALUE_BOUND_NULL;
-		bound->keys[i].comparator = id->fields[pk_from + i].comparator;
+		bound->keys[i].comparator = id->pk_comparators[i];
 	}
 }
 

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -141,7 +141,7 @@ o_get_key_len(BTreeDescr *desc, OTuple tuple, OIndexType type, bool keepVersion)
 
 	for (i = 0; i < id->nonLeafTupdesc->natts; i++)
 	{
-		int			attnum = (type == oIndexPrimary) ? id->fields[i].tableAttnum : i + 1;
+		int			attnum = (type == oIndexPrimary) ? id->tableAttnums[i] : i + 1;
 
 		Assert(attnum > 0);
 		values[i] = o_fastgetattr(tuple, attnum, id->leafTupdesc, &id->leafSpec, &isnull[i]);
@@ -196,7 +196,7 @@ o_create_key_tuple(BTreeDescr *desc, OTuple tuple, Pointer data,
 
 	for (i = 0; i < id->nonLeafTupdesc->natts; i++)
 	{
-		int			attnum = (type == oIndexPrimary) ? id->fields[i].tableAttnum + ctid_off : i + 1;
+		int			attnum = (type == oIndexPrimary) ? id->tableAttnums[i] + ctid_off : i + 1;
 
 		Assert(attnum > 0);
 		key[i] = o_fastgetattr(tuple, attnum, id->leafTupdesc, &id->leafSpec, &isnull[i]);
@@ -342,7 +342,7 @@ o_hash_key_from_tuple(OIndexDescr *idx, OTuple tuple)
 		int			attnum;
 
 		if (idx->desc.type == oIndexPrimary)
-			attnum = idx->fields[i].tableAttnum + ctid_off;
+			attnum = idx->tableAttnums[i] + ctid_off;
 		else
 			attnum = i + 1;
 

--- a/src/tuple/slot.c
+++ b/src/tuple/slot.c
@@ -122,7 +122,7 @@ tts_orioledb_make_key(TupleTableSlot *slot, OTableDescr *descr)
 
 	for (i = 0; i < id->nonLeafTupdesc->natts; i++)
 	{
-		int			attnum = id->fields[i].tableAttnum;
+		int			attnum = id->tableAttnums[i];
 
 		if (attnum == 1 && ctid_off == 1)
 		{
@@ -315,11 +315,11 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 			if (index_order)
 			{
 				if (cur_tbl_attnum >= idx->nFields ||
-					attnum != idx->tbl_attnums[cur_tbl_attnum].key)
+					attnum != idx->pk_tbl_field_map[cur_tbl_attnum].key)
 					res_attnum = -2;
 				else
 				{
-					res_attnum = idx->tbl_attnums[cur_tbl_attnum].value;
+					res_attnum = idx->pk_tbl_field_map[cur_tbl_attnum].value;
 					cur_tbl_attnum++;
 				}
 			}
@@ -1010,7 +1010,7 @@ tts_orioledb_get_index_values(TupleTableSlot *slot, OIndexDescr *idx,
 
 	for (i = 0; i < natts; i++)
 	{
-		int			attnum = idx->fields[i].tableAttnum;
+		int			attnum = idx->tableAttnums[i];
 
 		if (attnum != EXPR_ATTNUM)
 			values[i] = get_tbl_att(slot, attnum, idx->primaryIsCtid,
@@ -1082,7 +1082,7 @@ tts_orioledb_fill_key_bound(TupleTableSlot *slot, OIndexDescr *idx,
 		int			attnum;
 		Oid			typid;
 
-		attnum = idx->fields[i].tableAttnum;
+		attnum = idx->tableAttnums[i];
 
 		if (attnum != EXPR_ATTNUM)
 			value = get_tbl_att(slot, attnum, idx->primaryIsCtid,
@@ -1121,7 +1121,7 @@ appendStringInfoIndexKey(StringInfo str, TupleTableSlot *slot, OIndexDescr *id)
 	{
 		Datum		value;
 		bool		isnull;
-		int			attnum = id->fields[i].tableAttnum;
+		int			attnum = id->tableAttnums[i];
 
 		if (attnum != EXPR_ATTNUM)
 			value = get_tbl_att(slot, attnum, id->primaryIsCtid,

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -1425,8 +1425,52 @@ $$ LANGUAGE plpgsql;
 CREATE TABLE o_test_plpgsql_default (
     val_1 int DEFAULT LENGTH(o_test_plpgsql_default_func(6))
 ) USING orioledb;
+CREATE TABLE test_35_columns (
+  gid serial,
+  col1 varchar(1),
+  col2 varchar(1),
+  col3 varchar(1),
+  col4 varchar(1),
+  col5 varchar(1),
+  col6 varchar(1),
+  col7 varchar(1),
+  col8 varchar(1),
+  col9 varchar(1),
+  col10 varchar(1),
+  col11 varchar(1),
+  col12 varchar(1),
+  col13 varchar(1),
+  col14 varchar(1),
+  col15 varchar(1),
+  col16 varchar(1),
+  col17 varchar(1),
+  col18 varchar(1),
+  col19 varchar(1),
+  col20 varchar(1),
+  col21 varchar(1),
+  col22 varchar(1),
+  col23 varchar(1),
+  col24 varchar(1),
+  col25 varchar(1),
+  col26 varchar(1),
+  col27 varchar(1),
+  col28 varchar(1),
+  col29 varchar(1),
+  col30 varchar(1),
+  col31 varchar(1),
+  col32 varchar(1),
+  col33 varchar(1),
+  col34 varchar(1)
+) using orioledb;
+INSERT INTO test_35_columns (col27, col10) VALUES ('A', 'J');
+SELECT gid, col10, col15, col27, col33, col34 FROM test_35_columns;
+ gid | col10 | col15 | col27 | col33 | col34 
+-----+-------+-------+-------+-------+-------
+   1 | J     |       | A     |       | 
+(1 row)
+
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table o_ddl_missing
 drop cascades to table o_test_add_column
 drop cascades to table o_test_multiple_analyzes
@@ -1448,6 +1492,7 @@ drop cascades to table o_test_included_ix_name
 drop cascades to table o_test_add_pkey_empty_index
 drop cascades to table o_test_empty
 drop cascades to table o_test_plpgsql_default
+drop cascades to table test_35_columns
 DROP SCHEMA ddl CASCADE;
 NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/ddl_1.out
+++ b/test/expected/ddl_1.out
@@ -1426,8 +1426,52 @@ $$ LANGUAGE plpgsql;
 CREATE TABLE o_test_plpgsql_default (
     val_1 int DEFAULT LENGTH(o_test_plpgsql_default_func(6))
 ) USING orioledb;
+CREATE TABLE test_35_columns (
+  gid serial,
+  col1 varchar(1),
+  col2 varchar(1),
+  col3 varchar(1),
+  col4 varchar(1),
+  col5 varchar(1),
+  col6 varchar(1),
+  col7 varchar(1),
+  col8 varchar(1),
+  col9 varchar(1),
+  col10 varchar(1),
+  col11 varchar(1),
+  col12 varchar(1),
+  col13 varchar(1),
+  col14 varchar(1),
+  col15 varchar(1),
+  col16 varchar(1),
+  col17 varchar(1),
+  col18 varchar(1),
+  col19 varchar(1),
+  col20 varchar(1),
+  col21 varchar(1),
+  col22 varchar(1),
+  col23 varchar(1),
+  col24 varchar(1),
+  col25 varchar(1),
+  col26 varchar(1),
+  col27 varchar(1),
+  col28 varchar(1),
+  col29 varchar(1),
+  col30 varchar(1),
+  col31 varchar(1),
+  col32 varchar(1),
+  col33 varchar(1),
+  col34 varchar(1)
+) using orioledb;
+INSERT INTO test_35_columns (col27, col10) VALUES ('A', 'J');
+SELECT gid, col10, col15, col27, col33, col34 FROM test_35_columns;
+ gid | col10 | col15 | col27 | col33 | col34 
+-----+-------+-------+-------+-------+-------
+   1 | J     |       | A     |       | 
+(1 row)
+
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table o_ddl_missing
 drop cascades to table o_test_add_column
 drop cascades to table o_test_multiple_analyzes
@@ -1449,6 +1493,7 @@ drop cascades to table o_test_included_ix_name
 drop cascades to table o_test_add_pkey_empty_index
 drop cascades to table o_test_empty
 drop cascades to table o_test_plpgsql_default
+drop cascades to table test_35_columns
 DROP SCHEMA ddl CASCADE;
 NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/sql/ddl.sql
+++ b/test/sql/ddl.sql
@@ -493,6 +493,47 @@ CREATE TABLE o_test_plpgsql_default (
     val_1 int DEFAULT LENGTH(o_test_plpgsql_default_func(6))
 ) USING orioledb;
 
+CREATE TABLE test_35_columns (
+  gid serial,
+  col1 varchar(1),
+  col2 varchar(1),
+  col3 varchar(1),
+  col4 varchar(1),
+  col5 varchar(1),
+  col6 varchar(1),
+  col7 varchar(1),
+  col8 varchar(1),
+  col9 varchar(1),
+  col10 varchar(1),
+  col11 varchar(1),
+  col12 varchar(1),
+  col13 varchar(1),
+  col14 varchar(1),
+  col15 varchar(1),
+  col16 varchar(1),
+  col17 varchar(1),
+  col18 varchar(1),
+  col19 varchar(1),
+  col20 varchar(1),
+  col21 varchar(1),
+  col22 varchar(1),
+  col23 varchar(1),
+  col24 varchar(1),
+  col25 varchar(1),
+  col26 varchar(1),
+  col27 varchar(1),
+  col28 varchar(1),
+  col29 varchar(1),
+  col30 varchar(1),
+  col31 varchar(1),
+  col32 varchar(1),
+  col33 varchar(1),
+  col34 varchar(1)
+) using orioledb;
+
+INSERT INTO test_35_columns (col27, col10) VALUES ('A', 'J');
+SELECT gid, col10, col15, col27, col33, col34 FROM test_35_columns;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA ddl CASCADE;
 RESET search_path;


### PR DESCRIPTION
Closes https://github.com/orioledb/orioledb/issues/474

## Bug
Buffer overflow on wide table creation. Valgrind output:
```
==9832== Invalid write of size 2
==9832==    at 0x68388D0: o_index_fill_descr (o_indices.c:966)
==9832==    by 0x68875F8: get_index_descr (descr.c:987)
==9832==    by 0x68878B4: o_table_descr_fill_indices (descr.c:1050)
==9832==    by 0x6886807: fill_table_descr (descr.c:640)
==9832==    by 0x6886C03: create_table_descr (descr.c:726)
==9832==    by 0x6886D66: o_fetch_table_descr (descr.c:770)
==9832==    by 0x689441E: relation_get_descr (handler.c:2108)
==9832==    by 0x6890828: orioledb_get_row_ref_type (handler.c:370)
==9832==    by 0x42CC63E: table_get_row_ref_type (tableam.h:2154)
==9832==    by 0x42CEF57: addRangeTableEntry (parse_relation.c:1507)
==9832==    by 0x42A4966: transformTableEntry (parse_clause.c:400)
==9832==    by 0x42A65AB: transformFromClauseItem (parse_clause.c:1075)
==9832==  Address 0x618beb2 is 18 bytes after a block of size 13,952 alloc'd
==9832==    at 0x555D7C4: malloc (vg_replace_malloc.c:446)
==9832==    by 0x48DDF04: AllocSetAllocLarge (aset.c:715)
==9832==    by 0x48DE50A: AllocSetAlloc (aset.c:986)
==9832==    by 0x48EC8DD: MemoryContextAllocExtended (mcxt.c:1250)
==9832==    by 0x48B966B: DynaHashAlloc (dynahash.c:294)
==9832==    by 0x48BBACC: element_alloc (dynahash.c:1679)
==9832==    by 0x48B9EAE: hash_create (dynahash.c:613)
==9832==    by 0x6888994: o_tableam_descr_init (descr.c:1482)
==9832==    by 0x6866304: _PG_init (orioledb.c:912)
==9832==    by 0x48AF6E5: internal_load_library (dfmgr.c:289)
==9832==    by 0x48AF146: load_file (dfmgr.c:156)
==9832==    by 0x48BF069: load_libraries (miscinit.c:1828)
==9832==
```
## Fix

Allocate actual number of index fields instead of `INDEX_MAX_KEYS`

## Verifying the fix

Run `make installcheck-tests TESTS="test_setup create_table"` on running postgres with `default_access_method="orioledb"`.
Before this patch `create_table` fails, now both should pass.

## Notes

In the consequent PR `create_table` postgres regress test will be enabled in orioledb CI.