### PR TITLE
Issue #502: Check for interrupts when sleeping on ConditionVariable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ OBJS = src/btree/btree.o \
 	   src/tuple/slot.o \
 	   src/tuple/sort.o \
 	   src/workers/bgwriter.o \
+	   src/workers/interrupt.o \
 	   src/utils/compress.o \
 	   src/utils/o_buffers.o \
 	   src/utils/page_pool.o \

--- a/include/workers/interrupt.h
+++ b/include/workers/interrupt.h
@@ -1,0 +1,19 @@
+/*-------------------------------------------------------------------------
+ *
+ * interrupt.h
+ *		Routines for background workers interrupt handling.
+ *
+ * Copyright (c) 2021-2025, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/workers/interrupt.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef __WORKERS_INTERRUPT_H__
+#define __WORKERS_INTERRUPT_H__
+
+extern void o_worker_shutdown(int elevel);
+extern void o_worker_handle_interrupts(void);
+
+#endif							/* __WORKERS_INTERRUPT_H__ */

--- a/src/s3/worker.c
+++ b/src/s3/worker.c
@@ -26,6 +26,7 @@
 #include "miscadmin.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/bgwriter.h"
+#include "postmaster/interrupt.h"
 #include "storage/bufmgr.h"
 #include "storage/latch.h"
 #include "storage/proc.h"
@@ -54,7 +55,6 @@ typedef struct S3WorkerCtl
 	pg_atomic_flag workersInProgress[FLEXIBLE_ARRAY_MEMBER];
 } S3WorkerCtl;
 
-static volatile sig_atomic_t shutdown_requested = false;
 static volatile S3TaskLocation *workers_locations = NULL;
 static S3FileChecksum *workers_file_checksums = NULL;
 
@@ -106,13 +106,6 @@ s3_workers_init_shmem(Pointer ptr, bool found)
 			pg_atomic_init_flag(&workers_ctl->workersInProgress[i]);
 		}
 	}
-}
-
-static void
-handle_sigterm(SIGNAL_ARGS)
-{
-	shutdown_requested = true;
-	SetLatch(MyLatch);
 }
 
 void
@@ -926,7 +919,7 @@ s3worker_main(Datum main_arg)
 	SetProcessingMode(NormalProcessing);
 
 	/* catch SIGTERM signal for reason to not interupt background writing */
-	pqsignal(SIGTERM, handle_sigterm);
+	pqsignal(SIGTERM, SignalHandlerForShutdownRequest);
 	BackgroundWorkerUnblockSignals();
 
 	elog(LOG, "orioledb s3 worker %d started", worker_num);
@@ -958,7 +951,7 @@ s3worker_main(Datum main_arg)
 		{
 			uint64		taskLocation;
 
-			if (shutdown_requested)
+			if (ShutdownRequestPending)
 				break;
 
 			/*
@@ -969,7 +962,7 @@ s3worker_main(Datum main_arg)
 						   WAIT_EVENT_BGWRITER_MAIN);
 
 			if (rc & WL_POSTMASTER_DEATH)
-				shutdown_requested = true;
+				ShutdownRequestPending = true;
 
 			/*
 			 * Task processing loop.  It might happend that error occurs and

--- a/src/workers/interrupt.c
+++ b/src/workers/interrupt.c
@@ -1,0 +1,43 @@
+/*-------------------------------------------------------------------------
+ *
+ * interrupt.c
+ *		Routines for background workers interrupt handling.
+ *
+ * Copyright (c) 2025-2025, Oriole DB Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/src/worker/interrupt.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "workers/interrupt.h"
+
+#include "postmaster/interrupt.h"
+
+/*
+ * Exit from an orioledb worker
+ */
+void
+o_worker_shutdown(int elevel)
+{
+	Assert(MyBackendType == B_BG_WORKER);
+	ereport(elevel,
+			(errcode(ERRCODE_ADMIN_SHUTDOWN),
+			 errmsg("terminating orioledb worker due to administrator command")));
+}
+
+void
+o_worker_handle_interrupts(void)
+{
+	/*
+	 * In case of a pending shutdown request we just raise an ERROR message
+	 * currently.
+	 */
+	if (ShutdownRequestPending)
+		o_worker_shutdown(ERROR);
+}


### PR DESCRIPTION
Since OrioleDB background workers redefine SIGTERM handler they might get stuck when sleeping on ConditionVariable. This commit uses global ShutdownRequestPending variable instead of local
`detached`, `shutdown_requested` variables. Currently it is used by recovery, s3 and bgwriter workers.
Now we check for ShutdownRequestPending when sleeping on ConditionVariable to interrupt if necessary.

There still cases in S3 functions where it isn't checked, it might be fixed later.

The PR is based on https://github.com/orioledb/orioledb/pull/503 and therefore #503 should be merged first.

Issue https://github.com/orioledb/orioledb/issues/502.