### PR TITLE
move from codecov to coveralls

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,40 @@ jobs:
       - name: Show stuck processes
         run: bash ./orioledb/ci/list_stuck.sh
         if: ${{ always() }}
-      - name: Codecov
-        run: bash ./orioledb/ci/codecov.sh
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run lcov
+        if: ${{ matrix.check_type != 'sanitize' && matrix.check_type != 'check_page' }}
+        run: bash ./orioledb/ci/lcov.sh
+      - name: create artifact for coverage.info
+        if: ${{ matrix.check_type != 'sanitize' && matrix.check_type != 'check_page' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.pg_version }}_${{ matrix.compiler }}_${{ matrix.check_type }}_coverage.info
+          path: ./orioledb/coverage.info
+          retention-days: 1
+
+  finish:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout extension code into workspace directory
+        uses: actions/checkout@v4
+        with:
+          path: orioledb
+      - name: Retrieve saved coverage.infos
+        uses: actions/download-artifact@v4
+      - name: Merge coverage files
+        run: bash ./orioledb/ci/lcov_merge.sh
+      - name: coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          files: ./orioledb/coverage.info
+
+  cleanup:
+    needs: finish
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: remove artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+            name: '*coverage.info'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 (A solution to PostgreSQL’s wicked problems)
 
 [![check status](https://github.com/orioledb/orioledb/actions/workflows/check.yml/badge.svg)](https://github.com/orioledb/orioledb/actions)
-[![codecov](https://codecov.io/gh/orioledb/orioledb/branch/main/graph/badge.svg?token=shh4jn0DUK)](https://codecov.io/gh/orioledb/orioledb) [![dockerhub](https://github.com/orioledb/orioledb/actions/workflows/docker.yml/badge.svg)](https://hub.docker.com/r/orioledb/orioledb/tags)
+[![Coverage Status](https://coveralls.io/repos/github/orioledb/orioledb/badge.svg?branch=coveralls)](https://coveralls.io/github/orioledb/orioledb?branch=coveralls) [![dockerhub](https://github.com/orioledb/orioledb/actions/workflows/docker.yml/badge.svg)](https://hub.docker.com/r/orioledb/orioledb/tags)
 
 
 OrioleDB is a new storage engine for PostgreSQL, bringing a modern approach to

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -3,9 +3,5 @@
 set -eu
 
 cd orioledb
-if [ $COMPILER = "clang" ]; then
-	bash <(curl -s https://codecov.io/bash) -x "llvm-cov-$LLVM_VER gcov"
-else
-	bash <(curl -s https://codecov.io/bash)
-fi
+bash <(curl -s https://codecov.io/bash) -X gcov
 cd ..

--- a/ci/lcov.sh
+++ b/ci/lcov.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+cd orioledb
+if [ $COMPILER = "clang" ]; then
+    # trick with gcov-tool needed to not have gcov version mismatch: file.gcno:version '...*', prefer '...*'
+    lcov --gcov-tool "$PWD/ci/llvm-gcov.sh" --capture --directory . --no-external --output-file coverage.info
+else
+	lcov --capture --directory . --no-external --output-file coverage.info
+fi
+cd ..

--- a/ci/lcov_merge.sh
+++ b/ci/lcov_merge.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+sudo apt-get update -qq
+sudo apt-get install lcov
+lcov $(ls -d1 *coverage.info/coverage.info | xargs -I{} echo "-a {}") -o ./orioledb/coverage.info

--- a/ci/llvm-gcov.sh
+++ b/ci/llvm-gcov.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec llvm-cov-$LLVM_VER gcov "$@"

--- a/ci/prerequisites.sh
+++ b/ci/prerequisites.sh
@@ -12,7 +12,7 @@ sudo apt-get -y install -qq wget ca-certificates
 
 sudo apt-get update -qq
 
-apt_packages="build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3-full python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev libcurl4-openssl-dev libssl-dev"
+apt_packages="build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3-full python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev libcurl4-openssl-dev libssl-dev lcov"
 
 if [ $COMPILER = "clang" ]; then
 	apt_packages="$apt_packages llvm-$LLVM_VER clang-$LLVM_VER clang-tools-$LLVM_VER"


### PR DESCRIPTION
new approach; now it merges coverage files on ci itself

results are almost equal to codecov now:
- https://app.codecov.io/gh/orioledb/orioledb/commit/314bc2717128f8614df5d9d169ff1b33204cacb9/tree
- https://coveralls.io/builds/74216479
and also they are equal to report that is generated by genhtml