### PR TITLE
Issue #524: Fix bug of incorrectly indexing missing array for bridge index

### DIFF
--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -1066,8 +1066,8 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, OTable *oTable)
 		}
 		pg_qsort(descr->pk_tbl_field_map, descr->nFields, sizeof(AttrNumberMap), attrnumber_cmp);
 	}
-	MemoryContextSwitchTo(old_mcxt);
 	descr->econtext = CreateStandaloneExprContext();
+	MemoryContextSwitchTo(old_mcxt);
 
 	descr->maxTableAttnum = maxTableAttnum;
 

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -3792,6 +3792,18 @@ SELECT * FROM o_test_toast_with_bridged ORDER BY id;
 (2 rows)
 
 COMMIT;
+-- Test bug https://github.com/orioledb/orioledb/issues/524
+-- add a column to existing table
+CREATE TABLE IF NOT EXISTS refresh_tokens();
+ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS parent text;
+-- create a separate table with default value
+CREATE TABLE IF NOT EXISTS one_time_tokens (
+  token_hash text,
+  created_at timestamp without time zone NOT NULL DEFAULT now()
+);
+-- now create a hash index with bridge index
+CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx
+	ON one_time_tokens USING hash (token_hash);
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 10 other objects
@@ -3806,9 +3818,11 @@ drop cascades to table o_test_bridged_hash_btree_bitmap_scans
 drop cascades to table o_test_bridged_index_only_scan
 drop cascades to table o_test_toast_with_bridged
 DROP SCHEMA index_bridging CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to function btree_index_content(name)
 drop cascades to function hash_index_content(name)
 drop cascades to function gist_index_content(name)
 drop cascades to function generate_string(integer,integer)
+drop cascades to table refresh_tokens
+drop cascades to table one_time_tokens
 RESET search_path;

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -3731,6 +3731,18 @@ SELECT * FROM o_test_toast_with_bridged ORDER BY id;
 (2 rows)
 
 COMMIT;
+-- Test bug https://github.com/orioledb/orioledb/issues/524
+-- add a column to existing table
+CREATE TABLE IF NOT EXISTS refresh_tokens();
+ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS parent text;
+-- create a separate table with default value
+CREATE TABLE IF NOT EXISTS one_time_tokens (
+  token_hash text,
+  created_at timestamp without time zone NOT NULL DEFAULT now()
+);
+-- now create a hash index with bridge index
+CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx
+	ON one_time_tokens USING hash (token_hash);
 DROP EXTENSION pageinspect;
 ERROR:  extension "pageinspect" does not exist
 DROP EXTENSION orioledb CASCADE;
@@ -3746,5 +3758,8 @@ drop cascades to table o_test_bridged_hash_btree_bitmap_scans
 drop cascades to table o_test_bridged_index_only_scan
 drop cascades to table o_test_toast_with_bridged
 DROP SCHEMA index_bridging CASCADE;
-NOTICE:  drop cascades to function generate_string(integer,integer)
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to function generate_string(integer,integer)
+drop cascades to table refresh_tokens
+drop cascades to table one_time_tokens
 RESET search_path;

--- a/test/expected/index_bridging_2.out
+++ b/test/expected/index_bridging_2.out
@@ -3251,6 +3251,18 @@ SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
 (25 rows)
 
 COMMIT;
+-- Test bug https://github.com/orioledb/orioledb/issues/524
+-- add a column to existing table
+CREATE TABLE IF NOT EXISTS refresh_tokens();
+ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS parent text;
+-- create a separate table with default value
+CREATE TABLE IF NOT EXISTS one_time_tokens (
+  token_hash text,
+  created_at timestamp without time zone NOT NULL DEFAULT now()
+);
+-- now create a hash index with bridge index
+CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx
+	ON one_time_tokens USING hash (token_hash);
 DROP EXTENSION pageinspect;
 ERROR:  extension "pageinspect" does not exist
 DROP EXTENSION orioledb CASCADE;
@@ -3262,4 +3274,7 @@ drop cascades to table o_test_bitmap_scans
 drop cascades to table o_test_index_bridging_options
 drop cascades to table o_test_non_index_bridging_options
 DROP SCHEMA index_bridging CASCADE;
+NOTICE:  drop cascades to 2 other objects
+drop cascades to table refresh_tokens
+drop cascades to table one_time_tokens
 RESET search_path;

--- a/test/expected/index_bridging_3.out
+++ b/test/expected/index_bridging_3.out
@@ -3295,6 +3295,18 @@ SELECT * FROM o_test_non_index_bridging_options ORDER BY i;
 (25 rows)
 
 COMMIT;
+-- Test bug https://github.com/orioledb/orioledb/issues/524
+-- add a column to existing table
+CREATE TABLE IF NOT EXISTS refresh_tokens();
+ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS parent text;
+-- create a separate table with default value
+CREATE TABLE IF NOT EXISTS one_time_tokens (
+  token_hash text,
+  created_at timestamp without time zone NOT NULL DEFAULT now()
+);
+-- now create a hash index with bridge index
+CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx
+	ON one_time_tokens USING hash (token_hash);
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 6 other objects
@@ -3305,4 +3317,7 @@ drop cascades to table o_test_bitmap_scans
 drop cascades to table o_test_index_bridging_options
 drop cascades to table o_test_non_index_bridging_options
 DROP SCHEMA index_bridging CASCADE;
+NOTICE:  drop cascades to 2 other objects
+drop cascades to table refresh_tokens
+drop cascades to table one_time_tokens
 RESET search_path;

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -671,6 +671,19 @@ EXPLAIN (COSTS OFF) SELECT * FROM o_test_toast_with_bridged ORDER BY id;
 SELECT * FROM o_test_toast_with_bridged ORDER BY id;
 COMMIT;
 
+-- Test bug https://github.com/orioledb/orioledb/issues/524
+-- add a column to existing table
+CREATE TABLE IF NOT EXISTS refresh_tokens();
+ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS parent text;
+-- create a separate table with default value
+CREATE TABLE IF NOT EXISTS one_time_tokens (
+  token_hash text,
+  created_at timestamp without time zone NOT NULL DEFAULT now()
+);
+-- now create a hash index with bridge index
+CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx
+	ON one_time_tokens USING hash (token_hash);
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;


### PR DESCRIPTION
`o_tupdesc_load_constr()` incorrectly assumes that a bridge index is located after other user attributes. It is located in the beginning of attributes.

Issue https://github.com/orioledb/orioledb/issues/524