### PR TITLE
Use GetReplayXlogPtrHook

### DIFF
--- a/include/recovery/recovery.h
+++ b/include/recovery/recovery.h
@@ -44,6 +44,8 @@ is_recovery_in_progress(void)
 }
 
 extern XLogRecPtr recovery_get_current_ptr(void);
+extern XLogRecPtr recovery_get_effective_replay_ptr(void);
+
 extern int	recovery_queue_size_guc;
 extern int	recovery_pool_size_guc;
 extern int	recovery_idx_pool_size_guc;

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -1051,6 +1051,7 @@ _PG_init(void)
 	IndexAMRoutineHook = orioledb_indexam_routine_hook;
 	getRunningTransactionsExtension = orioledb_get_running_transactions_extension;
 	waitSnapshotHook = orioledb_wait_snapshot;
+	GetReplayXlogPtrHook = recovery_get_effective_replay_ptr;
 	if (enable_rewind)
 		VacuumHorizonHook = orioledb_vacuum_horizon_hook;
 	orioledb_setup_ddl_hooks();

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -311,8 +311,6 @@ class BaseTest(unittest.TestCase):
 	def catchup_orioledb(self, replica):
 		# wait for synchronization
 		replica.catchup()
-		replica.poll_query_until("SELECT orioledb_recovery_synchronized();",
-		                         expected=True)
 
 	@staticmethod
 	def sparse_files_supported():

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -188,7 +188,6 @@ class LogicalTest(BaseTest):
 
 					# wait until changes apply on subscriber and check them
 					sub.catchup()
-					# sub.poll_query_until("SELECT orioledb_recovery_synchronized();", expected=True)
 					self.assertListEqual(
 					    subscriber.execute(
 					        'SELECT * FROM o_test1 ORDER BY id'), [(2, '2'),
@@ -363,10 +362,6 @@ class LogicalTest(BaseTest):
 
 					# wait until changes apply on subscriber and check them
 					sub.catchup()
-					#					subscriber.poll_query_until(
-					#					    "SELECT orioledb_recovery_synchronized();",
-					#					    expected=True)
-					#					subscriber.safe_psql("CHECKPOINT;")
 					self.assertListEqual(
 					    subscriber.execute(
 					        'SELECT * FROM o_test_ctid ORDER BY i'),

--- a/test/t/s3_inherits_test.py
+++ b/test/t/s3_inherits_test.py
@@ -3,13 +3,6 @@ import os
 
 from .s3_base_test import S3BaseTest
 
-
-def catchup_orioledb(replica):
-	replica.catchup()
-	replica.poll_query_until("SELECT orioledb_recovery_synchronized();",
-	                         expected=True)
-
-
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
 


### PR DESCRIPTION
And get rid of `orioledb_recovery_synchronized()` calls during tests.