### PR TITLE
Don't pass null vals to datumIsEqual

### DIFF
--- a/src/tuple/slot.c
+++ b/src/tuple/slot.c
@@ -1834,6 +1834,22 @@ tts_orioledb_update_toast_values(TupleTableSlot *oldSlot,
 	return result;
 }
 
+/*
+ * tts_orioledb_modified - Check if specified attributes were modified between two tuples
+ *
+ * Compares the values of specific attributes between an old and new tuple slot
+ * to determine if any modifications have occurred. This is primarily used during
+ * UPDATE operations to distinguish between key and non-key updates.
+ *
+ * Parameters:
+ *   oldSlot - The original tuple slot before modification
+ *   newSlot - The new tuple slot with pending changes
+ *   attrs   - Bitmap set indicating which attributes to check for modifications.
+ *
+ * Returns:
+ *   true if any of the specified attributes have different values between
+ *   the old and new slots, false if all specified attributes are unchanged.
+ */
 bool
 tts_orioledb_modified(TupleTableSlot *oldSlot,
 					  TupleTableSlot *newSlot,
@@ -1866,11 +1882,11 @@ tts_orioledb_modified(TupleTableSlot *oldSlot,
 			bool		isnull1 = oldSlot->tts_isnull[i],
 						isnull2 = newSlot->tts_isnull[i];
 
-			if (isnull1 || isnull2)
-			{
-				if (isnull1 != isnull2)
-					return true;
-			}
+			if (isnull1 != isnull2)
+				return true;
+
+			if (isnull1)
+				continue;
 
 			if (!datumIsEqual(val1, val2, att->attbyval, att->attlen))
 				return true;

--- a/test/expected/nulls.out
+++ b/test/expected/nulls.out
@@ -388,6 +388,14 @@ TABLE o_test_unique_nulls_not_distinct;
        | six
 (1 row)
 
+CREATE TABLE o_test_unique_nulls_update (
+    id serial PRIMARY KEY,
+    path varchar,
+    payload bytea,
+    CONSTRAINT c_path_u UNIQUE (path)
+) using orioledb;
+INSERT INTO o_test_unique_nulls_update (id, payload) VALUES (3, '\x01');
+UPDATE o_test_unique_nulls_update SET payload = '\x02'::bytea WHERE id = 3;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------
@@ -395,12 +403,13 @@ SELECT orioledb_parallel_debug_stop();
 (1 row)
 
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to table o_test_null_clauses
 drop cascades to table o_test_null_comparison
 drop cascades to table o_test_null_row_comparison
 drop cascades to table o_test_row_comparison_nulls_first
 drop cascades to table o_test_nulls
 drop cascades to table o_test_unique_nulls_not_distinct
+drop cascades to table o_test_unique_nulls_update
 DROP SCHEMA nulls_schema CASCADE;
 RESET search_path;

--- a/test/expected/nulls_1.out
+++ b/test/expected/nulls_1.out
@@ -387,6 +387,14 @@ TABLE o_test_unique_nulls_not_distinct;
        | six
 (1 row)
 
+CREATE TABLE o_test_unique_nulls_update (
+    id serial PRIMARY KEY,
+    path varchar,
+    payload bytea,
+    CONSTRAINT c_path_u UNIQUE (path)
+) using orioledb;
+INSERT INTO o_test_unique_nulls_update (id, payload) VALUES (3, '\x01');
+UPDATE o_test_unique_nulls_update SET payload = '\x02'::bytea WHERE id = 3;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------
@@ -394,12 +402,13 @@ SELECT orioledb_parallel_debug_stop();
 (1 row)
 
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to table o_test_null_clauses
 drop cascades to table o_test_null_comparison
 drop cascades to table o_test_null_row_comparison
 drop cascades to table o_test_row_comparison_nulls_first
 drop cascades to table o_test_nulls
 drop cascades to table o_test_unique_nulls_not_distinct
+drop cascades to table o_test_unique_nulls_update
 DROP SCHEMA nulls_schema CASCADE;
 RESET search_path;

--- a/test/sql/nulls.sql
+++ b/test/sql/nulls.sql
@@ -156,6 +156,15 @@ INSERT INTO o_test_unique_nulls_not_distinct(val_2) VALUES ('six');
 INSERT INTO o_test_unique_nulls_not_distinct(val_2) VALUES ('seven');
 TABLE o_test_unique_nulls_not_distinct;
 
+CREATE TABLE o_test_unique_nulls_update (
+    id serial PRIMARY KEY,
+    path varchar,
+    payload bytea,
+    CONSTRAINT c_path_u UNIQUE (path)
+) using orioledb;
+INSERT INTO o_test_unique_nulls_update (id, payload) VALUES (3, '\x01');
+UPDATE o_test_unique_nulls_update SET payload = '\x02'::bytea WHERE id = 3;
+
 SELECT orioledb_parallel_debug_stop();
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA nulls_schema CASCADE;


### PR DESCRIPTION
Closes https://github.com/orioledb/orioledb/issues/639

The function `tts_orioledb_modified` incorrectly calls `datumIsEqual()` when both old and new values are NULL. The code checks if values differ when one is NULL and the other isn't, but fails to skip comparison when both are NULL, leading to `datumIsEqual()` being called with NULL pointers for pass-by-reference types.

Now the code skips datumIsEqual check when both values are NULL