### PR TITLE
Fix some of the cppcheck errors

### DIFF
--- a/ci/cppcheck-suppress
+++ b/ci/cppcheck-suppress
@@ -1,0 +1,5 @@
+redundantAssignment:*
+uselessAssignmentPtrArg:*
+incorrectStringBooleanError:*
+nullPointerRedundantCheck:*
+integerOverflowCond:*/atomics/generic.h

--- a/ci/static.sh
+++ b/ci/static.sh
@@ -12,15 +12,30 @@ if [ "$COMPILER" = "clang" ]; then
 		make USE_PGXS=1 IS_DEV=1 USE_ASSERT_CHECKING=1 || status=$?
 
 elif [ "$COMPILER" = "gcc" ]; then
+	# Collect all orioledb's include paths recursively
+	ORIOLEDB_INCLUDE_DIRS=$(find include -type d)
+
+	# Collect all PostgreSQL include paths recursively
+	PG_INCLUDE_DIRS=$(find "$(pg_config --includedir-server)" -type d)
+
+	# Combine and convert to -I flags
+	INCLUDE_FLAGS=$(for dir in $ORIOLEDB_INCLUDE_DIRS $PG_INCLUDE_DIRS; do echo -n "-I$dir "; done)
+
 	cppcheck \
 		--enable=warning,portability,performance \
-		--suppress=redundantAssignment \
-		--suppress=uselessAssignmentPtrArg \
-		--suppress=incorrectStringBooleanError \
-		--suppress=nullPointerRedundantCheck \
-		--std=c89 --inline-suppr --verbose src/*.c src/*/*.c include/*.h include/*/*.h 2> cppcheck.log
+		--suppressions-list=ci/cppcheck-suppress \
+		--std=c99 --inline-suppr --verbose \
+		-D__GNUC__ \
+		-D__x86_64__ \
+		-D__aarch64__ \
+		-D__arm \
+		-D__arm__ \
+		-DUSE_ASSERT_CHECKING \
+		$INCLUDE_FLAGS \
+		src/*.c src/*/*.c include/*.h include/*/*.h 2> cppcheck.log
 
 	if [ -s cppcheck.log ]; then
+		echo "cppcheck report:"
 		cat cppcheck.log
 		status=1 # error
 	fi

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -359,7 +359,7 @@ extern int	rewind_max_transactions;
 	 &oProcData[MYPROCNUMBER])
 #define O_GET_IN_MEMORY_PAGE(blkno) \
 	(AssertMacro(OInMemoryBlknoIsValid(blkno)), \
-	 (Page)(o_shared_buffers + ((uint64) (blkno)) * ((uint64) ORIOLEDB_BLCKSZ)))
+	 (Page)(o_shared_buffers + (((uint64) (blkno)) * ((uint64) ORIOLEDB_BLCKSZ))))
 #define O_GET_IN_MEMORY_PAGEDESC(blkno) \
 	(AssertMacro(OInMemoryBlknoIsValid(blkno)), page_descs + (blkno))
 #define O_GET_IN_MEMORY_PAGE_CHANGE_COUNT(blkno) \

--- a/src/btree/fastpath.c
+++ b/src/btree/fastpath.c
@@ -597,6 +597,7 @@ float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 
 	for (i = *lower; i < *upper; i++)
 	{
+		/* cppcheck-suppress invalidPointerCast */
 		float4		value = *((float4 *) p);
 
 		if (value == key && !lowerSet)
@@ -629,6 +630,7 @@ float8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 
 	for (i = *lower; i < *upper; i++)
 	{
+		/* cppcheck-suppress invalidPointerCast */
 		float8		value = *((float8 *) p);
 
 		if (value == key && !lowerSet)

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1415,7 +1415,6 @@ load_page(OBTreeFindPageContext *context)
 			chkpNum = S3_GET_CHKP_NUM(page_desc->fileExtent.off);
 
 		ereport(ERROR, (errcode_for_file_access(),
-		/* cppcheck-suppress unknownMacro */
 						errmsg("could not read page with file offset " UINT64_FORMAT " from %s: %m",
 							   DOWNLINK_GET_DISK_OFF(downlink),
 							   btree_smgr_filename(desc, DOWNLINK_GET_DISK_OFF(downlink), chkpNum))));

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -182,6 +182,7 @@ o_btree_find_tuple_by_key_cb(BTreeDescr *desc, void *key,
 				else
 				{
 					O_TUPLE_SET_NULL(result);
+					/* cppcheck-suppress uninitvar */
 					return result;
 				}
 			}

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -88,7 +88,7 @@ my_locked_page_del(OInMemoryBlkno blkno)
 	int			i = get_my_locked_page_index(blkno);
 	uint32		state;
 
-	Assert(i >= 0);
+	Assert(i >= 0 && i < MAX_PAGES_PER_PROCESS);
 	state = myLockedPages[i].state;
 	myLockedPages[i] = myLockedPages[--numberOfMyLockedPages];
 
@@ -100,7 +100,7 @@ my_locked_page_get_state(OInMemoryBlkno blkno)
 {
 	int			i = get_my_locked_page_index(blkno);
 
-	Assert(i >= 0);
+	Assert(i >= 0 && i < MAX_PAGES_PER_PROCESS);
 	return myLockedPages[i].state;
 }
 

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -687,15 +687,10 @@ void
 check_pending_truncates(void)
 {
 	uint64		offset;
-	uint64		length;
 	uint64		maxOffset;
-	ORelOids	relOids;
-	int			numTrees;
 	ORelOids   *relNodes = NULL;
 	int			relNodesAllocated = 0;
 	File		pendingTruncatesFile;
-
-	ORelOidsSetInvalid(relOids);
 
 	if (have_backup_in_progress() || pending_truncates_meta->pendingTruncatesLocation == 0)
 		return;
@@ -721,7 +716,9 @@ check_pending_truncates(void)
 	maxOffset = pending_truncates_meta->pendingTruncatesLocation;
 	while (offset < maxOffset)
 	{
-		int			i;
+		uint64		length;
+		int			numTrees;
+		ORelOids	relOids;
 
 		length = sizeof(relOids);
 		if (FileRead(pendingTruncatesFile, (Pointer) &relOids, length, offset,
@@ -757,7 +754,7 @@ check_pending_truncates(void)
 							errmsg("could not read pending truncates file %s: %m",
 								   PENDING_TRUNCATES_FILENAME)));
 
-		for (i = 0; i < numTrees; i++)
+		for (int i = 0; i < numTrees; i++)
 			cleanup_btree_files(relNodes[i].datoid, relNodes[i].relnode, true);
 	}
 

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -1516,6 +1516,7 @@ o_alter_column_type(AlterTableCmd *cmd, const char *queryString, Relation rel)
 		attnum = get_attnum(RelationGetRelid(rel), cmd->name);
 		alter_type_exprs =
 			lappend(alter_type_exprs,
+		/* cppcheck-suppress unknownEvaluationOrder */
 					list_make2(makeInteger(attnum), cooked_default));
 	}
 }
@@ -1757,6 +1758,7 @@ ATColumnChangeRequiresRewrite(OTableField *old_field, OTableField *field,
 	if (expr != NULL)
 	{
 		if (append_transform)
+			/* cppcheck-suppress unknownEvaluationOrder */
 			alter_type_exprs = lappend(alter_type_exprs, list_make2(makeInteger(subId), expr));
 		assign_expr_collations(pstate, expr);
 		expr = (Node *) expression_planner((Expr *) expr);
@@ -2785,6 +2787,7 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 							foundDep->deptype == DEPENDENCY_PARTITION_SEC)
 						{
 							partition_drop_index_list = list_append_unique(partition_drop_index_list,
+							/* cppcheck-suppress unknownEvaluationOrder */
 																		   list_make2_oid(rel->rd_rel->oid,
 																						  rel->rd_index->indrelid));
 							break;

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -243,10 +243,15 @@ recreate_o_table(OTable *old_o_table, OTable *o_table)
 	OXid		oxid;
 	int			oldTreeOidsNum,
 				newTreeOidsNum;
-	ORelOids	oldOids = old_o_table->oids,
+	ORelOids	oldOids,
 			   *oldTreeOids,
-				newOids = o_table->oids,
+				newOids,
 			   *newTreeOids;
+
+	Assert(old_o_table != NULL && o_table != NULL);
+
+	oldOids = old_o_table->oids;
+	newOids = o_table->oids;
 
 	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
 
@@ -399,10 +404,14 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 	uint8		fillfactor = BTREE_DEFAULT_FILLFACTOR;
 	OBTOptions *options;
 
+	Assert(index == NULL || !(OidIsValid(indoid)));
+
 	if (OidIsValid(indoid))
 		index = index_open(indoid, AccessShareLock);
 
 	ORelOidsSetFromRel(oids, heap);
+
+	Assert(index != NULL);
 
 	options = (OBTOptions *) index->rd_options;
 
@@ -2022,6 +2031,8 @@ o_find_ix_num_by_name(OTableDescr *descr, char *ix_name)
 {
 	OIndexNumber result = InvalidIndexNumber;
 	int			i;
+
+	Assert(descr != NULL);
 
 	for (i = 0; i < descr->nIndices; i++)
 	{

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -308,6 +308,7 @@ make_primary_o_index(OTable *table)
 				result->nIncludedFields--;
 
 			/* (fieldnum, original fieldnum) */
+			/* cppcheck-suppress unknownEvaluationOrder */
 			duplicate = list_make2_int(nadded, found_attnum);
 			result->duplicates = lappend(result->duplicates, duplicate);
 			continue;
@@ -353,8 +354,9 @@ add_index_fields(OIndex *index, OTable *table, OTableIndex *tableIndex, int *nad
 					else
 						index->nIncludedFields--;
 
-					Assert(CurrentMemoryContext == OGetIndexContext(index));
+					Assert(CurrentMemoryContext == index->index_mctx);
 					/* (fieldnum, original fieldnum) */
+					/* cppcheck-suppress unknownEvaluationOrder */
 					duplicate = list_make2_int(*nadded, found_attnum);
 					index->duplicates = lappend(index->duplicates, duplicate);
 				}
@@ -558,6 +560,8 @@ make_bridge_o_index(OTable *table)
 void
 free_o_index(OIndex *o_index)
 {
+	Assert(o_index != NULL);
+
 	pfree(o_index->leafTableFields);
 	pfree(o_index->leafFields);
 	if (o_index->index_mctx)
@@ -863,6 +867,8 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, OTable *oTable)
 	ListCell   *lc;
 	MemoryContext mcxt,
 				old_mcxt;
+
+	Assert(oIndex != NULL);
 
 	memset(descr, 0, sizeof(*descr));
 	descr->oids = oIndex->indexOids;

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -1168,6 +1168,8 @@ o_table_free(OTable *table)
 {
 	int			i;
 
+	Assert(table != NULL);
+
 	for (i = 0; i < table->nindices; i++)
 	{
 		if (table->indices[i].index_mctx)
@@ -1637,7 +1639,7 @@ serialize_o_table(OTable *o_table, int *size)
 	StringInfoData str;
 	int			i;
 
-	Assert(o_table->data_version == ORIOLEDB_DATA_VERSION);
+	Assert(o_table != NULL && o_table->data_version == ORIOLEDB_DATA_VERSION);
 	initStringInfo(&str);
 	appendBinaryStringInfo(&str, (Pointer) o_table,
 						   offsetof(OTable, indices));

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -3123,11 +3123,14 @@ checkpoint_fix_split_and_lock_page(BTreeDescr *descr, CheckpointState *state,
 			O_GET_IN_MEMORY_PAGE_CHANGE_COUNT(*blkno) != page_chage_count)
 			break;
 
+		Assert(level >= 0 && level < ORIOLEDB_MAX_DEPTH);
+
 		if (o_btree_split_is_incomplete(*blkno, &relocked))
 		{
 			o_btree_split_fix_and_unlock(descr, *blkno);
 			checkpoint_reserve_undo(descr->undoType, false);
 		}
+		/* cppcheck-suppress arrayIndexOutOfBoundsCond */
 		else if (!(level > 0 && *blkno == state->stack[level].hikeyBlkno) &&
 				 is_page_too_sparse(descr, O_GET_IN_MEMORY_PAGE(*blkno)))
 		{

--- a/src/rewind/rewind.c
+++ b/src/rewind/rewind.c
@@ -807,6 +807,7 @@ cleanup_rewind_files(OBuffersDesc *desc, uint32 tag)
 	while (true)
 	{
 		pg_snprintf(curFileName, MAXPGPATH,
+		/* cppcheck-suppress arrayIndexOutOfBoundsCond */
 					desc->filenameTemplate[tag],
 					(uint32) (fileNum >> 32),
 					(uint32) fileNum);

--- a/src/s3/checkpoint.c
+++ b/src/s3/checkpoint.c
@@ -329,6 +329,8 @@ s3_backup_scan_dir(S3BackupState *state, const char *path,
 	const char *lastDir = NULL; /* Split last dir from parent path. */
 	bool		isDbDir = false;	/* Does this directory contain relations? */
 
+	Assert(path != NULL);
+
 	/*
 	 * Determine if the current path is a database directory that can contain
 	 * relations.
@@ -343,7 +345,6 @@ s3_backup_scan_dir(S3BackupState *state, const char *path,
 		strspn(lastDir + 1, "0123456789") == strlen(lastDir + 1))
 	{
 		/* Part of path that contains the parent directory. */
-		/* cppcheck-suppress uninitvar */
 		int			parentPathLen = lastDir - path;
 
 		/*

--- a/src/s3/checksum.c
+++ b/src/s3/checksum.c
@@ -102,7 +102,7 @@ initHashTable(S3ChecksumState *state, const char *filename)
 	{
 		S3FileChecksum fileEntry;
 
-		if (sscanf(buf.data, "FILE: %1023[^,], CHECKSUM: %64[^,], CHECKPOINT: %d",
+		if (sscanf(buf.data, "FILE: %1023[^,], CHECKSUM: %64[^,], CHECKPOINT: %u",
 				   fileEntry.filename, fileEntry.checksum, &fileEntry.checkpointNumber) == 3)
 		{
 			char		key[MAXPGPATH];

--- a/src/s3/control.c
+++ b/src/s3/control.c
@@ -81,7 +81,6 @@ s3_check_control(const char **errmsgp, const char **errdetailp)
 		*errmsgp = psprintf("OrioleDB and the S3 bucket have files from "
 							"different instances and they are incompatible with "
 							"each other");
-		/* cppcheck-suppress unknownMacro */
 		*errdetailp = psprintf("OrioleDB control identifier " UINT64_FORMAT
 							   " differs from the S3 bucket identifier " UINT64_FORMAT,
 							   control.controlIdentifier,

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -1228,14 +1228,16 @@ o_find_comparator(Oid opfamily, Oid lefttype, Oid righttype, Oid collation)
 static OComparator *
 o_find_opclass_comparator(OOpclass *opclass, Oid collation)
 {
-	OComparatorKey key = {
-		.opfamily = opclass->opfamily,
-		.lefttype = opclass->inputtype,
-		.righttype = opclass->inputtype,
-		.collation = collation
-	};
+	OComparatorKey key;
 	OComparator *result;
 	OComparator comparator;
+
+	Assert(opclass != NULL);
+
+	key.opfamily = opclass->opfamily,
+		key.lefttype = opclass->inputtype,
+		key.righttype = opclass->inputtype,
+		key.collation = collation;
 
 	/*
 	 * At first, try to find existing comparator in cache.

--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -237,7 +237,6 @@ print_unloaded_tree(StringInfoData *buf, BTreeDescr *td, const char *treeName,
 		appendStringInfo(buf, "datoid = %d, relnode = %d, ",
 						 td->oids.datoid, td->oids.relnode);
 		if (DiskDownlinkIsValid(file_header.rootDownlink))
-			/* cppcheck-suppress unknownMacro */
 			appendStringInfo(buf, "rootOffset = " UINT64_FORMAT ", %u",
 							 DOWNLINK_GET_DISK_OFF(file_header.rootDownlink),
 							 DOWNLINK_GET_DISK_LEN(file_header.rootDownlink));
@@ -928,7 +927,7 @@ log_btree(BTreeDescr *desc)
 
 		for (i = 0; i < opaque.keyDesc->natts; i++)
 		{
-			Oid			output;
+			Oid			output = InvalidOid;
 			bool		varlena;
 
 			for (j = 0; j < sizeof(typeoids) / sizeof(typeoids[0]); j++)
@@ -1525,6 +1524,8 @@ fetch_index_descr_by_oid(Oid relid)
 	OTableDescr *descr;
 	OIndexNumber ixnum;
 	bool		index = false;
+
+	ORelOidsSetInvalid(idxOids);
 
 	rel = relation_open(relid, AccessShareLock);
 	if (rel->rd_rel->relkind == RELKIND_INDEX)

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -2091,6 +2091,8 @@ static const TableAmRoutine orioledb_am_methods = {
 bool
 is_orioledb_rel(Relation rel)
 {
+	Assert(rel != NULL);
+
 	return (rel->rd_tableam == (TableAmRoutine *) &orioledb_am_methods);
 }
 
@@ -2119,6 +2121,8 @@ relation_get_descr(Relation rel)
 {
 	OTableDescr *result;
 	ORelOids	oids;
+
+	Assert(rel != NULL);
 
 	ORelOidsSetFromRel(oids, rel);
 	if (!is_orioledb_rel(rel))

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -435,6 +435,7 @@ o_index_scan_getnext(OTableDescr *descr, OScanState *ostate,
 			if (so->numArrayKeys < 0)
 			{
 				O_TUPLE_SET_NULL(tup);
+				/* cppcheck-suppress uninitvar */
 				return tup;
 			}
 

--- a/src/tableam/key_bitmap.c
+++ b/src/tableam/key_bitmap.c
@@ -55,9 +55,13 @@ o_keybitmap_insert(RBTree *rbtree, uint64 value)
 	OKeyBitmapRBTNode node;
 	bool		is_new;
 
+	/*
+	 * For the moment, fill only the fields of node that will be looked at by
+	 * bm_rbt_combiner or bt_rbt_comparator.
+	 */
 	node.key = value;
 	node.bitmap = NULL;
-	(void) rbt_insert(rbtree, &node.rbtnode, &is_new);
+	(void) rbt_insert(rbtree, (RBTNode *) &node, &is_new);
 }
 
 bool
@@ -66,9 +70,13 @@ o_keybitmap_test(RBTree *rbtree, uint64 value)
 	OKeyBitmapRBTNode node;
 	OKeyBitmapRBTNode *found;
 
+	/*
+	 * For the moment, fill only the fields of node that will be looked at by
+	 * bt_rbt_comparator.
+	 */
 	node.key = value;
 	node.bitmap = NULL;
-	found = (OKeyBitmapRBTNode *) rbt_find(rbtree, &node.rbtnode);
+	found = (OKeyBitmapRBTNode *) rbt_find(rbtree, (RBTNode *) &node);
 	if (!found)
 		return false;
 
@@ -104,11 +112,15 @@ o_keybitmap_range_is_valid(RBTree *rbtree, uint64 low, uint64 high)
 	{
 		bool		skip_step = false;
 
+		/*
+		 * For the moment, fill only the fields of node that will be looked at
+		 * by bt_rbt_comparator.
+		 */
 		lowNode.key = low;
 		lowNode.bitmap = NULL;
 
 		node = (OKeyBitmapRBTNode *) rbt_find_great(rbtree,
-													&lowNode.rbtnode,
+													(RBTNode *) &lowNode,
 													true);
 		if (!node)
 			break;
@@ -204,10 +216,14 @@ o_keybitmap_get_next(RBTree *rbtree, uint64 prev, bool *found)
 	OKeyBitmapRBTNode *node;
 	RBTreeIterator iter;
 
+	/*
+	 * For the moment, fill only the fields of node that will be looked at by
+	 * bt_rbt_comparator.
+	 */
 	lowNode.key = prev;
 	lowNode.bitmap = NULL;
 	node = (OKeyBitmapRBTNode *) rbt_find_great(rbtree,
-												&lowNode.rbtnode,
+												(RBTNode *) &lowNode,
 												true);
 	if (!node)
 	{

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -1063,6 +1063,8 @@ o_update_secondary_index(OIndexDescr *id,
 	BTreeModifyCallbackInfo callbackInfo = nullCallbackInfo;
 
 	slot_getallattrs(oldSlot);
+
+	memset(&res, 0, sizeof(res));
 	res.success = true;
 	res.oldTuple = oldSlot;
 
@@ -1134,6 +1136,7 @@ o_tbl_indices_overwrite(OTableDescr *descr,
 		.arg = arg
 	};
 
+	memset(&result, 0, sizeof(result));
 	result.success = true;
 	result.oldTuple = NULL;
 
@@ -1212,6 +1215,7 @@ o_tbl_indices_reinsert(OTableDescr *descr,
 		.arg = newSlot
 	};
 
+	memset(&result, 0, sizeof(result));
 	result.success = true;
 	result.oldTuple = NULL;
 
@@ -1299,6 +1303,7 @@ o_tbl_index_delete(OIndexDescr *id, OIndexNumber ix_num, TupleTableSlot *slot,
 						 oxid, csn, RowLockUpdate,
 						 NULL, &callbackInfo);
 
+	memset(&result, 0, sizeof(result));
 	result.success = (res == OBTreeModifyResultDeleted) || marg.deleted;
 	if (!result.success)
 	{
@@ -1326,6 +1331,7 @@ o_tbl_indices_delete(OTableDescr *descr, OBTreeKeyBound *key,
 		.arg = arg
 	};
 
+	memset(&result, 0, sizeof(result));
 	result.oldTuple = NULL;
 
 	o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
@@ -1855,6 +1861,7 @@ o_lock_wait_callback(BTreeDescr *descr, OTuple tup, OTuple *newtup,
 					(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
 					 errmsg("could not obtain lock on row in relation \"%s\"",
 							RelationGetRelationName(o_arg->rel))));
+			/* cppcheck-suppress missingReturn */
 			break;
 		default:
 			elog(ERROR, "Unknown wait policy: %u", o_arg->waitPolicy);

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -485,6 +485,7 @@ o_plan_custom_path(PlannerInfo *root, RelOptInfo *rel,
 
 		custom_scan->custom_exprs = NIL;
 		custom_scan->custom_private =
+		/* cppcheck-suppress unknownEvaluationOrder */
 			list_make4(makeInteger(O_IndexPlan),
 					   makeInteger(ix_path->ix_num),
 					   makeInteger(ix_path->scandir),
@@ -501,6 +502,7 @@ o_plan_custom_path(PlannerInfo *root, RelOptInfo *rel,
 
 		Assert(primary->nFields == 1);
 		custom_scan->custom_private =
+		/* cppcheck-suppress unknownEvaluationOrder */
 			list_make2(makeInteger(O_BitmapHeapPlan),
 					   makeInteger(primary->fields[0].inputtype));
 	}

--- a/src/tableam/vacuum.c
+++ b/src/tableam/vacuum.c
@@ -1087,6 +1087,7 @@ lazy_scan_bridge_index(LVRelState *vacrel)
 			{
 				Assert(tupHdr->deleted == BTreeLeafTupleDeleted);
 
+				/* cppcheck-suppress unknownEvaluationOrder */
 				iptr = DatumGetItemPointer(o_fastgetattr(tup, 1, bridge->leafTupdesc, &bridge->leafSpec, &isnull));
 				add_dead_item(vacrel, iptr);
 				vacrel->lpdead_items++;

--- a/src/tuple/toast.c
+++ b/src/tuple/toast.c
@@ -147,8 +147,11 @@ o_toast_cmp(BTreeDescr *desc,
 	{
 		bool		null;
 
+		/* cppcheck-suppress unknownEvaluationOrder */
 		attnum1 = DatumGetInt16(o_fastgetattr(pk1, pkAttnum + ATTN_POS, toastd->nonLeafTupdesc, &toastd->nonLeafSpec, &null));
 		Assert(!null);
+
+		/* cppcheck-suppress unknownEvaluationOrder */
 		chunknum1 = DatumGetInt32(o_fastgetattr(pk1, pkAttnum + CHUNKN_POS, toastd->nonLeafTupdesc, &toastd->nonLeafSpec, &null));
 		Assert(!null);
 	}
@@ -162,8 +165,11 @@ o_toast_cmp(BTreeDescr *desc,
 	{
 		bool		null;
 
+		/* cppcheck-suppress unknownEvaluationOrder */
 		attnum2 = DatumGetInt16(o_fastgetattr(pk2, pkAttnum + ATTN_POS, toastd->nonLeafTupdesc, &toastd->nonLeafSpec, &null));
 		Assert(!null);
+
+		/* cppcheck-suppress unknownEvaluationOrder */
 		chunknum2 = DatumGetInt32(o_fastgetattr(pk2, pkAttnum + CHUNKN_POS, toastd->nonLeafTupdesc, &toastd->nonLeafSpec, &null));
 		Assert(!null);
 	}

--- a/src/utils/planner.c
+++ b/src/utils/planner.c
@@ -428,6 +428,7 @@ o_process_functions_in_node(Node *node,
 				{
 					functionId = get_opcode(lfirst_oid(opid));
 					inputcollid = lfirst_oid(collid);
+					/* cppcheck-suppress unknownEvaluationOrder */
 					args = list_make2(lfirst(larg),
 									  lfirst(rarg));
 

--- a/src/utils/stopevent.c
+++ b/src/utils/stopevent.c
@@ -29,6 +29,7 @@
 #include "utils/jsonpath.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/stopevents_data.h"
 
 #define QUERY_BUFFER_SIZE 1024
 
@@ -50,10 +51,6 @@ MemoryContext stopevents_cxt = NULL;
 PG_FUNCTION_INFO_V1(pg_stopevent_set);
 PG_FUNCTION_INFO_V1(pg_stopevent_reset);
 PG_FUNCTION_INFO_V1(pg_stopevents);
-
-static const char *const stopeventnames[] = {
-#include "utils/stopevents_data.h"
-};
 
 Size
 StopEventShmemSize(void)

--- a/stopevents_gen.py
+++ b/stopevents_gen.py
@@ -22,7 +22,9 @@ f.close()
 f = open('include/utils/stopevents_data.h', 'w')
 f.write('/* Generated file, see stopevents_gen.py */\n\n')
 
-for e in event_names:
+f.write('static const char *const stopeventnames[] = {')
+for i, e in enumerate(event_names):
 	f.write(f'"{e}",\n')
+f.write('};')
 
 f.close()


### PR DESCRIPTION
- Put generated `stopeventnames` array into `stopevents_data.h` completely to avoid syntax error by cppcheck
- Fix some cppcheck errors
- Suppress `integerOverflowCond:*/atomics/generic.h`
- Suppress many `unknownEvaluationOrder`
- Include OrioleDB and PostgreSQL headers recursively
- Limit possible paths by `-D` option specifying supported platforms