### PR TITLE
Added lockstep scan for arrays and fixed coercible calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,8 @@ REGRESSCHECKS = btree_sys_check \
 				toast \
 				trigger \
 				types \
-				rewind
+				rewind \
+				lockstep
 ISOLATIONCHECKS = bitmap_hist_scan \
 				  btree_iterate \
 				  btree_print_backend_id \

--- a/include/btree/btree.h
+++ b/include/btree/btree.h
@@ -38,16 +38,87 @@ typedef uint64 OTupleXactInfo;
 #define TOASTIndexNumber (0xFFFE)
 #define InvalidIndexNumber (0xFFFF)
 
+/*
+ * BTreeKeyType
+ *
+ * Defines the type of key used in B-tree operations. The type affects how
+ * keys are compared, hashed, and interpreted during tree traversal and
+ * modification operations.
+ */
 typedef enum BTreeKeyType
 {
+	/*
+	 * BTreeKeyLeafTuple: Represents a complete tuple stored in a leaf page.
+	 * Used when comparing or hashing full tuples that contain all columns
+	 * defined in the index, including non-key columns in the case of covering
+	 * indexes. This is the most common key type for insert, update, and delete
+	 * operations at the leaf level.
+	 */
 	BTreeKeyLeafTuple,
+	
+	/*
+	 * BTreeKeyNonLeafKey: Represents a key in non-leaf (internal) pages used
+	 * for navigation. These keys contain only the indexed columns and are used
+	 * to guide searches down the tree. Non-leaf keys are created from leaf
+	 * tuples via the tuple_make_key operation, which extracts just the key
+	 * columns (and optionally the version).
+	 */
 	BTreeKeyNonLeafKey,
+	
+	/*
+	 * BTreeKeyBound: Represents a search boundary key used for range scans
+	 * and lookups. This type is used with OBTreeKeyBound structures that
+	 * specify per-column boundary conditions (inclusive/exclusive, NULL,
+	 * unbounded, etc.). Bound keys enable flexible range queries with precise
+	 * control over boundary inclusion/exclusion.
+	 */
 	BTreeKeyBound,
+	
+	/*
+	 * BTreeKeyUniqueLowerBound: Lower bound for unique constraint checking.
+	 * Used during unique index insertions to find the starting point for
+	 * scanning tuples that might violate uniqueness. The scan continues until
+	 * BTreeKeyUniqueUpperBound is reached, checking all potentially conflicting
+	 * tuples within the unique key range.
+	 */
 	BTreeKeyUniqueLowerBound,
+	
+	/*
+	 * BTreeKeyUniqueUpperBound: Upper bound for unique constraint checking.
+	 * Marks the end of the range to scan when checking for unique constraint
+	 * violations. Together with BTreeKeyUniqueLowerBound, this defines the
+	 * exact range of tuples that must be checked to ensure uniqueness of the
+	 * indexed columns.
+	 */
 	BTreeKeyUniqueUpperBound,
-	/* following values are never passed to comparison function */
+	
+	/*
+	 * The following values are never passed to comparison functions and are
+	 * used for special tree traversal operations:
+	 */
+
+	/*
+	 * BTreeKeyNone: Requests the leftmost item/page in the tree. When used
+	 * during tree traversal, it directs the search to always take the leftmost
+	 * path, without performing any key comparisons. This is used for full
+	 * forward scans starting from the beginning of the index.
+	 */
 	BTreeKeyNone,
+	
+	/*
+	 * BTreeKeyPageHiKey: Represents the high key boundary of a B-tree page.
+	 * The high key is the upper bound of all keys that can be stored on a page.
+	 * This is used internally for page split operations and to determine if a
+	 * search needs to follow the right-link to a sibling page.
+	 */
 	BTreeKeyPageHiKey,
+	
+	/*
+	 * BTreeKeyRightmost: Requests the rightmost item/page in the tree. During
+	 * tree traversal, this directs the search to always take the rightmost path
+	 * without performing key comparisons. This is used for full backward scans
+	 * starting from the end of the index or for finding the maximum key.
+	 */
 	BTreeKeyRightmost
 } BTreeKeyType;
 

--- a/include/tableam/index_scan.h
+++ b/include/tableam/index_scan.h
@@ -32,6 +32,7 @@ typedef struct OScanState
 	bool		curKeyRangeIsLoaded;
 	int			numPrefixExactKeys;
 	bool		exact;
+	bool		use_lockstep;
 	OBTreeKeyRange curKeyRange;
 	BTreeIterator *iterator;
 	List	   *indexQuals;

--- a/include/tableam/key_range.h
+++ b/include/tableam/key_range.h
@@ -22,6 +22,7 @@
 #define O_VALUE_BOUND_LOWER 0x08
 #define O_VALUE_BOUND_UPPER 0x10
 #define O_VALUE_BOUND_COERCIBLE 0x20
+#define O_VALUE_BOUND_NON_COERCIBLE 0x40
 #define O_VALUE_BOUND_DIRECTIONS (O_VALUE_BOUND_LOWER | O_VALUE_BOUND_UPPER)
 #define O_VALUE_BOUND_NO_VALUE (O_VALUE_BOUND_NULL | O_VALUE_BOUND_UNBOUNDED)
 #define O_VALUE_BOUND_MINUS_INFINITY (O_VALUE_BOUND_LOWER | O_VALUE_BOUND_UNBOUNDED)
@@ -67,9 +68,11 @@ typedef struct
 extern bool o_key_data_to_key_range(OBTreeKeyRange *res,
 									ScanKeyData *keyData,
 									int numberOfKeys,
+									int numberOfArrayKeys,
 									BTArrayKeyInfo *arrayKeys,
 									int numPrefixExactKeys,
 									int resultNKeys,
-									OIndexField *fields);
+									OIndexField *fields,
+									bool *use_lockstep);
 
 #endif

--- a/src/btree/fastpath.c
+++ b/src/btree/fastpath.c
@@ -476,7 +476,7 @@ fastpath_find_chunk(Pointer pagePtr,
 	pg_read_barrier();
 
 	/* Possible we need to visit the rightlink */
-	if (*chunkIndex >= count)
+	if (*chunkIndex >= imgHdr->chunksCount)
 		return OBTreeFastPathFindSlowpath;
 
 	state = pg_atomic_read_u64(&hdr->o_header.state);

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -15,6 +15,7 @@
 
 #include "orioledb.h"
 
+#include "btree/fastpath.h"
 #include "btree/io.h"
 #include "btree/iterator.h"
 #include "tableam/bitmap_scan.h"
@@ -43,6 +44,7 @@ init_index_scan_state(OPlanState *o_plan_state, OScanState *ostate, Relation ind
 
 	scan = btbeginscan(index, *numScanKeys, 0);
 	ostate->scandesc = *scan;
+	ostate->use_lockstep = false;
 	pfree(scan);
 	scan = &ostate->scandesc;
 
@@ -98,8 +100,71 @@ row_key_tuple_is_valid(OBtreeRowKeyBound *row_key, OTuple tup, OIndexDescr *id,
 static inline bool
 o_bound_is_coercible(OBTreeValueBound *bound, OIndexField *field)
 {
-	return (bound->flags & O_VALUE_BOUND_COERCIBLE) ||
-		IsBinaryCoercible(bound->type, field->inputtype);
+	bool		result;
+
+	if (bound->flags & O_VALUE_BOUND_COERCIBLE)
+		return true;
+	if (bound->flags & O_VALUE_BOUND_NON_COERCIBLE)
+		return false;
+	/* Neither flag is set, compute and cache the result */
+	result = IsBinaryCoercible(bound->type, field->inputtype);
+	bound->flags |= result ? O_VALUE_BOUND_COERCIBLE : O_VALUE_BOUND_NON_COERCIBLE;
+	return result;
+}
+
+/*
+ * Compare tuple's prefix keys against current array elements for lockstep scanning.
+ * Returns:
+ *   -1 if tuple is less than current array combination
+ *    0 if tuple matches current array combination  
+ *    1 if tuple is greater than current array combination
+ */
+static int
+compare_tuple_with_array_keys(OTuple tup, OIndexDescr *id,
+							   BTScanOpaque so, int numPrefixExactKeys)
+{
+	BTArrayKeyInfo *arrayKeys = so->arrayKeys;
+	int			i;
+
+	for (i = 0; i < so->numArrayKeys; i++)
+	{
+		BTArrayKeyInfo *arrayKey = arrayKeys + i;
+		ScanKey		key = so->keyData + arrayKey->scan_key;
+		int			cmp;
+		bool		isnull;
+		Datum		value;
+		Datum		arrayValue;
+		OIndexField *field;
+
+		/* Only process prefix array keys for lockstep scanning */
+		if (arrayKey->scan_key >= numPrefixExactKeys)
+			break;
+
+		Assert((key->sk_flags & SK_SEARCHARRAY) &&
+			   key->sk_strategy == BTEqualStrategyNumber &&
+			   arrayKey->num_elems > 0);
+
+		value = o_fastgetattr(tup, key->sk_attno, id->leafTupdesc,
+							  &id->leafSpec, &isnull);
+		arrayValue = arrayKey->elem_values[arrayKey->cur_elem];
+		field = &id->fields[key->sk_attno - 1];
+
+		/*
+		 * Compare tuple value with current array element.
+		 * Note: NULL handling is done by the comparator. PostgreSQL's
+		 * array handling excludes NULL from IN arrays, and NULL tuples
+		 * will not match any array element per SQL semantics.
+		 */
+		cmp = o_call_comparator(field->comparator, value, arrayValue);
+		
+		if (!field->ascending)
+			cmp = -cmp;
+
+		if (cmp != 0)
+			return cmp;
+	}
+
+	return 0;
 }
 
 static bool
@@ -322,10 +387,12 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	ostate->exact = o_key_data_to_key_range(&ostate->curKeyRange,
 											so->keyData,
 											so->numberOfKeys,
+											so->numArrayKeys,
 											(so->numArrayKeys > 0) ? so->arrayKeys : NULL,
 											ostate->numPrefixExactKeys,
 											indexDescr->nonLeafTupdesc->natts,
-											indexDescr->fields);
+											indexDescr->fields,
+											&ostate->use_lockstep);
 
 	if (!ostate->exact)
 	{
@@ -343,6 +410,17 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	return true;
 }
 
+/**
+ * @brief Fetches the next valid tuple from the index scan using the specified scan state and key range.
+ *
+ * This function iterates over B-tree index ranges, attempting to retrieve the next visible tuple
+ * that satisfies the scan conditions. It handles exact key lookups, range scans, and optimized
+ * scanning for sorted arrays (SK_SEARCHARRAY), including lockstep comparison with array keys.
+ * The function advances through key ranges as needed and uses an iterator or direct lookup
+ * depending on the scan mode.
+ *
+ * "exact" mode means that we are looking for a specific key, so we can use direct lookup.
+ */
 OTuple
 o_iterate_index(OIndexDescr *indexDescr, OScanState *ostate,
 				CommitSeqNo *tupleCsn, MemoryContext tupleCxt,
@@ -384,24 +462,115 @@ o_iterate_index(OIndexDescr *indexDescr, OScanState *ostate,
 			bound = (ostate->scanDir == ForwardScanDirection
 					 ? &ostate->curKeyRange.high : &ostate->curKeyRange.low);
 
-			do
+			/*
+			 * Lockstep scanning optimization for SK_SEARCHARRAY (sorted arrays).
+			 * Check if we have array keys.
+			 * We compare tuples from the iterator with current array element,
+			 * advancing inline to avoid unnecessary range recalculation.
+			 */
+			if (ostate->use_lockstep)
 			{
-				tup = o_btree_iterator_fetch(ostate->iterator, tupleCsn,
-											 bound, BTreeKeyBound,
-											 true, hint);
-
-				if (O_TUPLE_IS_NULL(tup))
-					tup_is_valid = true;
-				else
+				do
 				{
-					tup_is_valid = is_tuple_valid(tup, indexDescr,
-												  &ostate->curKeyRange,
-												  so,
-												  ostate->numPrefixExactKeys);
-					if (tup_is_valid)
-						tup_fetched = true;
-				}
-			} while (!tup_is_valid);
+					int			cmp;
+					
+					/* 
+					 * Reuse tuple from previous iteration if we have one 
+					 * (happens when tuple > current array element)
+					 */
+					if (O_TUPLE_IS_NULL(tup))
+						tup = o_btree_iterator_fetch(ostate->iterator, tupleCsn,
+													 bound, BTreeKeyBound,
+													 true, hint);
+
+					if (O_TUPLE_IS_NULL(tup))
+					{
+						
+						/* 
+						 * End of iterator. Try to advance array and restart 
+						 * from beginning if we haven't tried all combinations.
+						 */
+						tup_fetched = false;
+						break;
+					}
+
+					/* Compare tuple with current array element combination */
+					cmp = compare_tuple_with_array_keys(tup, indexDescr, so,
+													   ostate->numPrefixExactKeys);
+
+					if (cmp < 0)
+					{
+						/* Tuple is less than current array element, skip it */
+						pfree(tup.data);
+						O_TUPLE_SET_NULL(tup);
+						continue;
+					}
+					else if (cmp > 0)
+					{
+						/*
+						 * Tuple is greater than current array element.
+						 * Advance to next array element inline without breaking out.
+						 */
+						bool	array_advanced;
+
+						array_advanced = o_bt_advance_array_keys_increment(ostate, 
+																		   ostate->scanDir);
+						if (!array_advanced)
+						{
+							/* 
+							 * No more array elements. Keep the tuple and break
+							 * to let outer loop call switch_to_next_range.
+							 */
+							tup_fetched = false;
+							O_TUPLE_SET_NULL(tup);
+							break;
+						}
+
+						/* Continue with same tuple against next array element */
+						continue;
+					}
+					else
+					{
+						/*
+						 * Tuple matches current array element.
+						 * Still need to validate against non-prefix array keys.
+						 */
+						tup_is_valid = is_tuple_valid(tup, indexDescr,
+													  &ostate->curKeyRange,
+													  so,
+													  ostate->numPrefixExactKeys);
+						if (tup_is_valid)
+						{
+							tup_fetched = true;
+							break;
+						}
+						pfree(tup.data);
+						O_TUPLE_SET_NULL(tup);
+					}
+				} while (true);
+			}
+			else
+			{
+				/* Regular range scanning without array keys in prefix */
+				do
+				{
+					tup = o_btree_iterator_fetch(ostate->iterator, tupleCsn,
+												bound, BTreeKeyBound,
+												true, hint);
+
+					if (O_TUPLE_IS_NULL(tup))
+						tup_is_valid = true;
+					else
+					{
+						tup_is_valid = is_tuple_valid(tup, indexDescr,
+													&ostate->curKeyRange,
+													so,
+													ostate->numPrefixExactKeys);
+						if (tup_is_valid)
+							tup_fetched = true;
+					}
+ 				} while (!tup_is_valid);
+			}
 		}
 		else
 		{

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -513,8 +513,12 @@ o_iterate_index(OIndexDescr *indexDescr, OScanState *ostate,
 						 */
 						bool	array_advanced;
 
+#if PG_VERSION_NUM >= 170000
 						array_advanced = o_bt_advance_array_keys_increment(ostate, 
 																		   ostate->scanDir);
+#else
+						array_advanced = _bt_advance_array_keys(scan, ForwardScanDirection);
+#endif
 						if (!array_advanced)
 						{
 							/* 

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -465,8 +465,16 @@ o_sidx_tuple_make_key(BTreeDescr *desc, OTuple tuple, Pointer data,
 static inline bool
 o_bound_is_coercible(OBTreeValueBound *bound, OIndexField *field)
 {
-	return (bound->flags & O_VALUE_BOUND_COERCIBLE) ||
-		IsBinaryCoercible(bound->type, field->inputtype);
+	bool		result;
+
+	if (bound->flags & O_VALUE_BOUND_COERCIBLE)
+		return true;
+	if (bound->flags & O_VALUE_BOUND_NON_COERCIBLE)
+		return false;
+	/* Neither flag is set, compute and cache the result */
+	result = IsBinaryCoercible(bound->type, field->inputtype);
+	bound->flags |= result ? O_VALUE_BOUND_COERCIBLE : O_VALUE_BOUND_NON_COERCIBLE;
+	return result;
 }
 
 /* fills key bound from tuple or index tuple that belongs to current BTree */

--- a/test/expected/lockstep.out
+++ b/test/expected/lockstep.out
@@ -1,0 +1,56 @@
+--
+-- Test orioledb indexes:
+--	lockstep scanning with IN clauses
+--
+CREATE SCHEMA lockstep;
+SET SESSION search_path = 'lockstep';
+CREATE EXTENSION orioledb;
+SELECT orioledb_parallel_debug_start();
+ orioledb_parallel_debug_start 
+-------------------------------
+ 
+(1 row)
+
+CREATE TABLE o_test_lockstep
+(
+	a int8 NOT NULL,
+	b int8 NOT NULL,
+	PRIMARY KEY(a,b)
+) USING orioledb;
+INSERT INTO o_test_lockstep SELECT t, t FROM generate_series(1, 1000) t;
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) AND 
+										   b in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+ count 
+-------
+    16
+(1 row)
+
+DROP TABLE o_test_lockstep;
+SELECT orioledb_parallel_debug_stop();
+ orioledb_parallel_debug_stop 
+------------------------------
+ 
+(1 row)
+
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA lockstep CASCADE;
+RESET search_path;

--- a/test/sql/lockstep.sql
+++ b/test/sql/lockstep.sql
@@ -1,0 +1,32 @@
+--
+-- Test orioledb indexes:
+--	lockstep scanning with IN clauses
+--
+
+CREATE SCHEMA lockstep;
+SET SESSION search_path = 'lockstep';
+CREATE EXTENSION orioledb;
+SELECT orioledb_parallel_debug_start();
+
+CREATE TABLE o_test_lockstep
+(
+	a int8 NOT NULL,
+	b int8 NOT NULL,
+	PRIMARY KEY(a,b)
+) USING orioledb;
+
+INSERT INTO o_test_lockstep SELECT t, t FROM generate_series(1, 1000) t;
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) AND 
+										   b in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+
+DROP TABLE o_test_lockstep;
+
+SELECT orioledb_parallel_debug_stop();
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA lockstep CASCADE;
+RESET search_path;


### PR DESCRIPTION
During Array scans like (SELECT ... WHERE id IN (1,3,4...)) orioledb does full tree descend for each element of the array. This is inefficient when the array is large and the elements are close to each other in the index. This commit adds lockstep scan for arrays, which descends the tree only once for all elements of the array and uses iterators.

Also fixed the problem with too many coercible calls during index scans (perf showed that it was having significant impact on performance).
Even if the key was not coercible, orioledb was trying to check that again and again during index scans.