### PR TITLE
Extend UndoStackItem.itemSize from u16 to u48 to avoid overflow and segfault

### DIFF
--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -318,7 +318,7 @@ make_undo_record(BTreeDescr *desc, OTuple tuple, bool is_tuple,
 	item = (BTreeModifyUndoStackItem *) get_undo_record(desc->undoType,
 														&undoLocation,
 														MAXALIGN(size));
-	item->header.itemSize = size;
+	UNDO_SET_ITEM_SIZE(&item->header, size);
 	if (action == BTreeOperationLock)
 		item->header.type = RowLockUndoItemType;
 	else
@@ -391,7 +391,7 @@ make_waiter_undo_record(BTreeDescr *desc, OInMemoryBlkno blkno, int pgprocno,
 	item = (BTreeModifyUndoStackItem *) get_undo_record(desc->undoType,
 														&undoLocation,
 														MAXALIGN(size));
-	item->header.itemSize = size;
+	UNDO_SET_ITEM_SIZE(&item->header, size);
 	item->header.type = ModifyUndoItemType;
 	item->header.indexType = desc->type;
 	item->action = BTreeOperationInsert;
@@ -947,7 +947,7 @@ add_undo_relnode(ORelOids oldOids, ORelOids *oldTreeOids, int oldNumTreeOids,
 				 ORelOids newOids, ORelOids *newTreeOids, int newNumTreeOids,
 				 bool fsync)
 {
-	LocationIndex size;
+	Size size;
 	UndoLocation location;
 	RelnodeUndoStackItem *item;
 
@@ -955,7 +955,7 @@ add_undo_relnode(ORelOids oldOids, ORelOids *oldTreeOids, int oldNumTreeOids,
 	item = (RelnodeUndoStackItem *) get_undo_record_unreserved(UndoLogSystem, &location, MAXALIGN(size));
 
 	item->header.base.type = RelnodeUndoItemType;
-	item->header.base.itemSize = size;
+	UNDO_SET_ITEM_SIZE(&item->header.base, size);
 	item->header.base.indexType = oIndexPrimary;
 	Assert(ORelOidsIsValid(oldOids) || ORelOidsIsValid(newOids));
 	if (ORelOidsIsValid(oldOids))
@@ -1672,7 +1672,7 @@ get_prev_leaf_header_and_tuple_from_undo(UndoLogType undoType,
 
 	*tuphdr = item.tuphdr;
 	tuple->formatFlags = tuphdr->formatFlags;
-	tupleSize = item.header.itemSize - sizeof(BTreeModifyUndoStackItem);
+	tupleSize = UNDO_GET_ITEM_SIZE(&item.header) - sizeof(BTreeModifyUndoStackItem);
 	if (sizeAvailable == 0)
 		tuple->data = palloc(tupleSize);
 	Assert(sizeAvailable == 0 || sizeAvailable >= tupleSize);

--- a/src/catalog/o_sys_cache.c
+++ b/src/catalog/o_sys_cache.c
@@ -969,7 +969,7 @@ o_add_undo_sys_cache_delete(OSysCache *sys_cache, OSysCacheKey *key)
 	item = (SysCacheDeleteUndoStackItem *) get_undo_record_unreserved(UndoLogSystem,
 																	  &location,
 																	  MAXALIGN(size));
-	item->header.itemSize = size;
+	UNDO_SET_ITEM_SIZE(&item->header, size);
 	item->header.type = SysCacheDeleteUndoItemType;
 	item->header.indexType = oIndexPrimary;
 	item->sys_cache = sys_cache;

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -5587,7 +5587,7 @@ add_systrees_lock_undo(bool lock)
 	item->lock = lock;
 	item->header.type = SysTreesLockUndoItemType;
 	item->header.indexType = oIndexPrimary;
-	item->header.itemSize = size;
+	UNDO_SET_ITEM_SIZE(&item->header, size);
 
 	add_new_undo_stack_item(UndoLogSystem, location);
 	release_undo_size(UndoLogSystem);

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -1401,7 +1401,7 @@ o_add_invalidate_comparator_undo_item(Oid opfamily, Oid lefttype, Oid righttype)
 	item->righttype = righttype;
 	item->header.base.type = InvalidateComparatorUndoItemType;
 	item->header.base.indexType = oIndexPrimary;
-	item->header.base.itemSize = size;
+	UNDO_SET_ITEM_SIZE(&item->header.base, size);
 
 	add_new_undo_stack_item(UndoLogSystem, location);
 	release_undo_size(UndoLogSystem);
@@ -1710,7 +1710,7 @@ o_add_invalidate_undo_item(ORelOids oids, uint32 flags)
 	item->flags = flags;
 	item->header.base.type = InvalidateUndoItemType;
 	item->header.base.indexType = oIndexPrimary;
-	item->header.base.itemSize = size;
+	UNDO_SET_ITEM_SIZE(&item->header.base, size);
 
 	add_new_undo_stack_item(UndoLogSystem, location);
 	release_undo_size(UndoLogSystem);


### PR DESCRIPTION
Previously itemSize used only 16 bits and could overflow when many undo items or relation-level operations occurred in a single transaction. The field is now expanded to 48 bits (u32 + u16).

The high 16 bits are placed into the former padding at the end of the struct, allowing backward compatibility when the padding was zeroed.

Also fixed dynamic buffer expansion: previously the buffer only doubled in size, which was insufficient when itemSize became large, leading to possible buffer overflow and memory corruption.

Fix for issue #673 
We had a significant out-of-bounds memory access issue here, which could have corrupted any memory in the system. This fix may also resolve other problems or segmentation faults that we experienced previously because of unknown reasons.

As of now I haven’t worked with OrioleDB’s undo-log system in depth, so my understanding is still limited. In case `UndoStackItem` is written to disk and we need to maintain compatibility with older undo logs, I placed the new field into the structure’s padding area. This way we should remain backward-compatible with existing undo records (assuming the memory was zero-initialized before use).
