### PR TITLE
Detailed comments on OrioleDB versioning and cross-version compatibility

### DIFF
--- a/include/checkpoint/control.h
+++ b/include/checkpoint/control.h
@@ -35,8 +35,9 @@ typedef struct
 #define ORIOLEDB_CHECKPOINT_CONTROL_VERSION	1
 
 /*
- * To ensure correct reading of controlFileVersion, changes in
- * struct layout are permitted only after it.
+ * To ensure correct reading of controlFileVersion, changes in struct layout
+ * are permitted only between .controlFileVersion and .crc, that
+ * should be the last.
  */
 typedef struct
 {
@@ -57,6 +58,7 @@ typedef struct
 	OXid		checkpointRetainXmax;
 	uint32		binaryVersion;
 	bool		s3Mode;
+	/* CRC of all fields above. It should be last */
 	pg_crc32c	crc;
 } CheckpointControl;
 

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -73,22 +73,35 @@ enum OrioleWalRecType
 };
 
 /*
- * Value has been fixed at the moment of introducing WAL versioning.
- * Now, when we have WAL version in the beginning of each container
- * we should never change this value.
- */
-#define FIRST_ORIOLEDB_WAL_VERSION (16)
-
-/*
+ * Current WAL version of OrioleDB.
  * Bump it when WAL format changes compared to previous release.
  * ORIOLEDB_WAL_VERSION makes sense and should be converted even between
  * different ORIOLEDB_BINARY_VERSION's. This is unlike
  * ORIOLEDB_SYS_TREE_VERSION, ORIOLEDB_PAGE_VERSION and
- * ORIOLEDB_COMPRESS_VERSION, that make sense only inside one
- * ORIOLEDB_BINARY_VERSION.
+ * ORIOLEDB_COMPRESS_VERSION (see big comment on versioning
+ * in include/orioledb.h)
  */
 #define ORIOLEDB_WAL_VERSION (17)
 
+/*
+ * Value has been fixed at the moment of introducing WAL versioning.
+ * WAL versions before FIRST_ORIOLEDB_WAL_VERSION are treated as zero
+ * and still supported for on-the fly conversion to the current
+ * ORIOLEDB_WAL_VERSION. (Exact value follows the fact that before
+ * WAL version was introduced in the beginning of the WAL container,
+ * WAL container started from rec_type byte with at most 4 lower bits
+ * occupied. So it's a way to distinguish pre-WAL version container
+ * from the container with WAL version.)
+ *
+ * We should never change this value.
+ */
+#define FIRST_ORIOLEDB_WAL_VERSION (16)
+
+/*
+ * Particular WAL version when per-container flags were added to WAL container.
+ *
+ * We should never change this value.
+ */
 #define ORIOLEDB_CONTAINER_FLAGS_WAL_VERSION (17)
 
 /* Constants for commitInProgressXlogLocation */

--- a/src/checkpoint/control.c
+++ b/src/checkpoint/control.c
@@ -89,14 +89,6 @@ check_checkpoint_control(CheckpointControl *control)
 	if (crc != control->crc)
 		elog(ERROR, "Wrong CRC in control file");
 
-	if (control->binaryVersion != ORIOLEDB_BINARY_VERSION)
-		ereport(FATAL,
-				(errmsg("database files are incompatible with server"),
-				 errdetail("OrioleDB was initialized with binary version %d,"
-						   " but the extension is compiled with binary version %d.",
-						   control->binaryVersion, ORIOLEDB_BINARY_VERSION),
-				 errhint("It looks like you need to initdb.")));
-
 	if (control->controlFileVersion != ORIOLEDB_CHECKPOINT_CONTROL_VERSION)
 	{
 		/*
@@ -111,6 +103,14 @@ check_checkpoint_control(CheckpointControl *control)
 						   " but the currently required version is %d.",
 						   control->controlFileVersion, ORIOLEDB_CHECKPOINT_CONTROL_VERSION)));
 	}
+
+	if (control->binaryVersion != ORIOLEDB_BINARY_VERSION)
+		ereport(FATAL,
+				(errmsg("database files are incompatible with server"),
+				 errdetail("OrioleDB was initialized with binary version %d,"
+						   " but the extension is compiled with binary version %d.",
+						   control->binaryVersion, ORIOLEDB_BINARY_VERSION),
+				 errhint("It looks like you need to initdb.")));
 
 	if (control->s3Mode != orioledb_s3_mode)
 		ereport(FATAL,


### PR DESCRIPTION
+ Check ORIOLEDB_CHECKPOINT_CONTROL_VERSION before ORIOLEDB_BINARY_VERSION