### PR TITLE
Issue #569: Handle NULL result of get_reorder_buffer_txn()

### DIFF
--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -2,13 +2,12 @@
 # coding: utf-8
 
 import json
-import os
-import sys
+import subprocess
 import testgres
 import unittest
 
 from tempfile import mkdtemp
-from testgres.utils import get_pg_config
+from testgres.utils import get_bin_path
 
 from .base_test import BaseTest
 
@@ -204,3 +203,40 @@ class LogicalTest(BaseTest):
 					self.assertListEqual(
 					    subscriber.execute(
 					        'SELECT * FROM o_test2 ORDER BY id'), [])
+
+	def test_recvlogical_and_drop_database(self):
+		node = self.node
+		node.start()
+
+		node.safe_psql("postgres", "CREATE DATABASE logicaldb")
+		node.safe_psql(
+		    "logicaldb",
+		    "SELECT pg_create_logical_replication_slot('logicaldb_slot', 'test_decoding')"
+		)
+
+		pg_recvlogical = subprocess.Popen([
+		    get_bin_path("pg_recvlogical"), "-d", "logicaldb", "-p",
+		    str(node.port), "-S", "logicaldb_slot", "-v", "-f", "-", "--start"
+		],
+		                                  stdout=subprocess.PIPE,
+		                                  stderr=subprocess.PIPE,
+		                                  text=True)
+
+		# Check that pg_recvlogical started without error
+		self.assertIsNone(pg_recvlogical.poll())
+
+		# Wait until pg_recvlogical starts streaming
+		node.poll_query_until(
+		    "SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = 'logicaldb_slot' AND active_pid IS NOT NULL)"
+		)
+
+		with self.assertRaises(testgres.QueryException) as e:
+			node.safe_psql("postgres", "DROP DATABASE logicaldb")
+
+		self.assertErrorMessageEquals(
+		    e,
+		    "database \"logicaldb\" is used by an active logical replication slot",
+		    "There is 1 active slot.", "DETAIL")
+
+		pg_recvlogical.terminate()
+		node.stop()


### PR DESCRIPTION
get_reorder_buffer_txn() can return NULL in case if a transaction cannot be found

Issue: https://github.com/orioledb/orioledb/issues/569