### PR TITLE
Fix synchronous_commit = 'remote_apply'

### DIFF
--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -35,6 +35,7 @@
 #define WAL_REC_REINSERT (15)	/* UPDATE with changed pkey represented as
 								 * DELETE + INSERT in OrioleDB but externally
 								 * exported as an UPDATE in logical decoding */
+#define WAL_REC_REPLAY_FEEDBACK	(16)
 
 #define FIRST_WAL_VERSION (16)
 

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -531,7 +531,8 @@ orioledb_decode(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 			 rec_type == WAL_REC_INSERT ? "INSERT" :
 			 rec_type == WAL_REC_UPDATE ? "UPDATE" :
 			 rec_type == WAL_REC_DELETE ? "DELETE" :
-			 rec_type == WAL_REC_REINSERT ? "REINSERT" : "_UNKNOWN");
+			 rec_type == WAL_REC_REINSERT ? "REINSERT" :
+			 rec_type == WAL_REC_REPLAY_FEEDBACK ? "FEEDBACK" : "_UNKNOWN");
 
 		if (rec_type == WAL_REC_XID)
 		{
@@ -755,7 +756,7 @@ orioledb_decode(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 				elog(DEBUG4, "reloid: %d natts: %u toast natts: %u", cur_oids.reloid, descr->tupdesc->natts, descr->toast->leafTupdesc->natts);
 
 		}
-		else if (rec_type == WAL_REC_O_TABLES_META_LOCK)
+		else if (rec_type == WAL_REC_O_TABLES_META_LOCK || rec_type == WAL_REC_REPLAY_FEEDBACK)
 		{
 			/* Skip */
 		}

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -2829,6 +2829,10 @@ replay_container(Pointer startPtr, Pointer endPtr,
 			recovery_xmin = Max(recovery_xmin, xmin);
 			dlist_push_tail(&joint_commit_list, &cur_state->joint_commit_list_node);
 		}
+		else if (rec_type == WAL_REC_REPLAY_FEEDBACK)
+		{
+			XLogRequestWalReceiverReply();
+		}
 		else if (rec_type == WAL_REC_RELATION)
 		{
 			OIndexType	ix_type;


### PR DESCRIPTION
 * Add WAL_REC_REPLAY_FEEDBACK WAL record.  Emit it when synchronous_commit is 'remote_apply'.  Provite feedback on replay of this record.
 * Wait for replay location to be reported when synchronous_commit is 'remote_apply'.

This should fix #607.