### PR TITLE
allow using commit hash in .pgtags

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -25,6 +25,9 @@ fi
 
 cd postgresql
 ./configure $CONFIG_ARGS
+if printf "%s\n" "$PGTAG" | grep -v -Fqe "patches$(sed -n "/PACKAGE_VERSION='\(.*\)'/ s//\1/ p" configure | cut -d'.' -f1 )_"; then \
+	echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global; \
+fi ;
 make -sj `nproc`
 make -sj `nproc` install
 make -C contrib -sj `nproc`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -187,7 +187,11 @@ RUN set -eux; \
 		# Therefore, the extra ${POSTGRESQL_VERSION} is added as a workaround.
 		--with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} alpine:${ALPINE_VERSION}+${BUILD_CC_COMPILER} build:${ORIOLEDB_BUILDTIME} ${POSTGRESQL_VERSION}" \
 	|| cat config.log ); \
-	echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	if printf "%s\n" "$PGTAG" | grep -Fqe "patches${PG_MAJOR}_"; then \
+		echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	else \
+		echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global; \
+	fi ; \
 	# install postgresql
 	make -j "$(nproc)"; \
 	make -C contrib -j "$(nproc)"; \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -209,7 +209,11 @@ RUN set -eux; \
 		# Therefore, the extra ${POSTGRESQL_VERSION} is added as a workaround.
 		--with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} ubuntu:${UBUNTU_VERSION}+${BUILD_CC_COMPILER} build:${ORIOLEDB_BUILDTIME} ${POSTGRESQL_VERSION}" \
 	|| cat config.log ); \
-	echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	if printf "%s\n" "$PGTAG" | grep -Fqe "patches${PG_MAJOR}_"; then \
+		echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	else \
+		echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global; \
+	fi ; \
 	# install postgresql
 	make -j "$(nproc)"; \
 	make -C contrib -j "$(nproc)"; \


### PR DESCRIPTION
Prove that it doesn't break Docker build
https://github.com/orioledb/orioledb/actions/runs/18608687804
and regular build and its CI
https://github.com/orioledb/orioledb/actions/runs/18608687821
with hash used for pg 17 and with tag used for pg 16

---
still works on local machines with tags from `git describe --tags` on non tagged commits in format 'patches17_14-3-g1deadded'