### PR TITLE
Rename `ORIOLEDB_DATA_VERSION` to `ORIOLEDB_SYS_TREE_VERSION`

### DIFF
--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -48,7 +48,7 @@
 /*
  * Clusters with different ORIOLEDB_BINARY_VERSION are completely incompatible.
  * Within the same ORIOLEDB_BINARY_VERSION clusters either fully compatible
- * or could be converted on the fly. See comment for ORIOLEDB_DATA_VERSION,
+ * or could be converted on the fly. See comment for ORIOLEDB_SYS_TREE_VERSION,
  * ORIOLEDB_PAGE_VERSION and ORIOLEDB_COMPRESS_VERSION below.
  *
  * ORIOLEDB_WAL_VERSION works even between different ORIOLEDB_BINARY_VERSION's
@@ -63,18 +63,18 @@
 /*
  * Sub-versions in the same ORIOLEDB_BINARY_VERSION.
  *
- * Same ORIOLEDB_DATA_VERSION, ORIOLEDB_PAGE_VERSION and
+ * Same ORIOLEDB_SYS_TREE_VERSION, ORIOLEDB_PAGE_VERSION and
  * ORIOLEDB_COMPRESS_VERSION clusters are compatible without conversion.
- * For different ORIOLEDB_DATA_VERSION conversion is done at the
+ * For different ORIOLEDB_SYS_TREE_VERSION conversion is done at the
  * reading/deserialization of system tables structures without using
  * any conversion tools.
  * For different ORIOLEDB_PAGE_VERSION and ORIOLEDB_COMPRESS_VERSION
  * conversion is done at first reading of disk page on the fly.
  */
-#define ORIOLEDB_DATA_VERSION	1	/* Version of system catalog */
-#define ORIOLEDB_PAGE_VERSION	1	/* Version of binary page format */
-#define ORIOLEDB_COMPRESS_VERSION 1 /* Version of page compression (only for
-									 * compressed pages) */
+#define ORIOLEDB_SYS_TREE_VERSION	1	/* Version of system catalog */
+#define ORIOLEDB_PAGE_VERSION		1	/* Version of binary page format */
+#define ORIOLEDB_COMPRESS_VERSION	1	/* Version of page compression (only
+										 * for compressed pages) */
 
 /*
  * perform_page_split() removes a key data from first right page downlink.

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -59,9 +59,11 @@
 
 /*
  * Bump it when WAL format changes compared to previous release.
- * ORIOLEDB_WAL_VERSION makes sense and should be converted even between different ORIOLEDB_BINARY_VERSION's.
- * This is unlike ORIOLEDB_DATA_VERSION, ORIOLEDB_PAGE_VERSION and ORIOLEDB_COMPRESS_VERSION,
- * that make sense only inside one ORIOLEDB_BINARY_VERSION.
+ * ORIOLEDB_WAL_VERSION makes sense and should be converted even between
+ * different ORIOLEDB_BINARY_VERSION's. This is unlike
+ * ORIOLEDB_SYS_TREE_VERSION, ORIOLEDB_PAGE_VERSION and
+ * ORIOLEDB_COMPRESS_VERSION, that make sense only inside one
+ * ORIOLEDB_BINARY_VERSION.
  */
 #define ORIOLEDB_WAL_VERSION (17)
 

--- a/src/catalog/o_aggregate_cache.c
+++ b/src/catalog/o_aggregate_cache.c
@@ -115,7 +115,7 @@ o_aggregate_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key,
 		*entry_ptr = (Pointer) o_agg;
 	}
 
-	o_agg->data_version = ORIOLEDB_DATA_VERSION;
+	o_agg->data_version = ORIOLEDB_SYS_TREE_VERSION;
 	o_agg->aggfinalfn = aggform->aggfinalfn;
 	o_agg->aggserialfn = aggform->aggserialfn;
 	o_agg->aggdeserialfn = aggform->aggdeserialfn;
@@ -176,8 +176,10 @@ o_aggregate_cache_serialize_entry(Pointer entry, int *len)
 	StringInfoData str;
 	OAggregate *o_agg = (OAggregate *) entry;
 
-	if (o_agg->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion from %u", o_agg->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_agg->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion from %u",
+			 o_agg->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	initStringInfo(&str);
 	appendBinaryStringInfo(&str, (Pointer) o_agg,
@@ -204,8 +206,10 @@ o_aggregate_cache_deserialize_entry(MemoryContext mcxt, Pointer data,
 	Assert((ptr - data) + len <= length);
 	memcpy(o_agg, ptr, len);
 	ptr += len;
-	if (o_agg->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion to %u", o_agg->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_agg->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion to %u",
+			 o_agg->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	if (o_agg->has_initval)
 		o_agg->agginitval = o_deserialize_string(&ptr);

--- a/src/catalog/o_class_cache.c
+++ b/src/catalog/o_class_cache.c
@@ -107,7 +107,7 @@ o_class_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 		*entry_ptr = (Pointer) o_class;
 		o_class->attrs = (FormData_pg_attribute *) palloc0(len);
 	}
-	o_class->data_version = ORIOLEDB_DATA_VERSION;
+	o_class->data_version = ORIOLEDB_SYS_TREE_VERSION;
 	o_class->reltype = rel->rd_rel->reltype;
 	o_class->natts = rel->rd_att->natts;
 	for (i = 0; i < o_class->natts; i++)
@@ -171,8 +171,10 @@ o_class_cache_serialize_entry(Pointer entry, int *len)
 	StringInfoData str;
 	OClass	   *o_class = (OClass *) entry;
 
-	if (o_class->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion from %u", o_class->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_class->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion from %u",
+			 o_class->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	initStringInfo(&str);
 	appendBinaryStringInfo(&str, (Pointer) o_class,
@@ -197,8 +199,10 @@ o_class_cache_deserialize_entry(MemoryContext mcxt, Pointer data, Size length)
 	Assert((ptr - data) + len <= length);
 	memcpy(o_class, ptr, len);
 	ptr += len;
-	if (o_class->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion to %u", o_class->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_class->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion to %u",
+			 o_class->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	len = o_class->natts * sizeof(FormData_pg_attribute);
 	o_class->attrs = MemoryContextAlloc(mcxt, len);

--- a/src/catalog/o_collation_cache.c
+++ b/src/catalog/o_collation_cache.c
@@ -108,7 +108,7 @@ o_collation_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key,
 		*entry_ptr = (Pointer) o_collation;
 	}
 
-	o_collation->data_version = ORIOLEDB_DATA_VERSION;
+	o_collation->data_version = ORIOLEDB_SYS_TREE_VERSION;
 	o_collation->collname = collform->collname;
 	o_collation->collprovider = collform->collprovider;
 	o_collation->collisdeterministic = collform->collisdeterministic;
@@ -168,8 +168,10 @@ o_collation_cache_serialize_entry(Pointer entry, int *len)
 	StringInfoData str;
 	OCollation *o_collation = (OCollation *) entry;
 
-	if (o_collation->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion from %u", o_collation->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_collation->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion from %u",
+			 o_collation->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	initStringInfo(&str);
 	appendBinaryStringInfo(&str, (Pointer) o_collation,
@@ -198,8 +200,10 @@ o_collation_cache_deserialize_entry(MemoryContext mcxt, Pointer data,
 	Assert((ptr - data) + len <= length);
 	memcpy(o_collation, ptr, len);
 	ptr += len;
-	if (o_collation->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion to %u", o_collation->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_collation->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion to %u",
+			 o_collation->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	o_collation->collcollate = o_deserialize_string(&ptr);
 	o_collation->collctype = o_deserialize_string(&ptr);

--- a/src/catalog/o_database_cache.c
+++ b/src/catalog/o_database_cache.c
@@ -100,7 +100,7 @@ o_database_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key,
 		*entry_ptr = (Pointer) o_database;
 	}
 
-	o_database->data_version = ORIOLEDB_DATA_VERSION;
+	o_database->data_version = ORIOLEDB_SYS_TREE_VERSION;
 	o_database->encoding = dbform->encoding;
 	o_database->datlocprovider = dbform->datlocprovider;
 
@@ -216,8 +216,10 @@ o_database_cache_serialize_entry(Pointer entry, int *len)
 	StringInfoData str;
 	ODatabase  *o_database = (ODatabase *) entry;
 
-	if (o_database->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion from %u", o_database->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_database->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion from %u",
+			 o_database->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	initStringInfo(&str);
 	appendBinaryStringInfo(&str, (Pointer) o_database,
@@ -251,8 +253,10 @@ o_database_cache_deserialize_entry(MemoryContext mcxt, Pointer data,
 	Assert((ptr - data) + len <= length);
 	memcpy(o_database, ptr, len);
 	ptr += len;
-	if (o_database->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion to %u", o_database->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_database->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion to %u",
+			 o_database->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 #if PG_VERSION_NUM >= 170000
 	len = offsetof(ODatabase, datlocale) - offsetof(ODatabase, datlocprovider);

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -772,8 +772,10 @@ serialize_o_index(OIndex *o_index, int *size)
 
 	initStringInfo(&str);
 
-	if (o_index->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion from %u", o_index->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_index->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion from %u",
+			 o_index->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	appendBinaryStringInfo(&str,
 						   (Pointer) o_index + offsetof(OIndex, tableOids),
@@ -815,8 +817,10 @@ deserialize_o_index(OIndexChunkKey *key, Pointer data, Size length)
 	Assert((ptr - data) + len <= length);
 	memcpy((Pointer) oIndex + offsetof(OIndex, tableOids), ptr, len);
 	ptr += len;
-	if (oIndex->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion to %u", oIndex->data_version, ORIOLEDB_DATA_VERSION);
+	if (oIndex->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion to %u",
+			 oIndex->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	len = oIndex->nLeafFields * sizeof(OTableField);
 	oIndex->leafTableFields = (OTableField *) palloc(len);
@@ -907,7 +911,7 @@ make_o_index(OTable *table, OIndexNumber ixNum, OIndexVersionMode ixVerMode)
 		index = make_secondary_o_index(table, tableIndex, ixVerMode);
 	}
 
-	index->data_version = ORIOLEDB_DATA_VERSION;
+	index->data_version = ORIOLEDB_SYS_TREE_VERSION;
 	return index;
 }
 

--- a/src/catalog/o_proc_cache.c
+++ b/src/catalog/o_proc_cache.c
@@ -213,7 +213,7 @@ o_proc_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 		*entry_ptr = (Pointer) o_proc;
 	}
 
-	o_proc->data_version = ORIOLEDB_DATA_VERSION;
+	o_proc->data_version = ORIOLEDB_SYS_TREE_VERSION;
 	o_proc->rettype = procform->prorettype;
 	o_proc->strict = procform->proisstrict;
 	o_proc->retset = procform->proretset;
@@ -322,8 +322,10 @@ o_proc_cache_serialize_entry(Pointer entry, int *len)
 	StringInfoData str;
 	OProc	   *o_proc = (OProc *) entry;
 
-	if (o_proc->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion from %u", o_proc->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_proc->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion from %u",
+			 o_proc->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	initStringInfo(&str);
 	appendBinaryStringInfo(&str, (Pointer) o_proc,
@@ -385,8 +387,10 @@ o_proc_cache_deserialize_entry(MemoryContext mcxt, Pointer data, Size length)
 	Assert((ptr - data) + len <= length);
 	memcpy(o_proc, ptr, len);
 	ptr += len;
-	if (o_proc->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion to %u", o_proc->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_proc->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion to %u",
+			 o_proc->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	o_proc->cxt = AllocSetContextCreate(mcxt, "o_proc mcxt",
 										ALLOCSET_DEFAULT_SIZES);

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -694,7 +694,7 @@ o_table_tableam_create(ORelOids oids, TupleDesc tupdesc, char relpersistence,
 	o_table->toast_compress = InvalidOCompress;
 	o_table->fillfactor = fillfactor;
 	o_table->persistence = relpersistence;
-	o_table->data_version = ORIOLEDB_DATA_VERSION;
+	o_table->data_version = ORIOLEDB_SYS_TREE_VERSION;
 	/* No index incarnations yet for a freshly created table. */
 	o_table->toast_ixversion = O_TABLE_INVALID_VERSION; /* uninitialized */
 	o_table->primary_ixversion = O_TABLE_INVALID_VERSION;	/* uninitialized */
@@ -1711,8 +1711,10 @@ serialize_o_table(OTable *o_table, int *size)
 	int			i;
 
 	Assert(o_table != NULL);
-	if (o_table->data_version != ORIOLEDB_DATA_VERSION)
-		elog(FATAL, "ORIOLEDB_DATA_VERSION %u of OrioleDB cluster is not among supported for conversion from %u", o_table->data_version, ORIOLEDB_DATA_VERSION);
+	if (o_table->data_version != ORIOLEDB_SYS_TREE_VERSION)
+		elog(FATAL,
+			 "ORIOLEDB_SYS_TREE_VERSION %u of OrioleDB cluster is not among supported for conversion from %u",
+			 o_table->data_version, ORIOLEDB_SYS_TREE_VERSION);
 
 	initStringInfo(&str);
 	appendBinaryStringInfo(&str, (Pointer) o_table,


### PR DESCRIPTION
Rename `ORIOLEDB_DATA_VERSION` to `ORIOLEDB_SYS_TREE_VERSION` to better reflect of its intended usage in the code, which is to check the system catalog version from the tree and backward compatibility of system catalog trees.