### PR TITLE
GitHub issue 571: New mechanics for logical xid assignment and switch xid for correct logical decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ lib*.pc
 # Ignore generated scripts
 sql/orioledb--1.0.sql
 sql/orioledb--1.4--1.5.sql
+sql/orioledb--1.5--1.6.sql
 # Exclude the PostGIS Docker build directory
 /docker-postgis

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/include_indices_test.py \
 						test/t/indices_build_test.py \
 						test/t/logical_test.py \
+						test/t/logical_xid_subxacts_test.py \
 						test/t/not_supported_yet_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \

--- a/include/transam/oxid.h
+++ b/include/transam/oxid.h
@@ -43,6 +43,15 @@ typedef struct
 
 extern XidMeta *xid_meta;
 
+typedef struct
+{
+	TransactionId xid;			/* a 32-bit transaction id to be used during
+								 * logical decoding */
+	bool		useHeap;		/* flag indicates if current logical xid was
+								 * allocated when heap xid has been already
+								 * set */
+} LogicalXidCtx;
+
 typedef struct OSnapshot
 {
 	CommitSeqNo csn;
@@ -84,6 +93,8 @@ o_check_isolation_level(void)
 
 #define XLOG_PTR_ALIGN(ptr) ((ptr) + ((ptr) & 1))
 
+extern void oxid_subxact_callback(SubXactEvent event, SubTransactionId mySubid, SubTransactionId parentSubid, void *arg);
+
 extern Size oxid_shmem_needs(void);
 extern void oxid_init_shmem(Pointer ptr, bool found);
 extern bool wait_for_oxid(OXid oxid, bool errorOk);
@@ -95,11 +106,12 @@ extern void assign_subtransaction_logical_xid(void);
 extern void set_oxid_csn(OXid oxid, CommitSeqNo csn);
 extern void set_oxid_xlog_ptr(OXid oxid, XLogRecPtr ptr);
 extern void set_current_oxid(OXid oxid);
-extern void set_current_logical_xid(TransactionId xid);
+extern void set_current_logical_xid(LogicalXidCtx *in);
 extern void parallel_worker_set_oxid(void);
 extern void reset_current_oxid(void);
 extern OXid get_current_oxid_if_any(void);
 extern TransactionId get_current_logical_xid(void);
+extern void get_current_logical_xid_ctx(LogicalXidCtx *output);
 extern void current_oxid_precommit(void);
 extern void current_oxid_xlog_precommit(void);
 extern void current_oxid_commit(CommitSeqNo csn);

--- a/include/transam/undo.h
+++ b/include/transam/undo.h
@@ -270,7 +270,7 @@ typedef struct
 	bool		has_retained_undo_location[(int) UndoLogsCount];
 	bool		local_wal_has_material_changes;
 	OXid		oxid;
-	TransactionId logicalXid;
+	LogicalXidCtx logicalXidContext;
 } OAutonomousTxState;
 
 /*

--- a/sql/orioledb--1.5--1.6_dev.sql
+++ b/sql/orioledb--1.5--1.6_dev.sql
@@ -1,0 +1,16 @@
+/* contrib/orioledb/sql/orioledb--1.5--1.6_dev.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.6'" to load this file. \quit
+
+-- Get current logical xid to remember it
+CREATE FUNCTION orioledb_get_current_logical_xid()
+RETURNS int8
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+-- Get current heap xid to remember it
+CREATE FUNCTION orioledb_get_current_heap_xid()
+RETURNS int8
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.5--1.6_prod.sql
+++ b/sql/orioledb--1.5--1.6_prod.sql
@@ -1,4 +1,4 @@
-/* contrib/orioledb/sql/orioledb--1.5--1.6.sql */
+/* contrib/orioledb/sql/orioledb--1.5--1.6_prod.sql */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION orioledb UPDATE TO '1.6'" to load this file. \quit

--- a/test/t/logical_xid_subxacts_test.py
+++ b/test/t/logical_xid_subxacts_test.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import subprocess
+
+from .base_test import BaseTest
+from testgres.exceptions import QueryException
+
+
+def equalZero(val):
+	return val == 0
+
+
+def aboveZero(val):
+	return val > 0
+
+
+class LogicalXidSubxactsTest(BaseTest):
+
+	o_table = "o_test"
+	h_table = "h_test"
+
+	orioledb_get_current_heap_xid = "SELECT orioledb_get_current_heap_xid();"
+	orioledb_get_current_logical_xid = "SELECT orioledb_get_current_logical_xid();"
+
+	check_stmt = f"""
+		{orioledb_get_current_heap_xid}
+		{orioledb_get_current_logical_xid}
+	"""
+	heap_xid = 0
+	oriole_xid = 1
+
+	def run_check(self, con, stmt, cb):
+		output = con.execute(f"""{stmt}""")
+		#print(output)
+		self.assertTrue(cb(output[0][0]))
+
+	def check(self, con, on_heap, on_oriole):
+		self.run_check(con, self.orioledb_get_current_heap_xid, on_heap)
+		self.run_check(con, self.orioledb_get_current_logical_xid, on_oriole)
+
+	def init(self):
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', f"""
+        		CREATE EXTENSION orioledb;
+        		CREATE TABLE {self.o_table} (a int PRIMARY KEY, b text) USING orioledb;
+    		""")
+
+	# top xact: readonly
+	# sub xact: heap write
+	def test_top_ro_sub_hwr(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(
+		    f"""CREATE TABLE {self.h_table} (a int PRIMARY KEY, b text);""")
+		self.check(con, aboveZero, equalZero)
+
+		con.commit()
+		con.close()
+		node.stop()
+
+	# top xact: readonly
+	# sub xact: oriole write
+	def test_top_ro_sub_owr(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(
+		    f"""INSERT INTO {self.o_table} (a, b) VALUES (1, 'one'), (2, 'two');"""
+		)
+		self.check(con, equalZero, aboveZero)
+
+		con.commit()
+		con.close()
+		node.stop()
+
+	# top xact: readonly
+	# sub xact: heap->oriole write
+	def test_top_ro_sub_howr(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(
+		    f"""CREATE TABLE {self.h_table} (a int PRIMARY KEY, b text) USING orioledb;"""
+		)
+		self.check(con, aboveZero, aboveZero)
+
+		con.commit()
+		con.close()
+		node.stop()
+
+	# top xact: readonly
+	# sub xact: heap->oriole write
+	# sub xact: readonly
+	def test_top_ro_sub_howr_ro(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(
+		    f"""CREATE TABLE {self.h_table} (a int PRIMARY KEY, b text) USING orioledb;"""
+		)
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute("SAVEPOINT sp2;")
+		self.check(con, equalZero, aboveZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, aboveZero)
+
+		con.commit()
+		con.close()
+		node.stop()
+
+	# top xact: readonly
+	# sub xact: oriole->heap write
+	def test_top_ro_sub_ohwr_1(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(
+		    f"""INSERT INTO {self.o_table} (a, b) VALUES (1, 'one'), (2, 'two');"""
+		)
+		self.check(con, equalZero, aboveZero)
+
+		con.execute(
+		    f"""CREATE TABLE {self.h_table} (a int PRIMARY KEY, b text);""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.commit()
+		con.close()
+		node.stop()
+
+	# top xact: readonly
+	# sub xact: oriole->heap write
+	def test_top_ro_sub_ohwr_2(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(
+		    f"""INSERT INTO {self.o_table} (a, b) VALUES (1, 'one'), (2, 'two');"""
+		)
+		self.check(con, equalZero, aboveZero)
+
+		con.execute(
+		    f"""CREATE TABLE {self.h_table} (a int PRIMARY KEY, b text);""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute(f"""
+			INSERT INTO {self.o_table} (a, b) VALUES (3, 'three'), (4, 'four');
+            INSERT INTO {self.o_table} (a, b) VALUES (5, 'five'), (6, 'six');
+		""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute("SAVEPOINT sp2;")
+		self.check(con, equalZero, aboveZero)
+
+		con.commit()
+		con.close()
+		node.stop()
+
+	def test_top_ro_sub_ALTER_01(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""ALTER TABLE {self.o_table} RENAME COLUMN b TO data;""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute(
+		    f"""INSERT INTO {self.o_table}(a, data) VALUES(1, '100');""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute("ROLLBACK TO sp1;")
+		self.check(con, equalZero, aboveZero)
+
+		con.execute(f"""INSERT INTO {self.o_table}(a, b) VALUES(2, '200');""")
+		self.check(con, equalZero, aboveZero)
+
+		con.commit()
+		con.close()
+		node.stop()
+
+	def test_top_ro_sub_ALTER_02(self):
+		node = self.node
+		self.init()
+		con = node.connect()
+		con.begin()
+
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""SELECT COUNT(*) FROM {self.o_table};""")
+		self.check(con, equalZero, equalZero)
+
+		con.execute("SAVEPOINT sp1;")
+		self.check(con, equalZero, equalZero)
+
+		con.execute(f"""ALTER TABLE {self.o_table} RENAME COLUMN b TO data;""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute(
+		    f"""INSERT INTO {self.o_table}(a, data) VALUES(1, '100');""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute("ROLLBACK TO sp1;")
+		self.check(con, equalZero, aboveZero)
+
+		con.execute(f"""ALTER TABLE {self.o_table} RENAME COLUMN b TO data;""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute(
+		    f"""INSERT INTO {self.o_table}(a, data) VALUES(2, '200');""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute("SAVEPOINT sp2;")
+		self.check(con, equalZero, aboveZero)
+
+		con.execute(
+		    f"""INSERT INTO {self.o_table}(a, data) VALUES(3, '300');""")
+		self.check(con, equalZero, aboveZero)
+
+		con.execute("SAVEPOINT sp3;")
+		self.check(con, equalZero, aboveZero)
+
+		con.execute(
+		    f"""ALTER TABLE {self.o_table} RENAME COLUMN data TO newdata;""")
+		self.check(con, aboveZero, aboveZero)
+
+		con.execute("SAVEPOINT sp4;")
+		self.check(con, equalZero, aboveZero)
+
+		con.execute("SAVEPOINT sp5;")
+		self.check(con, equalZero, aboveZero)
+
+		con.commit()
+		con.close()
+		node.stop()


### PR DESCRIPTION
New mechanics for logical xid assignment in a case when both Heap and Oriole apply changes within a single transaction (mixed transaction). For mixed transaction, Oriole's part acts as a sub-transaction for Heap.

New WAL record type (switch xid) added to determine a connection between Oriole's sub-transaction xid and a xid of the top Heap transaction.

Otherwise, without this connection, main transaction suddenly becomes splitted into two independent parts. From logical decoder's point of view this looks like two independent transactions but in fact internally related to each other. This situation outcomes in troubles for logical decoder with visibility of heap modifications in Oriole's sub-part due to incorrect state of the MVCC-historical snapshot.