### PR TITLE
Consider On-Disk TOAST values from HEAP tables

### DIFF
--- a/include/tuple/toast.h
+++ b/include/tuple/toast.h
@@ -205,6 +205,8 @@ o_get_src_size(Datum value)
 		memcpy(&ote, VARDATA_EXTERNAL(DatumGetPointer(value)), O_TOAST_EXTERNAL_SZ);
 		return ote.toasted_size;
 	}
+	else if (VARATT_IS_EXTERNAL_ONDISK(value))
+		return toast_datum_size(value) + VARHDRSZ;
 	else if (VARATT_IS_EXTERNAL(value))
 		return toast_datum_size(value);
 	else

--- a/src/tuple/slot.c
+++ b/src/tuple/slot.c
@@ -1249,7 +1249,8 @@ tts_orioledb_toast(TupleTableSlot *slot, OTableDescr *descr)
 	{
 		att = TupleDescAttr(tupdesc, i);
 		if (att->attlen <= 0 && !slot->tts_isnull[i]
-			&& VARATT_IS_EXTERNAL_ORIOLEDB(slot->tts_values[i]))
+			&& (VARATT_IS_EXTERNAL_ONDISK(slot->tts_values[i]) ||
+				VARATT_IS_EXTERNAL_ORIOLEDB(slot->tts_values[i])))
 			has_toasted = true;
 	}
 
@@ -1293,7 +1294,8 @@ tts_orioledb_toast(TupleTableSlot *slot, OTableDescr *descr)
 		if (slot->tts_isnull[toast_attn])
 			continue;
 
-		if (VARATT_IS_EXTERNAL_ORIOLEDB(slot->tts_values[toast_attn]))
+		if (VARATT_IS_EXTERNAL_ONDISK(slot->tts_values[toast_attn]) ||
+			VARATT_IS_EXTERNAL_ORIOLEDB(slot->tts_values[toast_attn]))
 		{
 			oslot->to_toast[toast_attn] = ORIOLEDB_TO_TOAST_ON;
 			to_toastn++;

--- a/test/expected/toast.out
+++ b/test/expected/toast.out
@@ -1287,6 +1287,49 @@ SELECT orioledb_tbl_structure('o_test2'::regclass, 'nue');
 
 DROP TABLE o_test1;
 DROP TABLE o_test2;
+-- Copy from heap table
+CREATE TABLE h_test1
+(
+	id integer PRIMARY KEY,
+	val text
+) USING heap;
+INSERT INTO h_test1 VALUES (1, generate_string(1, 4000));
+CREATE TABLE o_test2
+(
+	id integer PRIMARY KEY,
+	val text
+) USING orioledb;
+INSERT INTO o_test2 (SELECT * FROM h_test1);
+SELECT id, length(val), substr(val, 1, 20) FROM o_test2;
+ id | length |        substr        
+----+--------+----------------------
+  1 |   4000 | 551e8b15be547418fbf5
+(1 row)
+
+SELECT orioledb_tbl_structure('o_test2'::regclass, 'nue');
+                                         orioledb_tbl_structure                                         
+--------------------------------------------------------------------------------------------------------
+ Index o_test2_pkey contents                                                                           +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                                                   +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty                                   +
+     Leftmost, Rightmost                                                                               +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                                            +
+     Item 0: offset = 264, tuple = ('1', TOASTed)                                                      +
+                                                                                                       +
+ Index toast contents                                                                                  +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0                                                  +
+ state = free, datoid equal, relnode equal, ix_type = toast, dirty                                     +
+     Leftmost, Rightmost                                                                               +
+   Chunk 0: offset = 0, location = 256, hikey location = 64, hikey = (PK: ('1'), attnum 2, chunknum 1) +
+     Item 0: offset = 264, tuple = (PK: ('1'), attnum 2, chunknum 0, data_length 2657)                 +
+   Chunk 1: offset = 1, location = 2968, hikey location = 80                                           +
+     Item 1: offset = 2976, tuple = (PK: ('1'), attnum 2, chunknum 1, data_length 1347)                +
+                                                                                                       +
+ 
+(1 row)
+
+DROP TABLE h_test1;
+DROP TABLE o_test2;
 ----
 -- TOAST logical decoding
 ----

--- a/test/sql/toast.sql
+++ b/test/sql/toast.sql
@@ -519,6 +519,27 @@ SELECT orioledb_tbl_structure('o_test2'::regclass, 'nue');
 DROP TABLE o_test1;
 DROP TABLE o_test2;
 
+-- Copy from heap table
+CREATE TABLE h_test1
+(
+	id integer PRIMARY KEY,
+	val text
+) USING heap;
+INSERT INTO h_test1 VALUES (1, generate_string(1, 4000));
+
+CREATE TABLE o_test2
+(
+	id integer PRIMARY KEY,
+	val text
+) USING orioledb;
+INSERT INTO o_test2 (SELECT * FROM h_test1);
+
+SELECT id, length(val), substr(val, 1, 20) FROM o_test2;
+SELECT orioledb_tbl_structure('o_test2'::regclass, 'nue');
+
+DROP TABLE h_test1;
+DROP TABLE o_test2;
+
 ----
 -- TOAST logical decoding
 ----


### PR DESCRIPTION
OrioleDB couldn't copy TOAST values from HEAP tables since it didn't treat theam correctly if TOAST values are VARATT_IS_EXTERNAL_ONDISK.

Issue https://github.com/orioledb/orioledb/issues/255