### PR TITLE
WIP: Docker CI/CD | new orioledb-check with regression and isolation tests.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -76,7 +76,6 @@ Dockerfile.ubuntu
 
 # Exclude OrioleDB Docker test definitions and code
 # as they are not needed inside the Docker image.
-test/
 ci/local_docker_matrix.sh
 ci/docker_matrix.sh
 

--- a/ci/check_docker.sh
+++ b/ci/check_docker.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+set -Eeo pipefail
+
+# Generate test status markers for tracking test execution
+generate_test_marker() {
+    local test_name="$1"
+    local marker_type="$2"  # "start" or "success"
+
+    # Convert test name to marker format (each char separated by superscript minus)
+    local marker_suffix=""
+    for (( i=0; i<${#test_name}; i++ )); do
+        local char="${test_name:$i:1}"
+        marker_suffix="${marker_suffix}${char}⁻"
+    done
+
+    # Choose marker symbol based on type
+    case "$marker_type" in
+        "start")
+            echo "▶${marker_suffix}"
+            ;;
+        "success")
+            echo "✓${marker_suffix}"
+            ;;
+        *)
+            echo "ERROR: Invalid marker type: $marker_type" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Print test status marker to stdout (will be captured in test logs)
+print_test_marker() {
+    local test_name="$1"
+    local marker_type="$2"
+    local marker=$(generate_test_marker "$test_name" "$marker_type")
+    echo "$marker"
+}
+
+show_help() {
+    cat << EOF
+
+OrioleDB Docker Test Runner
+==========================
+
+This script runs OrioleDB test targets (from the Makefile)
+inside a specialized Docker container.
+It supports multiple Linux distributions (Alpine, Debian, Ubuntu)
+and ensures a consistent testing environment for the OrioleDB PostgreSQL extension.
+
+Usage:
+  ./ci/check_docker.sh [OPTIONS] [TEST_TARGETS]
+
+Options:
+  --running MODE
+    The execution mode (required). Possible values:
+      init  - Perform only environment initialization.
+      test  - Run tests only.
+      all   - Perform both initialization and tests (default).
+
+Test Targets (optional):
+  A space-separated list of test targets. Examples:
+    installcheck
+    regresscheck
+    isolationcheck
+    testgrescheck
+    testgrescheck_part_1
+    testgrescheck_part_2
+
+  If no targets are specified, the script automatically chooses:
+    - "installcheck" if Python 3.10 or higher is available,
+    - "regresscheck isolationcheck" otherwise.
+
+Examples (run inside a Docker container, with /local_workspace/ mounted):
+  /local_workspace/ci/check_docker.sh --running init
+  /local_workspace/ci/check_docker.sh --running test 'installcheck'
+  /local_workspace/ci/check_docker.sh --running all  'regresscheck isolationcheck'
+
+EOF
+    exit 1
+}
+
+
+# Parse script arguments
+RUNNING_MODE="all"
+TEST_TARGETS=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --running)
+            RUNNING_MODE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        *)
+            TEST_TARGETS="$1"
+            shift
+            ;;
+    esac
+done
+
+# Validate the execution mode
+if [[ ! "$RUNNING_MODE" =~ ^(init|test|all)$ ]]; then
+    echo "Error: Invalid running mode '$RUNNING_MODE'."
+    show_help
+fi
+
+# Ensure we are inside a Docker container with the required environment variables
+# [ ! -f /.dockerenv ] ||
+if [ -z "$PG_MAJOR" ] || [ -z "$DOCKER_PG_LLVM_DEPS" ]; then
+    echo "------------------------------------------------"
+    echo "Error: This script must be run inside Docker with"
+    echo "       the required environment variables set."
+    echo "------------------------------------------------"
+    exit 1
+else
+    echo "Running in Docker environment."
+fi
+
+# Define workspace paths
+export LOCAL_WORKSPACE="/local_workspace"
+export TEST_WORKSPACE="/test_workspace"
+export GITHUB_JOB="check-docker"
+
+# Run initialization steps if mode is 'init' or 'all'
+if [[ "$RUNNING_MODE" == "init" || "$RUNNING_MODE" == "all" ]]; then
+    # Create necessary directories for testing
+    mkdir -p $TEST_WORKSPACE
+
+    # Switch to the local workspace (where the repository is mounted)
+    cd ${LOCAL_WORKSPACE}
+
+    # Display OS details and install required packages
+    cat /etc/os-release
+    bash --version
+    if grep -Eq '^ID=(ubuntu|debian)' /etc/os-release; then
+        echo "Detected Ubuntu/Debian. Installing test dependencies..."
+        export DEBIAN_FRONTEND=noninteractive
+        apt update
+        apt-get -y install --no-install-recommends \
+            make \
+            python3-venv
+        python3 -m venv --system-site-packages "$TEST_WORKSPACE/python3-venv"
+    elif grep -q '^ID=alpine' /etc/os-release; then
+        echo "Detected Alpine. Installing test dependencies..."
+        apk add --no-cache \
+            diffutils \
+            make \
+            python3 \
+            py3-cffi \
+            py3-psutil \
+            py3-virtualenv \
+            py3-pip
+        python3 -m venv --system-site-packages "$TEST_WORKSPACE/python3-venv"
+    elif grep -Eq '^ID=(arch|cachyos)' /etc/os-release; then
+        echo "Detected Arch/CachyOS. Installing test dependencies..."
+        pacman -Sy --noconfirm --noprogressbar || true
+        pacman -S --noconfirm --needed --noprogressbar \
+            make \
+            python \
+            python-pip \
+            diffutils \
+            which || true
+        # On Arch, 'python' provides venv; use 'python' explicitly.
+        python -m venv --system-site-packages "$TEST_WORKSPACE/python3-venv"
+    elif grep -q '^ID=fedora' /etc/os-release; then
+        echo "Detected Fedora. Installing test dependencies..."
+        dnf -y update || true
+        # TODO: not yet perfect.
+        dnf -y install \
+            make \
+            diffutils \
+            python3 \
+            python3-pip \
+            python3-devel \
+            gcc \
+            libffi-devel \
+            bison \
+            flex \
+            pkgconf-pkg-config \
+            readline-devel \
+            gdb \
+            perl-IPC-Run \
+            libicu-devel \
+            libcurl-devel \
+            openssl-devel \
+        || true
+        python3 -m venv --system-site-packages "$TEST_WORKSPACE/python3-venv"
+    else
+        echo "Unsupported OS. Exiting. (Please extend support if needed!)"
+        exit 1
+    fi
+
+    # Prepare test environment for the  'postgres' user
+    cd ${TEST_WORKSPACE}
+    rm -Rf ${TEST_WORKSPACE}/temp_orioledb
+    mkdir -p ${TEST_WORKSPACE}/temp_orioledb
+
+    # Copy orioledb test files to the test workspace
+    cd ${LOCAL_WORKSPACE}
+    cp -r ./test ./src ./sql ./include ./ci ${TEST_WORKSPACE}/temp_orioledb/
+    find . -maxdepth 1 -type f -exec cp {}  ${TEST_WORKSPACE}/temp_orioledb/ \;
+
+    # activate a Python virtual environment for additional test dependencies
+    # (This mimics the 'ci/post_build_prerequisites.sh' script.)
+    # shellcheck disable=SC1091
+    source "$TEST_WORKSPACE/python3-venv/bin/activate"
+    # Upgrade core Python packaging tools. On older distros (e.g., Alpine 3.12)
+    # the system 'packaging' is too old for latest setuptools, so upgrade it too.
+    python -m pip install --upgrade "pip>=23.1" "setuptools>=68" "wheel>=0.41" "packaging>=24"
+    # Avoid building cryptography/cffi from source on Alpine 3.12 (py38, musl):
+    # preinstall a wheel-only cryptography version known to provide musllinux wheels for cp38.
+    python -m pip install --only-binary=:all: "cryptography<42" || true
+    # Then install the rest of test deps, preferring wheels and using system-site cffi where possible.
+    python -m pip install --upgrade --prefer-binary psycopg2-binary six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
+    python -m pip freeze
+
+    # Grant ownership to the 'postgres' user
+    chown -R postgres:postgres "${TEST_WORKSPACE}"
+
+fi
+
+
+
+# Run tests if mode is 'test' or 'all'
+if [[ "$RUNNING_MODE" == "test" || "$RUNNING_MODE" == "all" ]]; then
+    # Determine which Makefile targets to run
+    MAKE_TARGETS=""
+    if [ -n "$TEST_TARGETS" ]; then
+        MAKE_TARGETS="$TEST_TARGETS"
+    else
+        # Default targets depend on Python version
+        if python3 -c "import sys; sys.exit(0) if sys.version_info >= (3, 12) else sys.exit(1)"; then
+            MAKE_TARGETS="regresscheck isolationcheck testgrescheck"
+        else
+            MAKE_TARGETS="regresscheck isolationcheck"
+        fi
+    fi
+
+    # Check if the test environment is properly set up
+    if [ ! -f "$TEST_WORKSPACE/python3-venv/bin/activate" ]; then
+        echo "Error: Test environment not found. Please run with '--running init' first."
+        exit 1
+    fi
+
+    echo "Running with targets: ${MAKE_TARGETS}"
+
+    # Parse individual test targets and print start markers
+    echo "Printing test status markers..."
+    for target in $MAKE_TARGETS; do
+        print_test_marker "$target" "start"
+    done
+
+    # Execute tests as the 'postgres' user - without installing the extension
+    trap 'echo "--- check_docker: FAILED : ${MAKE_TARGETS}"' ERR
+    CHECKCMD="  set -Eeo pipefail \
+        && cd ${TEST_WORKSPACE}/temp_orioledb \
+        && source $TEST_WORKSPACE/python3-venv/bin/activate \
+        && export PYTHONPATH=${TEST_WORKSPACE}/temp_orioledb:\$PYTHONPATH \
+        && make \
+            IS_DEV=1 \
+            NO_INSTALL=1 \
+            USE_PGXS=1 \
+            ${MAKE_TARGETS} \
+            -j$(nproc) \
+            LANG=C \
+            PGUSER=postgres \
+        && echo \'--- check_docker: OK : ${MAKE_TARGETS}\' \
+    "
+
+    echo "....Running tests as the 'postgres' user...."
+    if time su postgres -c "bash -c \"$CHECKCMD\""; then
+        # Tests completed successfully - print success markers
+        echo "Tests completed successfully. Printing success markers..."
+        for target in $MAKE_TARGETS; do
+            print_test_marker "$target" "success"
+        done
+    else
+        echo "Tests failed or were interrupted."
+        exit 1
+    fi
+
+fi

--- a/ci/check_docker.sh
+++ b/ci/check_docker.sh
@@ -212,7 +212,7 @@ if [[ "$RUNNING_MODE" == "init" || "$RUNNING_MODE" == "all" ]]; then
     # preinstall a wheel-only cryptography version known to provide musllinux wheels for cp38.
     python -m pip install --only-binary=:all: "cryptography<42" || true
     # Then install the rest of test deps, preferring wheels and using system-site cffi where possible.
-    python -m pip install --upgrade --prefer-binary psycopg2-binary six testgres moto[s3] flask flask_cors boto3 pyOpenSSL
+    python -m pip install --upgrade --prefer-binary psycopg2-binary six testgres==1.11.0 moto[s3] flask flask_cors boto3 pyOpenSSL
     python -m pip freeze
 
     # Grant ownership to the 'postgres' user

--- a/docker/Dockerfile.archlinux
+++ b/docker/Dockerfile.archlinux
@@ -1,0 +1,300 @@
+# Experimental only for testing!
+#
+# Arch Linux-based multi-stage image for OrioleDB + PostgreSQL
+
+# Base image configuration
+# BASE_IMAGE=archlinux
+# BASE_VERSION= [ latest base-devel ]
+# New recommended way:
+#   docker build --build-arg BASE_IMAGE=archlinux --build-arg BASE_VERSION=latest -f docker/Dockerfile.archlinux -t orioletest:archlinux-latest .
+ARG BASE_IMAGE=archlinux
+ARG BASE_VERSION=latest
+ARG BASE_OS=${BASE_IMAGE}:${BASE_VERSION}
+
+########################
+# Base updated stage
+########################
+FROM ${BASE_OS} AS base-updated
+
+# System update and keyring setup (shared by builder and runtime)
+RUN set -eux; \
+    # Initialize and populate keyring for package verification
+    pacman-key --init; \
+    pacman-key --populate archlinux; \
+    # Full system update with clean package cache
+    pacman -Syu --noconfirm --noprogressbar; \
+    # Aggressive cleanup for size optimization
+    pacman -Sc --noconfirm; \
+    rm -rf /var/cache/pacman/pkg/* /var/log/pacman.log /tmp/*
+
+########################
+# Builder stage
+########################
+FROM base-updated AS builder
+
+# Record build information (metadata)
+ARG BASE_OS
+ENV BASE_OS="${BASE_OS}"
+
+# Build-time settings
+ARG PG_MAJOR=17
+ENV PG_MAJOR=${PG_MAJOR}
+
+# set compiler: [ clang gcc ]
+ARG BUILD_CC_COMPILER=clang
+ENV BUILD_CC_COMPILER=${BUILD_CC_COMPILER}
+
+# Define build dependencies for LLVM (default system toolchain)
+ARG DOCKER_PG_LLVM_DEPS="llvm clang"
+ENV DOCKER_PG_LLVM_DEPS=${DOCKER_PG_LLVM_DEPS}
+
+# Enable to keep toolchain and sources around for debugging (larger image)
+ARG DEBUG_MODE=false
+ENV DEBUG_MODE=${DEBUG_MODE}
+
+# Create postgres user/group (uid/gid 999 similar to Debian-based image)
+RUN set -eux; \
+    groupadd -r postgres --gid=999 || groupadd -r postgres; \
+    useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres || \
+      useradd -r -g postgres --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+    mkdir -p /var/lib/postgresql; \
+    chown -R postgres:postgres /var/lib/postgresql
+
+# Install build-specific packages (build toolchain)
+RUN set -eux; \
+    # Generate en_US.UTF-8 locale BEFORE installing perl to avoid warnings
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen; \
+    locale-gen; \
+    # Install build essentials and development packages
+    pacman -S --noconfirm --noprogressbar --needed \
+      ca-certificates curl wget gnupg tzdata \
+      # Build essentials (base-devel includes make, gcc, etc.)
+      base-devel ${DOCKER_PG_LLVM_DEPS} \
+      # Build and runtime deps for PostgreSQL + OrioleDB
+      bison flex libxml2 libxslt icu lz4 zstd \
+      openldap openssl readline util-linux e2fsprogs \
+      tcl perl perl-ipc-run perl-test-harness python pkgconf \
+      # optional helpers
+      which git gdb \
+    ; \
+    # Cleanup build packages cache
+    pacman -Sc --noconfirm; \
+    rm -rf /var/cache/pacman/pkg/* /tmp/*
+
+# Set locale (now that en_US.UTF-8 is generated)
+ENV LANG=en_US.UTF-8
+
+# Ensure Arch core_perl tools (e.g., prove) are on PATH
+ENV PATH="${PATH}:/usr/bin/core_perl"
+
+# Install gosu in builder
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+    dpkgArch="$(uname -m)"; \
+    case "$dpkgArch" in \
+      x86_64) dpkgArch=amd64 ;; \
+      aarch64) dpkgArch=arm64 ;; \
+      armv7l|armv7) dpkgArch=armhf ;; \
+      ppc64le) dpkgArch=ppc64el ;; \
+      s390x) dpkgArch=s390x ;; \
+      *) echo "Unsupported arch: $dpkgArch" >&2; exit 1 ;; \
+    esac; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu --version; \
+    gosu nobody true
+
+# Prepare source tree and build
+RUN mkdir -p /usr/src/postgresql/contrib/orioledb
+COPY . /usr/src/postgresql/contrib/orioledb
+
+RUN set -eux; \
+    PGTAG=$(grep "^$PG_MAJOR: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+    ORIOLEDB_VERSION=$(grep "^#define ORIOLEDB_VERSION" /usr/src/postgresql/contrib/orioledb/include/orioledb.h | cut -d'"' -f2) ; \
+    ORIOLEDB_BUILDTIME=$(date -Iseconds) ; \
+    echo "PG_MAJOR=$PG_MAJOR" ; \
+    echo "PGTAG=$PGTAG" ; \
+    echo "BUILD_CC_COMPILER=$BUILD_CC_COMPILER" ; \
+    echo "ORIOLEDB_VERSION=$ORIOLEDB_VERSION" ; \
+    echo "ORIOLEDB_BUILDTIME=$ORIOLEDB_BUILDTIME" ; \
+    echo "DOCKER_PG_LLVM_DEPS=$DOCKER_PG_LLVM_DEPS" ; \
+    echo "DEBUG_MODE=$DEBUG_MODE" ; \
+    # Emit tool versions (compiler, zstd, python)
+    CC_BIN="$(command -v "${BUILD_CC_COMPILER}" || true)"; \
+    COMPILER_VER="unknown"; \
+    if [ -n "$CC_BIN" ]; then \
+      if "$CC_BIN" --version 2>/dev/null | head -n1 | grep -qi 'clang'; then \
+        v=$("$CC_BIN" --version 2>/dev/null | head -n1 | sed -E 's/.*clang version ([0-9]+(\.[0-9]+){1,2}).*/\1/'); \
+        [ -n "$v" ] || v=$("$CC_BIN" --version 2>/dev/null | head -n1 | grep -oE '[0-9]+(\.[0-9]+){1,2}'); \
+        COMPILER_VER="clang${v}"; \
+      else \
+        v=$("$CC_BIN" -dumpfullversion 2>/dev/null || "$CC_BIN" -dumpversion 2>/dev/null || true); \
+        [ -n "$v" ] || v=$("$CC_BIN" --version 2>/dev/null | head -n1 | grep -oE '[0-9]+(\.[0-9]+){1,2}'); \
+        COMPILER_VER="gcc${v}"; \
+      fi; \
+    fi; \
+    ZSTD_VER=$(pacman -Q zstd 2>/dev/null | awk '{print $2}' | sed -E 's/-.*//' || true); \
+    PY_VER=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")'); \
+    { echo "ORIOLEINFO: compiler=${COMPILER_VER}"; echo "ORIOLEINFO: zstd=${ZSTD_VER:-unknown}"; echo "ORIOLEINFO: python=${PY_VER:-unknown}"; } | tee -a "/_oriole_build_versions.txt"; \
+    \
+    # Fetch PostgreSQL sources matching the patchset tag
+    curl -o postgresql.tar.gz \
+      --header "Accept: application/vnd.github.v3.raw" \
+      --remote-name \
+      --location https://github.com/orioledb/postgres/tarball/$PGTAG; \
+    mkdir -p /usr/src/postgresql; \
+    tar --extract --file postgresql.tar.gz --directory /usr/src/postgresql --strip-components 1; \
+    rm -f postgresql.tar.gz; \
+    \
+    cd /usr/src/postgresql; \
+    POSTGRESQL_VERSION=$(grep "PACKAGE_VERSION=" ./configure | cut -d"'" -f2) ; \
+    echo "POSTGRESQL_VERSION=$POSTGRESQL_VERSION" ; \
+    # Update socket dir default to match Debian/Ubuntu images
+    awk '$1 == "#define" && $2 == "DEFAULT_PGSOCKET_DIR" && $3 == "\"/tmp\"" { $3 = "\"/var/run/postgresql\""; print; next } { print }' src/include/pg_config_manual.h > src/include/pg_config_manual.h.new; \
+    grep '/var/run/postgresql' src/include/pg_config_manual.h.new; \
+    mv src/include/pg_config_manual.h.new src/include/pg_config_manual.h; \
+    # Refresh config.{guess,sub} to support more arches
+    cp /usr/src/postgresql/contrib/orioledb/docker/config.guess config/config.guess; \
+    cp /usr/src/postgresql/contrib/orioledb/docker/config.sub   config/config.sub; \
+    gnuArch="$(sh config/config.guess)"; \
+    # Configure and build
+    ( CC=${BUILD_CC_COMPILER} ./configure \
+        --build="$gnuArch" \
+        --enable-integer-datetimes \
+        --enable-tap-tests \
+        --disable-rpath \
+        --with-uuid=e2fs \
+        --with-pgport=5432 \
+        --with-system-tzdata=/usr/share/zoneinfo \
+        --prefix=/usr/local \
+        --with-gssapi \
+        --with-ldap \
+        --with-tcl \
+        --with-perl \
+        --with-python \
+        --with-openssl \
+        --with-libxml \
+        --with-libxslt \
+        --with-icu \
+        --with-llvm \
+        --with-lz4 \
+        --with-zstd \
+        --with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} ${BASE_OS}+${BUILD_CC_COMPILER} build:${ORIOLEDB_BUILDTIME} ${POSTGRESQL_VERSION}" \
+      || cat config.log ); \
+    echo "ORIOLEDB_PATCHSET_VERSION = $(echo "$PGTAG" | cut -d'_' -f2)" >> src/Makefile.global; \
+    make -j "$(nproc)"; \
+    make -C contrib -j "$(nproc)"; \
+    make install-strip; \
+    make -C contrib install; \
+    # Build and install OrioleDB extension
+    cd /usr/src/postgresql/contrib/orioledb; \
+    make USE_PGXS=1 IS_DEV=1 -j "$(nproc)"; \
+    make USE_PGXS=1 IS_DEV=1 install; \
+    # Strip libraries to reduce size
+    strip /usr/local/lib/postgresql/*.so || true; \
+    find /usr/local/lib -type f -name "*.so*" -exec strip --strip-unneeded {} + || true; \
+    # Stash PGXS to a neutral path for later copy (path can be lib or lib64)
+    PGXS_MK="$(pg_config --pgxs 2>/dev/null || true)"; \
+    if [ -n "$PGXS_MK" ] && [ -f "$PGXS_MK" ]; then \
+      PGXS_DIR="$(dirname "$(dirname "$(dirname "$PGXS_MK")")")"; \
+      mkdir -p /_pgxs; \
+      cp -a "$PGXS_DIR/." /_pgxs/; \
+    fi
+
+########################
+# Runtime stage
+########################
+FROM base-updated AS runtime
+
+ARG BASE_OS
+ENV BASE_OS="${BASE_OS}"
+
+# Build-time settings needed by check_docker.sh script
+ARG PG_MAJOR=17
+ENV PG_MAJOR=${PG_MAJOR}
+
+ARG DOCKER_PG_LLVM_DEPS="llvm clang"
+ENV DOCKER_PG_LLVM_DEPS=${DOCKER_PG_LLVM_DEPS}
+
+ENV LANG=en_US.UTF-8
+
+# Set PATH to include PostgreSQL binaries (bin and sbin)
+ENV PATH=$PATH:/usr/local/bin:/usr/local/sbin
+
+# Create postgres user/group and essential dirs
+RUN set -eux; \
+    groupadd -r postgres --gid=999 || groupadd -r postgres; \
+    useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres || \
+      useradd -r -g postgres --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+    mkdir -p /var/lib/postgresql; \
+    chown -R postgres:postgres /var/lib/postgresql
+
+# Install only runtime dependencies (optimized for size)
+RUN set -eux; \
+    # Generate en_US.UTF-8 locale BEFORE installing perl to avoid warnings
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen; \
+    locale-gen; \
+    # Install runtime packages only (no toolchain, no -dev packages)
+    pacman -S --noconfirm --noprogressbar --needed \
+      ca-certificates tzdata \
+      # PostgreSQL runtime libs only
+      icu lz4 zstd libxml2 libxslt \
+      openssl openldap \
+      readline util-linux \
+      which \
+      llvm-libs \
+    ; \
+    # Cleanup runtime packages cache
+    pacman -Sc --noconfirm; \
+    rm -rf /var/cache/pacman/pkg/* /tmp/*
+
+# Copy runtime artifacts from builder
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/sbin /usr/local/sbin
+COPY --from=builder /usr/local/lib/postgresql /usr/local/lib/postgresql
+COPY --from=builder /usr/local/lib/libpq.so* /usr/local/lib/
+COPY --from=builder /usr/local/include /usr/local/include
+COPY --from=builder /_pgxs /_pgxs
+COPY --from=builder /usr/local/share/postgresql /usr/local/share/postgresql
+COPY --from=builder /_oriole_build_versions.txt /_oriole_build_versions.txt
+
+# Configure libraries, directories and entrypoint
+RUN set -eux; \
+    # Ensure dynamic linker can find /usr/local/lib
+    echo "/usr/local/lib" > /etc/ld.so.conf.d/postgresql.conf; \
+    ldconfig; \
+    # If PGXS was staged, install it under the path expected by pg_config
+    if [ -d /_pgxs ]; then \
+      PGXS_TARGET="$(dirname "$(dirname "$(dirname "$(pg_config --pgxs)")")")"; \
+      mkdir -p "${PGXS_TARGET}"; \
+      cp -a /_pgxs/. "${PGXS_TARGET}/"; \
+      rm -rf /_pgxs; \
+    fi; \
+    # Create runtime directories
+    mkdir /docker-entrypoint-initdb.d /docker-default-initdb.d; \
+    mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql; \
+    mkdir -p /var/lib/postgresql/data && chown -R postgres:postgres /var/lib/postgresql/data && chmod 777 /var/lib/postgresql/data; \
+    mkdir -p /etc/postgresql && chown -R postgres:postgres /etc/postgresql && chmod 700 /etc/postgresql
+
+ENV PGDATA=/var/lib/postgresql/data
+VOLUME /var/lib/postgresql/data
+COPY --chown=postgres:postgres docker/init/postgresql.docker.conf /etc/postgresql/postgresql.conf
+ENV PG_CONF=/etc/postgresql/postgresql.conf
+
+ENV POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=en"
+
+COPY docker/init/docker-entrypoint.sh /usr/local/bin/
+COPY docker/init/default-orioledb.sh /docker-default-initdb.d/
+RUN sed -i -e 's/su-exec/gosu/g' "/usr/local/bin/docker-entrypoint.sh"
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+STOPSIGNAL SIGINT
+
+EXPOSE 5432
+CMD ["postgres", "-D", "/etc/postgresql"]

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -1,0 +1,289 @@
+# Experimental only for testing!
+#
+# Fedora-based multi-stage image for OrioleDB + PostgreSQL
+
+# Parameterized base (defaults keep original behavior)
+ARG BASE_IMAGE=fedora
+ARG BASE_VERSION=42
+ARG BASE_OS=${BASE_IMAGE}:${BASE_VERSION}
+
+########################
+# Base updated stage
+########################
+FROM ${BASE_OS} AS base-updated
+
+# System update and base setup (shared by builder and runtime)
+RUN set -eux; \
+    # System update with size optimizations
+    dnf -y update; \
+    # Aggressive cleanup for size optimization
+    dnf clean all; \
+    rm -rf /var/cache/dnf /var/lib/dnf/history.* /var/log/dnf.*
+
+########################
+# Builder stage
+########################
+FROM base-updated AS builder
+
+# Record build information (metadata)
+ARG BASE_OS
+ENV BASE_OS="${BASE_OS}"
+
+# Build-time settings
+ARG PG_MAJOR=17
+ENV PG_MAJOR=${PG_MAJOR}
+
+# set compiler: [ clang gcc ]
+ARG BUILD_CC_COMPILER=gcc
+ENV BUILD_CC_COMPILER=${BUILD_CC_COMPILER}
+
+# Define build dependencies for LLVM (default system toolchain)
+# Note: On Fedora, llvm-config is provided by llvm-devel (not llvm).
+ARG DOCKER_PG_LLVM_DEPS="llvm-devel clang"
+ENV DOCKER_PG_LLVM_DEPS=${DOCKER_PG_LLVM_DEPS}
+
+# Enable to keep toolchain and sources around for debugging (larger image)
+ARG DEBUG_MODE=false
+ENV DEBUG_MODE=${DEBUG_MODE}
+
+# Install build-specific packages (build toolchain)
+RUN set -eux; \
+    # Install build essentials and development packages
+    dnf -y install --setopt=install_weak_deps=False --setopt=tsflags=nodocs \
+      ca-certificates curl wget gnupg2 tzdata \
+      make pkgconf-pkg-config \
+      gcc gcc-c++ bison flex \
+      libxml2-devel libxslt-devel \
+      libicu-devel krb5-devel \
+      lz4-devel libzstd-devel \
+      openldap-devel openssl-devel readline-devel \
+      libcurl-devel \
+      libuuid-devel \
+      tcl-devel perl perl-IPC-Run perl-Test-Harness \
+      python3 python3-devel python3-pip \
+      ${DOCKER_PG_LLVM_DEPS} \
+    ; \
+    # Cleanup build packages cache
+    dnf clean all; \
+    rm -rf /var/cache/dnf /var/lib/dnf/history.* /var/log/dnf.*
+
+# Install gosu in builder
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+    dpkgArch="$(uname -m)"; \
+    case "$dpkgArch" in \
+      x86_64) dpkgArch=amd64 ;; \
+      aarch64) dpkgArch=arm64 ;; \
+      armv7l|armv7) dpkgArch=armhf ;; \
+      ppc64le) dpkgArch=ppc64el ;; \
+      s390x) dpkgArch=s390x ;; \
+      *) echo "Unsupported arch: $dpkgArch" >&2; exit 1 ;; \
+    esac; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu --version; \
+    gosu nobody true
+
+# Prepare source tree and build
+RUN mkdir -p /usr/src/postgresql/contrib/orioledb
+COPY . /usr/src/postgresql/contrib/orioledb
+
+RUN set -eux; \
+    PGTAG=$(grep "^$PG_MAJOR: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+    ORIOLEDB_VERSION=$(grep "^#define ORIOLEDB_VERSION" /usr/src/postgresql/contrib/orioledb/include/orioledb.h | cut -d'"' -f2) ; \
+    ORIOLEDB_BUILDTIME=$(date -Iseconds) ; \
+    echo "PG_MAJOR=$PG_MAJOR" ; \
+    echo "PGTAG=$PGTAG" ; \
+    echo "BUILD_CC_COMPILER=$BUILD_CC_COMPILER" ; \
+    echo "ORIOLEDB_VERSION=$ORIOLEDB_VERSION" ; \
+    echo "ORIOLEDB_BUILDTIME=$ORIOLEDB_BUILDTIME" ; \
+    echo "DOCKER_PG_LLVM_DEPS=$DOCKER_PG_LLVM_DEPS" ; \
+    echo "DEBUG_MODE=$DEBUG_MODE" ; \
+    CC_BIN="$(command -v "${BUILD_CC_COMPILER}" || true)"; \
+    COMPILER_VER="unknown"; \
+    if [ -n "$CC_BIN" ]; then \
+      if "$CC_BIN" --version 2>/dev/null | head -n1 | grep -qi 'clang'; then \
+        v=$("$CC_BIN" --version 2>/dev/null | head -n1 | sed -E 's/.*clang version ([0-9]+(\.[0-9]+){1,2}).*/\1/'); \
+        [ -n "$v" ] || v=$("$CC_BIN" --version 2>/dev/null | head -n1 | grep -oE '[0-9]+(\.[0-9]+){1,2}'); \
+        COMPILER_VER="clang${v}"; \
+      else \
+        v=$("$CC_BIN" -dumpfullversion 2>/dev/null || "$CC_BIN" -dumpversion 2>/dev/null || true); \
+        [ -n "$v" ] || v=$("$CC_BIN" --version 2>/dev/null | head -n1 | grep -oE '[0-9]+(\.[0-9]+){1,2}'); \
+        COMPILER_VER="gcc${v}"; \
+      fi; \
+    fi; \
+    ZSTD_VER=$(pkg-config --modversion libzstd 2>/dev/null || true); \
+    PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")'); \
+    { echo "ORIOLEINFO: compiler=${COMPILER_VER}"; echo "ORIOLEINFO: zstd=${ZSTD_VER:-unknown}"; echo "ORIOLEINFO: python=${PY_VER:-unknown}"; } | tee -a "/_oriole_build_versions.txt"; \
+    \
+    curl -o postgresql.tar.gz \
+      --header "Accept: application/vnd.github.v3.raw" \
+      --location https://github.com/orioledb/postgres/tarball/$PGTAG; \
+    mkdir -p /usr/src/postgresql; \
+    tar --extract --file postgresql.tar.gz --directory /usr/src/postgresql --strip-components 1; \
+    rm -f postgresql.tar.gz; \
+    \
+    cd /usr/src/postgresql; \
+    POSTGRESQL_VERSION=$(grep "PACKAGE_VERSION=" ./configure | cut -d"'" -f2) ; \
+    echo "POSTGRESQL_VERSION=$POSTGRESQL_VERSION" ; \
+    awk '$1 == "#define" && $2 == "DEFAULT_PGSOCKET_DIR" && $3 == "\"/tmp\"" { $3 = "\"/var/run/postgresql\""; print; next } { print }' src/include/pg_config_manual.h > src/include/pg_config_manual.h.new; \
+    grep '/var/run/postgresql' src/include/pg_config_manual.h.new; \
+    mv src/include/pg_config_manual.h.new src/include/pg_config_manual.h; \
+    cp /usr/src/postgresql/contrib/orioledb/docker/config.guess config/config.guess; \
+    cp /usr/src/postgresql/contrib/orioledb/docker/config.sub   config/config.sub; \
+    gnuArch="$(sh config/config.guess)"; \
+    ( CC=${BUILD_CC_COMPILER} ./configure \
+        --build="$gnuArch" \
+        --enable-integer-datetimes \
+        --enable-tap-tests \
+        --disable-rpath \
+        --with-uuid=e2fs \
+        --with-pgport=5432 \
+        --with-system-tzdata=/usr/share/zoneinfo \
+        --prefix=/usr/local \
+        --with-gssapi \
+        --with-ldap \
+        --with-tcl \
+        --with-perl \
+        --with-python \
+        --with-openssl \
+        --with-libxml \
+        --with-libxslt \
+        --with-icu \
+        --with-llvm \
+        --with-lz4 \
+        --with-zstd \
+        --with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} ${BASE_OS}+${BUILD_CC_COMPILER} build:${ORIOLEDB_BUILDTIME} ${POSTGRESQL_VERSION}" \
+      || cat config.log ); \
+    echo "ORIOLEDB_PATCHSET_VERSION = $(echo "$PGTAG" | cut -d'_' -f2)" >> src/Makefile.global; \
+    make -j "$(nproc)"; \
+    make -C contrib -j "$(nproc)"; \
+    make install-strip; \
+    make -C contrib install; \
+    # Build and install OrioleDB extension first (needs headers)
+    cd /usr/src/postgresql/contrib/orioledb; \
+    make USE_PGXS=1 IS_DEV=1 -j "$(nproc)"; \
+    make USE_PGXS=1 IS_DEV=1 install; \
+    # Now remove static libs but keep headers for runtime Python package builds
+    rm -rf /usr/local/lib/*.a /usr/local/lib/*.la; \
+    # Strip all shared libraries
+    strip /usr/local/lib/postgresql/*.so || true; \
+    find /usr/local/lib -type f -name "*.so*" -exec strip --strip-unneeded {} + || true; \
+    # Stash PGXS to a neutral path for later copy (path can be lib or lib64)
+    PGXS_MK="$(pg_config --pgxs 2>/dev/null || true)"; \
+    if [ -n "$PGXS_MK" ] && [ -f "$PGXS_MK" ]; then \
+      PGXS_DIR="$(dirname "$(dirname "$(dirname "$PGXS_MK")")")"; \
+      mkdir -p /_pgxs; \
+      cp -a "$PGXS_DIR/." /_pgxs/; \
+    fi
+
+########################
+# Runtime stage
+########################
+FROM base-updated AS runtime
+
+ARG BASE_OS
+ENV BASE_OS="${BASE_OS}"
+
+# Build-time settings needed by check_docker.sh script
+ARG PG_MAJOR=17
+ENV PG_MAJOR=${PG_MAJOR}
+
+ARG DOCKER_PG_LLVM_DEPS="llvm-devel clang"
+ENV DOCKER_PG_LLVM_DEPS=${DOCKER_PG_LLVM_DEPS}
+
+ENV LANG=en_US.utf8
+
+# Set PATH to include PostgreSQL binaries (bin and sbin)
+ENV PATH=$PATH:/usr/local/bin:/usr/local/sbin
+
+
+# Copy only runtime essentials from builder
+# - Binaries (postgres, initdb, psql, gosu, etc.)
+# - Server modules and extensions under lib/postgresql
+# - Client library libpq (for psql and tooling)
+# - PostgreSQL shared data (BKI, timezone, extension SQL/control)
+# - Development bits (headers + pgxs) are required by our CI runner
+#   (ci/check_docker.sh) to build/test the extension via PGXS inside the
+#   container. If you need a slimmer pure-runtime image, consider adding an
+#   ARG to delete these after copy.
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/sbin /usr/local/sbin
+COPY --from=builder /usr/local/lib/postgresql /usr/local/lib/postgresql
+COPY --from=builder /usr/local/lib/libpq.so* /usr/local/lib/
+COPY --from=builder /usr/local/include /usr/local/include
+COPY --from=builder /_pgxs /_pgxs
+COPY --from=builder /usr/local/share/postgresql /usr/local/share/postgresql
+COPY --from=builder /_oriole_build_versions.txt /_oriole_build_versions.txt
+
+# Setup runtime environment: user, packages, and initial directories
+RUN set -eux; \
+    # Create postgres user/group (uid/gid 999 similar to Debian-based image)
+    groupadd -r postgres --gid=999 || groupadd -r postgres; \
+    useradd  -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres || \
+      useradd -r -g postgres --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+    mkdir -p /var/lib/postgresql; \
+    chown -R postgres:postgres /var/lib/postgresql; \
+    \
+    # Install runtime dependencies only (no toolchain, no -devel) - optimized for size
+    # System already updated in base-updated layer
+    dnf -y install --setopt=install_weak_deps=False --setopt=tsflags=nodocs \
+      ca-certificates tzdata glibc-langpack-en \
+      libicu lz4-libs libzstd libxml2 libxslt \
+      openssl-libs openldap \
+      readline libuuid \
+      util-linux \
+      which \
+      llvm-libs \
+    ; \
+    # Aggressive cleanup for size optimization
+    dnf clean all; \
+    rm -rf /var/cache/dnf /var/lib/dnf/history.* /var/log/dnf.*
+
+# Configure libraries, directories and entrypoint
+RUN set -eux; \
+    # Ensure dynamic linker can find /usr/local/lib
+    echo "/usr/local/lib" > /etc/ld.so.conf.d/postgresql.conf; \
+    ldconfig; \
+    # If PGXS was staged, install it under the path expected by pg_config
+    if [ -d /_pgxs ]; then \
+      PGXS_TARGET="$(dirname "$(dirname "$(dirname "$(pg_config --pgxs)")")")"; \
+      mkdir -p "${PGXS_TARGET}"; \
+      cp -a /_pgxs/. "${PGXS_TARGET}/"; \
+      rm -rf /_pgxs; \
+    fi; \
+    # Debug: Check library dependencies
+    echo "=== Checking PostgreSQL binary dependencies ==="; \
+    ldd $(which postgres) || true; \
+    echo "=== Checking initdb binary dependencies ==="; \
+    ldd $(which initdb) || true; \
+    echo "=== Library check complete ==="; \
+    \
+    # Create runtime directories
+    mkdir /docker-entrypoint-initdb.d /docker-default-initdb.d; \
+    mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql; \
+    mkdir -p /var/lib/postgresql/data && chown -R postgres:postgres /var/lib/postgresql/data && chmod 777 /var/lib/postgresql/data; \
+    mkdir -p /etc/postgresql && chown -R postgres:postgres /etc/postgresql && chmod 700 /etc/postgresql
+
+ENV PGDATA=/var/lib/postgresql/data
+VOLUME /var/lib/postgresql/data
+COPY docker/init/postgresql.docker.conf /etc/postgresql/postgresql.conf
+ENV PG_CONF=/etc/postgresql/postgresql.conf
+
+ENV POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=en"
+
+COPY docker/init/docker-entrypoint.sh /usr/local/bin/
+COPY docker/init/default-orioledb.sh /docker-default-initdb.d/
+RUN sed -i -e 's/su-exec/gosu/g' "/usr/local/bin/docker-entrypoint.sh"
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+STOPSIGNAL SIGINT
+
+EXPOSE 5432
+CMD ["postgres", "-D", "/etc/postgresql"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,43 @@
-# Testing OrioleDB Docker images
+# OrioleDB Docker images
+
+This directory contains Dockerfiles, init scripts, and test runners for building and validating OrioleDB images. It supports local development and CI via the Docker Official Images test suite and project-specific checks. The sections below outline the layout and primary entry points.
+
+## Directory structure:
+
+```
+docker\
+  ├── config.guess
+  ├── config.sub
+  ├── Dockerfile             # alpine Dockerfile
+  ├── Dockerfile.ubuntu      # ubuntu/debian Dockerfile
+  ├── Dockerfile.archlinux   # experimental - archlinux Dockerfile
+  ├── Dockerfile.fedora      # experimental - fedora Dockerfile
+  ├── init                       # docker image - init files
+  │   ├── default-orioledb.sh     # initialisation
+  │   ├── docker-entrypoint.sh    # docker-entrypoint
+  │   └── postgresql.docker.conf  # postgresql.conf for the orioledb docker image
+  ├── orioledb-config.sh     # docker test config
+  ├── README.md              # this file
+  └── tests
+      ├── orioledb-basics
+      │   └── run.sh         # minimal orioledb test
+      └── orioledb-check
+          ├── debug.sh       # test file for debugging.
+          ├── Dockerfile.orioledb-check # run the checks.
+          └── run.sh         # run the "check"
+
+Related files:
+./ci/docker_matrix.sh        # run local matrix builds/tests (alpine/ubuntu)
+                             #  note: fedora/archlinux Dockerfiles exist, but not in this matrix yet.
+./ci/check_docker.sh         # create a test-python environment in a docker image
+                             # and run the checks.
+
+./.github/workflows/dockertest.yml # build + test images in GitHub CI
+./.github/workflows/docker.yml     # publish images (no tests)
+
+```
+
+## Testing OrioleDB Docker images
 
 Running the Docker Official Image tests against orioledb images,
 see: "Docker Official Images Test Suite":
@@ -7,9 +46,8 @@ see: "Docker Official Images Test Suite":
 Used by:
 * `./ci/docker_matrix.sh`
 * `./.github/workflows/dockertest.yml`
-* todo: add to `./.github/workflows/docker.yml`
 
-## Running docker test suite
+### Running docker test suite
 
 ```bash
 # clone official-images test suite
@@ -27,24 +65,40 @@ git clone "$OFFIMG_REPO_URL" "$OFFIMG_LOCAL_CLONE"
 If the test is ok, you can see:
 
 ```bash
-testing orioletest:17-gcc-ubuntu-24.04
-	'utc' [1/6]...passed
-	'no-hard-coded-passwords' [2/6]...passed
-	'override-cmd' [3/6]...passed
-	'postgres-basics' [4/6]....passed
-	'postgres-initdb' [5/6]....passed
-	'orioledb-basics' [6/6]...passed
+testing orioletest:17-clang-ubuntu-noble-debug-false
+        'utc' [1/7]...passed
+        'no-hard-coded-passwords' [2/7]...passed
+        'override-cmd' [3/7]...passed
+        'postgres-basics' [4/7]....passed
+        'postgres-initdb' [5/7]....passed
+        'orioledb-basics' [6/7]...NOTICE:  extension "orioledb" already exists, skipping
+               passed
+        'orioledb-check' [7/7]...#0 building with "default" instance using docker driver
+    < ..orioledb-check log....>
+
 ```
 
-## test: postgres-basics
+### test: postgres-basics
 
 https://github.com/docker-library/official-images/blob/master/test/tests/postgres-basics/run.sh
 
-## test: postgres-initdb
+### test: postgres-initdb
 
 https://github.com/docker-library/official-images/blob/master/test/tests/postgres-initdb/run.sh
 https://github.com/docker-library/official-images/blob/master/test/tests/postgres-initdb/initdb.sql
 
-## test: orioledb-basics
+### test: orioledb-basics
 
 * `./tests/orioledb-basics/run.sh`
+
+### test: orioledb-check
+
+* `./tests/orioledb-check/run.sh`
+  Runs in the `./tests/orioledb-check/Dockerfile.orioledb-check` environment:
+  * Sets up the Python3 test environment.
+  * Runs `regresscheck`.
+  * Runs `isolationcheck`.
+  * If Python >= 3.12: runs `testgrescheck_part_1`.
+  * If Python >= 3.12: runs `testgrescheck_part_2`.
+
+Note: wal2json-related OrioleDB tests are skipped.

--- a/docker/orioledb-config.sh
+++ b/docker/orioledb-config.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034,SC2154
+#
+# OrioleDB + Docker Official test suite
+# See usage and examples: docker/README.md
+# Test suite reference: https://github.com/docker-library/official-images/tree/master/test
 
+# Reuse upstream `postgres` tests for repository `orioletest`.
 testAlias[orioletest]=postgres
 
+# Image tests for `orioletest`:
+# - <project-root>/docker/test/orioledb-basics : minimal OrioleDB smoke test
+# - <project-root>/docker/test/orioledb-check  : extended regression checks
+#
+# Disable by removing the line below:
 imageTests[orioletest]='
 	orioledb-basics
+	orioledb-check
 '

--- a/docker/tests/orioledb-check/Dockerfile.orioledb-check
+++ b/docker/tests/orioledb-check/Dockerfile.orioledb-check
@@ -1,0 +1,28 @@
+# create orioledb install check image , for cahcing python dependencies
+ARG BASE
+FROM ${BASE}
+COPY . /local_workspace
+
+# initialisation; calling ./ci/check_docker.sh
+# and setup python3 test environments - as a docker layer for a better caching
+RUN bash /local_workspace/ci/check_docker.sh --running init
+
+# this checks working on python 3.8+
+RUN bash /local_workspace/ci/check_docker.sh --running test regresscheck
+RUN bash /local_workspace/ci/check_docker.sh --running test isolationcheck
+
+## orioledb testgrescheck_part_1 , testgrescheck_part_2 : are python 3.12+
+## don't work with older python3 versions. so we skip.
+
+RUN python3 --version
+RUN if python3 -c "import sys; sys.exit(0) if sys.version_info >= (3, 12) else sys.exit(1)"; then \
+      bash /local_workspace/ci/check_docker.sh --running test testgrescheck_part_1; \
+    else \
+      echo "Skip test: testgrescheck_part_1 (python < 3.12)"; \
+    fi
+
+RUN if python3 -c "import sys; sys.exit(0) if sys.version_info >= (3, 12) else sys.exit(1)"; then \
+      bash /local_workspace/ci/check_docker.sh --running test testgrescheck_part_2; \
+    else \
+      echo "Skip test: testgrescheck_part_2 (python < 3.12)"; \
+    fi

--- a/docker/tests/orioledb-check/debug.sh
+++ b/docker/tests/orioledb-check/debug.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eo pipefail
+
+
+
+# run from the repo root.
+# ./docker/tests/orioledb-check/debug.sh <orioletest-image>
+#
+# example:
+#  bash -x ./docker/tests/orioledb-check/debug.sh orioletest:17-clang-fedora-43
+#
+#  in the docker shell - run the steps (find the Dockerfile.orioledb-check )
+#  1.:  bash -x /local_workspace/ci/check_docker.sh --running init
+#  2.:  bash -x /local_workspace/ci/check_docker.sh --running test regresscheck
+
+echo "start debugging ..."
+
+# Get the image from the first argument
+image="$1"
+
+# start Docker container with the specified image
+docker run --network=host  -it \
+  --volume "$(pwd)":/local_workspace \
+  "$image" bash
+

--- a/docker/tests/orioledb-check/run.sh
+++ b/docker/tests/orioledb-check/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+# Get the image from the first argument
+image="$1"
+
+serverImage="librarytest/orioledb-check:$(echo "$image" | sed 's![:/]!-!g')"
+
+docker build --progress=plain --network=host \
+   --build-arg BASE="$image" \
+   -f "$dir/Dockerfile.orioledb-check" \
+   -t "$serverImage" \
+   .  >&2
+
+docker images $serverImage >&2
+
+echo "orioledb-check completed." >&2


### PR DESCRIPTION
This PR proposal updates and improves https://github.com/orioledb/orioledb/pull/381 
with the goal of testing orioledb docker images ( alpine, ubuntu, debian)  with regression and isolation tests.

Notes:

* New `orioledb-check` runs `regresscheck` and `isolationcheck`
   * `testgrescheck` runs only if python >= 3.12 
*  `dockerTEST.yml` runs these checks, adding ~ 9–11 minutes per test case.
* Fedora and Arch Linux Dockerfiles will stay only if there is demand.
* `wal2json` is not installed, so the related tests are currently skipped.  ( can be added to the base image if needed, small footprint).

