### PR TITLE
page inspection function

### DIFF
--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -33,6 +33,11 @@
 #define WAL_REC_TRUNCATE	(13)
 #define WAL_REC_BRIDGE_ERASE (14)
 
+#define FIRST_WAL_VERSION (16)
+
+/* Bump it when WAL format changes */
+#define CURRENT_WAL_VERSION (16)
+
 /* Constants for commitInProgressXlogLocation */
 #define OWalTmpCommitPos			(0)
 #define OWalInvalidCommitPos		UINT64_MAX
@@ -144,5 +149,6 @@ extern void o_wal_delete_key(BTreeDescr *desc, OTuple key);
 extern void add_truncate_wal_record(ORelOids oids);
 extern bool get_local_wal_has_material_changes(void);
 extern void set_local_wal_has_material_changes(bool value);
+extern uint16 check_wal_container_version(Pointer *ptr);
 
 #endif							/* __WAL_H__ */

--- a/sql/orioledb--1.4--1.5_prod.sql
+++ b/sql/orioledb--1.4--1.5_prod.sql
@@ -49,6 +49,19 @@ AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
 
 
+CREATE FUNCTION orioledb_page_items(IN relname oid, IN blkno int8, IN datalimit int default -1,
+    OUT itemoffset smallint,
+    OUT chunckno smallint,
+    OUT itemheader text,
+    OUT itemheaderfields jsonb,
+    OUT itemlen smallint,
+    OUT itemdata text
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'orioledb_page_items'
+LANGUAGE C STRICT PARALLEL SAFE;
+
+
 --CREATE FUNCTION orioledb_rewind_queue_age()
 --RETURNS bigint
 --AS 'MODULE_PATHNAME'

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -260,6 +260,16 @@ orioledb_decode(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 	OIndexType	ix_type = oIndexInvalid;
 	TupleDescData *o_toast_tupDesc = NULL;
 	TupleDescData *heap_toast_tupDesc = NULL;
+	uint16		wal_version;
+
+	wal_version = check_wal_container_version(&ptr);
+
+	if (wal_version > CURRENT_WAL_VERSION)
+	{
+		/* WAL from future version */
+		elog(ERROR, "Can't logically decode WAL version %u that is newer than supported %u", wal_version, CURRENT_WAL_VERSION);
+		return;
+	}
 
 	while (ptr < endPtr)
 	{

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -216,6 +216,8 @@ wal_commit(OXid oxid, TransactionId logicalXid)
 	flush_local_wal_if_needed(sizeof(WALRecFinish));
 	Assert(local_wal_buffer_offset + sizeof(WALRecFinish) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE);
 
+	add_wal_container_header_if_needed();
+
 	if (!local_wal_contains_xid)
 		add_xid_wal_record(oxid, logicalXid);
 
@@ -235,6 +237,8 @@ wal_joint_commit(OXid oxid, TransactionId logicalXid, TransactionId xid)
 
 	flush_local_wal_if_needed(sizeof(WALRecJointCommit));
 	Assert(local_wal_buffer_offset + sizeof(WALRecJointCommit) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE);
+
+	add_wal_container_header_if_needed();
 
 	if (!local_wal_contains_xid)
 		add_xid_wal_record(oxid, logicalXid);
@@ -276,6 +280,8 @@ wal_rollback(OXid oxid, TransactionId logicalXid)
 	Assert(!is_recovery_process());
 	flush_local_wal_if_needed(sizeof(WALRecFinish));
 	Assert(local_wal_buffer_offset + sizeof(WALRecFinish) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE);
+
+	add_wal_container_header_if_needed();
 	if (!local_wal_contains_xid)
 		add_xid_wal_record(oxid, logicalXid);
 

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -39,6 +39,53 @@ static void add_rel_wal_record(ORelOids oids, OIndexType type);
 static void flush_local_wal_if_needed(int required_length);
 static inline void add_local_modify(uint8 record_type, OTuple record, OffsetNumber length);
 
+uint16
+check_wal_container_version(Pointer *ptr)
+{
+	uint16		wal_version;
+
+	if (**ptr >= FIRST_WAL_VERSION)
+	{
+		/*
+		 * Container starts with a valid WAL version. First WAL record is just
+		 * after it.
+		 */
+		memcpy(&wal_version, *ptr, sizeof(uint16));
+		(*ptr) += sizeof(uint16);
+	}
+	else
+	{
+		/*
+		 * Container starts with rec_type of first WAL record (its maximum
+		 * value was under FIRST_WAL_VERSION at the time of introducing WAL
+		 * versioning. Consider this as version 0 and don't increase pointer
+		 */
+		wal_version = 0;
+	}
+
+	if (wal_version > CURRENT_WAL_VERSION)
+	{
+#ifdef IS_DEV
+		/* Always fail tests on difference */
+		elog(FATAL, "Can't apply WAL container version %u that is newer than supported %u. Intentionally fail tests", wal_version, CURRENT_WAL_VERSION);
+#else
+		elog(WARNING, "Can't apply WAL container version %u that is newer than supported %u", wal_version, CURRENT_WAL_VERSION);
+		/* Further fail and output is caller-specific */
+#endif
+	}
+	else if (wal_version < CURRENT_WAL_VERSION)
+	{
+#ifdef IS_DEV
+		/* Always fail tests on difference */
+		elog(FATAL, "WAL container version %u is older than current %u. Intentionally fail tests", wal_version, CURRENT_WAL_VERSION);
+#else
+		elog(LOG, "WAL container version %u is older than current %u. Applying with conversion.", wal_version, CURRENT_WAL_VERSION);
+#endif
+	}
+
+	return wal_version;
+}
+
 void
 add_modify_wal_record(uint8 rec_type, BTreeDescr *desc,
 					  OTuple tuple, OffsetNumber length)
@@ -164,6 +211,7 @@ wal_commit(OXid oxid, TransactionId logicalXid)
 
 	if (local_wal_buffer_offset == 0)
 		add_xid_wal_record(oxid, logicalXid);
+
 	add_finish_wal_record(WAL_REC_COMMIT, pg_atomic_read_u64(&xid_meta->runXmin));
 	walPos = flush_local_wal(true);
 	local_wal_has_material_changes = false;
@@ -183,6 +231,7 @@ wal_joint_commit(OXid oxid, TransactionId logicalXid, TransactionId xid)
 
 	if (local_wal_buffer_offset == 0)
 		add_xid_wal_record(oxid, logicalXid);
+
 	add_joint_commit_wal_record(xid, pg_atomic_read_u64(&xid_meta->runXmin));
 	walPos = flush_local_wal(true);
 	local_wal_has_material_changes = false;
@@ -222,6 +271,7 @@ wal_rollback(OXid oxid, TransactionId logicalXid)
 	Assert(local_wal_buffer_offset + sizeof(WALRecFinish) <= LOCAL_WAL_BUFFER_SIZE);
 	if (local_wal_buffer_offset == 0)
 		add_xid_wal_record(oxid, logicalXid);
+
 	add_finish_wal_record(WAL_REC_ROLLBACK, pg_atomic_read_u64(&xid_meta->runXmin));
 	wait_pos = flush_local_wal(false);
 	local_wal_has_material_changes = false;
@@ -279,10 +329,17 @@ static void
 add_xid_wal_record(OXid oxid, TransactionId logicalXid)
 {
 	WALRecXid  *rec;
+	uint16	   *wal_version_header;
 
 	Assert(!is_recovery_process());
 	Assert(OXidIsValid(oxid));
-	Assert(local_wal_buffer_offset + sizeof(*rec) <= LOCAL_WAL_BUFFER_SIZE);
+	Assert(local_wal_buffer_offset == 0);
+	Assert(sizeof(*rec) + sizeof(uint16) <= LOCAL_WAL_BUFFER_SIZE);
+
+	wal_version_header = (uint16 *) (&local_wal_buffer[local_wal_buffer_offset]);
+	Assert(CURRENT_WAL_VERSION >= FIRST_WAL_VERSION);
+	*wal_version_header = CURRENT_WAL_VERSION;
+	local_wal_buffer_offset += sizeof(uint16);
 
 	rec = (WALRecXid *) (&local_wal_buffer[local_wal_buffer_offset]);
 	rec->recType = WAL_REC_XID;


### PR DESCRIPTION
I would like suggest page inspection function analog of _bt_page_items_ from _pageinspect_ extension.
Currently it works only with "in memory" pages. In future we can add option to look into "on disk" pages as well.