### PR TITLE
Issue #508: Rely on autovacuum to clean up orphaned temp tables

### DIFF
--- a/include/catalog/o_tables.h
+++ b/include/catalog/o_tables.h
@@ -145,7 +145,7 @@ extern void o_tables_drop_all(OXid oxid, CommitSeqNo csn, Oid database_id);
 extern void o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid type_oid);
 
 /* Drops all temporary tables that left after crash */
-extern void o_tables_drop_all_temporary(void);
+extern void o_tables_truncate_all_unlogged(void);
 
 /* Adds a new table to o_tables list */
 extern bool o_tables_add(OTable *table, OXid oxid, CommitSeqNo csn);

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -2064,7 +2064,7 @@ orioledb_snapshot_hook(Snapshot snapshot)
 	if (*was_in_recovery &&
 		!pg_atomic_exchange_u32(after_recovery_cleaned, true))
 	{
-		o_tables_drop_all_temporary();
+		o_tables_truncate_all_unlogged();
 	}
 
 	for (i = 0; i < (int) UndoLogsCount; i++)


### PR DESCRIPTION
Because OrioleDB tried to clean up orphaned temp tables by itself, it could create inconsistency in metadata between PostgreSQL and OrioleDB catalogs. To avoid that we rely on PostgreSQL autovacuum which cleans up orphaned temp tables already.

Fixes #508 
Possibly fixes #507 