### PR TITLE
Zero out `undo_stacks` array since it might be copied into a temp file 

### DIFF
--- a/include/transam/undo.h
+++ b/include/transam/undo.h
@@ -354,7 +354,8 @@ extern void add_new_undo_stack_item_to_process(UndoLogType undoType,
 											   LocalTransactionId localXid);
 extern void read_shared_undo_locations(UndoStackLocations *to, UndoStackSharedLocations *from);
 extern void write_shared_undo_locations(UndoStackSharedLocations *to, UndoStackLocations *from);
-extern UndoStackLocations get_cur_undo_locations(UndoLogType undoType);
+extern void get_cur_undo_locations(UndoStackLocations *locations,
+								   UndoLogType undoType);
 extern void set_cur_undo_locations(UndoLogType undoType,
 								   UndoStackLocations locations);
 extern void reset_cur_undo_locations(void);

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -444,7 +444,7 @@ o_tbl_insert_with_arbiter(Relation rel,
 
 	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
 	csn = oSnapshot.csn;
-	undoStackLocations = get_cur_undo_locations(UndoLogRegular);
+	get_cur_undo_locations(&undoStackLocations, UndoLogRegular);
 
 	ioc_arg.desc = descr;
 	ioc_arg.oxid = oxid;

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -1456,23 +1456,20 @@ write_shared_undo_locations(UndoStackSharedLocations *to, UndoStackLocations *fr
 	pg_atomic_write_u64(&to->onCommitLocation, from->onCommitLocation);
 }
 
-UndoStackLocations
-get_cur_undo_locations(UndoLogType undoType)
+void
+get_cur_undo_locations(UndoStackLocations *locations, UndoLogType undoType)
 {
-	UndoStackLocations location;
 	UndoStackSharedLocations *sharedLocations = GET_CUR_UNDO_STACK_LOCATIONS(undoType);
 
-	read_shared_undo_locations(&location, sharedLocations);
-
-	return location;
+	read_shared_undo_locations(locations, sharedLocations);
 }
 
 void
-set_cur_undo_locations(UndoLogType undoType, UndoStackLocations location)
+set_cur_undo_locations(UndoLogType undoType, UndoStackLocations locations)
 {
 	UndoStackSharedLocations *sharedLocations = GET_CUR_UNDO_STACK_LOCATIONS(undoType);
 
-	write_shared_undo_locations(sharedLocations, &location);
+	write_shared_undo_locations(sharedLocations, &locations);
 }
 
 void
@@ -2070,9 +2067,11 @@ have_current_undo(UndoLogType undoType)
 	}
 	else
 	{
-		UndoStackLocations location = get_cur_undo_locations(undoType);
+		UndoStackLocations locations;
 
-		return (!UndoLocationIsValid(location.location));
+		get_cur_undo_locations(&locations, undoType);
+
+		return (!UndoLocationIsValid(locations.location));
 	}
 }
 


### PR DESCRIPTION
- `undo_stacks` array might be copied into a temp file therefore zero it
out
- refactor `get_cur_undo_locations()` to be able to zero it out before
assigning values to undo_stacks

Based on the PR https://github.com/orioledb/orioledb/pull/646