### PR TITLE
Issue #535: Assign fake ctid only when PK is not ctid

### DIFF
--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -1597,15 +1597,19 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 		{
 			tts_orioledb_store_tuple(slot, tuple, descr, COMMITSEQNO_INPROGRESS,
 									 PrimaryIndexNumber, false, NULL);
-			ItemPointerSetBlockNumber(&slot->tts_tid, ItemPointerGetBlockNumber(&fake_iptr));
-			ItemPointerSetOffsetNumber(&slot->tts_tid, ItemPointerGetOffsetNumber(&fake_iptr));
-			if ((OffsetNumber) (ItemPointerGetOffsetNumber(&fake_iptr) + 1) == InvalidOffsetNumber)
+
+			if (!pk->primaryIsCtid)
 			{
-				ItemPointerSetBlockNumber(&fake_iptr, ItemPointerGetBlockNumber(&fake_iptr) + 1);
-				ItemPointerSetOffsetNumber(&fake_iptr, 1);
+				ItemPointerSetBlockNumber(&slot->tts_tid, ItemPointerGetBlockNumber(&fake_iptr));
+				ItemPointerSetOffsetNumber(&slot->tts_tid, ItemPointerGetOffsetNumber(&fake_iptr));
+				if ((OffsetNumber) (ItemPointerGetOffsetNumber(&fake_iptr) + 1) == InvalidOffsetNumber)
+				{
+					ItemPointerSetBlockNumber(&fake_iptr, ItemPointerGetBlockNumber(&fake_iptr) + 1);
+					ItemPointerSetOffsetNumber(&fake_iptr, 1);
+				}
+				else
+					ItemPointerSetOffsetNumber(&fake_iptr, ItemPointerGetOffsetNumber(&fake_iptr) + 1);
 			}
-			else
-				ItemPointerSetOffsetNumber(&fake_iptr, ItemPointerGetOffsetNumber(&fake_iptr) + 1);
 
 			liverows += 1;
 


### PR DESCRIPTION
`orioledb_acquire_sample_rows()` assigns fake ctid to `slot->tts_tid`, `ExecCopySlotHeapTuple()` reads all attributes of tuples and copies them to rows array as `HeapTuple` by calling `tts_orioledb_getsomeattrs()`. `tts_orioledb_getsomeattrs()` also assigns ctid of a tuple if it has TOAST values to detoast it later during ANALYZE:
https://github.com/orioledb/orioledb/blob/9c92e8295d09649bf8094c82170007637bda36b6/src/tuple/slot.c#L422

If we assign fake ctid if PK is ctid then we won't be able to detoast later.

Issue https://github.com/orioledb/orioledb/issues/535