### PR TITLE
Update Dockerfile.ubuntu to use gosu 1.19

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -64,7 +64,7 @@ ENV LANG=en_US.utf8
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION=1.17
+ENV GOSU_VERSION=1.19
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \


### PR DESCRIPTION
This Pull Request updates `gosu` from version `1.17` to `1.19` in `Dockerfile.ubuntu`.

The official Docker Postgres image has already upgraded to gosu 1.19,  
and this change helps keep the OrioleDB Docker environment aligned with the upstream base.

Using the latest gosu release may also help reduce potential security warnings  
reported by container scanners.

No functional changes beyond the version update.

---

### References

- Upstream Postgres Dockerfile (gosu 1.19):  
  * https://github.com/docker-library/postgres/blob/master/Dockerfile-debian.template
  * https://github.com/docker-library/postgres/commit/a2433755c76d294477c85945d68944f8cdb7cf4b

- gosu 1.19 release notes:  
  https://github.com/tianon/gosu/releases/tag/1.19
  
- trivy scan (old gosu 1.17 + `orioledb/orioledb:latest-pg17-ubuntu` ) example:

```bash
$ trivy image --ignore-unfixed  orioledb/orioledb:latest-pg17-ubuntu
...
usr/local/bin/gosu (gobinary)

Total: 63 (UNKNOWN: 0, LOW: 1, MEDIUM: 27, HIGH: 32, CRITICAL: 3)

```