### PR TITLE
Normalize C file headers

### DIFF
--- a/include/rewind/rewind.h
+++ b/include/rewind/rewind.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/include/workers/rewind.h
+ *	  contrib/orioledb/include/rewind/rewind.h
  *
  *-------------------------------------------------------------------------
  */

--- a/include/s3/checksum.h
+++ b/include/s3/checksum.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/include/utils/checksum.h
+ *	  contrib/orioledb/include/s3/checksum.h
  *
  *-------------------------------------------------------------------------
  */

--- a/include/s3/headers.h
+++ b/include/s3/headers.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/include/utils/headers.h
+ *	  contrib/orioledb/include/s3/headers.h
  *
  *-------------------------------------------------------------------------
  */

--- a/include/workers/bgwriter.h
+++ b/include/workers/bgwriter.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/include/utils/bgwriter.h
+ *	  contrib/orioledb/include/workers/bgwriter.h
  *
  *-------------------------------------------------------------------------
  */

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -1,13 +1,13 @@
 /*-------------------------------------------------------------------------
  *
- * interator.c
+ * iterator.c
  *		Implemetation of orioledb B-tree iterator.
  *
  * Copyright (c) 2021-2025, Oriole DB Inc.
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/src/btree/interator.c
+ *	  contrib/orioledb/src/btree/iterator.c
  *
  *-------------------------------------------------------------------------
  */

--- a/src/catalog/o_opclass_cache.c
+++ b/src/catalog/o_opclass_cache.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * o_opclass.c
+ * o_opclass_cache.c
  *		Routines for orioledb operator classes sys cache.
  *
  * Operator class B-tree stores data used by comparator and field initialization
@@ -10,7 +10,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/src/catalog/o_opclass.c
+ *	  contrib/orioledb/src/catalog/o_opclass_cache.c
  *
  *-------------------------------------------------------------------------
  */

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * recovery.c
+ * logical.c
  *		Support for logical decoding of OrioleDB tables.
  *
  * Copyright (c) 2024-2025, Oriole DB Inc.

--- a/src/rewind/rewind.c
+++ b/src/rewind/rewind.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/src/workers/rewind.c
+ *	  contrib/orioledb/src/rewind/rewind.c
  *
  *-------------------------------------------------------------------------
  */

--- a/src/tuple/sort.c
+++ b/src/tuple/sort.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * slot.c
+ * sort.c
  * 		Implementation of orioledb tuple sorting
  *
  * Copyright (c) 2021-2025, Oriole DB Inc.

--- a/src/tuple/toast.c
+++ b/src/tuple/toast.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * toast.h
+ * toast.c
  * 		Routines for orioledb TOAST implementation
  *
  * Copyright (c) 2021-2025, Oriole DB Inc.

--- a/src/utils/o_buffers.c
+++ b/src/utils/o_buffers.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/src/catalog/o_indices.c
+ *	  contrib/orioledb/src/utils/o_buffers.c
  *
  *-------------------------------------------------------------------------
  */

--- a/src/workers/interrupt.c
+++ b/src/workers/interrupt.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2025, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/src/worker/interrupt.c
+ *	  contrib/orioledb/src/workers/interrupt.c
  *
  *-------------------------------------------------------------------------
  */


### PR DESCRIPTION
Update the top-of-file headers in .c/.h:
- Line 3 matches the file basename.
- IDENTIFICATION path is `contrib/orioledb/<repo-relative-path>`.
Indentation preserved. No functional changes.
- generated by [a bash script ](https://gist.github.com/ImreSamu/834267246d2983c57c1ef10a4bcebf62)

---