### PR TITLE
Revert "Remove useless rootInfo assignment"

### DIFF
--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -326,6 +326,7 @@ o_btree_load_shmem_internal(BTreeDescr *desc, bool checkpoint)
 			evictable_tree_init(desc, true, &was_evicted);
 		}
 		is_compressed = OCompressIsValid(desc->compress);
+		desc->rootInfo = sharedRootInfo->rootInfo;
 
 		init_extents = false;
 		if (is_compressed && !was_evicted)


### PR DESCRIPTION
Reverts orioledb/orioledb#701

Transient deadlock in test results/opclass.out appeared twice:
https://github.com/orioledb/orioledb/actions/runs/21474551585/job/61855168062
https://github.com/orioledb/orioledb/actions/runs/21603520281/job/62255322483
