### PR TITLE
Multiple fixes related to pg regression tests

### DIFF
--- a/ci/post_build_prerequisites.sh
+++ b/ci/post_build_prerequisites.sh
@@ -8,11 +8,11 @@ export PATH="$GITHUB_WORKSPACE/pgsql/bin:$GITHUB_WORKSPACE/python3-venv/bin:$PAT
 
 # psycopg2 depends on existing postgres installation
 if [ $GITHUB_JOB = "run-benchmark" ]; then
-	pip_packages="psycopg2-binary six testgres==1.11.0 unidiff python-telegram-bot matplotlib"
+	pip_packages="psycopg2-binary six testgres unidiff python-telegram-bot matplotlib"
 elif [ $GITHUB_JOB = "pgindent" ]; then
-	pip_packages="psycopg2 six testgres==1.11.0 unidiff moto[s3] flask flask_cors boto3 pyOpenSSL yapf"
+	pip_packages="psycopg2 six testgres unidiff moto[s3] flask flask_cors boto3 pyOpenSSL yapf"
 else
-	pip_packages="psycopg2 six testgres==1.11.0 unidiff moto[s3] flask flask_cors boto3 pyOpenSSL"
+	pip_packages="psycopg2 six testgres unidiff moto[s3] flask flask_cors boto3 pyOpenSSL"
 fi
 
 # install required packages

--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -174,6 +174,8 @@ struct OIndexDescr
 	TupleTableSlot *index_slot;
 	TupleTableSlot *old_leaf_slot;
 	TupleTableSlot *new_leaf_slot;
+	/* Copy of duplicates from OIndex */
+	List	   *duplicates;
 };
 
 /*

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -1183,8 +1183,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 			case REINDEX_OBJECT_SCHEMA:
 			case REINDEX_OBJECT_SYSTEM:
 			case REINDEX_OBJECT_DATABASE:
-				if (concurrently)
-					has_orioledb = check_multiple_tables(stmt->name, stmt->kind, concurrently);
+				has_orioledb = check_multiple_tables(stmt->name, stmt->kind, concurrently);
 				break;
 			default:
 				elog(ERROR, "unrecognized object type: %d",

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -103,7 +103,6 @@
 static ProcessUtility_hook_type next_ProcessUtility_hook = NULL;
 static object_access_hook_type old_objectaccess_hook = NULL;
 
-static bool isTopLevel PG_USED_FOR_ASSERTS_ONLY = false;
 List	   *drop_index_list = NIL;
 List	   *partition_drop_index_list = NIL;
 static List *alter_type_exprs = NIL;
@@ -111,6 +110,7 @@ Oid			o_saved_relrewrite = InvalidOid;
 Oid			o_saved_reltablespace = InvalidOid;
 static ORelOids saved_oids;
 static bool in_rewrite = false;
+static bool in_refresh_mat_view = false;
 List	   *reindex_list = NIL;
 Query	   *savedDataQuery = NULL;
 IndexBuildResult o_pkey_result = {0};
@@ -869,16 +869,13 @@ orioledb_utility_command(PlannedStmt *pstmt,
 {
 	bool		call_next = true;
 
-#ifdef USE_ASSERT_CHECKING
-	isTopLevel = (context == PROCESS_UTILITY_TOPLEVEL);
-#endif
-
 	/* copied from standard_ProcessUtility */
 	if (readOnlyTree)
 		pstmt = copyObject(pstmt);
 
 	in_rewrite = false;
-	o_saved_relrewrite = InvalidOid;
+	if (!in_refresh_mat_view && OidIsValid(o_saved_relrewrite))
+		o_saved_relrewrite = InvalidOid;
 	o_saved_reltablespace = InvalidOid;
 	savedDataQuery = NULL;
 	in_nontransactional_truncate = false;
@@ -1293,6 +1290,11 @@ orioledb_utility_command(PlannedStmt *pstmt,
 		if (matviewRel->rd_rel->relkind == RELKIND_MATVIEW &&
 			is_orioledb_rel(matviewRel))
 		{
+			if (stmt->concurrent)
+			{
+				elog(WARNING, "Concurrent REFRESH MATERIALIZED VIEW not implemented for orioledb materialized vies yet, using simple one");
+				stmt->concurrent = false;
+			}
 			if (!stmt->skipData)
 			{
 				savedDataQuery = linitial_node(Query, matviewRel->rd_rules->rules[0]->actions);
@@ -1310,6 +1312,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 				}
 			}
 			stmt->skipData = true;
+			in_refresh_mat_view = true;
 		}
 		table_close(matviewRel, AccessShareLock);
 	}
@@ -1468,6 +1471,10 @@ orioledb_utility_command(PlannedStmt *pstmt,
 			list_free(alter_type_exprs);
 			alter_type_exprs = NIL;
 		}
+	}
+	else if (IsA(pstmt->utilityStmt, RefreshMatViewStmt))
+	{
+		in_refresh_mat_view = false;
 	}
 }
 
@@ -3918,7 +3925,9 @@ o_ddl_cleanup(void)
 		reindex_list = NIL;
 	}
 	memset(&o_pkey_result, 0, sizeof(o_pkey_result));
-	o_saved_relrewrite = InvalidOid;
+	if (!in_refresh_mat_view)
+		o_saved_relrewrite = InvalidOid;
+	in_refresh_mat_view = false;
 	in_rewrite = false;
 	o_in_add_column = false;
 }

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -1032,6 +1032,7 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, OTable *oTable)
 
 	old_mcxt = MemoryContextSwitchTo(mcxt);
 	descr->predicate = list_copy_deep(oIndex->predicate);
+	descr->duplicates = list_copy_deep(oIndex->duplicates);
 	if (descr->predicate)
 		descr->predicate_str = pstrdup(oIndex->predicate_str);
 	descr->expressions = list_copy_deep(oIndex->expressions);

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -505,7 +505,6 @@ orioledb_aminsert(Relation rel, Datum *values, bool *isnull,
 	OTuple		tuple;
 	CommitSeqNo csn;
 	OBTOptions *options = (OBTOptions *) rel->rd_options;
-	int			ctid_off = 0;
 
 	if (options && !options->orioledb_index)
 	{
@@ -565,33 +564,36 @@ orioledb_aminsert(Relation rel, Datum *values, bool *isnull,
 	}
 	Assert(ix_num < descr->nIndices);
 
-	if (index_descr->primaryIsCtid)
-		ctid_off++;
-	if (index_descr->bridging)
-		ctid_off++;
-
-	if (index_descr->leafTupdesc->natts - ctid_off <= rel->rd_att->natts)
+	if (index_descr->duplicates != NIL)
 	{
-		/* Remove duplicates like we do in orioledb tables */
-		int			skipped = 0;
+		ListCell   *lc = NULL;
+		List	   *duplicate = NIL;
+		int			cur_attr;
+		int			i;
 
-		for (int copy_from = 0; copy_from < rel->rd_att->natts; copy_from++)
+		/* Remove duplicate column values to store in our index */
+
+		if (index_descr->duplicates != NIL)
+			lc = list_head(index_descr->duplicates);
+		if (lc != NULL)
+			duplicate = (List *) lfirst(lc);
+
+		cur_attr = 0;
+		for (i = 0; i < rel->rd_att->natts; i++)
 		{
-			Form_pg_attribute orig_attr = &rel->rd_att->attrs[copy_from];
-			Form_pg_attribute idx_attr;
-
-			if (copy_from - skipped >= index_descr->leafTupdesc->natts)
-				break;
-
-			idx_attr = &index_descr->leafTupdesc->attrs[copy_from - skipped];
-
-			if (strncmp(orig_attr->attname.data, idx_attr->attname.data, NAMEDATALEN) == 0)
+			if (duplicate != NIL && linitial_int(duplicate) == cur_attr)
 			{
-				if (skipped > 0)
-					values[copy_from - skipped] = values[copy_from];
+				lc = lnext(index_descr->duplicates, lc);
+				if (lc != NULL)
+					duplicate = (List *) lfirst(lc);
+				else
+					duplicate = NIL;
 			}
 			else
-				skipped++;
+			{
+				values[cur_attr] = values[i];
+				cur_attr++;
+			}
 		}
 	}
 	append_rowid_values(index_descr,
@@ -1515,6 +1517,44 @@ fill_hitup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
 	scan->xs_hitup = ExecCopySlotHeapTuple(slot);
 }
 
+/* Search all duplicates with same original attrnum */
+static inline void
+search_next_dup_range(List *duplicates, int dup_range_lc_id, int *dup_range_start, int *dup_range_end)
+{
+	List	   *duplicate = NIL;
+	ListCell   *dup_range_lc = NULL;
+	int			dup_range_src_attnum = -1;
+
+	*dup_range_start = -1;
+	*dup_range_end = -1;
+	do
+	{
+		if (dup_range_lc_id >= 0)
+			dup_range_lc = list_nth_cell(duplicates, dup_range_lc_id);
+		else
+			dup_range_lc = NULL;
+
+		if (dup_range_lc != NULL)
+		{
+			duplicate = (List *) lfirst(dup_range_lc);
+			if (*dup_range_end < 0)
+			{
+				*dup_range_end = dup_range_lc_id;
+				dup_range_src_attnum = linitial_int(duplicate);
+			}
+			else if (linitial_int(duplicate) != dup_range_src_attnum)
+			{
+				*dup_range_start = dup_range_lc_id + 1;
+			}
+		}
+		else
+		{
+			*dup_range_start = dup_range_lc_id + 1;
+		}
+		dup_range_lc_id--;
+	} while (*dup_range_start < 0);
+}
+
 /* TODO: Rewrite */
 static void
 fill_itup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
@@ -1538,27 +1578,63 @@ fill_itup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
 	 * moving values from duplicate field places that will be filled during
 	 * index_form_tuple
 	 */
-	if (index_descr->itupdesc->natts > index_descr->leafTupdesc->natts)
+	if (index_descr->duplicates != NIL)
 	{
-		int			skipped = index_descr->itupdesc->natts - index_descr->leafTupdesc->natts;
+		int			lc_id = 0;
+		ListCell   *lc = NULL;
+		List	   *duplicate = NIL;
+		int			i;
+		int			cur_attr;
+		int			ctid_off = index_descr->primaryIsCtid ? 1 : 0;
+		int			dup_range_start = -1;
+		int			dup_range_end = -1;
+		int			dup_range_diff = -1;
 
-		for (int copy_to = index_descr->itupdesc->natts - 1; copy_to >= 0; copy_to--)
+		lc_id = list_length(index_descr->duplicates) - 1;
+
+		search_next_dup_range(index_descr->duplicates, lc_id, &dup_range_start, &dup_range_end);
+		lc = list_nth_cell(index_descr->duplicates, dup_range_end);
+		Assert(lc != NULL);
+		duplicate = (List *) lfirst(lc);
+		dup_range_diff = dup_range_end - dup_range_start + 1;
+
+		lc = list_nth_cell(index_descr->duplicates, lc_id);
+		Assert(lc != NULL);
+		duplicate = (List *) lfirst(lc);
+
+		cur_attr = index_descr->leafTupdesc->natts - 1 - ctid_off;
+		for (i = index_descr->itupdesc->natts - 1; i >= 0; i--)
 		{
-			Form_pg_attribute idx_attr = &index_descr->itupdesc->attrs[copy_to];
-			Form_pg_attribute slot_attr = &index_descr->leafTupdesc->attrs[copy_to - skipped];
-
-			if (strncmp(slot_attr->attname.data, idx_attr->attname.data, NAMEDATALEN) == 0)
+			if (duplicate != NIL &&
+				i >= linitial_int(duplicate) + dup_range_start &&
+				i <= linitial_int(duplicate) + dup_range_start - 1 + dup_range_diff)
 			{
-				if (skipped == 0)
-					break;
-				slot->tts_values[copy_to] = slot->tts_values[copy_to - skipped];
-				slot->tts_isnull[copy_to] = slot->tts_isnull[copy_to - skipped];
+				slot->tts_values[i] = 0;
+				slot->tts_isnull[i] = true;
 			}
 			else
 			{
-				slot->tts_values[copy_to] = 0;
-				slot->tts_isnull[copy_to] = true;
-				skipped--;
+				if (duplicate != NIL && i == linitial_int(duplicate) + dup_range_start - 1)
+				{
+					lc_id = dup_range_start - 1;
+
+					if (lc_id >= 0)
+					{
+						search_next_dup_range(index_descr->duplicates, lc_id, &dup_range_start, &dup_range_end);
+						lc = list_nth_cell(index_descr->duplicates, dup_range_end);
+						Assert(lc != NULL);
+						duplicate = (List *) lfirst(lc);
+						dup_range_diff = dup_range_end - dup_range_start + 1;
+					}
+					else
+					{
+						lc = NULL;
+						duplicate = NIL;
+					}
+				}
+				slot->tts_values[i] = slot->tts_values[cur_attr];
+				slot->tts_isnull[i] = slot->tts_isnull[cur_attr];
+				cur_attr--;
 			}
 		}
 	}

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -272,7 +272,7 @@ orioledb_ambuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	}
 
 	relname = makeString(index->rd_rel->relname.data);
-	if (list_member(reindex_list, relname))
+	if (!in_nontransactional_truncate && list_member(reindex_list, relname))
 	{
 		reindex = true;
 		reindex_list = list_delete(reindex_list, relname);

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -1659,6 +1659,12 @@ undo_xact_callback(XactEvent event, void *arg)
 				reset_command_undo_locations();
 				oxid_needs_wal_flush = false;
 				minParentSubId = InvalidSubTransactionId;
+
+				/*
+				 * TODO: Find a better place or add a hook at the end of
+				 * heap_truncate_one_rel
+				 */
+				in_nontransactional_truncate = false;
 				break;
 			case XACT_EVENT_ABORT:
 				if (!RecoveryInProgress())
@@ -1671,6 +1677,12 @@ undo_xact_callback(XactEvent event, void *arg)
 				current_oxid_abort();
 				set_oxid_xlog_ptr(oxid, InvalidXLogRecPtr);
 				oxid_needs_wal_flush = false;
+
+				/*
+				 * TODO: Find a better place or add a hook at the end of
+				 * heap_truncate_one_rel
+				 */
+				in_nontransactional_truncate = false;
 
 				/*
 				 * Remove registered snapshot one-by-one, so that we can avoid

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -7503,9 +7503,9 @@ SELECT orioledb_tbl_structure('o_test_pkey_mixed'::regclass, 'nue');
  state = free, datoid equal, relnode equal, ix_type = regular, dirty                              +
      Leftmost, Rightmost                                                                          +
    Chunk 0: offset = 0, location = 256, hikey location = 64                                       +
-     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '8', '8', '6', '7')                       +
-     Item 1: offset = 312, tuple = ('40', '10', '90', '20', '80', '80', '60', '70')               +
-     Item 2: offset = 360, tuple = ('400', '100', '900', '200', '800', '800', '600', '700')       +
+     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '8', '5', '6', '7')                       +
+     Item 1: offset = 312, tuple = ('40', '10', '90', '20', '80', '50', '60', '70')               +
+     Item 2: offset = 360, tuple = ('400', '100', '900', '200', '800', '500', '600', '700')       +
                                                                                                   +
  Index toast: not loaded                                                                          +
  
@@ -7577,9 +7577,9 @@ EXPLAIN (COSTS OFF) SELECT i1, f1, pk4, f2, pk4, pk3, i2, pk1, pk2 FROM o_test_p
 SELECT i1, f1, pk4, f2, pk4, pk3, i2, pk1, pk2 FROM o_test_pkey_mixed ORDER BY i1;
  i1  | f1  | pk4 | f2  | pk4 | pk3 | i2  | pk1 | pk2 
 -----+-----+-----+-----+-----+-----+-----+-----+-----
-   4 |   1 |   9 |   2 |   9 |   8 |   8 |   6 |   7
-  40 |  10 |  90 |  20 |  90 |  80 |  80 |  60 |  70
- 400 | 100 | 900 | 200 | 900 | 800 | 800 | 600 | 700
+   4 |   1 |   9 |   2 |   9 |   8 |   5 |   6 |   7
+  40 |  10 |  90 |  20 |  90 |  80 |  50 |  60 |  70
+ 400 | 100 | 900 | 200 | 900 | 800 | 500 | 600 | 700
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -7492,9 +7492,9 @@ SELECT orioledb_tbl_structure('o_test_pkey_mixed'::regclass, 'nue');
  state = free, datoid equal, relnode equal, ix_type = regular, dirty                              +
      Leftmost, Rightmost                                                                          +
    Chunk 0: offset = 0, location = 256, hikey location = 64                                       +
-     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '8', '8', '6', '7')                       +
-     Item 1: offset = 312, tuple = ('40', '10', '90', '20', '80', '80', '60', '70')               +
-     Item 2: offset = 360, tuple = ('400', '100', '900', '200', '800', '800', '600', '700')       +
+     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '8', '5', '6', '7')                       +
+     Item 1: offset = 312, tuple = ('40', '10', '90', '20', '80', '50', '60', '70')               +
+     Item 2: offset = 360, tuple = ('400', '100', '900', '200', '800', '500', '600', '700')       +
                                                                                                   +
  Index toast: not loaded                                                                          +
  
@@ -7566,9 +7566,9 @@ EXPLAIN (COSTS OFF) SELECT i1, f1, pk4, f2, pk4, pk3, i2, pk1, pk2 FROM o_test_p
 SELECT i1, f1, pk4, f2, pk4, pk3, i2, pk1, pk2 FROM o_test_pkey_mixed ORDER BY i1;
  i1  | f1  | pk4 | f2  | pk4 | pk3 | i2  | pk1 | pk2 
 -----+-----+-----+-----+-----+-----+-----+-----+-----
-   4 |   1 |   9 |   2 |   9 |   8 |   8 |   6 |   7
-  40 |  10 |  90 |  20 |  90 |  80 |  80 |  60 |  70
- 400 | 100 | 900 | 200 | 900 | 800 | 800 | 600 | 700
+   4 |   1 |   9 |   2 |   9 |   8 |   5 |   6 |   7
+  40 |  10 |  90 |  20 |  90 |  80 |  50 |  60 |  70
+ 400 | 100 | 900 | 200 | 900 | 800 | 500 | 600 | 700
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -18,12 +18,12 @@ import unittest
 
 from threading import Thread
 from testgres.enums import NodeStatus
-from testgres.exceptions import PortForException
 from testgres.node import PostgresNode
-from testgres.operations.os_ops import OsOperations, ConnectionParams
-from testgres.port_manager import PortManager__Generic
+from testgres.operations.os_ops import OsOperations
+from testgres.node import PortManager__Generic
 from testgres.utils import get_pg_version, get_pg_config
 from typing import Any
+from types import MethodType
 
 
 class TestPortManager(PortManager__Generic):
@@ -33,44 +33,18 @@ class TestPortManager(PortManager__Generic):
 		self._available_ports: typing.Set[int] = set(
 		    [base_port, base_port + 1])
 
-	def is_port_free(self, port: int):
-		port_free = port in self._available_ports
+	def is_port_free(self, number: int):
+		assert type(number) == int  # noqa: E721
+		assert number >= 0
+		assert number <= 65535  # OK?
 
-		if port_free:
-			with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-				s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-				try:
-					s.bind(("", port))
-					return True
-				except OSError:
-					return False
-		return False
-
-	def reserve_port(self) -> int:
-		assert self._guard is not None
-		assert type(self._available_ports) == set  # noqa: E721t
-		assert type(self._reserved_ports) == set  # noqa: E721
-
-		with self._guard:
-			t = tuple(self._available_ports)
-			assert len(t) == len(self._available_ports)
-			t = None
-
-			for port in self._available_ports:
-				assert not (port in self._reserved_ports)
-
-				port_free = self.is_port_free(port)
-
-				if not port_free:
-					continue
-
-				self._reserved_ports.add(port)
-				self._available_ports.discard(port)
-				assert port in self._reserved_ports
-				assert not (port in self._available_ports)
-				return port
-
-		raise PortForException("Can't select a port.")
+		with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+			s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+			try:
+				s.bind(("", number))
+				return True
+			except OSError:
+				return False
 
 
 class BaseTest(unittest.TestCase):
@@ -79,6 +53,8 @@ class BaseTest(unittest.TestCase):
 	restoredNode = None
 	basePort = None
 	_myName = None
+	_os_ops = None
+	_port_manager = None
 
 	def getTestNum(self):
 		testFullName = inspect.getfile(self.__class__)
@@ -112,18 +88,7 @@ class BaseTest(unittest.TestCase):
 
 	def getSubsriber(self) -> testgres.PostgresNode:
 		if self.subscriber is None:
-			(test_path, t) = os.path.split(
-			    os.path.dirname(inspect.getfile(self.__class__)))
-			baseDir = os.path.join(test_path, 'tmp_check_t',
-			                       self.myName + '_tgss')
-			if os.path.exists(baseDir):
-				shutil.rmtree(baseDir)
-
-			subscriber = testgres.get_new_node('subscriber',
-			                                   port=self.getBasePort() + 1,
-			                                   base_dir=baseDir)
-			subscriber.init(["--no-locale", "--encoding=UTF8"])
-			subscriber.append_conf(shared_preload_libraries='orioledb')
+			subscriber = self.initNode('tgss', 'subscriber')
 			subscriber.append_conf(wal_level='logical')
 			self.subscriber = subscriber
 		return self.subscriber
@@ -131,7 +96,7 @@ class BaseTest(unittest.TestCase):
 	def restoreNode(self, port: int, filename: str) -> testgres.PostgresNode:
 		self.assertIsNone(self.restoredNode)
 
-		restoredNode = self.initNode(port, "restored_tgsn")
+		restoredNode = self.initNode("restored_tgsn")
 		restoredNode.start()
 		restoredNode.restore(filename)
 
@@ -139,7 +104,7 @@ class BaseTest(unittest.TestCase):
 
 		return restoredNode
 
-	def initNode(self, base_port: int, suffix='tgsn') -> testgres.PostgresNode:
+	def initNode(self, suffix='tgsn', name='test') -> testgres.PostgresNode:
 		(test_path,
 		 t) = os.path.split(os.path.dirname(inspect.getfile(self.__class__)))
 		baseDir = os.path.join(test_path, 'tmp_check_t',
@@ -147,7 +112,7 @@ class BaseTest(unittest.TestCase):
 		if os.path.exists(baseDir):
 			shutil.rmtree(baseDir)
 		if not self._os_ops:
-			self._os_ops = PostgresNode._get_os_ops(ConnectionParams())
+			self._os_ops = PostgresNode._get_os_ops()
 			self._os_ops.is_port_free = MethodType(
 			    TestPortManager.is_port_free, self._os_ops)
 		if not self._port_manager:
@@ -155,7 +120,8 @@ class BaseTest(unittest.TestCase):
 			                                     self.getBasePort())
 		node = testgres.get_new_node(name,
 		                             base_dir=baseDir,
-		                             port_manager=port_manager)
+		                             os_ops=self._os_ops,
+		                             port_manager=self._port_manager)
 		node.init(["--no-locale", "--encoding=UTF8"])  # run initdb
 		node.append_conf(
 		    'postgresql.conf', "shared_preload_libraries = orioledb\n"
@@ -177,7 +143,7 @@ class BaseTest(unittest.TestCase):
 
 	def setUp(self):
 		self.startTime = time.time()
-		self.node = self.initNode(self.getBasePort())
+		self.node = self.initNode()
 
 	def list2reason(self, exc_list):
 		if exc_list and exc_list[-1][0] is self:

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -146,9 +146,14 @@ class BaseTest(unittest.TestCase):
 		                       self.myName + '_' + suffix)
 		if os.path.exists(baseDir):
 			shutil.rmtree(baseDir)
-		port_manager = TestPortManager(
-		    PostgresNode._get_os_ops(ConnectionParams()), base_port)
-		node = testgres.get_new_node('test',
+		if not self._os_ops:
+			self._os_ops = PostgresNode._get_os_ops(ConnectionParams())
+			self._os_ops.is_port_free = MethodType(
+			    TestPortManager.is_port_free, self._os_ops)
+		if not self._port_manager:
+			self._port_manager = TestPortManager(self._os_ops,
+			                                     self.getBasePort())
+		node = testgres.get_new_node(name,
 		                             base_dir=baseDir,
 		                             port_manager=port_manager)
 		node.init(["--no-locale", "--encoding=UTF8"])  # run initdb

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -128,6 +128,7 @@ class LogicalTest(BaseTest):
 			publisher.start()
 
 			subscriber = self.getSubsriber()
+
 			with subscriber.start() as subscriber:
 				create_sql = """
 					CREATE EXTENSION IF NOT EXISTS orioledb;

--- a/test/t/s3_test.py
+++ b/test/t/s3_test.py
@@ -496,7 +496,7 @@ class S3Test(S3BaseTest):
 		while node.status() == NodeStatus.Running:
 			pass
 
-		with self.initNode(self.getBasePort() + 1, 'tgsb') as new_node:
+		with self.initNode('tgsb') as new_node:
 			self.loader.download(new_node.data_dir)
 			new_node.append_conf(port=new_node.port)
 
@@ -553,7 +553,7 @@ class S3Test(S3BaseTest):
 		while node.status() == NodeStatus.Running:
 			pass
 
-		with self.initNode(self.getBasePort() + 1, 'tgsb') as new_node:
+		with self.initNode('tgsb') as new_node:
 			self.loader.download(new_node.data_dir)
 			new_node.append_conf(port=new_node.port)
 
@@ -609,7 +609,7 @@ class S3Test(S3BaseTest):
 		while node.status() == NodeStatus.Running:
 			pass
 
-		with self.initNode(self.getBasePort() + 1, 'tgsb') as new_node:
+		with self.initNode('tgsb') as new_node:
 			self.loader.download(new_node.data_dir)
 			new_node.append_conf(port=new_node.port)
 
@@ -662,7 +662,7 @@ class S3Test(S3BaseTest):
 		while node.status() == NodeStatus.Running:
 			pass
 
-		with self.initNode(self.getBasePort() + 1, 'tgsb') as new_node:
+		with self.initNode('tgsb') as new_node:
 			self.loader.download(new_node.data_dir)
 			new_node.append_conf(port=new_node.port)
 
@@ -714,7 +714,7 @@ class S3Test(S3BaseTest):
 		while node.status() == NodeStatus.Running:
 			pass
 
-		with self.initNode(self.getBasePort() + 1, 'tgsb') as new_node:
+		with self.initNode('tgsb') as new_node:
 			self.loader.download(new_node.data_dir)
 			new_node.append_conf(port=new_node.port)
 
@@ -752,7 +752,7 @@ class S3Test(S3BaseTest):
 			node.stop()
 
 			# Test that PostgreSQL won't start in case of absent control file
-			new_node = self.initNode(self.getBasePort() + 1, 'tgsb')
+			new_node = self.initNode('tgsb')
 			new_node.append_conf(f"""
 				orioledb.s3_mode = true
 				orioledb.s3_host = '{self.host}:{self.port}/{self.bucket_name}'


### PR DESCRIPTION
- Fix testgres 1.11.1 compatibility
- Do not clean o_saved_relrewrite until the end of refresh mat view
- Fixes REINDEX SCHEMA for temp tables with ON COMMIT DELETE ROWS
- copied duplicates field from oIndex to OIndexDescr to make duplicate column logic less complex