### PR TITLE
do not fsync truncate on temp tables

### DIFF
--- a/include/btree/io.h
+++ b/include/btree/io.h
@@ -32,7 +32,7 @@ extern int	assign_io_num(OInMemoryBlkno blkno, OffsetNumber offnum);
 extern OWalkPageResult walk_page(OInMemoryBlkno blkno, bool evict);
 extern void unlock_io(int ionum);
 extern void wait_for_io_completion(int ionum);
-extern bool cleanup_btree_files(Oid datoid, Oid relnode);
+extern bool cleanup_btree_files(Oid datoid, Oid relnode, bool fsync);
 extern bool fsync_btree_files(Oid datoid, Oid relnode);
 extern int	OFileRead(File file, char *buffer, int amount, off_t offset,
 					  uint32 wait_event_info);

--- a/include/tableam/handler.h
+++ b/include/tableam/handler.h
@@ -124,7 +124,7 @@ get_ea_counters(OrioleDBPageDesc *desc)
 			ix_counter->evict++; \
 	}
 
-extern void cleanup_btree(Oid datoid, Oid relnode, bool files);
+extern void cleanup_btree(Oid datoid, Oid relnode, bool files, bool fsync);
 extern bool o_drop_shared_root_info(Oid datoid, Oid relnode);
 extern void o_tableam_descr_init(void);
 extern void o_invalidate_descrs(Oid datoid, Oid reloid, Oid relfilenode);

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -3065,16 +3065,18 @@ unlink_callback(const char *filename, uint32 segno, char *ext, void *arg)
 	 * data file.  So, we durably delete the first data file to evade
 	 * situation when partially deleted file data is visible.
 	 */
-	if (segno == 0 && ext == NULL)
+	bool		fsync = *(bool *) arg;
+
+	if (segno == 0 && ext == NULL && fsync)
 		durable_unlink(filename, ERROR);
 	else
 		unlink(filename);
 }
 
 bool
-cleanup_btree_files(Oid datoid, Oid relnode)
+cleanup_btree_files(Oid datoid, Oid relnode, bool fsync)
 {
-	return iterate_relnode_files(datoid, relnode, unlink_callback, NULL);
+	return iterate_relnode_files(datoid, relnode, unlink_callback, (void *) &fsync);
 }
 
 static void

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -758,7 +758,7 @@ check_pending_truncates(void)
 								   PENDING_TRUNCATES_FILENAME)));
 
 		for (i = 0; i < numTrees; i++)
-			cleanup_btree_files(relNodes[i].datoid, relNodes[i].relnode);
+			cleanup_btree_files(relNodes[i].datoid, relNodes[i].relnode, true);
 	}
 
 	pending_truncates_meta->pendingTruncatesLocation = 0;
@@ -856,7 +856,7 @@ btree_relnode_undo_callback(UndoLogType undoType, UndoLocation location,
 			o_tables_rel_lock_extended_no_inval(&dropTreeOids[i], AccessExclusiveLock, true);
 			if (doCleanup)
 			{
-				cleanup_btree(dropTreeOids[i].datoid, dropTreeOids[i].relnode, cleanupFiles);
+				cleanup_btree(dropTreeOids[i].datoid, dropTreeOids[i].relnode, cleanupFiles, true);
 				o_delete_chkp_num(dropTreeOids[i].datoid, dropTreeOids[i].relnode);
 				o_tablespace_cache_delete(dropTreeOids[i].datoid, dropTreeOids[i].relnode);
 			}

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -922,7 +922,7 @@ o_insert_shared_root_placeholder(Oid datoid, Oid relnode)
 }
 
 void
-cleanup_btree(Oid datoid, Oid relnode, bool files)
+cleanup_btree(Oid datoid, Oid relnode, bool files, bool fsync)
 {
 	SharedRootInfoKey key;
 	SharedRootInfo *shared = NULL;
@@ -945,7 +945,7 @@ cleanup_btree(Oid datoid, Oid relnode, bool files)
 		pfree(shared);
 	}
 	if (files)
-		cleanup_btree_files(key.datoid, key.relnode);
+		cleanup_btree_files(key.datoid, key.relnode, fsync);
 }
 
 bool


### PR DESCRIPTION
### Motivation

fsync is a costly operation, but there is no need to fsync truncate for temp tables as they will be freed anyway on session end.