### PR TITLE
Add `get_pgtag.sh` to get commit id from git describe format

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Get the required tag name
         shell: bash
         run: |
-          echo "PGTAG=$(grep '^${{ matrix.pg_version }}: ' .pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+          bash ./orioledb/ci/get_pgtag.sh ${{ matrix.pg_version }} orioledb/.pgtags
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Get the required tag name
         shell: bash
         run: |
-          echo "PGTAG=$(grep '^${{ github.event.inputs.pg_version }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+          bash ./orioledb/ci/get_pgtag.sh ${{ github.event.inputs.pg_version }} orioledb/.pgtags
       - name: Checkout PostgreSQL code into workspace directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Get the required tag name
         shell: bash
         run: |
-          echo "PGTAG=$(grep '^${{ matrix.pg_version }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+          bash ./orioledb/ci/get_pgtag.sh ${{ matrix.pg_version }} orioledb/.pgtags
       - name: Checkout PostgreSQL code into workspace directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pgindent.yml
+++ b/.github/workflows/pgindent.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get the required tag name
         shell: bash
         run: |
-          echo "PGTAG=$(grep '^${{ matrix.pg_version }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+          bash ./orioledb/ci/get_pgtag.sh ${{ matrix.pg_version }} orioledb/.pgtags
       - name: Checkout PostgreSQL code into workspace directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Get the required tag name
         shell: bash
         run: |
-          echo "PGTAG=$(grep '^${{ github.event.inputs.version }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+          bash ./orioledb/ci/get_pgtag.sh ${{ github.event.inputs.version }} orioledb/.pgtags
       - name: Checkout PostgreSQL code into workspace directory
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get the required tag name
         shell: bash
         run: |
-          echo "PGTAG=$(grep '^${{ matrix.pg_version }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+          bash ./orioledb/ci/get_pgtag.sh ${{ matrix.pg_version }} orioledb/.pgtags
       - name: Checkout PostgreSQL code into workspace directory
         uses: actions/checkout@v4
         with:

--- a/.pgtags
+++ b/.pgtags
@@ -1,2 +1,2 @@
-17: fd5baeb1b4af0affa698d480f46380aecae37ad1
-16: 5f9e2afd3888ac1b37a2d4d641705da9ae084701
+17: patches17_14-4-gfd5baeb1b4    fd5baeb1b4af0affa698d480f46380aecae37ad1
+16: patches16_41-3-g5f9e2afd38    5f9e2afd3888ac1b37a2d4d641705da9ae084701

--- a/check_patchset_version.py
+++ b/check_patchset_version.py
@@ -14,19 +14,27 @@ def main():
 	with open('.pgtags', 'r') as f:
 		for line in f:
 			if line.startswith(f'{major_version}:'):
-				expected = line.split()[1].strip()
+				parts = line.split()
+				# Possible formats:
+				# "17: patches17_14-4-gfd5baeb1b4    fd5baeb1b4af0affa698d480f46380aecae37ad1"
+				# "17: patches17_14"
+				expected_tag = parts[1].strip()
+				expected_hash = parts[2].strip() if len(parts) >= 3 else None
 				break
 		else:
 			print(f"No version found for PostgreSQL {major_version}")
 			sys.exit(1)
 
-	# Extract numeric version if format is like "patches17_14"
-	if '_' in expected:
-		expected_num = expected.split('_')[1]
-		tag_format = f"tag 'patches{major_version}_{expected_num}'"
+	# Extract numeric version from git describe format
+	# Examples:
+	#   patches17_14 -> 14
+	#   patches17_14-4-gfd5baeb1b4 -> 14-4-gfd5baeb1b4
+	match = re.match(r'^patches\d+_(\d+(?:-\d+-g[0-9a-f]+)?)$', expected_tag)
+	if match:
+		expected_num = match.group(1)
 	else:
-		expected_num = expected
-		tag_format = f"commit '{expected}'"
+		print(f"Wrong tag format {expected_tag}")
+		sys.exit(1)
 
 	# Check if provided version is numeric (not a hash)
 	is_numeric = re.match(
@@ -34,19 +42,27 @@ def main():
 	# Check if provided version is part of `git describe --tags`
 	is_describe_tag = re.match(r'^\d+-\d+-g[0-9a-f]+$',
 	                           provided_version) is not None
+	# Check if provided version is a full commit hash
+	is_hash = re.match(r'^[0-9a-f]{40}$', provided_version) is not None
 
+	actual_mismatch = True
 	# Compare appropriately
 	if is_numeric or is_describe_tag:
+		# Compare against the extracted numeric/describe version
 		actual_mismatch = (expected_num != provided_version)
-	else:
-		actual_mismatch = (expected != provided_version)
+	elif is_hash and expected_hash:
+		# Compare full hash against the one from .pgtags
+		actual_mismatch = (expected_hash != provided_version)
+	elif is_hash and not expected_hash:
+		# Full hash provided but not in .pgtags - this is a mismatch
+		actual_mismatch = True
 
 	if actual_mismatch:
 		print(
 		    f"Wrong orioledb patchset version: expected {expected_num}, got {provided_version}"
 		)
 		print(
-		    f"Rebuild and install patched orioledb/postgres using {tag_format}"
+		    f"Rebuild and install patched orioledb/postgres using tag '{expected_tag}'"
 		)
 		sys.exit(1)
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -25,9 +25,12 @@ fi
 
 cd postgresql
 ./configure $CONFIG_ARGS
-if printf "%s\n" "$PGTAG" | grep -v -Fqe "patches$(sed -n "/PACKAGE_VERSION='\(.*\)'/ s//\1/ p" configure | cut -d'.' -f1 )_"; then \
-	echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global; \
-fi ;
+
+# Check if PGTAG looks like a full commit hash (40 hex chars)
+if [[ "$PGTAG" =~ ^[0-9a-f]{40}$ ]]; then
+	echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global
+fi
+
 make -sj `nproc`
 make -sj `nproc` install
 make -C contrib -sj `nproc`

--- a/ci/get_pgtag.sh
+++ b/ci/get_pgtag.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+# Usage: ./get_pgtag.sh <pg_version> <pgtags_file>
+PG_VERSION=$1
+PGTAGS_FILE=${2:-.pgtags}
+
+# Extract the version/tag from .pgtags
+PGTAG_LINE=$(grep "^${PG_VERSION}: " "$PGTAGS_FILE")
+
+if [ -z "$PGTAG_LINE" ]; then
+  echo "Error: No tag found for PostgreSQL version $PG_VERSION in $PGTAGS_FILE" >&2
+  exit 1
+fi
+
+# Extract fields: first field after colon is git describe, second (optional) is full hash
+# Use awk to handle variable whitespace properly
+PGTAG_RAW=$(echo "$PGTAG_LINE" | awk '{print $2}')
+FULL_HASH=$(echo "$PGTAG_LINE" | awk '{print $3}')
+
+# If a full hash is provided (40 characters), use it
+if [ -n "$FULL_HASH" ] && [ ${#FULL_HASH} -eq 40 ]; then
+  PGTAG="$FULL_HASH"
+  echo "Using full commit hash: $PGTAG" >&2
+  echo "Git describe: $PGTAG_RAW" >&2
+# Check if it's a git describe format (extract base tag)
+elif [[ "$PGTAG_RAW" =~ ^(.+)_([0-9]+)-([0-9]+)-g[0-9a-f]+$ ]]; then
+  echo "PGTAG_RAW: $PGTAG_RAW, FULL_HASH: $FULL_HASH"
+  echo "Error: No full commit hash provided for tag: $PGTAG_RAW"
+  exit 1
+else
+  # Regular tag
+  PGTAG="$PGTAG_RAW"
+  echo "Using ref: $PGTAG" >&2
+fi
+
+if [ -n "$GITHUB_ENV" ]; then
+  echo "PGTAG=$PGTAG" >> "$GITHUB_ENV"
+fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 
 RUN set -eux; \
 	\
-	PGTAG=$(grep "^$PG_MAJOR: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+	PGTAG=$(grep "^$PG_MAJOR: " /usr/src/postgresql/contrib/orioledb/.pgtags | awk '{if ($3 != "" && length($3) == 40) print $3; else print $2}') ; \
 	ORIOLEDB_VERSION=$(grep "^#define ORIOLEDB_VERSION" /usr/src/postgresql/contrib/orioledb/include/orioledb.h | cut -d'"' -f2) ; \
 	ORIOLEDB_BUILDTIME=$(date -Iseconds) ; \
 	ALPINE_VERSION=$(cat /etc/os-release | grep VERSION_ID | cut -d = -f 2 | cut -d . -f 1,2 | cut -d _ -f 1) ; \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -96,7 +96,7 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 RUN set -eux; \
 	\
-	PGTAG=$(grep "^$PG_MAJOR: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+	PGTAG=$(grep "^$PG_MAJOR: " /usr/src/postgresql/contrib/orioledb/.pgtags | awk '{if ($3 != "" && length($3) == 40) print $3; else print $2}') ; \
 	ORIOLEDB_VERSION=$(grep "^#define ORIOLEDB_VERSION" /usr/src/postgresql/contrib/orioledb/include/orioledb.h | cut -d'"' -f2) ; \
 	ORIOLEDB_BUILDTIME=$(date -Iseconds) ; \
 	\


### PR DESCRIPTION
- Add `ci/get_pgtag.sh` — new helper that extracts the correct PGTAG value from .pgtags.
- Update CI workflow steps (`.github/workflows/*.yml`) to call `ci/get_pgtag.sh` instead of using inline grep/cut.
- Update `.pgtags` format to include both a git-describe-like value and the corresponding full commit hash (example lines added).