### PR TITLE
CI: increase 'check' timeout from 20 to 25 minutes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install post build prerequisites
         run: bash ./orioledb/ci/post_build_prerequisites.sh
       - name: Check
-        timeout-minutes: ${{ startsWith(matrix.check_type, 'valgrind_') && 150 || 20 }}
+        timeout-minutes: ${{ startsWith(matrix.check_type, 'valgrind_') && 150 || 25 }}
         run: bash ./orioledb/ci/check.sh
       - name: Check output
         run: bash ./orioledb/ci/check_output.sh


### PR DESCRIPTION
fixing: 'check (arm64, 17, gcc, debug) '  -  "Error: The action 'Check' has timed out after 20 minutes.''
https://github.com/orioledb/orioledb/actions/runs/17644307390/job/50138457788?pr=439#step:8:789

As the number of tests increases, 
it has become more common for the 'check' job to stop due to the 20-minute timeout. 
To avoid such premature failures, the limit is raised to 25 minutes. 
The valgrind case remains unchanged at 150 minutes.




