### PR TITLE
 fix segfault on replica concurent read/write

### DIFF
--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -780,8 +780,19 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 					 * need to save tuples for the iterators code from the
 					 * parent.
 					 */
+					BTreePageHeader *hdr = (BTreePageHeader *) context->parentImg;
+					OffsetNumber chunkIdx = loc.chunkOffset;
+
 					memcpy(context->parentImg, intCxt.pagePtr, ORIOLEDB_BLCKSZ);
 					context->partial.isPartial = false;
+
+					/*
+					 * We need to ensure that chunk in locator points to
+					 * context memory instead of "in memory" block
+					 */
+					context->items[context->index].locator.chunk =
+						(BTreePageChunk *) (context->parentImg + SHORT_GET_LOCATION(hdr->chunkDesc[chunkIdx].shortLocation));
+
 				}
 			}
 			else


### PR DESCRIPTION
Аfter page loading into find context locator become points to shared buffer. When items reading via locator there is no lock checking, so when concurrent insert (even it has rite lock) change in memory page content get item in find context will failed.

To avoid this locator in context always shows point to context copy of page.

It is fix half of #565: only crash with explicit primary key.  