### PR TITLE
Add make.flags file with default build parameters and import it in Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -85,3 +85,6 @@ doc/
 
 # Exclude the PostGIS Docker build directory
 docker-postgis
+
+# Misc
+make.flags

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ win32ver.rc
 *.exe
 lib*dll.def
 lib*.pc
+make.flags
 
 # Local excludes in root directory
 /test/t/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 # contrib/orioledb/Makefile
+# Import make flags if make.flags file is present
+-include make.flags
+export
 
 MODULE_big = orioledb
 EXTENSION = orioledb

--- a/make.flags.example
+++ b/make.flags.example
@@ -1,0 +1,8 @@
+# Makefile checks if the variable is defined, the value is ignored
+# Remove/comment out the flag to deactivate it
+
+USE_PGXS=1
+
+IS_DEV=1
+
+#VALGRIND=1


### PR DESCRIPTION
This enables one to adjust `make.flags` file (which is in `.gitignore`) to their needs.
This is backwards compatible. Variables supplied with `make` command take precedence.