### PR TITLE
Refactor OrioleDB WAL container parsing into dedicated wal_reader module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ OBJS = src/btree/btree.o \
 	   src/recovery/logical.o \
 	   src/recovery/recovery.o \
 	   src/recovery/wal.o \
+	   src/recovery/wal_reader.o \
 	   src/recovery/worker.o \
 	   src/rewind/rewind.o \
 	   src/s3/archive.o \

--- a/include/recovery/wal_reader.h
+++ b/include/recovery/wal_reader.h
@@ -1,0 +1,275 @@
+/*-------------------------------------------------------------------------
+ *
+ * wal_reader.h
+ * 		WAL parser declarations for OrioleDB.
+ *
+ * Copyright (c) 2026, Oriole DB Inc.
+ * Copyright (c) 2026, Supabase Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/recovery/wal_reader.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef __WAL_READER_H__
+#define __WAL_READER_H__
+
+typedef unsigned int wal_type_t;
+
+/*
+ * WalRecord instances are transient and reused across iterations.
+ *
+ * Callers must not retain pointers to the record itself.
+ * Any data that must outlive the callback must be copied.
+ */
+typedef struct WalRecord
+{
+	wal_type_t	type;
+
+	uint32		delta;
+	Pointer		value_ptr;
+	uint16		wal_version;
+
+	ORelOids	oids;
+	OXid		oxid;
+	TransactionId logicalXid;
+	TransactionId heapXid;
+	char		relreplident;
+
+	RepOriginId origin_id;
+	XLogRecPtr	origin_lsn;
+
+	union
+	{
+		struct
+		{
+			OXid		xmin;
+			CommitSeqNo csn;
+		}			finish;
+		struct
+		{
+			TransactionId topXid;
+			TransactionId subXid;
+		}			swxid;
+		struct
+		{
+			TransactionId xid;
+			OXid		xmin;
+			CommitSeqNo csn;
+		}			joint_commit;
+		struct
+		{
+			uint8		treeType;
+			OSnapshot	snapshot;
+			uint32		version;
+			uint32		base_version;
+		}			relation;
+		struct
+		{
+			Oid			relreplident_ix_oid;
+		}			relreplident;
+		struct
+		{
+			ORelOids	oids;
+			Oid			oldRelnode;
+		}			unlock;
+		struct
+		{
+			ORelOids	oids;
+		}			truncate;
+		struct
+		{
+			SubTransactionId parentSubid;
+			TransactionId parentLogicalXid;
+		}			savepoint;
+		struct
+		{
+			SubTransactionId parentSubid;
+			OXid		xmin;
+			CommitSeqNo csn;
+		}			rb_to_sp;
+		struct
+		{
+			ItemPointerData iptr;
+		}			bridge_erase;
+
+		struct
+		{
+			OTuple		t1;
+			OffsetNumber len1;
+
+			OTuple		t2;
+			OffsetNumber len2;
+
+			bool		read_two_tuples;
+		}			modify;
+
+		/* Flags */
+		struct
+		{
+			TimestampTz xactTime;
+			TransactionId xid;
+		}			xact_info;
+
+	}			u;
+
+} WalRecord;
+
+/*
+ * WalParseResult
+ *
+ * Status codes returned by the WAL container parser and callbacks.
+ *
+ * WALPARSE_OK
+ *     Success.
+ *
+ * WALPARSE_STOP
+ *     Terminate parser.
+ *
+ * WALPARSE_EOF
+ *     Not enough bytes in the input buffer to parse the requested element.
+ *     This is a "need more data" / framing error depending on the caller.
+ *
+ * WALPARSE_BAD_TYPE
+ *     Unknown record/flag type, missing descriptor, or otherwise
+ *     unparseable tag. Treated as a hard protocol error.
+ *
+ * WALPARSE_BAD_VERSION
+ *     Container version policy rejected by the consumer (typically WAL from
+ *     a newer or unsupported OrioleDB version).
+ *
+ * WALPARSE_INTERNAL
+ *     Internal invariant violation or unexpected condition.
+ */
+typedef enum WalParseResult
+{
+	WALPARSE_OK = 0,
+	WALPARSE_STOP,
+	WALPARSE_EOF,				/* not enough bytes */
+	WALPARSE_BAD_TYPE,
+	WALPARSE_BAD_VERSION,
+	WALPARSE_INTERNAL
+
+} WalParseResult;
+
+struct WalReaderState;
+
+/*
+ * WalCheckVersionFn
+ *
+ * Optional consumer-level version policy check.
+ *
+ * Called after container framing has been validated, but before any
+ * records are delivered. Allows recovery/decoder code to reject WAL
+ * based on semantic compatibility rules.
+ */
+typedef WalParseResult (*WalCheckVersionFn) (const struct WalReaderState *r);
+typedef WalParseResult (*WalOnFlagFn) (void *ctx, const WalRecord *rec);
+typedef WalParseResult (*WalOnRecordFn) (void *ctx, WalRecord *rec);
+
+/*
+ * Cursor advancement invariant:
+ *
+ * r->ptr must only be advanced by:
+ *
+ *   - WR_PARSE / WR_SKIP,
+ *   - record parse routines,
+ *   - container flag parsers.
+ *
+ * Consumers must never modify ptr.
+ */
+typedef struct WalReaderState
+{
+	Pointer		start;
+	Pointer		end;
+	Pointer		ptr;
+	uint16		wal_version;
+	uint8		wal_flags;
+
+	/* Consumer */
+	void	   *ctx;
+	WalCheckVersionFn check_version;
+	WalOnFlagFn on_flag;
+	WalOnRecordFn on_record;
+
+} WalReaderState;
+
+/*
+ * WalParseFn
+ *
+ * Parser routine for a single record type.
+ *
+ * The parser must:
+ *   - read exactly this record's payload from r->ptr,
+ *   - populate rec->u.* fields as needed,
+ *   - leave r->ptr positioned at the next record tag.
+ *
+ * It must not read beyond r->end; use WR_REQUIRE_SIZE / WR_PARSE / WR_SKIP.
+ *
+ * For payload-less records, descriptor->parse is NULL (record is tag-only).
+ */
+typedef WalParseResult (*WalParseFn) (WalReaderState *r, WalRecord *rec);
+
+/*
+ * WalRecordDesc
+ *
+ * Static descriptor for a record (or flag) type.
+ *
+ * The descriptor table is the single source of truth for:
+ *   - mapping type -> name (debug),
+ *   - mapping type -> payload parser.
+ */
+typedef struct WalRecordDesc
+{
+	wal_type_t	type;
+	const char *name;
+	WalParseFn	parse;
+
+} WalRecordDesc;
+
+/*
+ * Reader helpers.
+ *
+ * WR_REQUIRE_SIZE()
+ *     Ensures that at least nbytes remain in the input buffer.
+ *
+ * WR_PARSE()
+ *     Copies sizeof(*out) bytes from r->ptr into *out and advances r->ptr.
+ *
+ * WR_SKIP()
+ *     Advances r->ptr by sz bytes after bounds check.
+ *
+ * These macros are the preferred way to move the cursor. Direct arithmetic
+ * on r->ptr should be avoided outside of low-level parsing code.
+ */
+
+#define WR_REQUIRE_SIZE(r, nbytes) \
+do { \
+	if (((size_t) ((r)->end - (r)->ptr)) < (size_t)(nbytes)) \
+		return WALPARSE_EOF; \
+} while (0)
+
+#define WR_PARSE(r, out) \
+{ \
+	WR_REQUIRE_SIZE(r, sizeof(*out)); \
+	memcpy(out, r->ptr, sizeof(*out)); \
+    r->ptr += sizeof(*out); \
+}
+
+#define WR_SKIP(r, sz) \
+{ \
+	WR_REQUIRE_SIZE(r, sz); \
+    r->ptr += sz; \
+}
+
+extern void build_fixed_tuples(const WalRecord *rec, OFixedTuple *tuple1, OFixedTuple *tuple2);
+
+extern const WalRecordDesc *wal_get_desc(wal_type_t type);
+extern const WalRecordDesc *wal_flag_get_desc(wal_type_t type);
+
+extern const char *wal_type_name(wal_type_t type);
+extern const char *wal_flag_type_name(wal_type_t type);
+
+extern WalParseResult parse_wal_container(WalReaderState *r, bool allow_logging);
+
+#endif							/* __WAL_READER_H__ */

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -21,6 +21,7 @@
 #include "recovery/recovery.h"
 #include "recovery/internal.h"
 #include "recovery/wal.h"
+#include "recovery/wal_reader.h"
 #include "tableam/descr.h"
 #include "tuple/slot.h"
 
@@ -580,6 +581,691 @@ remove_skipped_dml(HTAB **cache, uint64 oxid)
 }
 
 /*
+ * Per-process cache of "skipped DML" flags for Oriole transactions
+ * (OXID).
+ *
+ * Why this exists: During ABORT/ROLLBACK OrioleDB actively walks the undo
+ * chain and removes aborted versions.  Logical decoding, however, may
+ * still receive Oriole WAL records for such a transaction and might need
+ * to fetch "historical" descriptors (OTable/OIndex) to decode tuples.  If
+ * the transaction was rolled back, those historical versions can become
+ * unreachable because the corresponding undo chain has already been
+ * cleaned.
+ *
+ * In that case we intentionally skip decoding individual DML records
+ * (INSERT/UPDATE/DELETE/REINSERT) because we cannot reliably reconstruct
+ * the relation/index descriptors for the required historical snapshot.
+ *
+ * We must remember that we have skipped at least one DML record for a
+ * given OXID, so that when the transaction finishes we can: - log/report
+ * this fact, and/or - ensure the flag does not leak to subsequent
+ * transactions.
+ *
+ * Lifetime: The cache is allocated in TopMemoryContext and stored in a
+ * static pointer so it survives across multiple invocations of
+ * orioledb_decode() within the same decoding backend.  (Logical decoding
+ * calls decode repeatedly for many records; we need state that outlives a
+ * single call.)
+ *
+ * Scope / semantics: The cache is local to the decoding process; it is
+ * not shared between backends and not persisted.  Entries are inserted
+ * when we skip a DML record for an OXID and removed when we observe the
+ * transaction finish record
+ * (COMMIT/ROLLBACK/ROLLBACK_TO_SAVEPOINT/JOIN_COMMIT as applicable).
+ */
+static HTAB *skippedDMLHash = NULL;
+
+static WalParseResult
+decode_wal_check_version(const WalReaderState *r)
+{
+	Assert(r);
+
+	if (r->wal_version > ORIOLEDB_WAL_VERSION)
+	{
+		/* WAL from future version */
+		elog(ERROR, "Can't logically decode WAL version %u that is newer than supported %u", r->wal_version, ORIOLEDB_WAL_VERSION);
+		return WALPARSE_BAD_VERSION;
+	}
+
+	return WALPARSE_OK;
+}
+
+typedef struct
+{
+	/* Input params */
+	XLogRecPtr	xlogRecPtr;
+	XLogRecPtr	xlogRecEndPtr;
+	LogicalDecodingContext *dctx;
+	XLogRecordBuffer *dbuf;
+
+	/* Decoder state params */
+	OTableDescr *descr;
+	OIndexDescr *indexDescr;
+	OIndexType	ix_type;
+	TupleDescData *o_toast_tupDesc;
+	TupleDescData *heap_toast_tupDesc;
+	bool		has_origin;
+} DecodeWalDescCtx;
+
+static WalParseResult
+decode_wal_containter_info(void *vctx, const WalRecord *rec)
+{
+	DecodeWalDescCtx *ctx = (DecodeWalDescCtx *) vctx;
+
+	Assert(ctx);
+	Assert(rec);
+
+	switch (rec->type)
+	{
+		case WAL_CONTAINER_HAS_XACT_INFO:
+			/* Skip WAL_REC_XACT_INFO */
+			break;
+
+		case WAL_CONTAINER_HAS_ORIGIN_INFO:
+			ctx->has_origin = rec->origin_id != InvalidRepOriginId;
+			break;
+
+		default:
+			break;
+	}
+
+	return WALPARSE_OK;
+}
+
+static WalParseResult
+decode_wal_record(void *vctx, WalRecord *rec)
+{
+	DecodeWalDescCtx *ctx = (DecodeWalDescCtx *) vctx;
+	const char *recname = NULL;
+
+	Assert(ctx);
+	Assert(rec);
+
+	recname = wal_type_name(rec->type);
+
+	elog(DEBUG4, "[%s] GET RTYPE %d `%s`", __func__, rec->type, recname);
+
+	switch (rec->type)
+	{
+		case WAL_REC_XID:
+			{
+				if (TransactionIdIsValid(rec->logicalXid))
+				{
+					CSNSnapshotData *csnSnapshot;
+
+					elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u",
+						 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+					csnSnapshot = SnapBuildGetCSNSnaphot(ctx->dctx->snapshot_builder);
+					csnSnapshot->nextXid = Max(csnSnapshot->nextXid, rec->oxid);
+				}
+				else
+				{
+					/*
+					 * Oriole logical xid stays invalid for an autonomous
+					 * transactions (internal Oriole's mechanism intended for
+					 * independed commit of Oriole system catalog changes)
+					 */
+					elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu",
+						 rec->type, recname, rec->oxid);
+				}
+				break;
+			}
+
+		case WAL_REC_SWITCH_LOGICAL_XID:
+			{
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->delta;
+				TransactionId topXid = rec->u.swxid.topXid;
+				TransactionId subXid = rec->u.swxid.subXid;
+
+				elog(DEBUG4, "RECEIVE record type %d (%s) %u=>%u oxid %lu logicalXId %u heapXid %u xlogPtr %X/%X",
+					 rec->type, recname, topXid, subXid,
+					 rec->oxid, rec->logicalXid, rec->heapXid, LSN_FORMAT_ARGS(xlogPtr));
+
+				Assert(TransactionIdIsValid(topXid));
+				Assert(TransactionIdIsValid(subXid));
+
+				ReorderBufferAssignChild(ctx->dctx->reorder, topXid, subXid, xlogPtr);
+
+				break;
+			}
+
+		case WAL_REC_COMMIT:
+		case WAL_REC_ROLLBACK:
+			{
+				dlist_iter	cur_txn_i;
+				ReorderBufferTXN *txn = NULL;
+				CSNSnapshotData *csnSnapshot = NULL;
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->delta;
+
+				elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u",
+					 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+				if (!TransactionIdIsValid(rec->logicalXid))
+				{
+					/*
+					 * Oriole logical xid stays invalid for an autonomous
+					 * transactions
+					 */
+					elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu",
+						 rec->type, recname, rec->oxid);
+
+					UpdateDecodingStats(ctx->dctx);
+
+					return WALPARSE_OK;
+				}
+
+				csnSnapshot = SnapBuildGetCSNSnaphot(ctx->dctx->snapshot_builder);
+				csnSnapshot->snapshotcsn = rec->u.finish.csn;
+				csnSnapshot->xlogptr = ctx->xlogRecEndPtr;
+				csnSnapshot->xmin = rec->u.finish.xmin;
+
+				if (!set_snapshot(ctx->dctx, rec->logicalXid, xlogPtr))
+					return WALPARSE_OK;
+
+				txn = get_reorder_buffer_txn(ctx->dctx->reorder, rec->logicalXid);
+
+				if (txn == NULL)
+				{
+					elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u :: unknown transaction, nothing to replay",
+						 rec->type, recname, rec->oxid, rec->logicalXid);
+				}
+
+				/* unknown transaction, nothing to replay */
+				if (txn != NULL)
+				{
+					Assert(TransactionIdIsValid(rec->logicalXid));
+
+					if (rec->type == WAL_REC_COMMIT)
+					{
+						if (remove_skipped_dml(&skippedDMLHash, rec->oxid))
+						{
+							/*
+							 * We have skipped at least one DML record for
+							 * this transaction due to missing historical
+							 * metadata (typically after undo cleanup on
+							 * rollback paths). A COMMIT with skipped changes
+							 * is unexpected from the consumer's perspective:
+							 * it means we are about to finalize a transaction
+							 * without having emitted some of its changes.
+							 */
+							elog(ERROR, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u",
+								 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+						}
+
+						/*
+						 * SnapBuildXactNeedsSkip() does strict comparison.
+						 * So, subtract xlogRecEndPtr by one to fit snapshot
+						 * just taken after commit.
+						 */
+						if (SnapBuildXactNeedsSkip(ctx->dctx->snapshot_builder, ctx->xlogRecEndPtr - 1) || ctx->dctx->fast_forward)
+						{
+							elog(DEBUG4, "FORGET record type %d (%s) oxid %lu logicalXid %u heapXid %u",
+								 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+							dlist_foreach(cur_txn_i, &txn->subtxns)
+							{
+								ReorderBufferTXN *cur_txn;
+
+								cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
+								ReorderBufferForget(ctx->dctx->reorder, cur_txn->xid,
+													ctx->xlogRecPtr);
+							}
+							ReorderBufferForget(ctx->dctx->reorder, txn->xid,
+												ctx->xlogRecPtr);
+
+							rec->oxid = InvalidOXid;
+							rec->logicalXid = InvalidTransactionId;
+
+							/* Skip processing of this transaction */
+							return WALPARSE_OK;
+						}
+
+						/*
+						 * Proceed to commit this transaction and
+						 * subtransactions
+						 */
+						dlist_foreach(cur_txn_i, &txn->subtxns)
+						{
+							ReorderBufferTXN *cur_txn;
+
+							cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
+							ReorderBufferCommitChild(ctx->dctx->reorder, txn->xid, cur_txn->xid,
+													 ctx->xlogRecPtr, ctx->xlogRecEndPtr);
+						}
+						elog(DEBUG4, "COMMIT record type %d (%s) oxid %lu logicalXid %u heapXid %u, origin_id %u, origin_lsn %X/%X",
+							 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid,
+							 rec->origin_id, LSN_FORMAT_ARGS(rec->origin_lsn));
+
+						ReorderBufferCommit(ctx->dctx->reorder, rec->logicalXid,
+											xlogPtr, ctx->xlogRecEndPtr,
+											0, rec->origin_id, rec->origin_lsn);
+					}
+					else
+					{
+						Assert(rec->type == WAL_REC_ROLLBACK);
+
+						if (remove_skipped_dml(&skippedDMLHash, rec->oxid))
+						{
+							/*
+							 * Skipped DML is expected on abort paths: if we
+							 * couldn't decode some DML records (e.g. due to
+							 * missing historical descriptors), and the
+							 * transaction ends up rolled back, there is
+							 * nothing to emit to the output plugin. We still
+							 * must clear the cache to avoid leaking state.
+							 */
+							elog(DEBUG4, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u",
+								 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+						}
+
+						dlist_foreach(cur_txn_i, &txn->subtxns)
+						{
+							ReorderBufferTXN *cur_txn;
+
+							cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
+							ReorderBufferAbort(ctx->dctx->reorder, cur_txn->xid, ctx->xlogRecPtr, 0);
+						}
+						elog(DEBUG4, "ABORT record type %d (%s) oxid %lu logicalXid %u heapXid %u",
+							 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+						ReorderBufferAbort(ctx->dctx->reorder, rec->logicalXid, ctx->xlogRecPtr, 0);
+					}
+				}
+
+				UpdateDecodingStats(ctx->dctx);
+
+				rec->oxid = InvalidOXid;
+				rec->logicalXid = InvalidTransactionId;
+
+				break;
+			}
+
+		case WAL_REC_JOINT_COMMIT:
+			{
+				CSNSnapshotData *csnSnapshot = NULL;
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->delta;
+
+				elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u",
+					 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+				if (!TransactionIdIsValid(rec->logicalXid))
+				{
+					/*
+					 * Oriole logical xid stays invalid for an autonomous
+					 * transactions
+					 */
+					elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu",
+						 rec->type, recname, rec->oxid);
+
+					UpdateDecodingStats(ctx->dctx);
+					return WALPARSE_OK;
+				}
+
+				if (remove_skipped_dml(&skippedDMLHash, rec->oxid))
+				{
+					/*
+					 * We have skipped at least one DML record for this
+					 * transaction due to missing historical metadata
+					 * (typically after undo cleanup on rollback paths).  A
+					 * COMMIT with skipped changes is unexpected from the
+					 * consumer's perspective: it means we are about to
+					 * finalize a transaction without having emitted some of
+					 * its changes.
+					 */
+					elog(ERROR, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u",
+						 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+				}
+
+				csnSnapshot = SnapBuildGetCSNSnaphot(ctx->dctx->snapshot_builder);
+				csnSnapshot->snapshotcsn = rec->u.joint_commit.csn;
+				csnSnapshot->xlogptr = ctx->xlogRecEndPtr;
+				csnSnapshot->xmin = rec->u.joint_commit.xmin;
+
+				if (!set_snapshot(ctx->dctx, rec->logicalXid, xlogPtr))
+					return WALPARSE_OK;
+
+				/* Skip actual commit processing */
+				if (SnapBuildXactNeedsSkip(ctx->dctx->snapshot_builder, ctx->xlogRecEndPtr - 1) || ctx->dctx->fast_forward)
+				{
+					elog(DEBUG4, "FORGET record type %d (%s) oxid %lu logicalXid %u heapXid %u",
+						 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+					ReorderBufferForget(ctx->dctx->reorder, rec->logicalXid, ctx->xlogRecPtr);
+				}
+				else
+				{
+					if (TransactionIdIsValid(rec->heapXid) && TransactionIdIsValid(rec->logicalXid))
+					{
+						/*
+						 * Oriole txn acts as a sub-txn to heap txn, needs
+						 * ReorderBufferCommitChild
+						 */
+						elog(DEBUG4, "ReorderBufferCommitChild on record type %d (%s) oxid %lu logicalXid %u heapXid %u",
+							 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+						ReorderBufferCommitChild(ctx->dctx->reorder, rec->heapXid, rec->logicalXid, ctx->dbuf->origptr, ctx->dbuf->endptr);
+					}
+
+					UpdateDecodingStats(ctx->dctx);
+				}
+
+				rec->oxid = InvalidOXid;
+				rec->logicalXid = InvalidTransactionId;
+
+				break;
+			}
+
+		case WAL_REC_RELATION:
+			{
+				int			sys_tree_num = -1;
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->delta;
+
+				if (rec->wal_version >= 17)
+				{
+					rec->u.relation.snapshot.xlogptr = xlogPtr;
+				}
+
+				ctx->ix_type = rec->u.relation.treeType;
+				rec->relreplident = REPLICA_IDENTITY_DEFAULT;
+				ctx->descr = NULL;
+
+				elog(DEBUG4, "oxid %lu logicalXid %u heapXid %u WAL_REC_RELATION latest_oids [ %u %u %u ] latest_version %u ix_type %d",
+					 rec->oxid, rec->logicalXid, rec->heapXid, rec->oids.datoid, rec->oids.reloid, rec->oids.relnode,
+					 rec->u.relation.version, ctx->ix_type);
+
+				if (!TransactionIdIsValid(rec->logicalXid))
+				{
+					/*
+					 * Oriole logical xid stays invalid for an autonomous
+					 * transactions
+					 */
+					elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec->type, recname, rec->oxid);
+					return WALPARSE_OK;
+				}
+
+				/* Skip actual relation processing in fast_forward mode */
+				if (ctx->dctx->fast_forward)
+				{
+					elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec->type, recname, rec->oxid);
+					return WALPARSE_OK;
+				}
+
+				if (IS_SYS_TREE_OIDS(rec->oids))
+					sys_tree_num = rec->oids.relnode;
+				else
+					sys_tree_num = -1;
+
+				if (sys_tree_num > 0)
+				{
+					ctx->descr = NULL;
+					/* indexDescr = NULL; */
+					Assert(sys_tree_get_storage_type(sys_tree_num) == BTreeStoragePersistence);
+				}
+				else if (ctx->ix_type == oIndexInvalid)
+				{
+					elog(DEBUG4, "WAL_REC_RELATION oIndexInvalid :: FETCH RELATION [ %u %u %u ] version %u",
+						 rec->oids.datoid, rec->oids.reloid, rec->oids.relnode, rec->u.relation.version);
+
+					ctx->descr = o_fetch_table_descr_extended(rec->oids, build_fetch_context(&rec->u.relation.snapshot, rec->u.relation.version));
+					ctx->indexDescr = ctx->descr ? GET_PRIMARY(ctx->descr) : NULL;
+					if (ctx->descr)
+					{
+						Assert(ctx->indexDescr);
+					}
+				}
+				else if (ctx->ix_type == oIndexToast)
+				{
+					elog(DEBUG4, "WAL_REC_RELATION [1] oIndexToast :: FETCH INDEX oids [ %u %u %u ] version %u base_version %u",
+						 rec->oids.datoid, rec->oids.reloid, rec->oids.relnode,
+						 rec->u.relation.version, rec->u.relation.base_version);
+
+					ctx->indexDescr = o_fetch_index_descr_extended(rec->oids, ctx->ix_type, false,
+																   build_fetch_context(&rec->u.relation.snapshot, rec->u.relation.version),
+																   build_fetch_context(&rec->u.relation.snapshot, rec->u.relation.base_version));
+					if (ctx->indexDescr)
+					{
+						elog(DEBUG4, "WAL_REC_RELATION [2] oIndexToast :: FETCH RELATION [ %u %u %u ] version %u",
+							 ctx->indexDescr->tableOids.datoid, ctx->indexDescr->tableOids.reloid, ctx->indexDescr->tableOids.relnode,
+							 rec->u.relation.base_version);
+
+						ctx->descr = o_fetch_table_descr_extended(ctx->indexDescr->tableOids,
+																  build_fetch_context(&rec->u.relation.snapshot, rec->u.relation.base_version));
+						Assert(ctx->descr);
+
+						ctx->o_toast_tupDesc = ctx->descr->toast->leafTupdesc;
+					}
+
+					/* Init heap tupledesc for toast table */
+					ctx->heap_toast_tupDesc = CreateTemplateTupleDesc(3);
+					o_tables_tupdesc_init_builtin(ctx->heap_toast_tupDesc, (AttrNumber) 1, "chunk_id", OIDOID);
+					o_tables_tupdesc_init_builtin(ctx->heap_toast_tupDesc, (AttrNumber) 2, "chunk_seq", INT4OID);
+					o_tables_tupdesc_init_builtin(ctx->heap_toast_tupDesc, (AttrNumber) 3, "chunk_data", BYTEAOID);
+					/* Ensure that the toast table doesn't itself get toasted */
+					TupleDescAttr(ctx->heap_toast_tupDesc, 0)->attstorage = TYPSTORAGE_PLAIN;
+					TupleDescAttr(ctx->heap_toast_tupDesc, 1)->attstorage = TYPSTORAGE_PLAIN;
+					TupleDescAttr(ctx->heap_toast_tupDesc, 2)->attstorage = TYPSTORAGE_PLAIN;
+					/* Toast field should not be compressed */
+					TupleDescAttr(ctx->heap_toast_tupDesc, 0)->attcompression = InvalidCompressionMethod;
+					TupleDescAttr(ctx->heap_toast_tupDesc, 1)->attcompression = InvalidCompressionMethod;
+					TupleDescAttr(ctx->heap_toast_tupDesc, 2)->attcompression = InvalidCompressionMethod;
+				}
+				else
+				{
+					Assert(ctx->ix_type == oIndexBridge);
+				}
+
+				if (ctx->descr && ctx->descr->toast)
+					elog(DEBUG4, "reloid: %d natts: %u toast natts: %u", rec->oids.reloid, ctx->descr->tupdesc->natts, ctx->descr->toast->leafTupdesc->natts);
+
+				break;
+			}
+
+		case WAL_REC_RELREPLIDENT:
+		case WAL_REC_O_TABLES_META_LOCK:
+		case WAL_REC_REPLAY_FEEDBACK:
+		case WAL_REC_O_TABLES_META_UNLOCK:
+		case WAL_REC_TRUNCATE:
+		case WAL_REC_BRIDGE_ERASE:
+			/* Skip */
+			break;
+
+		case WAL_REC_SAVEPOINT:
+			elog(DEBUG4, "APPLY record type %d (%s) oxid %lu logicalXid %u parentLogicalXid %u",
+				 rec->type, recname, rec->oxid, rec->logicalXid, rec->u.savepoint.parentLogicalXid);
+
+			if (!ctx->dctx->fast_forward)
+				ReorderBufferAssignChild(ctx->dctx->reorder, rec->u.savepoint.parentLogicalXid, rec->logicalXid, ctx->dbuf->origptr);
+
+			break;
+
+		case WAL_REC_ROLLBACK_TO_SAVEPOINT:
+			{
+				dlist_iter	cur_txn_i;
+				ReorderBufferTXN *txn = NULL;
+				CSNSnapshotData *csnSnapshot = NULL;
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->delta;
+
+				if (rec->wal_version < 17)
+				{
+					/* Skip */
+					return WALPARSE_OK;
+				}
+
+				elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u parentSubid %u",
+					 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid, rec->u.rb_to_sp.parentSubid);
+
+				if (remove_skipped_dml(&skippedDMLHash, rec->oxid))
+				{
+					/*
+					 * This transaction performed a rollback-to-savepoint, so
+					 * previously skipped changes may now be irrelevant
+					 * (rolled back).  Clear the cache to keep per-OXID state
+					 * consistent.
+					 */
+					elog(DEBUG4, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u parentSubid %u",
+						 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid, rec->u.rb_to_sp.parentSubid);
+				}
+
+				if (!TransactionIdIsValid(rec->logicalXid))
+				{
+					/*
+					 * Oriole logical xid stays invalid for an autonomous
+					 * transactions
+					 */
+					elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec->type, recname, rec->oxid);
+
+					UpdateDecodingStats(ctx->dctx);
+					return WALPARSE_OK;
+				}
+
+				csnSnapshot = SnapBuildGetCSNSnaphot(ctx->dctx->snapshot_builder);
+				csnSnapshot->snapshotcsn = rec->u.rb_to_sp.csn;
+				csnSnapshot->xlogptr = ctx->xlogRecEndPtr;
+				csnSnapshot->xmin = rec->u.rb_to_sp.xmin;
+
+				if (!set_snapshot(ctx->dctx, rec->logicalXid, xlogPtr))
+					return WALPARSE_OK;
+
+				txn = get_reorder_buffer_txn(ctx->dctx->reorder, rec->logicalXid);
+
+				if (txn == NULL)
+				{
+					elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u :: unknown transaction, nothing to replay",
+						 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+				}
+
+				/* unknown transaction, nothing to replay */
+				if (txn != NULL)
+				{
+					Assert(TransactionIdIsValid(rec->logicalXid));
+
+					dlist_foreach(cur_txn_i, &txn->subtxns)
+					{
+						ReorderBufferTXN *cur_txn;
+
+						cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
+						ReorderBufferAbort(ctx->dctx->reorder, cur_txn->xid, ctx->xlogRecPtr, 0);
+					}
+					elog(DEBUG4, "ABORT record type %d (%s) oxid %lu logicalXid %u heapXid %u",
+						 rec->type, recname, rec->oxid, rec->logicalXid, rec->heapXid);
+
+					ReorderBufferAbort(ctx->dctx->reorder, rec->logicalXid, ctx->xlogRecPtr, 0);
+				}
+
+				UpdateDecodingStats(ctx->dctx);
+
+				rec->oxid = InvalidOXid;
+				rec->logicalXid = InvalidTransactionId;
+
+				break;
+			}
+
+		case WAL_REC_INSERT:
+		case WAL_REC_UPDATE:
+		case WAL_REC_DELETE:
+		case WAL_REC_REINSERT:
+			{
+				OFixedTuple tuple1,
+							tuple2;
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->delta;
+				ReorderBufferTXN *txn = NULL;
+
+				build_fixed_tuples(rec, &tuple1, &tuple2);
+
+				elog(DEBUG4, "RECEIVE record type %d (%s) oids [ %u %u %u ] oxid %lu logicalXId %u heapXid %u",
+					 rec->type, recname,
+					 rec->oids.datoid, rec->oids.reloid, rec->oids.relnode,
+					 rec->oxid, rec->logicalXid, rec->heapXid);
+
+				if (!TransactionIdIsValid(rec->logicalXid))
+				{
+					/*
+					 * Oriole logical xid stays invalid for an autonomous
+					 * transactions
+					 */
+					elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec->type, recname, rec->oxid);
+					return WALPARSE_OK;
+				}
+
+				ReorderBufferProcessXid(ctx->dctx->reorder, rec->logicalXid, xlogPtr);
+
+				/* If the origin is defined and filtering is enabled, Skip */
+				if (ctx->has_origin && FilterByOrigin(ctx->dctx, rec->origin_id))
+				{
+					elog(DEBUG4, "IGNORED record type %d (%s) for oxid %lu due to origin filtering (origin_id=%u)",
+						 rec->type, recname, rec->oxid, rec->origin_id);
+					return WALPARSE_OK;
+				}
+
+				if (SnapBuildCurrentState(ctx->dctx->snapshot_builder) < SNAPBUILD_FULL_SNAPSHOT)
+					return WALPARSE_OK;
+
+				(void) set_snapshot(ctx->dctx, rec->logicalXid, xlogPtr);
+
+				txn = get_reorder_buffer_txn(ctx->dctx->reorder, rec->logicalXid);
+				txn->txn_flags |= RBTXN_DISTR_SKIP_CLEANUP;
+
+				/* Skip actual record processing in fast_forward mode */
+				if (ctx->dctx->fast_forward)
+					return WALPARSE_OK;
+
+				if ((ctx->ix_type == oIndexInvalid || ctx->ix_type == oIndexToast) &&
+					rec->oids.datoid == ctx->dctx->slot->data.database)
+				{
+					if (!ctx->descr || !ctx->indexDescr)
+					{
+						/*
+						 * We cannot decode this change because we failed to
+						 * obtain the required relation/index descriptors for
+						 * the historical snapshot of this record.
+						 *
+						 * One common reason is that the transaction has been
+						 * rolled back and Oriole's undo cleanup removed the
+						 * historical versions needed to resolve metadata at
+						 * this point.  Record the fact that we skipped DML
+						 * for this OXID so that the finish record handler can
+						 * report it and clear the flag.
+						 */
+						register_skipped_dml(&skippedDMLHash, rec->oxid);
+					}
+					else
+					{
+						ReorderBufferChange *change;
+
+						Assert(ctx->descr != NULL);
+						Assert(!O_TUPLE_IS_NULL(tuple1.tuple));
+						change = ReorderBufferGetChange(ctx->dctx->reorder);
+						change->data.tp.rlocator.spcOid = DEFAULTTABLESPACE_OID;
+						change->data.tp.rlocator.dbOid = rec->oids.datoid;
+						change->data.tp.rlocator.relNumber = rec->oids.relnode;
+						elog(DEBUG4, "reloid: %u", rec->oids.reloid);
+
+						o_decode_modify_tuples(ctx->dctx->reorder, rec->type, ctx->ix_type, change,
+											   ctx->descr, ctx->indexDescr, ctx->o_toast_tupDesc, ctx->heap_toast_tupDesc,
+											   tuple1.tuple, tuple2.tuple, rec->u.modify.len1, rec->relreplident);
+
+						ReorderBufferQueueChange(ctx->dctx->reorder, rec->logicalXid,
+												 xlogPtr, change, (ctx->ix_type == oIndexToast));
+					}
+				}
+				else
+				{
+					/* Do nothing */
+					elog(DEBUG4, "Logical decoding modify ix_type, %u", ctx->ix_type);
+				}
+
+				break;
+			}
+
+		default:
+			break;
+	}
+
+	return WALPARSE_OK;
+}
+
+/*
  * Handle OrioleDB records for LogicalDecodingProcessRecord().
  */
 void
@@ -590,692 +1276,49 @@ orioledb_decode(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 	XLogRecPtr	endXLogPtr = record->EndRecPtr;
 	Pointer		startPtr = (Pointer) XLogRecGetData(record);
 	Pointer		endPtr = startPtr + XLogRecGetDataLen(record);
-	Pointer		ptr = startPtr;
-	OTableDescr *descr = NULL;
-	OIndexDescr *indexDescr = NULL;
-	ORelOids	latest_oids = {0, 0, 0};
-	uint32		latest_version = O_TABLE_INVALID_VERSION;
-	char		relreplident = REPLICA_IDENTITY_DEFAULT;
-	OXid		oxid = InvalidOXid;
-	TransactionId logicalXid = InvalidTransactionId,
-				heapXid = InvalidTransactionId;
-	uint8		rec_type;
-	OIndexType	ix_type = oIndexInvalid;
-	TupleDescData *o_toast_tupDesc = NULL;
-	TupleDescData *heap_toast_tupDesc = NULL;
-	uint16		wal_version;
-	uint8		wal_flags;
-	RepOriginId origin_id = InvalidRepOriginId;
-	XLogRecPtr	origin_lsn = InvalidXLogRecPtr;
-	bool		has_origin = false;
 
-	/*
-	 * Per-process cache of "skipped DML" flags for Oriole transactions
-	 * (OXID).
-	 *
-	 * Why this exists: During ABORT/ROLLBACK OrioleDB actively walks the undo
-	 * chain and removes aborted versions.  Logical decoding, however, may
-	 * still receive Oriole WAL records for such a transaction and might need
-	 * to fetch "historical" descriptors (OTable/OIndex) to decode tuples.  If
-	 * the transaction was rolled back, those historical versions can become
-	 * unreachable because the corresponding undo chain has already been
-	 * cleaned.
-	 *
-	 * In that case we intentionally skip decoding individual DML records
-	 * (INSERT/UPDATE/DELETE/REINSERT) because we cannot reliably reconstruct
-	 * the relation/index descriptors for the required historical snapshot.
-	 *
-	 * We must remember that we have skipped at least one DML record for a
-	 * given OXID, so that when the transaction finishes we can: - log/report
-	 * this fact, and/or - ensure the flag does not leak to subsequent
-	 * transactions.
-	 *
-	 * Lifetime: The cache is allocated in TopMemoryContext and stored in a
-	 * static pointer so it survives across multiple invocations of
-	 * orioledb_decode() within the same decoding backend.  (Logical decoding
-	 * calls decode repeatedly for many records; we need state that outlives a
-	 * single call.)
-	 *
-	 * Scope / semantics: The cache is local to the decoding process; it is
-	 * not shared between backends and not persisted.  Entries are inserted
-	 * when we skip a DML record for an OXID and removed when we observe the
-	 * transaction finish record
-	 * (COMMIT/ROLLBACK/ROLLBACK_TO_SAVEPOINT/JOIN_COMMIT as applicable).
-	 */
-	static HTAB *skippedDMLHash = NULL;
+	DecodeWalDescCtx dctx = {
+		.xlogRecPtr = startXLogPtr,
+		.xlogRecEndPtr = endXLogPtr,
+
+		.dctx = ctx,
+		.dbuf = buf,
+
+		.descr = NULL,
+		.indexDescr = NULL,
+		.ix_type = oIndexInvalid,
+
+		.o_toast_tupDesc = NULL,
+		.heap_toast_tupDesc = NULL,
+
+		.has_origin = false
+	};
+
+	WalReaderState r = {
+		.start = startPtr,
+		.end = endPtr,
+		.ptr = startPtr,
+		.wal_version = 0,
+		.wal_flags = 0,
+		/* Consumer */
+		.ctx = &dctx,
+		.check_version = decode_wal_check_version,
+		.on_flag = decode_wal_containter_info,
+		.on_record = decode_wal_record
+	};
+
+	WalParseResult st;
 
 	/* do our best to disable streaming */
 	ctx->streaming = false;
-	ptr = wal_container_read_header(ptr, &wal_version, &wal_flags);
-	if (wal_version > ORIOLEDB_WAL_VERSION)
-	{
-		/* WAL from future version */
-		elog(ERROR, "Can't logically decode WAL version %u that is newer than supported %u", wal_version, ORIOLEDB_WAL_VERSION);
-		return;
-	}
 
-	if (wal_flags & WAL_CONTAINER_HAS_XACT_INFO)
-	{
-		/* Skip WAL_REC_XACT_INFO */
-		ptr = wal_parse_container_xact_info(ptr, NULL, NULL);
-	}
+	elog(DEBUG4, "OrioleDB decode started startXLogPtr %X/%X endXLogPtr %X/%X",
+		 LSN_FORMAT_ARGS(startXLogPtr), LSN_FORMAT_ARGS(endXLogPtr));
 
-	if (wal_flags & WAL_CONTAINER_HAS_ORIGIN_INFO)
-	{
-		ptr = wal_parse_container_origin_info(ptr, &origin_id, &origin_lsn);
-		has_origin = origin_id != InvalidRepOriginId;
-	}
+	st = parse_wal_container(&r, true /* allow_logging */ );
 
-	elog(DEBUG4, "OrioleDB decode started startXLogPtr %X/%X endXLogPtr %X/%X", LSN_FORMAT_ARGS(startXLogPtr), LSN_FORMAT_ARGS(endXLogPtr));
-
-	while (ptr < endPtr)
-	{
-		const char *rec_type_str;
-		XLogRecPtr	changeXLogPtr = startXLogPtr + (ptr - startPtr);
-
-		rec_type = *ptr;
-		ptr++;
-
-		rec_type_str = wal_record_type_to_string(rec_type);
-
-		elog(DEBUG4, "RECEIVE record type %d (%s)", rec_type, rec_type_str);
-
-		if (rec_type == WAL_REC_XID)
-		{
-			ptr = wal_parse_rec_xid(ptr, &oxid, &logicalXid, &heapXid, wal_version);
-
-			if (TransactionIdIsValid(logicalXid))
-			{
-				CSNSnapshotData *csnSnapshot;
-
-				elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u", rec_type, rec_type_str, oxid, logicalXid, heapXid);
-
-				csnSnapshot = SnapBuildGetCSNSnaphot(ctx->snapshot_builder);
-				csnSnapshot->nextXid = Max(csnSnapshot->nextXid, oxid);
-			}
-			else
-			{
-				/*
-				 * Oriole logical xid stays invalid for an autonomous
-				 * transactions (internal Oriole's mechanism intended for
-				 * independed commit of Oriole system catalog changes)
-				 */
-				elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec_type, rec_type_str, oxid);
-			}
-		}
-		else if (rec_type == WAL_REC_SWITCH_LOGICAL_XID)
-		{
-			TransactionId topXid,
-						subXid;
-
-			ptr = wal_parse_rec_switch_logical_xid(ptr, &topXid, &subXid);
-
-			elog(DEBUG4, "RECEIVE record type %d (%s) %u=>%u oxid %lu logicalXId %u heapXid %u changeXLogPtr %X/%X",
-				 rec_type, rec_type_str,
-				 topXid, subXid,
-				 oxid, logicalXid, heapXid, LSN_FORMAT_ARGS(changeXLogPtr));
-
-			Assert(TransactionIdIsValid(topXid));
-			Assert(TransactionIdIsValid(subXid));
-
-			ReorderBufferAssignChild(ctx->reorder,
-									 topXid, subXid,
-									 changeXLogPtr);
-		}
-		else if (rec_type == WAL_REC_COMMIT || rec_type == WAL_REC_ROLLBACK)
-		{
-			OXid		xmin;
-			dlist_iter	cur_txn_i;
-			ReorderBufferTXN *txn;
-			CommitSeqNo csn;
-			CSNSnapshotData *csnSnapshot;
-
-			ptr = wal_parse_rec_finish(ptr, &xmin, &csn);
-
-			elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u",
-				 rec_type, rec_type_str, oxid, logicalXid, heapXid);
-
-			if (!TransactionIdIsValid(logicalXid))
-			{
-				/*
-				 * Oriole logical xid stays invalid for an autonomous
-				 * transactions
-				 */
-				elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec_type, rec_type_str, oxid);
-
-				UpdateDecodingStats(ctx);
-				continue;
-			}
-
-			csnSnapshot = SnapBuildGetCSNSnaphot(ctx->snapshot_builder);
-			csnSnapshot->snapshotcsn = csn;
-			csnSnapshot->xlogptr = endXLogPtr;
-			csnSnapshot->xmin = xmin;
-
-			if (!set_snapshot(ctx, logicalXid, changeXLogPtr))
-				continue;
-
-			txn = get_reorder_buffer_txn(ctx->reorder, logicalXid);
-
-			if (txn == NULL)
-			{
-				elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u :: unknown transaction, nothing to replay",
-					 rec_type, rec_type_str, oxid, logicalXid);
-			}
-
-			/* unknown transaction, nothing to replay */
-			if (txn != NULL)
-			{
-				Assert(TransactionIdIsValid(logicalXid));
-
-				if (rec_type == WAL_REC_COMMIT)
-				{
-					if (remove_skipped_dml(&skippedDMLHash, oxid))
-					{
-						/*
-						 * We have skipped at least one DML record for this
-						 * transaction due to missing historical metadata
-						 * (typically after undo cleanup on rollback paths). A
-						 * COMMIT with skipped changes is unexpected from the
-						 * consumer's perspective: it means we are about to
-						 * finalize a transaction without having emitted some
-						 * of its changes.
-						 */
-						elog(ERROR, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u",
-							 rec_type, rec_type_str, oxid, logicalXid, heapXid);
-					}
-
-					/*
-					 * SnapBuildXactNeedsSkip() does strict comparison.  So,
-					 * subtract endXLogPtr by one to fit snapshot just taken
-					 * after commit.
-					 */
-					if (SnapBuildXactNeedsSkip(ctx->snapshot_builder,
-											   endXLogPtr - 1) ||
-						ctx->fast_forward)
-					{
-						elog(DEBUG4, "FORGET record type %d (%s) oxid %lu logicalXid %u heapXid %u", rec_type, rec_type_str, oxid, logicalXid, heapXid);
-
-						dlist_foreach(cur_txn_i, &txn->subtxns)
-						{
-							ReorderBufferTXN *cur_txn;
-
-							cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
-							ReorderBufferForget(ctx->reorder, cur_txn->xid,
-												startXLogPtr);
-						}
-						ReorderBufferForget(ctx->reorder, txn->xid,
-											startXLogPtr);
-
-						oxid = InvalidOXid;
-						logicalXid = InvalidTransactionId;
-
-						/* Skip processing of this transaction */
-						continue;
-					}
-
-					/*
-					 * Proceed to commit this transaction and subtransactions
-					 */
-					dlist_foreach(cur_txn_i, &txn->subtxns)
-					{
-						ReorderBufferTXN *cur_txn;
-
-						cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
-						ReorderBufferCommitChild(ctx->reorder, txn->xid, cur_txn->xid,
-												 startXLogPtr, endXLogPtr);
-					}
-					elog(DEBUG4, "COMMIT record type %d (%s) oxid %lu logicalXid %u heapXid %u, origin_id %u, origin_lsn %X/%X", rec_type, rec_type_str, oxid, logicalXid, heapXid, origin_id, LSN_FORMAT_ARGS(origin_lsn));
-					ReorderBufferCommit(ctx->reorder, logicalXid,
-										changeXLogPtr, endXLogPtr,
-										0, origin_id, origin_lsn);
-				}
-				else
-				{
-					Assert(rec_type == WAL_REC_ROLLBACK);
-
-					if (remove_skipped_dml(&skippedDMLHash, oxid))
-					{
-						/*
-						 * Skipped DML is expected on abort paths: if we
-						 * couldn't decode some DML records (e.g. due to
-						 * missing historical descriptors), and the
-						 * transaction ends up rolled back, there is nothing
-						 * to emit to the output plugin. We still must clear
-						 * the cache to avoid leaking state.
-						 */
-						elog(DEBUG4, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u",
-							 rec_type, rec_type_str, oxid, logicalXid, heapXid);
-					}
-
-					dlist_foreach(cur_txn_i, &txn->subtxns)
-					{
-						ReorderBufferTXN *cur_txn;
-
-						cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
-						ReorderBufferAbort(ctx->reorder, cur_txn->xid,
-										   startXLogPtr, 0);
-					}
-					elog(DEBUG4, "ABORT record type %d (%s) oxid %lu logicalXid %u heapXid %u", rec_type, rec_type_str, oxid, logicalXid, heapXid);
-					ReorderBufferAbort(ctx->reorder, logicalXid,
-									   startXLogPtr, 0);
-				}
-			}
-
-			UpdateDecodingStats(ctx);
-
-			oxid = InvalidOXid;
-			logicalXid = InvalidTransactionId;
-		}
-		else if (rec_type == WAL_REC_JOINT_COMMIT)
-		{
-			TransactionId xid;
-			OXid		xmin;
-			CommitSeqNo csn;
-			CSNSnapshotData *csnSnapshot;
-
-			ptr = wal_parse_rec_joint_commit(ptr, &xid, &xmin, &csn);
-
-			elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u",
-				 rec_type, rec_type_str, oxid, logicalXid, heapXid);
-
-			if (!TransactionIdIsValid(logicalXid))
-			{
-				/*
-				 * Oriole logical xid stays invalid for an autonomous
-				 * transactions
-				 */
-				elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec_type, rec_type_str, oxid);
-
-				UpdateDecodingStats(ctx);
-				continue;
-			}
-
-			if (remove_skipped_dml(&skippedDMLHash, oxid))
-			{
-				/*
-				 * We have skipped at least one DML record for this
-				 * transaction due to missing historical metadata (typically
-				 * after undo cleanup on rollback paths).  A COMMIT with
-				 * skipped changes is unexpected from the consumer's
-				 * perspective: it means we are about to finalize a
-				 * transaction without having emitted some of its changes.
-				 */
-				elog(ERROR, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u",
-					 rec_type, rec_type_str, oxid, logicalXid, heapXid);
-			}
-
-			csnSnapshot = SnapBuildGetCSNSnaphot(ctx->snapshot_builder);
-			csnSnapshot->snapshotcsn = csn;
-			csnSnapshot->xlogptr = endXLogPtr;
-			csnSnapshot->xmin = xmin;
-
-			if (!set_snapshot(ctx, logicalXid, changeXLogPtr))
-				continue;
-
-			/* Skip actual commit processing */
-			if (SnapBuildXactNeedsSkip(ctx->snapshot_builder, endXLogPtr - 1) ||
-				ctx->fast_forward)
-			{
-				elog(DEBUG4, "FORGET record type %d (%s) oxid %lu logicalXid %u heapXid %u", rec_type, rec_type_str, oxid, logicalXid, heapXid);
-
-				ReorderBufferForget(ctx->reorder, logicalXid, startXLogPtr);
-			}
-			else
-			{
-				if (TransactionIdIsValid(heapXid) && TransactionIdIsValid(logicalXid))
-				{
-					/*
-					 * Oriole txn acts as a sub-txn to heap txn, needs
-					 * ReorderBufferCommitChild
-					 */
-					elog(DEBUG4, "ReorderBufferCommitChild on record type %d (%s) oxid %lu logicalXid %u heapXid %u", rec_type, rec_type_str, oxid, logicalXid, heapXid);
-
-					ReorderBufferCommitChild(ctx->reorder, heapXid, logicalXid, buf->origptr, buf->endptr);
-				}
-
-				UpdateDecodingStats(ctx);
-			}
-
-			oxid = InvalidOXid;
-			logicalXid = InvalidTransactionId;
-		}
-		else if (rec_type == WAL_REC_RELATION)
-		{
-			int			sys_tree_num = -1;
-			uint8		treeType = 0;
-			OXid		xmin;
-
-			OSnapshot	snapshot;
-			uint32		base_version;
-
-			ptr = wal_parse_rec_relation(ptr, &treeType, &latest_oids, &xmin, &snapshot.csn, &snapshot.cid, &latest_version, &base_version, wal_version);
-
-			if (wal_version >= 17)
-			{
-				snapshot.xmin = xmin;
-				snapshot.xlogptr = changeXLogPtr;
-			}
-			else
-			{
-				/* Override undefined values from WAL */
-				snapshot = o_non_deleted_snapshot;
-			}
-
-			ix_type = treeType;
-			relreplident = REPLICA_IDENTITY_DEFAULT;
-			descr = NULL;
-
-			elog(DEBUG4, "oxid %lu logicalXid %u heapXid %u WAL_REC_RELATION latest_oids [ %u %u %u ] latest_version %u ix_type %d",
-				 oxid, logicalXid, heapXid, latest_oids.datoid, latest_oids.reloid, latest_oids.relnode,
-				 latest_version, ix_type);
-
-			if (!TransactionIdIsValid(logicalXid))
-			{
-				/*
-				 * Oriole logical xid stays invalid for an autonomous
-				 * transactions
-				 */
-				elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec_type, rec_type_str, oxid);
-				continue;
-			}
-
-			/* Skip actual relation processing in fast_forward mode */
-			if (ctx->fast_forward)
-			{
-				elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec_type, rec_type_str, oxid);
-				continue;
-			}
-
-			if (IS_SYS_TREE_OIDS(latest_oids))
-				sys_tree_num = latest_oids.relnode;
-			else
-				sys_tree_num = -1;
-
-			if (sys_tree_num > 0)
-			{
-				descr = NULL;
-				/* indexDescr = NULL; */
-				Assert(sys_tree_get_storage_type(sys_tree_num) == BTreeStoragePersistence);
-			}
-			else if (ix_type == oIndexInvalid)
-			{
-				elog(DEBUG4, "WAL_REC_RELATION oIndexInvalid :: FETCH RELATION [ %u %u %u ] version %u",
-					 latest_oids.datoid, latest_oids.reloid, latest_oids.relnode,
-					 latest_version);
-
-				descr = o_fetch_table_descr_extended(latest_oids, build_fetch_context(&snapshot, latest_version));
-				indexDescr = descr ? GET_PRIMARY(descr) : NULL;
-				if (descr)
-				{
-					Assert(indexDescr);
-				}
-			}
-			else if (ix_type == oIndexToast)
-			{
-				elog(DEBUG4, "WAL_REC_RELATION [1] oIndexToast :: FETCH INDEX oids [ %u %u %u ] version %u base_version %u",
-					 latest_oids.datoid, latest_oids.reloid, latest_oids.relnode,
-					 latest_version, base_version);
-
-				indexDescr = o_fetch_index_descr_extended(latest_oids, ix_type, false,
-														  build_fetch_context(&snapshot, latest_version),
-														  build_fetch_context(&snapshot, base_version));
-				if (indexDescr)
-				{
-					elog(DEBUG4, "WAL_REC_RELATION [2] oIndexToast :: FETCH RELATION [ %u %u %u ] version %u",
-						 indexDescr->tableOids.datoid, indexDescr->tableOids.reloid, indexDescr->tableOids.relnode,
-						 base_version);
-
-					descr = o_fetch_table_descr_extended(indexDescr->tableOids, build_fetch_context(&snapshot, base_version));
-					Assert(descr);
-
-					o_toast_tupDesc = descr->toast->leafTupdesc;
-				}
-
-				/* Init heap tupledesc for toast table */
-				heap_toast_tupDesc = CreateTemplateTupleDesc(3);
-				o_tables_tupdesc_init_builtin(heap_toast_tupDesc, (AttrNumber) 1, "chunk_id", OIDOID);
-				o_tables_tupdesc_init_builtin(heap_toast_tupDesc, (AttrNumber) 2, "chunk_seq", INT4OID);
-				o_tables_tupdesc_init_builtin(heap_toast_tupDesc, (AttrNumber) 3, "chunk_data", BYTEAOID);
-				/* Ensure that the toast table doesn't itself get toasted */
-				TupleDescAttr(heap_toast_tupDesc, 0)->attstorage = TYPSTORAGE_PLAIN;
-				TupleDescAttr(heap_toast_tupDesc, 1)->attstorage = TYPSTORAGE_PLAIN;
-				TupleDescAttr(heap_toast_tupDesc, 2)->attstorage = TYPSTORAGE_PLAIN;
-				/* Toast field should not be compressed */
-				TupleDescAttr(heap_toast_tupDesc, 0)->attcompression = InvalidCompressionMethod;
-				TupleDescAttr(heap_toast_tupDesc, 1)->attcompression = InvalidCompressionMethod;
-				TupleDescAttr(heap_toast_tupDesc, 2)->attcompression = InvalidCompressionMethod;
-			}
-			else
-			{
-				Assert(ix_type == oIndexBridge);
-			}
-
-			if (descr && descr->toast)
-				elog(DEBUG4, "reloid: %d natts: %u toast natts: %u", latest_oids.reloid, descr->tupdesc->natts, descr->toast->leafTupdesc->natts);
-
-		}
-		else if (rec_type == WAL_REC_RELREPLIDENT)
-		{
-			Oid			relreplident_ix_oid;	/* Unused yet */
-
-			ptr = wal_parse_rec_relreplident(ptr, &relreplident, &relreplident_ix_oid);
-
-			/* Skip */
-		}
-		else if (rec_type == WAL_REC_O_TABLES_META_LOCK || rec_type == WAL_REC_REPLAY_FEEDBACK)
-		{
-			/* Skip */
-		}
-		else if (rec_type == WAL_REC_O_TABLES_META_UNLOCK)
-		{
-			ORelOids	oids;
-			Oid			oldRelnode;
-
-			ptr = wal_parse_rec_o_tables_meta_unlock(ptr, &oids, &oldRelnode);
-
-			/* Skip */
-		}
-		else if (rec_type == WAL_REC_TRUNCATE)
-		{
-			ORelOids	oids;
-
-			ptr = wal_parse_rec_truncate(ptr, &oids);
-
-			/* Skip */
-		}
-		else if (rec_type == WAL_REC_SAVEPOINT)
-		{
-			SubTransactionId parentSubid;
-			TransactionId parentLogicalXid;
-
-			ptr = wal_parse_rec_savepoint(ptr, &parentSubid, &logicalXid, &parentLogicalXid);
-
-			elog(DEBUG4, "APPLY record type %d (%s) oxid %lu logicalXid %u parentLogicalXid %u", rec_type, rec_type_str, oxid, logicalXid, parentLogicalXid);
-
-			if (!ctx->fast_forward)
-				ReorderBufferAssignChild(ctx->reorder, parentLogicalXid, logicalXid, buf->origptr);
-
-			/* Skip */
-		}
-		else if (rec_type == WAL_REC_ROLLBACK_TO_SAVEPOINT)
-		{
-			SubTransactionId parentSubid;
-			OXid		xmin;
-			dlist_iter	cur_txn_i;
-			ReorderBufferTXN *txn;
-			CommitSeqNo csn;
-			CSNSnapshotData *csnSnapshot;
-
-			ptr = wal_parse_rec_rollback_to_savepoint(ptr, &parentSubid, &xmin, &csn, wal_version);
-
-			if (wal_version < 17)
-			{
-				/* Skip */
-				continue;
-			}
-
-			elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u parentSubid %u",
-				 rec_type, rec_type_str, oxid, logicalXid, heapXid, parentSubid);
-
-			if (remove_skipped_dml(&skippedDMLHash, oxid))
-			{
-				/*
-				 * This transaction performed a rollback-to-savepoint, so
-				 * previously skipped changes may now be irrelevant (rolled
-				 * back).  Clear the cache to keep per-OXID state consistent.
-				 */
-				elog(DEBUG4, "SKIPPED DML for record type %d (%s) oxid %lu logicalXId %u heapXid %u parentSubid %u",
-					 rec_type, rec_type_str, oxid, logicalXid, heapXid, parentSubid);
-			}
-
-			if (!TransactionIdIsValid(logicalXid))
-			{
-				/*
-				 * Oriole logical xid stays invalid for an autonomous
-				 * transactions
-				 */
-				elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec_type, rec_type_str, oxid);
-
-				UpdateDecodingStats(ctx);
-				continue;
-			}
-
-			csnSnapshot = SnapBuildGetCSNSnaphot(ctx->snapshot_builder);
-			csnSnapshot->snapshotcsn = csn;
-			csnSnapshot->xlogptr = endXLogPtr;
-			csnSnapshot->xmin = xmin;
-
-			if (!set_snapshot(ctx, logicalXid, changeXLogPtr))
-				continue;
-
-			txn = get_reorder_buffer_txn(ctx->reorder, logicalXid);
-
-			if (txn == NULL)
-			{
-				elog(DEBUG4, "RECEIVE record type %d (%s) oxid %lu logicalXId %u heapXid %u :: unknown transaction, nothing to replay",
-					 rec_type, rec_type_str, oxid, logicalXid, heapXid);
-			}
-
-			/* unknown transaction, nothing to replay */
-			if (txn != NULL)
-			{
-				Assert(TransactionIdIsValid(logicalXid));
-
-				dlist_foreach(cur_txn_i, &txn->subtxns)
-				{
-					ReorderBufferTXN *cur_txn;
-
-					cur_txn = dlist_container(ReorderBufferTXN, node, cur_txn_i.cur);
-					ReorderBufferAbort(ctx->reorder, cur_txn->xid,
-									   startXLogPtr, 0);
-				}
-				elog(DEBUG4, "ABORT record type %d (%s) oxid %lu logicalXid %u heapXid %u", rec_type, rec_type_str, oxid, logicalXid, heapXid);
-				ReorderBufferAbort(ctx->reorder, logicalXid,
-								   startXLogPtr, 0);
-			}
-
-			UpdateDecodingStats(ctx);
-
-			oxid = InvalidOXid;
-			logicalXid = InvalidTransactionId;
-		}
-		else if (rec_type == WAL_REC_INSERT || rec_type == WAL_REC_UPDATE || rec_type == WAL_REC_DELETE || rec_type == WAL_REC_REINSERT)
-		{
-			OFixedTuple tuple1;
-			OFixedTuple tuple2;
-			OffsetNumber debug_length;
-			ReorderBufferTXN *txn;
-			bool		read_two_tuples;
-
-			read_two_tuples = (rec_type == WAL_REC_REINSERT || (rec_type == WAL_REC_UPDATE && relreplident == REPLICA_IDENTITY_FULL));
-			ptr = wal_parse_rec_modify(ptr, &tuple1, &tuple2, &debug_length, read_two_tuples);
-
-			elog(DEBUG4, "RECEIVE record type %d (%s) oids [ %u %u %u ] oxid %lu logicalXId %u heapXid %u",
-				 rec_type, rec_type_str,
-				 latest_oids.datoid, latest_oids.reloid, latest_oids.relnode,
-				 oxid, logicalXid, heapXid);
-
-			if (!TransactionIdIsValid(logicalXid))
-			{
-				/*
-				 * Oriole logical xid stays invalid for an autonomous
-				 * transactions
-				 */
-				elog(DEBUG4, "IGNORED record type %d (%s) invalid logicalXid for oxid %lu", rec_type, rec_type_str, oxid);
-				continue;
-			}
-
-			ReorderBufferProcessXid(ctx->reorder, logicalXid, changeXLogPtr);
-
-			/* If the origin is defined and filtering is enabled, Skip */
-			if (has_origin && FilterByOrigin(ctx, origin_id))
-			{
-				elog(DEBUG4, "IGNORED record type %d (%s) for oxid %lu due to origin filtering (origin_id=%u)", rec_type, rec_type_str, oxid, origin_id);
-				continue;
-			}
-
-			if (SnapBuildCurrentState(ctx->snapshot_builder) < SNAPBUILD_FULL_SNAPSHOT)
-				continue;
-
-			(void) set_snapshot(ctx, logicalXid, changeXLogPtr);
-
-			txn = get_reorder_buffer_txn(ctx->reorder, logicalXid);
-			txn->txn_flags |= RBTXN_DISTR_SKIP_CLEANUP;
-
-			/* Skip actual record processing in fast_forward mode */
-			if (ctx->fast_forward)
-				continue;
-
-			if ((ix_type == oIndexInvalid || ix_type == oIndexToast) &&
-				latest_oids.datoid == ctx->slot->data.database)
-			{
-				if (!descr || !indexDescr)
-				{
-					/*
-					 * We cannot decode this change because we failed to
-					 * obtain the required relation/index descriptors for the
-					 * historical snapshot of this record.
-					 *
-					 * One common reason is that the transaction has been
-					 * rolled back and Oriole's undo cleanup removed the
-					 * historical versions needed to resolve metadata at this
-					 * point.  Record the fact that we skipped DML for this
-					 * OXID so that the finish record handler can report it
-					 * and clear the flag.
-					 */
-					register_skipped_dml(&skippedDMLHash, oxid);
-				}
-				else
-				{
-					ReorderBufferChange *change;
-
-					Assert(descr != NULL);
-					Assert(!O_TUPLE_IS_NULL(tuple1.tuple));
-					change = ReorderBufferGetChange(ctx->reorder);
-					change->data.tp.rlocator.spcOid = DEFAULTTABLESPACE_OID;
-					change->data.tp.rlocator.dbOid = latest_oids.datoid;
-					change->data.tp.rlocator.relNumber = latest_oids.relnode;
-					elog(DEBUG4, "reloid: %u", latest_oids.reloid);
-
-					o_decode_modify_tuples(ctx->reorder, rec_type, ix_type, change, descr, indexDescr, o_toast_tupDesc, heap_toast_tupDesc, tuple1.tuple, tuple2.tuple, debug_length, relreplident);
-
-					ReorderBufferQueueChange(ctx->reorder, logicalXid,
-											 changeXLogPtr,
-											 change, (ix_type == oIndexToast));
-				}
-			}
-			else
-			{
-				/* Do nothing */
-				elog(DEBUG4, "Logical decoding modify ix_type, %u", ix_type);
-			}
-		}
-		else
-		{
-			elog(FATAL, "Unknown WAL record");
-		}
-	}
+	if (st != WALPARSE_OK)
+		elog(FATAL, "[WAL PARSE ERROR %d]", st);
 }
 
 static inline bool

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -95,15 +95,29 @@ wal_record_type_to_string(int wal_record)
 	return "UNKNOWN";
 }
 
-#define PARSE(ptr, valptr) \
-do \
-{ \
-	if (valptr) \
-	{ \
-		memcpy(valptr, ptr, sizeof(*(valptr))); \
-	} \
-	ptr += sizeof(*(valptr)); \
-} while(0)
+WalParseResult
+wal_parse_container_xact_info(WalReaderState *r, WalRecord *rec)
+{
+	Assert(r);
+	Assert(rec);
+
+	WR_PARSE(r, &rec->u.xact_info.xactTime);
+	WR_PARSE(r, &rec->u.xact_info.xid);
+
+	return WALPARSE_OK;
+}
+
+WalParseResult
+wal_parse_container_origin_info(WalReaderState *r, WalRecord *rec)
+{
+	Assert(r);
+	Assert(rec);
+
+	WR_PARSE(r, &rec->origin_id);
+	WR_PARSE(r, &rec->origin_lsn);
+
+	return WALPARSE_OK;
+}
 
 #define ASSIGN(ptr, value) \
 do { \
@@ -111,262 +125,196 @@ do { \
 } while(0)
 
 /* Parser for WAL_REC_XID */
-Pointer
-wal_parse_rec_xid(Pointer ptr, OXid *oxid, TransactionId *logicalXid, TransactionId *heapXid, uint16 wal_version)
+WalParseResult
+wal_parse_rec_xid(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, oxid);
-	PARSE(ptr, logicalXid);
-	if (wal_version >= 17)
+	WR_PARSE(r, &rec->oxid);
+	WR_PARSE(r, &rec->logicalXid);
+	if (r->wal_version >= 17)
 	{
-		PARSE(ptr, heapXid);
+		WR_PARSE(r, &rec->heapXid);
 	}
 	else
 	{
-		ASSIGN(heapXid, InvalidTransactionId);
+		rec->heapXid = InvalidTransactionId;
 	}
-
-	return ptr;
-}
-
-/* Parser for WAL_CONTAINER_XACT_INFO */
-Pointer
-wal_parse_container_xact_info(Pointer ptr, TimestampTz *xactTime, TransactionId *xid)
-{
-	Assert(ptr);
-
-	PARSE(ptr, xactTime);
-	PARSE(ptr, xid);
-
-	return (ptr);
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_COMMIT and WAL_REC_ROLLBACK */
-Pointer
-wal_parse_rec_finish(Pointer ptr, OXid *xmin, CommitSeqNo *csn)
+WalParseResult
+wal_parse_rec_finish(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, xmin);
-	PARSE(ptr, csn);
+	WR_PARSE(r, &rec->u.finish.xmin);
+	WR_PARSE(r, &rec->u.finish.csn);
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_JOINT_COMMIT */
-Pointer
-wal_parse_rec_joint_commit(Pointer ptr, TransactionId *xid, OXid *xmin, CommitSeqNo *csn)
+WalParseResult
+wal_parse_rec_joint_commit(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, xid);
-	PARSE(ptr, xmin);
-	PARSE(ptr, csn);
+	WR_PARSE(r, &rec->u.joint_commit.xid);
+	WR_PARSE(r, &rec->u.joint_commit.xmin);
+	WR_PARSE(r, &rec->u.joint_commit.csn);
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_RELATION */
-Pointer
-wal_parse_rec_relation(Pointer ptr, uint8 *treeType, ORelOids *oids, OXid *xmin, CommitSeqNo *csn, CommandId *cid, uint32 *version, uint32 *base_version, uint16 wal_version)
+WalParseResult
+wal_parse_rec_relation(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
-	Assert(oids);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, treeType);
-	PARSE(ptr, &oids->datoid);
-	PARSE(ptr, &oids->reloid);
-	PARSE(ptr, &oids->relnode);
+	WR_PARSE(r, &rec->u.relation.treeType);
+	WR_PARSE(r, &rec->oids.datoid);
+	WR_PARSE(r, &rec->oids.reloid);
+	WR_PARSE(r, &rec->oids.relnode);
 
-	if (wal_version >= 17)
+	if (r->wal_version >= 17)
 	{
-		PARSE(ptr, xmin);
-		PARSE(ptr, csn);
-		PARSE(ptr, cid);
+		OXid		xmin;
 
-		PARSE(ptr, version);
-		PARSE(ptr, base_version);
+		WR_PARSE(r, &xmin);
+		WR_PARSE(r, &rec->u.relation.snapshot.csn);
+		WR_PARSE(r, &rec->u.relation.snapshot.cid);
+
+		rec->u.relation.snapshot.xmin = xmin;
+
+		WR_PARSE(r, &rec->u.relation.version);
+		WR_PARSE(r, &rec->u.relation.base_version);
 	}
 	else
 	{
-		ASSIGN(xmin, InvalidOXid);
-		ASSIGN(csn, 0);
-		ASSIGN(cid, InvalidCommandId);
-
-		ASSIGN(version, O_TABLE_INVALID_VERSION);
-		ASSIGN(base_version, O_TABLE_INVALID_VERSION);
+		rec->u.relation.snapshot = o_non_deleted_snapshot;
+		rec->u.relation.version = O_TABLE_INVALID_VERSION;
+		rec->u.relation.base_version = O_TABLE_INVALID_VERSION;
 	}
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_RELREPLIDENT */
-Pointer
-wal_parse_rec_relreplident(Pointer ptr, char *relreplident, Oid *relreplident_ix_oid)
+WalParseResult
+wal_parse_rec_relreplident(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
-	Assert(relreplident);
-	/* Should be set only once and only from default */
-	Assert(*relreplident == REPLICA_IDENTITY_DEFAULT);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, relreplident);
+	/* Should be set only once and only from default */
+	Assert(rec->relreplident == REPLICA_IDENTITY_DEFAULT);
+
+	WR_PARSE(r, &rec->relreplident);
 
 	/*
 	 * relreplident_ix_oid is reserved in the WAL_REC_RELREPLIDENT for the
 	 * future implementation of REPLICA IDENTITY USING INDEX and not used now
 	 */
-	PARSE(ptr, relreplident_ix_oid);
-	Assert(*relreplident_ix_oid == InvalidOid);
+	WR_PARSE(r, &rec->u.relreplident.relreplident_ix_oid);
+	Assert(rec->u.relreplident.relreplident_ix_oid == InvalidOid);
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_O_TABLES_META_UNLOCK */
-Pointer
-wal_parse_rec_o_tables_meta_unlock(Pointer ptr, ORelOids *oids, Oid *old_relnode)
+WalParseResult
+wal_parse_rec_o_tables_meta_unlock(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
-	Assert(oids);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, &oids->datoid);
-	PARSE(ptr, &oids->reloid);
-	PARSE(ptr, old_relnode);
-	PARSE(ptr, &oids->relnode);
+	WR_PARSE(r, &rec->u.unlock.oids.datoid);
+	WR_PARSE(r, &rec->u.unlock.oids.reloid);
+	WR_PARSE(r, &rec->u.unlock.oldRelnode);
+	WR_PARSE(r, &rec->u.unlock.oids.relnode);
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_SAVEPOINT */
-Pointer
-wal_parse_rec_savepoint(Pointer ptr, SubTransactionId *parentSubid, TransactionId *logicalXid, TransactionId *parentLogicalXid)
+WalParseResult
+wal_parse_rec_savepoint(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, parentSubid);
-	PARSE(ptr, logicalXid);
-	PARSE(ptr, parentLogicalXid);
+	WR_PARSE(r, &rec->u.savepoint.parentSubid);
+	WR_PARSE(r, &rec->logicalXid);
+	WR_PARSE(r, &rec->u.savepoint.parentLogicalXid);
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_ROLLBACK_TO_SAVEPOINT */
-Pointer
-wal_parse_rec_rollback_to_savepoint(Pointer ptr, SubTransactionId *parentSubid, OXid *xmin, CommitSeqNo *csn, uint16 wal_version)
+WalParseResult
+wal_parse_rec_rollback_to_savepoint(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, parentSubid);
-	if (wal_version >= 17)
+	WR_PARSE(r, &rec->u.rb_to_sp.parentSubid);
+	if (r->wal_version >= 17)
 	{
-		PARSE(ptr, xmin);
-		PARSE(ptr, csn);
+		WR_PARSE(r, &rec->u.rb_to_sp.xmin);
+		WR_PARSE(r, &rec->u.rb_to_sp.csn);
 	}
 	else
 	{
-		ASSIGN(xmin, InvalidOXid);
-		ASSIGN(csn, 0);
+		rec->u.rb_to_sp.xmin = InvalidOXid;
+		rec->u.rb_to_sp.csn = 0;
 	}
-
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_TRUNCATE */
-Pointer
-wal_parse_rec_truncate(Pointer ptr, ORelOids *oids)
+WalParseResult
+wal_parse_rec_truncate(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
-	Assert(oids);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, &oids->datoid);
-	PARSE(ptr, &oids->reloid);
-	PARSE(ptr, &oids->relnode);
+	WR_PARSE(r, &rec->u.truncate.oids.datoid);
+	WR_PARSE(r, &rec->u.truncate.oids.reloid);
+	WR_PARSE(r, &rec->u.truncate.oids.relnode);
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_BRIDGE_ERASE */
-Pointer
-wal_parse_rec_bridge_erase(Pointer ptr, ItemPointerData *iptr)
+WalParseResult
+wal_parse_rec_bridge_erase(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, iptr);
+	WR_PARSE(r, &rec->u.bridge_erase.iptr);
 
-	return ptr;
+	return WALPARSE_OK;
 }
 
 /* Parser for WAL_REC_SWITCH_LOGICAL_XID */
-Pointer
-wal_parse_rec_switch_logical_xid(Pointer ptr, TransactionId *topXid, TransactionId *subXid)
+WalParseResult
+wal_parse_rec_switch_logical_xid(WalReaderState *r, WalRecord *rec)
 {
-	Assert(ptr);
+	Assert(r);
+	Assert(rec);
 
-	PARSE(ptr, topXid);
-	PARSE(ptr, subXid);
+	WR_PARSE(r, &rec->u.swxid.topXid);
+	WR_PARSE(r, &rec->u.swxid.subXid);
 
-	return ptr;
-}
-
-Pointer
-wal_container_read_header(Pointer ptr, uint16 *version, uint8 *flags)
-{
-	uint16		wal_version = 0;
-	uint8		wal_flags = 0;
-
-	if (*ptr >= FIRST_ORIOLEDB_WAL_VERSION)
-	{
-		/*
-		 * Container starts with a valid WAL version. First WAL record is just
-		 * after it.
-		 */
-		memcpy(&wal_version, ptr, sizeof(wal_version));
-		ptr += sizeof(wal_version);
-	}
-	else
-	{
-		/*
-		 * Container starts with rec_type of first WAL record (its maximum
-		 * value was under FIRST_ORIOLEDB_WAL_VERSION at the time of
-		 * introducing WAL versioning. Consider this as version 0 and don't
-		 * increase pointer
-		 */
-		wal_version = 0;
-	}
-
-	if (wal_version > ORIOLEDB_WAL_VERSION)
-	{
-#ifdef IS_DEV
-		/* Always fail tests on difference */
-		elog(FATAL, "Can't apply WAL container version %u that is newer than supported %u. Intentionally fail tests", wal_version, ORIOLEDB_WAL_VERSION);
-#else
-		elog(WARNING, "Can't apply WAL container version %u that is newer than supported %u", wal_version, ORIOLEDB_WAL_VERSION);
-		/* Further fail and output is caller-specific */
-#endif
-	}
-	else if (wal_version < ORIOLEDB_WAL_VERSION)
-	{
-#ifdef IS_DEV
-		/* Always fail tests on difference */
-		elog(FATAL, "WAL container version %u is older than current %u. Intentionally fail tests", wal_version, ORIOLEDB_WAL_VERSION);
-#else
-		elog(LOG, "WAL container version %u is older than current %u. Applying with conversion.", wal_version, ORIOLEDB_WAL_VERSION);
-#endif
-	}
-
-	if (wal_version >= ORIOLEDB_XACT_INFO_WAL_VERSION)
-	{
-		/*
-		 * WAL container flags were added by ORIOLEDB_XACT_INFO_WAL_VERSION.
-		 */
-		memcpy(&wal_flags, ptr, sizeof(wal_flags));
-		ptr += sizeof(wal_flags);
-	}
-
-	*version = wal_version;
-	*flags = wal_flags;
-
-	return ptr;
+	return WALPARSE_OK;
 }
 
 void
@@ -1213,66 +1161,42 @@ set_local_wal_has_material_changes(bool value)
  * Read one or two tuples from modify WAL record.
  * Two tuples in certain cases: (1) WAL_REC_REINSERT, (2) WAL_REC_UPDATE with REPLICA_IDENTITY_FULL
  */
-Pointer
-wal_parse_rec_modify(Pointer ptr, OFixedTuple *tuple1, OFixedTuple *tuple2, OffsetNumber *length1_out, bool read_two_tuples)
+WalParseResult
+wal_parse_rec_modify(WalReaderState *r, WalRecord *rec)
 {
-	OffsetNumber length1;
-	OffsetNumber length2;
+	Assert(r);
+	Assert(rec);
 
-	if (!read_two_tuples)
+	rec->u.modify.read_two_tuples = (rec->type == WAL_REC_REINSERT || (rec->type == WAL_REC_UPDATE && rec->relreplident == REPLICA_IDENTITY_FULL));
+
+	if (!rec->u.modify.read_two_tuples)
 	{
-		PARSE(ptr, &tuple1->tuple.formatFlags);
-		memcpy(&length1, ptr, sizeof(OffsetNumber));
-		ptr += sizeof(OffsetNumber);
-		Assert(length1 > 0);
+		WR_PARSE(r, &rec->u.modify.t1.formatFlags);
+		WR_PARSE(r, &rec->u.modify.len1);
+		Assert(rec->u.modify.len1 > 0);
 
-		Assert(tuple1->fixedData);
-		memcpy(tuple1->fixedData, ptr, length1);
-		if (length1 != MAXALIGN(length1))
-			memset(&tuple1->fixedData[length1], 0, MAXALIGN(length1) - length1);
+		rec->u.modify.t1.data = r->ptr;
+		WR_SKIP(r, rec->u.modify.len1);
 
-		ptr += length1;
-		tuple1->tuple.data = tuple1->fixedData;
-		O_TUPLE_SET_NULL(tuple2->tuple);
+		O_TUPLE_SET_NULL(rec->u.modify.t2);
 	}
 	else
 	{
-		PARSE(ptr, &tuple1->tuple.formatFlags);
-		PARSE(ptr, &tuple2->tuple.formatFlags);
-		memcpy(&length1, ptr, sizeof(OffsetNumber));
-		ptr += sizeof(OffsetNumber);
-		memcpy(&length2, ptr, sizeof(OffsetNumber));
-		ptr += sizeof(OffsetNumber);
+		WR_PARSE(r, &rec->u.modify.t1.formatFlags);
+		WR_PARSE(r, &rec->u.modify.t2.formatFlags);
 
-		Assert(length1 > 0 && length2 > 0);
+		WR_PARSE(r, &rec->u.modify.len1);
+		WR_PARSE(r, &rec->u.modify.len2);
 
-		Assert(tuple1->fixedData);
-		memcpy(tuple1->fixedData, ptr, length1);
-		if (length1 != MAXALIGN(length1))
-			memset(&tuple1->fixedData[length1], 0, MAXALIGN(length1) - length1);
+		Assert(rec->u.modify.len1 > 0);
+		Assert(rec->u.modify.len2 > 0);
 
-		ptr += length1;
-		tuple1->tuple.data = tuple1->fixedData;
+		rec->u.modify.t1.data = r->ptr;
+		WR_SKIP(r, rec->u.modify.len1);
 
-		Assert(tuple2->fixedData);
-		memcpy(tuple2->fixedData, ptr, length2);
-		if (length2 != MAXALIGN(length2))
-			memset(&tuple2->fixedData[length2], 0, MAXALIGN(length2) - length2);
-
-		ptr += length2;
-		tuple2->tuple.data = tuple2->fixedData;
+		rec->u.modify.t2.data = r->ptr;
+		WR_SKIP(r, rec->u.modify.len2);
 	}
-	*length1_out = length1;
 
-	return ptr;
-}
-
-Pointer
-wal_parse_container_origin_info(Pointer ptr, RepOriginId *origin_id, XLogRecPtr *origin_lsn)
-{
-	Assert(ptr);
-	PARSE(ptr, origin_id);
-	PARSE(ptr, origin_lsn);
-
-	return ptr;
+	return WALPARSE_OK;
 }

--- a/src/recovery/wal_reader.c
+++ b/src/recovery/wal_reader.c
@@ -1,0 +1,617 @@
+/*-------------------------------------------------------------------------
+ *
+ * wal_reader.c
+ *		Routines dealing with WAL parsing for OrioleDB.
+ *
+ * Copyright (c) 2026, Oriole DB Inc.
+ * Copyright (c) 2026, Supabase Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/src/recovery/wal_reader.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "btree/btree.h"
+#include "btree/page_contents.h"
+
+#include "replication/origin.h"
+
+#include "recovery/wal_reader.h"
+#include "recovery/wal.h"
+
+/*
+ * This file implements the generic OrioleDB WAL container parser.
+ *
+ * The parser is responsible only for:
+ *   - container framing (header, flags prefix, record tag/payload scanning),
+ *   - descriptor-driven payload decoding,
+ *   - safe cursor advancement with bounds checking.
+ *
+ * Parsing is strictly single-pass and forward-only.
+ *
+ * The reader never rewinds and never performs lookahead beyond what is
+ * required for the current record. This guarantees predictable cursor
+ * movement and avoids quadratic behavior on large containers.
+ *
+ * All semantic decisions (version policy, applying changes, decoding, etc.)
+ * are delegated to the WalReaderState's consumer callbacks.
+ *
+ * Descriptor tables are generated from ORIOLE_WAL_RECORDS / ORIOLE_WAL_FLAGS,
+ * making the type->parser mapping a single source of truth and preventing
+ * protocol-breaking omissions when new types/flags are introduced.
+ */
+
+/*
+ * g_wal_descs / g_wal_flag_descs
+ *
+ * Static descriptor tables generated from the X-macro lists.
+ *
+ * Keeping these tables centralized ensures that adding a new WAL record or
+ * container flag is a single-point change: the parser automatically learns
+ * about new types via the descriptor list, and cannot "forget" to handle a
+ * flag payload (which would desynchronize the stream).
+ */
+
+static const WalRecordDesc g_wal_descs[] =
+{
+#define X(sym, val, name, fn) { (wal_type_t)(val), name, (fn) },
+	ORIOLE_WAL_RECORDS(X)
+#undef X
+};
+
+static const WalRecordDesc g_wal_flag_descs[] =
+{
+#define X(sym, val, name, fn) { (wal_type_t)(val), name, (fn) },
+	ORIOLE_WAL_FLAGS(X)
+#undef X
+};
+
+/*
+ * wal_get_desc() / wal_flag_get_desc()
+ *
+ * Lookup descriptor for a record/flag type.
+ *
+ * Returns NULL if the type is not registered in the static descriptor
+ * tables generated from ORIOLE_WAL_RECORDS / ORIOLE_WAL_FLAGS.
+ *
+ * Note: unknown type is a hard protocol error for parse_wal_container(),
+ * because without a descriptor we cannot determine payload length and cannot
+ * safely advance the cursor.
+ */
+
+const WalRecordDesc *
+wal_get_desc(wal_type_t type)
+{
+	for (size_t i = 0; i < lengthof(g_wal_descs); i++)
+		if (g_wal_descs[i].type == type)
+			return &g_wal_descs[i];
+	return NULL;
+}
+
+const WalRecordDesc *
+wal_flag_get_desc(wal_type_t type)
+{
+	for (size_t i = 0; i < lengthof(g_wal_flag_descs); i++)
+		if (g_wal_flag_descs[i].type == type)
+			return &g_wal_flag_descs[i];
+	return NULL;
+}
+
+const char *
+wal_type_name(wal_type_t type)
+{
+	const WalRecordDesc *d = wal_get_desc(type);
+
+	return d ? d->name : "UNKNOWN";
+}
+
+const char *
+wal_flag_type_name(wal_type_t type)
+{
+	const WalRecordDesc *d = wal_flag_get_desc(type);
+
+	return d ? d->name : "UNKNOWN";
+}
+
+static void
+build_fixed_tuple_from_tuple_view(const OTuple *view, const OffsetNumber len, OFixedTuple *tuple)
+{
+	Assert(view);
+	Assert(tuple);
+
+	tuple->tuple.formatFlags = view->formatFlags;
+	Assert(tuple->fixedData);
+	memcpy(tuple->fixedData, view->data, len);
+	if (len != MAXALIGN(len))
+		memset(&tuple->fixedData[len], 0, MAXALIGN(len) - len);
+	tuple->tuple.data = tuple->fixedData;
+}
+
+/*
+ * build_fixed_tuples()
+ *
+ * Helper for consumers that need stable tuple bytes for modify records.
+ *
+ * Modify records (INSERT/UPDATE/DELETE/REINSERT) expose tuple payload as
+ * pointers into the WAL container buffer. This is intentional: the parser
+ * does not allocate or copy data.
+ *
+ * This function exists to make the ownership boundary explicit:
+ * the WAL parser never allocates.
+ *
+ * build_fixed_tuples() copies the tuple bytes into OFixedTuple buffers
+ * provided by the caller (including MAXALIGN padding), producing OTuple
+ * instances safe to use after the current callback returns.
+ *
+ * The function expects tuple->fixedData to be allocated by the caller and
+ * sized to hold MAXALIGN(len).
+ */
+void
+build_fixed_tuples(const WalRecord *rec, OFixedTuple *tuple1, OFixedTuple *tuple2)
+{
+	Assert(rec);
+	Assert(tuple1);
+	Assert(tuple2);
+	Assert(rec->type == WAL_REC_INSERT || rec->type == WAL_REC_UPDATE || rec->type == WAL_REC_DELETE || rec->type == WAL_REC_REINSERT);
+
+	if (!rec->u.modify.read_two_tuples)
+	{
+		build_fixed_tuple_from_tuple_view(&rec->u.modify.t1, rec->u.modify.len1, tuple1);
+		O_TUPLE_SET_NULL(tuple2->tuple);
+	}
+	else
+	{
+		build_fixed_tuple_from_tuple_view(&rec->u.modify.t1, rec->u.modify.len1, tuple1);
+		build_fixed_tuple_from_tuple_view(&rec->u.modify.t2, rec->u.modify.len2, tuple2);
+	}
+}
+
+/*
+ * wal_container_read_header()
+ *
+ * Reads and validates container-level framing:
+ *   - extracts wal_version and wal_flags,
+ *   - ensures the container format is structurally compatible with
+ *     this build (i.e. we understand its framing rules).
+ *
+ * This function performs a format-level compatibility check only.
+ *
+ * It guarantees that:
+ *   - we can safely interpret the container layout,
+ *   - header fields are readable,
+ *   - flag prefix handling is valid for this wal_version.
+ *
+ * It does NOT decide whether WAL from this version should be applied.
+ * Higher-level version policy (e.g. cross-version replay rules) is
+ * delegated to the consumer via r->check_version().
+ *
+ * On success, r->ptr is positioned at the first byte after the
+ * container header.
+ */
+static WalParseResult
+wal_container_read_header(WalReaderState *r, bool allow_logging)
+{
+	uint16		wal_version = 0;
+	uint8		wal_flags = 0;
+	uint8		firstByte = 0;
+
+	firstByte = *(uint8 *) r->ptr;
+
+	if (firstByte >= FIRST_ORIOLEDB_WAL_VERSION)
+	{
+		/*
+		 * Container starts with a valid WAL version. First WAL record is just
+		 * after it.
+		 */
+		WR_PARSE(r, &wal_version);
+	}
+	else
+	{
+		/*
+		 * Container starts with rec_type of first WAL record (its maximum
+		 * value was under FIRST_ORIOLEDB_WAL_VERSION at the time of
+		 * introducing WAL versioning. Consider this as version 0 and don't
+		 * increase pointer
+		 */
+		wal_version = 0;
+	}
+
+	if (wal_version > ORIOLEDB_WAL_VERSION)
+	{
+#ifdef IS_DEV
+		/* Always fail tests on difference */
+		if (allow_logging)
+			elog(FATAL, "Can't apply WAL container version %u that is newer than supported %u. Intentionally fail tests", wal_version, ORIOLEDB_WAL_VERSION);
+
+		return WALPARSE_BAD_VERSION;
+#else
+		if (allow_logging)
+			elog(WARNING, "Can't apply WAL container version %u that is newer than supported %u", wal_version, ORIOLEDB_WAL_VERSION);
+
+		/* Further fail and output is caller-specific */
+#endif
+	}
+	else if (wal_version < ORIOLEDB_WAL_VERSION)
+	{
+#ifdef IS_DEV
+		/* Always fail tests on difference */
+		if (allow_logging)
+			elog(FATAL, "WAL container version %u is older than current %u. Intentionally fail tests", wal_version, ORIOLEDB_WAL_VERSION);
+
+		return WALPARSE_BAD_VERSION;
+#else
+		if (allow_logging)
+			elog(LOG, "WAL container version %u is older than current %u. Applying with conversion.", wal_version, ORIOLEDB_WAL_VERSION);
+#endif
+	}
+
+	if (wal_version >= ORIOLEDB_CONTAINER_FLAGS_WAL_VERSION)
+	{
+		/*
+		 * WAL container flags were added by
+		 * ORIOLEDB_CONTAINER_FLAGS_WAL_VERSION.
+		 */
+		WR_PARSE(r, &wal_flags);
+	}
+
+	r->wal_version = wal_version;
+	r->wal_flags = wal_flags;
+
+	return WALPARSE_OK;
+}
+
+/*
+ * wal_container_parse_flag()
+ *
+ * Consume a single container flag payload if the flag is present.
+ *
+ * Container flags are advertised as a bitmask (r->wal_flags) but some flags
+ * carry additional bytes in the stream. Such payload is part of the container
+ * header prefix and MUST be consumed before reading the first record tag.
+ *
+ * Semantics:
+ *
+ *   - If the flag bit is not set, the function is a no-op and does not advance
+ *     r->ptr.
+ *
+ *   - If the flag bit is set, the flag descriptor is mandatory. We must know
+ *     the exact payload format and length in order to advance r->ptr safely.
+ *     A missing descriptor or parser is treated as WALPARSE_BAD_TYPE: without
+ *     it, we cannot maintain record boundary alignment.
+ *
+ *   - If the flag has a payload parser, it must consume exactly this flag's
+ *     payload bytes and leave r->ptr positioned at the next element
+ *     (either another flag payload or the first record tag).
+ *
+ *   - After successful parsing, the flag is optionally delivered to the
+ *     consumer via r->on_flag(). The callback may capture header-wide context
+ *     (e.g. PG xid/origin) needed for interpreting subsequent records, but must
+ *     not attempt to move r->ptr.
+ *
+ * Note: flags with payload are protocol-critical. Forgetting to consume a flag
+ * payload would desynchronize the stream and cause the next record tag to be
+ * misread.
+ */
+static inline WalParseResult
+wal_container_parse_flag(WalReaderState *r, wal_type_t type)
+{
+	WalParseResult st = WALPARSE_OK;
+
+	Assert(r);
+
+	if (r->wal_flags & type)
+	{
+		/*
+		 * Descriptor is required to know payload length and keep cursor
+		 * aligned.
+		 */
+		const WalRecordDesc *d = wal_flag_get_desc(type);
+
+		Assert(d && d->parse);
+		if (d && d->parse)
+		{
+			WalRecord	rec;
+
+			memset(&rec, 0, sizeof(rec));
+
+			rec.type = type;
+			st = d->parse(r, &rec);
+			if (st == WALPARSE_OK && r->on_flag)
+				st = r->on_flag(r->ctx, &rec);
+		}
+		else
+			st = WALPARSE_BAD_TYPE;
+	}
+
+	return st;
+}
+
+/*
+ * wal_container_parse_flags()
+ *
+ * Consume all known container flags (header prefix).
+ *
+ * Flags are parsed in a deterministic order defined by ORIOLE_WAL_FLAGS.
+ *
+ * Although flags are represented on-wire as a bitmask, their payloads (if any)
+ * are serialized as a byte stream in the container header area. Therefore,
+ * the parser must consume payloads in a deterministic, protocol-defined order.
+ *
+ * We define that order by expanding ORIOLE_WAL_FLAGS(X) and calling
+ * wal_container_parse_flag() once per declared flag. This provides a single
+ * source of truth: introducing a new container flag requires updating only
+ * ORIOLE_WAL_FLAGS, and the parser automatically starts consuming its payload.
+ *
+ * This is intentionally not a runtime loop: the expansion is compile-time and
+ * avoids maintaining a separate hand-written list of flags in the parser,
+ * which is otherwise easy to forget and would silently break protocol framing.
+ *
+ * On success, r->ptr is positioned at the first record tag byte.
+ */
+static inline WalParseResult
+wal_container_parse_flags(WalReaderState *r)
+{
+	WalParseResult st = WALPARSE_OK;
+
+	Assert(r);
+
+#define X(sym, val, name, fn) \
+do { \
+	st = wal_container_parse_flag(r, sym); \
+	if (st != WALPARSE_OK) \
+		return st; \
+} while(0);
+
+	ORIOLE_WAL_FLAGS(X)
+
+#undef X
+
+		return st;
+}
+
+/*
+ * parse_wal_container()
+ *
+ * Parse a single OrioleDB WAL container payload and deliver records to a
+ * consumer.
+ *
+ * The function is responsible for:
+ *   - reading the container header (version + flags),
+ *   - invoking consumer's check_version() (if provided),
+ *   - consuming and delivering all container flags (header prefix),
+ *   - scanning the record stream and invoking consumer's on_record() per record.
+ *
+ * It is intentionally minimal:
+ *   - no allocations,
+ *   - no buffering,
+ *   - no policy beyond protocol safety.
+ *
+ * Error handling:
+ *   - returns WALPARSE_EOF if the input buffer ends mid-element,
+ *   - returns WALPARSE_BAD_TYPE for unknown types / missing descriptors,
+ *   - returns consumer-provided status for version policy decisions.
+ *
+ * The caller owns the input buffer; record-local pointers are valid only
+ * while the input buffer remains valid.
+ */
+WalParseResult
+parse_wal_container(WalReaderState *r, bool allow_logging)
+{
+	WalParseResult st;
+	WalRecord	rec;
+
+	Assert(r);
+	Assert(r->on_record);		/* consumer must handle every record */
+
+	memset(&rec, 0, sizeof(rec));
+
+	rec.relreplident = REPLICA_IDENTITY_DEFAULT;
+	rec.origin_id = InvalidRepOriginId;
+	rec.origin_lsn = InvalidXLogRecPtr;
+
+	/*
+	 * Read and validate container header framing and check structural
+	 * compatibility via WAL version.
+	 *
+	 * First (common) check of wal_version ensures that WAL container from the
+	 * future that can't be parsed is rejected.
+	 */
+	st = wal_container_read_header(r, allow_logging);
+	if (st != WALPARSE_OK)
+		return st;
+
+	/*
+	 * Version policy check (consumer-level).
+	 *
+	 * wal_container_read_header() has already verified that the container
+	 * framing is structurally compatible with this build.
+	 *
+	 * Here we delegate higher-level compatibility policy to the consumer.
+	 * Even if the format is understood, the consumer may reject WAL based on
+	 * semantic/version rules (e.g. replaying WAL from a different OrioleDB
+	 * major version).
+	 *
+	 * parse_wal_container() itself remains version-agnostic and does not
+	 * enforce cross-version replay policy.
+	 */
+	if (r->check_version)
+	{
+		st = r->check_version(r);
+		if (st != WALPARSE_OK)
+			return st;
+	}
+
+	rec.wal_version = r->wal_version;
+
+	/*
+	 * Process container-level flags (a header prefix).
+	 *
+	 * Flags describe metadata that applies to the whole container and may
+	 * carry their own payload. These bytes logically belong to the header
+	 * area and must be consumed before we start scanning record tags.
+	 * Otherwise, r->ptr would be misaligned and record parsing would
+	 * desynchronize.
+	 *
+	 * The flag handling also gives the consumer a chance to capture
+	 * header-wide context (e.g. xact-info) before any records are delivered.
+	 */
+	st = wal_container_parse_flags(r);
+	if (st != WALPARSE_OK)
+		return st;
+
+	/*
+	 * Main record scan.
+	 *
+	 * Container format is: [tag byte][payload...][tag byte][payload...]...
+	 *
+	 * For each record:
+	 *
+	 * - read the tag (rec_type = rec.type),
+	 *
+	 * - look up its descriptor,
+	 *
+	 * - if the record has a payload, parse it and advance r->ptr,
+	 *
+	 * - deliver the event to the consumer.
+	 */
+	while (r->ptr < r->end)
+	{
+		uint8		rec_type;
+		const WalRecordDesc *d = NULL;
+
+		/*
+		 * Offset from container start at which this record tag was found.
+		 * Useful for consumers that need stable relative addressing, debug
+		 * logging, or for building LSN-relative positions.
+		 */
+		rec.delta = r->ptr - r->start;
+
+		/*
+		 * Read record tag byte. After this, r->ptr points to payload (if
+		 * any).
+		 */
+		WR_PARSE(r, &rec_type);
+		rec.type = rec_type;
+
+		/*
+		 * value_ptr points to the first byte after the tag, i.e. to the
+		 * payload. For payload-less records, value_ptr points to the next
+		 * record tag.
+		 *
+		 * Consumers must treat value_ptr as "record-local" pointer only; it
+		 * is valid only while the reader buffer remains intact.
+		 */
+		rec.value_ptr = r->ptr;
+
+		d = wal_get_desc(rec.type);
+		if (!d)
+		{
+			/*
+			 * Unknown record type.
+			 *
+			 * No descriptor registered for the record type we have just read.
+			 *
+			 * parse_wal_container() is the single authority for OrioleDB WAL
+			 * container binary format: it reads a record type byte and then
+			 * advances the reader by calling the corresponding parse routine.
+			 *
+			 * If wal_get_desc() returns NULL, we cannot safely continue
+			 * because we don't know how many bytes belong to this record
+			 * (i.e. we can't advance r->ptr without risking
+			 * desynchronization). Treat it as a hard protocol error.
+			 *
+			 * This typically means one of:
+			 *
+			 * 1) WAL / binary version mismatch (WAL from the "future"): The
+			 * WAL stream contains a record type introduced in a newer
+			 * OrioleDB version than the current build understands. The
+			 * version check above is expected to prevent this; hitting this
+			 * path may indicate that the container version/flags are
+			 * inconsistent, or that the version gate in r->check_version is
+			 * incomplete.
+			 *
+			 * 2) Registration mistake for a new record type: A new WAL_REC_*
+			 * constant was added, but the corresponding WalRecordDesc entry
+			 * was not registered via ORIOLE_WAL_RECORDS (or the descriptor
+			 * table generator), so wal_get_desc() can't find it. This is a
+			 * build-time integration bug.
+			 *
+			 * 3) Stream corruption / desynchronization: The reader is not
+			 * positioned at a real record boundary. This can be caused by:
+			 *
+			 * - corrupted WAL container payload,
+			 *
+			 * - an earlier parser advancing r->ptr incorrectly (e.g. wrong
+			 * size calculation / missing bounds checks),
+			 *
+			 * - reordering/truncation bugs leading to partial containers.
+			 *
+			 * In these cases the "type byte" may just be random data.
+			 *
+			 * 4) Feature/flag mismatch within the same WAL version: A record
+			 * type is conditionally present under a container flag (or
+			 * extension feature), but the corresponding flag handling was not
+			 * applied (or was parsed incorrectly), shifting r->ptr.
+			 *
+			 * We return WALPARSE_BAD_TYPE to make the failure explicit and to
+			 * avoid cascading parse errors.
+			 */
+			if (allow_logging)
+			{
+				elog(LOG, "[%s] UNKNOWN WAL RECORD TYPE %u(`%s`): chunk/tail len %ld/%ld",
+					 __func__, rec.type, wal_type_name(rec.type),
+					 r->end - r->start,
+					 r->end - r->ptr);
+			}
+			return WALPARSE_BAD_TYPE;
+		}
+
+		if (allow_logging)
+		{
+			elog(DEBUG4, "[%s] WAL RECORD TYPE %u(`%s`)", __func__, rec.type, wal_type_name(rec.type));
+		}
+
+		/*
+		 * Parse record payload (if any).
+		 *
+		 * Some OrioleDB WAL records are intentionally zero-length markers:
+		 * they consist only of the tag byte and carry no additional bytes in
+		 * the container. Their descriptor must have d->parse == NULL.
+		 *
+		 * This is distinct from an unknown record type: unknown types are
+		 * rejected above, while known types with d->parse == NULL are valid
+		 * and must still be delivered to the consumer.
+		 *
+		 * Parser contract:
+		 *
+		 * - if d->parse is present, it must consume exactly this record's
+		 * payload and leave r->ptr positioned at the next record tag;
+		 *
+		 * - if d->parse is NULL, r->ptr already points to the next record
+		 * tag.
+		 */
+		if (d->parse)
+		{
+			st = d->parse(r, &rec);
+			if (st != WALPARSE_OK)
+				return st;
+		}
+
+		/*
+		 * Deliver the (possibly parsed) event to the consumer.
+		 *
+		 * Consumers may update decoding/replay state, apply changes, or
+		 * selectively ignore records. Any non-OK status is treated as fatal
+		 * for this container iteration.
+		 */
+		st = r->on_record(r->ctx, &rec);
+		if (st != WALPARSE_OK)
+			return st;
+	}
+
+	return WALPARSE_OK;
+}


### PR DESCRIPTION
# Summary

This patch extracts the OrioleDB WAL container parsing logic into a dedicated, reusable module (`wal_reader.[ch]`) and migrates existing consumers (recovery, logical decoding, etc.) to a unified descriptor-driven parsing API.

The primary goal is to establish a **single source of truth for the WAL container binary protocol**, covering:
- container header (version + flags),
- flag prefix parsing,
- record tag/payload iteration,
- descriptor-based payload decoding,
- safe cursor advancement with strict bounds checking.

This eliminates duplicated parsing logic and reduces the risk of protocol desynchronization when extending WAL with new record types or flags.

# Motivation

Before this change, WAL container parsing logic was partially distributed across different parts of the codebase:
- container framing and cursor movement were handled in multiple places,
- record type dispatch was duplicated,
- flag handling was not structurally enforced,
- extension of the protocol required coordinated manual updates.

This creates typical binary protocol risks:
- adding a new record type or flag requires modifying multiple code paths,
- forgetting to parse a flag payload causes cursor misalignment,
- desynchronization errors manifest far from their root cause,
- it is difficult to reason about invariants related to cursor movement.

This patch consolidates parsing into a minimal, forward-only reader with strict responsibilities and explicit contracts.

# High-Level Design

## 1. New WAL Reader Module

Introduced:
- `include/recovery/wal_reader.h`
- `src/recovery/wal_reader.c`

This module implements a generic OrioleDB WAL container parser responsible strictly for:
- reading container header (version + flags),
- processing container-level flags,
- iterating over record stream [tag][payload]...,
- invoking descriptor-driven parse functions,
- delivering parsed records to consumer callbacks.

The reader:
- performs no memory allocation,
- performs no buffering,
- makes no semantic decisions about applying or decoding changes,
- operates in a strictly forward-only, single-pass manner.

All higher-level logic (recovery, logical decoding, policy decisions) is delegated to the consumer.

## 2. Descriptor-Driven Parsing (X-macro Tables)

Record types and container flags are now registered via X-macro lists:
- `ORIOLE_WAL_RECORDS(X)`
- `ORIOLE_WAL_FLAGS(X)`

These generate:
- `g_wal_descs[]`
- `g_wal_flag_descs[]`

This makes the descriptor tables the **single authoritative** mapping:
- type -> name (debugging)
- type -> payload parser

As a result:
- adding a new record type or flag is a **single-point change**,
- the parser cannot forget to handle a type,
- unknown types become explicit hard protocol errors,
- payload length is always derived from the descriptor contract.

If a descriptor is missing, parsing fails with `WALPARSE_BAD_TYPE`, preventing unsafe cursor advancement.

## 3. Unified Record Structure: WalRecord

`WalRecord` represents a parsed WAL entity (record or flag). This provides a uniform record abstraction independent of consumer logic.

## 4. Explicit Consumer Contract

The parsing API is consumer-driven via callbacks stored in `WalReaderState`:
- `check_version()` — container version compatibility policy,
- `on_flag()` — invoked for container-level flags,
- `on_record()` — invoked for each WAL record.

The parser itself is version-agnostic and policy-free. It only guarantees protocol correctness and safe cursor movement.

## 5. Deterministic Container Flag Handling

Container flags are stored on-wire as a bitmask but may have payloads.

This patch enforces:
- all flag payloads must be parsed before scanning record tags,
- flag parsing occurs in deterministic order defined by `ORIOLE_WAL_FLAGS`.

This guarantees:
- header-prefix bytes are fully consumed before record scanning,
- cursor alignment invariants are preserved,
- extending flags does not require manual updates in parsing logic.

## 6. Explicit Ownership Boundary for Tuple Payloads

Modify-type records expose tuple data as pointers into the WAL container buffer.

The parser does not allocate or copy tuple bytes.

This clarifies the boundary:
- parser = zero-allocation, zero-copy,
- consumer = responsible for stabilizing data if needed.

# Behavioral Impact

Protocol format is unchanged. However:
- header and flag handling is now centralized and mandatory,
- record scanning is descriptor-driven,
- adding new record types or flags requires only updating X-macro lists and defining a parse function,
- consumers no longer perform manual cursor arithmetic.

This improves safety and maintainability without altering WAL format semantics.

# Design Rationale

This design prioritizes:
- protocol safety,
- centralized framing logic,
- descriptor-driven extensibility,
- compile-time enforcement of type registration,
- explicit ownership semantics.

It intentionally avoids:
- implicit behavior,
- hidden parsing entry points,
- scattered cursor manipulation,
- duplication of binary protocol handling.

The result is a minimal yet sufficient API surface for WAL container parsing.
