### PR TITLE
Add missing NOTICE message to alter_storage.out

### DIFF
--- a/test/expected/alter_storage.out
+++ b/test/expected/alter_storage.out
@@ -316,4 +316,5 @@ DROP TABLE o_storage_index_test;
 DROP TABLE o_storage_test;
 DROP TABLE o_plain_varlena;
 DROP SCHEMA alter_storage CASCADE;
+NOTICE:  drop cascades to extension orioledb
 RESET search_path;


### PR DESCRIPTION
It isn't visible by CI due to changes to pg_regress:
https://github.com/orioledb/postgres/blob/4c226adc13bd3e9197f4f7dfb387bded5fead2ab/src/test/regress/pg_regress.c#L65-L66