### PR TITLE
Make check of ORIOLEDB_PATCHSET_VERSION in a Python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,53 +331,8 @@ ifndef ORIOLEDB_PATCHSET_VERSION
 ORIOLEDB_PATCHSET_VERSION=1
 endif
 
-CUR_ORIOLEDB_PATCHSET_VERSION := $(shell grep '^$(MAJORVERSION):' .pgtags | cut -d' ' -f2)
-
 check_patchset_version:
-	@status=0 ; \
-	PATCHSET_IS_HASH=1 ; \
-	expr 0 + $(ORIOLEDB_PATCHSET_VERSION) 2>/dev/null || status=$$? ; \
-	if [ "$$status" -eq 0 ] && [ $$(expr length $(ORIOLEDB_PATCHSET_VERSION)) -lt 6 ]; then \
-		PATCHSET_IS_HASH=0 ; \
-	fi ; \
-	CUR_PATCHSET_IS_HASH=1 ; \
-	if printf '%s\n' "$(CUR_ORIOLEDB_PATCHSET_VERSION)" | grep -Fqe '_'; then \
-		CUR_PATCHSET_IS_HASH=0 ; \
-	fi ; \
-	EXPECTED=$(CUR_ORIOLEDB_PATCHSET_VERSION) ; \
-	if [ "$$CUR_PATCHSET_IS_HASH" -eq 0 ] ; then \
-		EXPECTED=$$(echo $$EXPECTED | cut -d'_' -f2) ; \
-	fi ; \
-	GOT=$(ORIOLEDB_PATCHSET_VERSION) ; \
-	DIFFER=0 ; \
-	if [ "$$PATCHSET_IS_HASH" -eq 0 ]; then \
-		if [ "$$CUR_PATCHSET_IS_HASH" -eq 0 ]; then \
-			if [ "$$EXPECTED" != "$(ORIOLEDB_PATCHSET_VERSION)" ]; then \
-				DIFFER=1 ; \
-				USE="tag 'patches$(MAJORVERSION)_$$EXPECTED'" ; \
-			fi ; \
-		else \
-			DIFFER=1 ; \
-			USE="commit $$EXPECTED" ; \
-		fi ; \
-	else \
-		if [ "$$CUR_PATCHSET_IS_HASH" -eq 0 ]; then \
-			DIFFER=1 ; \
-			USE="tag 'patches$(MAJORVERSION)_$$EXPECTED'" ; \
-		else \
-			if [ $(CUR_ORIOLEDB_PATCHSET_VERSION) != $(ORIOLEDB_PATCHSET_VERSION) ]; then \
-				DIFFER=1 ; \
-				USE="commit '$$EXPECTED'" ; \
-			fi ; \
-		fi ; \
-	fi ; \
-	if [ "$$DIFFER" -eq 1 ]; then \
-		echo "Wrong orioledb patchset version:" \
-				"expected $$EXPECTED," \
-				"got $$GOT"; \
-		echo "Rebuild and install patched orioledb/postgres using $$USE"; \
-		false; \
-	fi
+	@python3 check_patchset_version.py $(MAJORVERSION) $(ORIOLEDB_PATCHSET_VERSION)
 
 $(OBJS): include/utils/stopevents_defs.h check_patchset_version
 

--- a/check_patchset_version.py
+++ b/check_patchset_version.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import sys
+import re
+
+
+def main():
+	if len(sys.argv) != 3:
+		sys.exit(1)
+
+	major_version = sys.argv[1]
+	provided_version = sys.argv[2]
+
+	# Read .pgtags file
+	with open('.pgtags', 'r') as f:
+		for line in f:
+			if line.startswith(f'{major_version}:'):
+				expected = line.split()[1].strip()
+				break
+		else:
+			print(f"No version found for PostgreSQL {major_version}")
+			sys.exit(1)
+
+	# Extract numeric version if format is like "patches17_14"
+	if '_' in expected:
+		expected_num = expected.split('_')[1]
+		tag_format = f"tag 'patches{major_version}_{expected_num}'"
+	else:
+		expected_num = expected
+		tag_format = f"commit '{expected}'"
+
+	# Check if provided version is numeric (not a hash)
+	is_numeric = re.match(r'^\d+$',
+	                      provided_version) and len(provided_version) < 6
+
+	# Compare appropriately
+	if is_numeric:
+		actual_mismatch = (expected_num != provided_version)
+	else:
+		actual_mismatch = (expected != provided_version)
+
+	if actual_mismatch:
+		print(
+		    f"Wrong orioledb patchset version: expected {expected_num}, got {provided_version}"
+		)
+		print(
+		    f"Rebuild and install patched orioledb/postgres using {tag_format}"
+		)
+		sys.exit(1)
+
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
The shell code in Makefile is a bit complicated and fails on some shells, for example fish.