### PR TITLE
Fix pgindent instructions in doc/contributing/structure.mdx

### DIFF
--- a/doc/contributing/structure.mdx
+++ b/doc/contributing/structure.mdx
@@ -74,7 +74,7 @@ which can spot various types of errors.
 - `pgindent` -- automatically indents OrioleDB sources.
   [pgindent](https://github.com/postgres/postgres/blob/master/src/tools/pgindent/pgindent)
   tool should be available in `$PATH`. Note, that you need to install
-  [pg_bsd_indent](https://git.postgresql.org/gitweb/?p=pg_bsd_indent.git;a=summary)
+  [pg_bsd_indent](https://github.com/postgres/postgres/blob/master/src/tools/pg_bsd_indent/README#L17)
   first. Also, you need GNU Objdump available in `$PATH` as `objdump` or
   `gobjdump`, or be specified in `OBJDUMP` environment variable.
 


### PR DESCRIPTION
`pg_bsd_indent` was merged into the main Postgres source tree under `src/tools/pg_bsd_indent`.

See [this commit](https://git.postgresql.org/gitweb/?p=pg_bsd_indent.git;a=commit;h=681a3706d6b1bcfe879f37ba83008b3382575447)