### PR TITLE
Introduce Local page pool

### DIFF
--- a/include/btree/btree.h
+++ b/include/btree/btree.h
@@ -176,7 +176,7 @@ struct BTreeDescr
 	OSmgr		smgr;
 	ORelOids	oids;
 	OIndexType	type;
-	OPagePool  *ppool;
+	PagePool   *ppool;
 	OCompress	compress;
 	uint8		fillfactor;
 	UndoLogType undoType;

--- a/include/btree/merge.h
+++ b/include/btree/merge.h
@@ -22,7 +22,7 @@ extern bool btree_try_merge_pages(BTreeDescr *desc,
 								  OFixedKey *parent_hikey,
 								  bool *merge_parent,
 								  OInMemoryBlkno left_blkno,
-								  BTreePageItemLocator right_loc,
+								  BTreePageItemLocator *right_loc,
 								  OInMemoryBlkno right_blkno,
 								  bool checkpoint);
 extern bool btree_try_merge_and_unlock(BTreeDescr *desc, OInMemoryBlkno blkno,

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -449,6 +449,7 @@ extern XLogRecPtr replay_until_lsn;
 	(AssertMacro(MYPROCNUMBER >= 0 && \
 				 MYPROCNUMBER < max_procs), \
 	 &oProcData[MYPROCNUMBER])
+#define O_PAGE_IS_LOCAL(blkno) ((blkno) < 0)
 #define O_GET_IN_MEMORY_PAGE(blkno) \
 	(AssertMacro(OInMemoryBlknoIsValid(blkno)), \
 	 (Page)(o_shared_buffers + (((uint64) (blkno)) * ((uint64) ORIOLEDB_BLCKSZ))))
@@ -494,13 +495,13 @@ typedef enum OPagePoolType
 } OPagePoolType;
 #define OPagePoolTypesCount 3
 
-typedef struct OPagePool OPagePool;
+typedef struct PagePool PagePool;
 struct BTreeDescr;
 
 extern void o_verify_dir_exists_or_create(char *dirname, bool *created, bool *found);
 extern uint64 orioledb_device_alloc(struct BTreeDescr *descr, uint32 size);
-extern OPagePool *get_ppool(OPagePoolType type);
-extern OPagePool *get_ppool_by_blkno(OInMemoryBlkno blkno);
+extern PagePool *get_ppool(OPagePoolType type);
+extern PagePool *get_ppool_by_blkno(OInMemoryBlkno blkno);
 extern OInMemoryBlkno get_dirty_pages_count_sum(void);
 extern void jsonb_push_key(JsonbParseState **state, char *key);
 extern void jsonb_push_null_key(JsonbParseState **state, char *key);

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -129,7 +129,10 @@
 
 #define GetMaxBackends() MaxBackends
 
-/* Number of orioledb page */
+/*
+ * Number of orioledb page.
+ * If high bit is set, it means the page is in the local memory.
+ */
 typedef uint32 OInMemoryBlkno;
 #define OInvalidInMemoryBlkno		((OInMemoryBlkno) 0xFFFFFFFF)
 #define OInMemoryBlknoIsValid(blockNumber) \
@@ -396,6 +399,7 @@ typedef struct
 /* orioledb.c */
 extern Size orioledb_buffers_size;
 extern Size orioledb_buffers_count;
+extern Size orioledb_temp_buffers_count;
 extern Size undo_circular_buffer_size;
 extern uint32 undo_buffers_count;
 extern Size xid_circular_buffer_size;
@@ -407,7 +411,9 @@ extern uint32 rewind_buffers_count;
 extern Pointer o_shared_buffers;
 extern ODBProcData *oProcData;
 extern int	max_procs;
+extern Page *local_ppool_pages;
 extern OrioleDBPageDesc *page_descs;
+extern OrioleDBPageDesc *local_ppool_page_descs;
 extern bool remove_old_checkpoint_files;
 extern bool skip_unmodified_trees;
 extern bool debug_disable_bgwriter;
@@ -449,12 +455,17 @@ extern XLogRecPtr replay_until_lsn;
 	(AssertMacro(MYPROCNUMBER >= 0 && \
 				 MYPROCNUMBER < max_procs), \
 	 &oProcData[MYPROCNUMBER])
-#define O_PAGE_IS_LOCAL(blkno) ((blkno) < 0)
+/* Needed to get blkno without high bit that defines if page is local or not */
+#define O_BLKNO_MASK ((OInMemoryBlkno) 0x7FFFFFFF)
+#define O_PAGE_IS_LOCAL(blkno) ((blkno) >> 31 != 0)
 #define O_GET_IN_MEMORY_PAGE(blkno) \
 	(AssertMacro(OInMemoryBlknoIsValid(blkno)), \
-	 (Page)(o_shared_buffers + (((uint64) (blkno)) * ((uint64) ORIOLEDB_BLCKSZ))))
+	 (O_PAGE_IS_LOCAL(blkno) ? local_ppool_pages[(blkno) & O_BLKNO_MASK] : \
+	  (Page)(o_shared_buffers + (((uint64) ((blkno) & O_BLKNO_MASK)) * ((uint64) ORIOLEDB_BLCKSZ)))))
 #define O_GET_IN_MEMORY_PAGEDESC(blkno) \
-	(AssertMacro(OInMemoryBlknoIsValid(blkno)), page_descs + (blkno))
+	(AssertMacro(OInMemoryBlknoIsValid(blkno)), \
+     (O_PAGE_IS_LOCAL(blkno) ? local_ppool_page_descs + ((blkno) & O_BLKNO_MASK) : \
+      page_descs + ((blkno) & O_BLKNO_MASK)))
 #define O_GET_IN_MEMORY_PAGE_CHANGE_COUNT(blkno) \
 	(O_PAGE_GET_CHANGE_COUNT(O_GET_IN_MEMORY_PAGE(blkno)))
 
@@ -496,7 +507,10 @@ typedef enum OPagePoolType
 #define OPagePoolTypesCount 3
 
 typedef struct PagePool PagePool;
+typedef struct LocalPagePool LocalPagePool;
 struct BTreeDescr;
+
+extern LocalPagePool local_ppool;
 
 extern void o_verify_dir_exists_or_create(char *dirname, bool *created, bool *found);
 extern uint64 orioledb_device_alloc(struct BTreeDescr *descr, uint32 size);
@@ -509,6 +523,7 @@ extern void jsonb_push_bool_key(JsonbParseState **state, char *key, bool value);
 extern void jsonb_push_int8_key(JsonbParseState **state, char *key, int64 value);
 extern void jsonb_push_string_key(JsonbParseState **state, const char *key, const char *value);
 extern bool is_bump_memory_context(MemoryContext mxct);
+extern void o_page_desc_init(OrioleDBPageDesc *desc);
 
 extern CheckPoint_hook_type next_CheckPoint_hook;
 

--- a/include/utils/page_pool.h
+++ b/include/utils/page_pool.h
@@ -37,8 +37,51 @@
 #define PPOOL_RESERVE_MASK_ALL (PPOOL_RESERVE_META_MASK | PPOOL_RESERVE_INSERT_MASK \
 								| PPOOL_RESERVE_FIND_MASK | PPOOL_RESERVE_SHARED_INFO_INSERT_MASK)
 
-struct OPagePool
+typedef struct PagePool PagePool;
+
+typedef struct PagePoolConfig PagePoolConfig;
+
+/*
+ * Page pool operations - implemented by each pool type
+ */
+typedef struct PagePoolOps
 {
+	/* Page allocation/deallocation */
+	OInMemoryBlkno (*alloc_page) (PagePool *pool, int pageReserveKind);
+	OInMemoryBlkno (*alloc_metapage) (PagePool *pool);
+	void		(*free_page) (PagePool *pool, OInMemoryBlkno blkno, bool haveLock);
+
+	/* Page reservation system */
+	void		(*reserve_pages) (PagePool *pool, int pageReserveKind, int count);
+	void		(*release_reserved) (PagePool *pool, uint32 kind_mask);
+
+	OInMemoryBlkno (*free_pages_count) (PagePool *pool);
+	OInMemoryBlkno (*dirty_pages_count) (PagePool *pool);
+	void		(*run_clock) (PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
+	OInMemoryBlkno (*size) (PagePool *pool);
+
+	/* Usage tracking */
+	void		(*ucm_inc_usage) (PagePool *pool, OInMemoryBlkno blkno);
+	void		(*ucm_change_usage) (PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount);
+	uint32		(*ucm_get_epoch) (PagePool *pool);
+	bool		(*ucm_epoch_needs_shift) (PagePool *pool);
+	void		(*ucm_epoch_shift) (PagePool *pool);
+	uint64		(*ucm_update_state) (PagePool *pool, OInMemoryBlkno blkno, uint64 state);
+	void		(*ucm_after_update_state) (PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState);
+
+	Pointer		(*get_pagedesc_array) (PagePool *pool);
+} PagePoolOps;
+
+typedef struct PagePool
+{
+	const PagePoolOps *ops;
+} PagePool;
+
+extern void ppool_release_all_pages(void);
+
+typedef struct OPagePool
+{
+	PagePool	base;
 	/* count of available to reserve pages in the pool */
 	pg_atomic_uint64 *availablePagesCount;
 	/* count of dirty pages in the pool */
@@ -56,20 +99,32 @@ struct OPagePool
 	Size		ucmShmemSize;
 	/* seed for random values */
 	pg_prng_state prngSeed;
-};
+} OPagePool;
 
-extern Size ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno size, bool debug);
-extern void ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found);
-extern OInMemoryBlkno ppool_free_pages_count(OPagePool *pool);
-extern OInMemoryBlkno ppool_dirty_pages_count(OPagePool *pool);
-extern void ppool_run_clock(OPagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
+/* Shared memory based page pool operations */
 
-extern void ppool_reserve_pages(OPagePool *pool, int kind, int count);
-extern void ppool_release_reserved(OPagePool *pool, uint32 mask);
-extern void ppool_release_all_pages(void);
-extern OInMemoryBlkno ppool_get_metapage(OPagePool *pool);
-extern OInMemoryBlkno ppool_get_page(OPagePool *pool, int kind);
-extern void ppool_free_page(OPagePool *pool, OInMemoryBlkno blkno, bool haveLock);
+extern Size o_ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno size, bool debug);
+extern void o_ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found);
+
+extern OInMemoryBlkno o_ppool_get_page(PagePool *pool, int kind);
+extern OInMemoryBlkno o_ppool_get_metapage(PagePool *pool);
+extern void o_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock);
+
+extern void o_ppool_reserve_pages(PagePool *pool, int kind, int count);
+extern void o_ppool_release_reserved(PagePool *pool, uint32 mask);
+
+extern OInMemoryBlkno o_ppool_free_pages_count(PagePool *pool);
+extern OInMemoryBlkno o_ppool_dirty_pages_count(PagePool *pool);
+extern void o_ppool_run_clock(PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
+extern OInMemoryBlkno o_ppool_size(PagePool *pool);
+
+extern void o_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno);
+extern void o_ucm_change_usage(PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount);
+extern uint32 o_ucm_get_epoch(PagePool *pool);
+extern bool o_ucm_epoch_needs_shift(PagePool *pool);
+extern void o_ucm_epoch_shift(PagePool *pool);
+extern uint64 o_ucm_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 state);
+extern void o_ucm_after_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState);
 
 #define PAGE_DESC_FLAG_DIRTY			1	/* Modified since the the last
 											 * time being written out */
@@ -81,9 +136,11 @@ extern void ppool_free_page(OPagePool *pool, OInMemoryBlkno blkno, bool haveLock
 #define IS_DIRTY_CONCURRENT(blkno) (O_GET_IN_MEMORY_PAGEDESC(blkno)->flags & PAGE_DESC_FLAG_CONCURRENT_DIRTY)
 #define CLEAN_DIRTY_CONCURRENT(blkno) (O_GET_IN_MEMORY_PAGEDESC(blkno)->flags &= ~PAGE_DESC_FLAG_CONCURRENT_DIRTY)
 
+/*  Local page can never be dirty as it's never synced with disk */
 #define MARK_DIRTY_EXTENDED(desc, blkno, skipMeta) \
 	do \
 	{ \
+	    if (O_PAGE_IS_LOCAL(blkno)) break; \
 		if (!(skipMeta)) \
 		{ \
 			BTREE_GET_META(desc)->dirtyFlag1 = true; \
@@ -91,7 +148,7 @@ extern void ppool_free_page(OPagePool *pool, OInMemoryBlkno blkno, bool haveLock
 		} \
 		if (!IS_DIRTY(blkno)) { \
 			O_GET_IN_MEMORY_PAGEDESC(blkno)->flags |= PAGE_DESC_FLAG_BOTH_DIRTY; \
-			pg_atomic_fetch_add_u32((desc)->ppool->dirtyPagesCount, 1); \
+			pg_atomic_fetch_add_u32(((OPagePool*)(desc)->ppool)->dirtyPagesCount, 1); \
 		} \
 		else if (!IS_DIRTY_CONCURRENT(blkno)) \
 		{ \
@@ -103,18 +160,20 @@ extern void ppool_free_page(OPagePool *pool, OInMemoryBlkno blkno, bool haveLock
 #define MARK_DIRTY(desc, blkno) \
 	MARK_DIRTY_EXTENDED(desc, blkno, false)
 
+/*  Local page can never be dirty as it's never synced with disk */
 #define CLEAN_DIRTY(pool, blkno) \
 	if (IS_DIRTY(blkno)) { \
 		O_GET_IN_MEMORY_PAGEDESC(blkno)->flags &= ~PAGE_DESC_FLAG_BOTH_DIRTY; \
-		pg_atomic_fetch_sub_u32((pool)->dirtyPagesCount, 1); \
+		pg_atomic_fetch_sub_u32(((OPagePool*)(pool))->dirtyPagesCount, 1); \
 	}
 
 #define FREE_PAGE_IF_VALID(pool, blkno) \
 	if (OInMemoryBlknoIsValid((blkno))) \
 	{ \
-		CLEAN_DIRTY((pool), (blkno)); \
-		ppool_free_page((pool), (blkno), false); \
+        CLEAN_DIRTY((pool), (blkno)); \
+		(*(pool)->ops->free_page)((pool), (blkno), false); \
 		(blkno) = OInvalidInMemoryBlkno; \
 	} \
+
 
 #endif							/* __PAGE_POOL_H__ */

--- a/include/utils/page_pool.h
+++ b/include/utils/page_pool.h
@@ -79,6 +79,7 @@ typedef struct PagePool
 
 extern void ppool_release_all_pages(void);
 
+/* Shared memory based page pool handle */
 typedef struct OPagePool
 {
 	PagePool	base;
@@ -105,26 +106,6 @@ typedef struct OPagePool
 
 extern Size o_ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno size, bool debug);
 extern void o_ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found);
-
-extern OInMemoryBlkno o_ppool_get_page(PagePool *pool, int kind);
-extern OInMemoryBlkno o_ppool_get_metapage(PagePool *pool);
-extern void o_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock);
-
-extern void o_ppool_reserve_pages(PagePool *pool, int kind, int count);
-extern void o_ppool_release_reserved(PagePool *pool, uint32 mask);
-
-extern OInMemoryBlkno o_ppool_free_pages_count(PagePool *pool);
-extern OInMemoryBlkno o_ppool_dirty_pages_count(PagePool *pool);
-extern void o_ppool_run_clock(PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
-extern OInMemoryBlkno o_ppool_size(PagePool *pool);
-
-extern void o_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno);
-extern void o_ucm_change_usage(PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount);
-extern uint32 o_ucm_get_epoch(PagePool *pool);
-extern bool o_ucm_epoch_needs_shift(PagePool *pool);
-extern void o_ucm_epoch_shift(PagePool *pool);
-extern uint64 o_ucm_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 state);
-extern void o_ucm_after_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState);
 
 #define PAGE_DESC_FLAG_DIRTY			1	/* Modified since the the last
 											 * time being written out */

--- a/include/utils/page_pool.h
+++ b/include/utils/page_pool.h
@@ -57,19 +57,12 @@ typedef struct PagePoolOps
 
 	OInMemoryBlkno (*free_pages_count) (PagePool *pool);
 	OInMemoryBlkno (*dirty_pages_count) (PagePool *pool);
-	void		(*run_clock) (PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
+	void		(*run_maintenance) (PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
 	OInMemoryBlkno (*size) (PagePool *pool);
 
 	/* Usage tracking */
 	void		(*ucm_inc_usage) (PagePool *pool, OInMemoryBlkno blkno);
-	void		(*ucm_change_usage) (PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount);
-	uint32		(*ucm_get_epoch) (PagePool *pool);
-	bool		(*ucm_epoch_needs_shift) (PagePool *pool);
-	void		(*ucm_epoch_shift) (PagePool *pool);
-	uint64		(*ucm_update_state) (PagePool *pool, OInMemoryBlkno blkno, uint64 state);
-	void		(*ucm_after_update_state) (PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState);
-
-	Pointer		(*get_pagedesc_array) (PagePool *pool);
+	void		(*ucm_init) (PagePool *pool, OInMemoryBlkno blkno);
 } PagePoolOps;
 
 typedef struct PagePool
@@ -107,6 +100,25 @@ typedef struct OPagePool
 extern Size o_ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno size, bool debug);
 extern void o_ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found);
 
+/* Local memory page pool handler */
+typedef struct LocalPagePool
+{
+	PagePool	base;
+	MemoryContext slab_context;
+	uint32		size;
+	uint32		alloc_current_slot;
+	uint32		evict_current_slot;
+	/* count of available to reserve pages in the pool */
+	uint32		availablePagesCount;
+	/* count of dirty pages in the pool */
+	uint32		dirtyPagesCount;
+	/* reserved pages count by type array */
+	uint32		numPagesReserved[PPOOL_RESERVE_COUNT];
+	uint32	   *usage_count;
+} LocalPagePool;
+
+extern void local_ppool_init(LocalPagePool *pool);
+
 #define PAGE_DESC_FLAG_DIRTY			1	/* Modified since the the last
 											 * time being written out */
 #define PAGE_DESC_FLAG_CONCURRENT_DIRTY	2	/* Second "dirty" flag used to
@@ -116,12 +128,12 @@ extern void o_ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found);
 #define IS_DIRTY(blkno) (O_GET_IN_MEMORY_PAGEDESC(blkno)->flags & PAGE_DESC_FLAG_DIRTY)
 #define IS_DIRTY_CONCURRENT(blkno) (O_GET_IN_MEMORY_PAGEDESC(blkno)->flags & PAGE_DESC_FLAG_CONCURRENT_DIRTY)
 #define CLEAN_DIRTY_CONCURRENT(blkno) (O_GET_IN_MEMORY_PAGEDESC(blkno)->flags &= ~PAGE_DESC_FLAG_CONCURRENT_DIRTY)
+#define BLKNO_LOCAL_BIT 0x80000000
 
 /*  Local page can never be dirty as it's never synced with disk */
 #define MARK_DIRTY_EXTENDED(desc, blkno, skipMeta) \
 	do \
 	{ \
-	    if (O_PAGE_IS_LOCAL(blkno)) break; \
 		if (!(skipMeta)) \
 		{ \
 			BTREE_GET_META(desc)->dirtyFlag1 = true; \
@@ -129,7 +141,11 @@ extern void o_ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found);
 		} \
 		if (!IS_DIRTY(blkno)) { \
 			O_GET_IN_MEMORY_PAGEDESC(blkno)->flags |= PAGE_DESC_FLAG_BOTH_DIRTY; \
-			pg_atomic_fetch_add_u32(((OPagePool*)(desc)->ppool)->dirtyPagesCount, 1); \
+			if(O_PAGE_IS_LOCAL(blkno)) { \
+				((LocalPagePool*)(desc)->ppool)->dirtyPagesCount++; \
+			} else { \
+				pg_atomic_fetch_add_u32(((OPagePool*)(desc)->ppool)->dirtyPagesCount, 1); \
+			} \
 		} \
 		else if (!IS_DIRTY_CONCURRENT(blkno)) \
 		{ \
@@ -145,7 +161,11 @@ extern void o_ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found);
 #define CLEAN_DIRTY(pool, blkno) \
 	if (IS_DIRTY(blkno)) { \
 		O_GET_IN_MEMORY_PAGEDESC(blkno)->flags &= ~PAGE_DESC_FLAG_BOTH_DIRTY; \
-		pg_atomic_fetch_sub_u32(((OPagePool*)(pool))->dirtyPagesCount, 1); \
+		if(O_PAGE_IS_LOCAL(blkno)) { \
+			((LocalPagePool*)(pool))->dirtyPagesCount--; \
+		} else { \
+			pg_atomic_fetch_sub_u32(((OPagePool*)(pool))->dirtyPagesCount, 1); \
+		} \
 	}
 
 #define FREE_PAGE_IF_VALID(pool, blkno) \

--- a/src/btree/btree.c
+++ b/src/btree/btree.c
@@ -215,7 +215,7 @@ free_meta_page(PagePool *pool, OInMemoryBlkno metaPageBlkno)
 	 * freeing the meta page until the last scan is released.
 	 */
 	if (meta_page_get_num_seq_scans(metaPageBlkno) == 0)
-	    (*pool->ops->free_page) (pool, metaPageBlkno, NULL);
+		(*pool->ops->free_page) (pool, metaPageBlkno, NULL);
 	else
 		meta_page->toBeFreedOnSeqScanRelease = true;
 }

--- a/src/btree/btree.c
+++ b/src/btree/btree.c
@@ -160,7 +160,7 @@ mark_page_pre_cleanup(OInMemoryBlkno blkno, uint32 pageChangeCount)
  * Frees given page and all of its children recursively.
  */
 static void
-free_page(OPagePool *pool, OInMemoryBlkno blkno, uint32 pageChangeCount)
+free_page(PagePool *pool, OInMemoryBlkno blkno, uint32 pageChangeCount)
 {
 	OInMemoryBlkno childPageNumbers[BTREE_PAGE_MAX_CHUNK_ITEMS];
 	uint32		childPageChangeCounts[BTREE_PAGE_MAX_CHUNK_ITEMS];
@@ -187,12 +187,11 @@ free_page(OPagePool *pool, OInMemoryBlkno blkno, uint32 pageChangeCount)
 	Assert(O_GET_IN_MEMORY_PAGEDESC(blkno)->ionum < 0);
 	page_block_reads(blkno);
 	CLEAN_DIRTY(pool, blkno);
-	ppool_free_page(pool, blkno, true);
-
+	(*pool->ops->free_page) (pool, blkno, true);
 }
 
 static inline void
-free_meta_page(OPagePool *pool, OInMemoryBlkno metaPageBlkno)
+free_meta_page(PagePool *pool, OInMemoryBlkno metaPageBlkno)
 {
 	BTreeMetaPage *meta_page;
 	int			i,
@@ -216,7 +215,7 @@ free_meta_page(OPagePool *pool, OInMemoryBlkno metaPageBlkno)
 	 * freeing the meta page until the last scan is released.
 	 */
 	if (meta_page_get_num_seq_scans(metaPageBlkno) == 0)
-		ppool_free_page(pool, metaPageBlkno, NULL);
+	    (*pool->ops->free_page) (pool, metaPageBlkno, NULL);
 	else
 		meta_page->toBeFreedOnSeqScanRelease = true;
 }
@@ -237,7 +236,7 @@ free_meta_page(OPagePool *pool, OInMemoryBlkno metaPageBlkno)
 void
 o_btree_cleanup_pages(OInMemoryBlkno rootPageBlkno, OInMemoryBlkno metaPageBlkno, uint32 rootPageChangeCount)
 {
-	OPagePool  *pool = get_ppool_by_blkno(rootPageBlkno);
+	PagePool   *pool = get_ppool_by_blkno(rootPageBlkno);
 
 	Assert(OInMemoryBlknoIsValid(rootPageBlkno));
 	Assert(OInMemoryBlknoIsValid(metaPageBlkno));

--- a/src/btree/build.c
+++ b/src/btree/build.c
@@ -28,6 +28,7 @@
 #include "tuple/sort.h"
 #include "transam/oxid.h"
 #include "utils/seq_buf.h"
+#include "utils/page_pool.h"
 
 #include "access/genam.h"
 #include "access/relation.h"

--- a/src/btree/check.c
+++ b/src/btree/check.c
@@ -600,7 +600,7 @@ btree_check_compression_recursive(BTreeDescr *desc, BTreeCompressStats *stats, O
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	size_t		compressed_size;
 
-	page_inc_usage_count(&desc->ppool->ucm, blkno);
+	(*desc->ppool->ops->ucm_inc_usage) (desc->ppool, blkno);
 
 	context->index++;
 	context->items[context->index].blkno = blkno;

--- a/src/btree/insert.c
+++ b/src/btree/insert.c
@@ -221,7 +221,7 @@ o_btree_finish_root_split_internal(BTreeDescr *desc,
 	page_desc->fileExtent = root_extent;
 
 	Assert(left_blkno);
-	Assert(page_is_locked(desc->rootInfo.rootPageBlkno));
+	Assert(page_is_locked(desc->rootInfo.rootPageBlkno) || O_PAGE_IS_LOCAL(desc->rootInfo.rootPageBlkno));
 
 	BTREE_PAGE_LOCATOR_FIRST(p, &loc);
 	page_locator_insert_item(p, &loc, BTreeNonLeafTuphdrSize);

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1490,8 +1490,7 @@ load_page(OBTreeFindPageContext *context)
 	}
 
 	put_page_image(blkno, buf);
-	(*desc->ppool->ops->ucm_change_usage) (desc->ppool, blkno,
-										   ((*desc->ppool->ops->ucm_get_epoch) (desc->ppool) + 2) % UCM_USAGE_LEVELS);
+	(*desc->ppool->ops->ucm_init) (desc->ppool, blkno);
 	page_desc->type = parent_page_desc->type;
 	page_desc->oids = parent_page_desc->oids;
 
@@ -2086,7 +2085,7 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 	/* rootPageBlkno can not be evicted here */
 	Assert(!evict || !is_root);
 	Assert(OInMemoryBlknoIsValid(desc->rootInfo.rootPageBlkno));
-	Assert(page_is_locked(blkno));
+	Assert(page_is_locked(blkno) || O_PAGE_IS_LOCAL(blkno));
 	EA_EVICT_INC(blkno);
 
 	if (!is_root)
@@ -2370,7 +2369,7 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 	bool		hasMetaLock = LWLockHeldByMe(&checkpoint_state->oTablesMetaLock);
 
 	Assert(ORootPageIsValid(desc) && OMetaPageIsValid(desc) &&
-		   O_PAGE_STATE_IS_LOCKED(pg_atomic_read_u64(&(O_PAGE_HEADER(rootPageBlkno)->state))));
+		   (O_PAGE_STATE_IS_LOCKED(pg_atomic_read_u64(&(O_PAGE_HEADER(rootPageBlkno)->state))) || O_PAGE_IS_LOCAL(root_blkno)));
 
 	/*
 	 * Additional protection: don't evict the tree root page if the resource

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1462,8 +1462,8 @@ load_page(OBTreeFindPageContext *context)
 	unlock_page(parent_blkno);
 
 	/* Prepare new page metaPage-data */
-	ppool_reserve_pages(desc->ppool, PPOOL_RESERVE_FIND, 1);
-	blkno = ppool_get_page(desc->ppool, PPOOL_RESERVE_FIND);
+	(*desc->ppool->ops->reserve_pages) (desc->ppool, PPOOL_RESERVE_FIND, 1);
+	blkno = (*desc->ppool->ops->alloc_page) (desc->ppool, PPOOL_RESERVE_FIND);
 	lock_page(blkno);
 	page_block_reads(blkno);
 
@@ -1490,8 +1490,8 @@ load_page(OBTreeFindPageContext *context)
 	}
 
 	put_page_image(blkno, buf);
-	page_change_usage_count(&desc->ppool->ucm, blkno,
-							(pg_atomic_read_u32(desc->ppool->ucm.epoch) + 2) % UCM_USAGE_LEVELS);
+	(*desc->ppool->ops->ucm_change_usage) (desc->ppool, blkno,
+										   ((*desc->ppool->ops->ucm_get_epoch) (desc->ppool) + 2) % UCM_USAGE_LEVELS);
 	page_desc->type = parent_page_desc->type;
 	page_desc->oids = parent_page_desc->oids;
 
@@ -2272,7 +2272,7 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 		unlock_page(parent_blkno);
 
 	if (evict)
-		ppool_free_page(desc->ppool, blkno, NULL);
+		(*desc->ppool->ops->free_page) (desc->ppool, blkno, NULL);
 
 	perform_writeback(&io_writeback);
 }
@@ -2432,7 +2432,7 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 
 	file_header.rootDownlink = new_downlink;
 
-	ppool_free_page(desc->ppool, root_blkno, NULL);
+	(*desc->ppool->ops->free_page) (desc->ppool, root_blkno, NULL);
 
 	if (orioledb_s3_mode)
 		chkpNum = S3_GET_CHKP_NUM(DOWNLINK_GET_DISK_OFF(new_downlink));
@@ -2461,7 +2461,7 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 	if (!orioledb_s3_mode || desc->storageType == BTreeStorageTemporary)
 		btree_finalize_private_seq_bufs(desc, &evicted_tree_data, notModified);
 
-	ppool_free_page(desc->ppool, desc->rootInfo.metaPageBlkno, NULL);
+	(*desc->ppool->ops->free_page) (desc->ppool, desc->rootInfo.metaPageBlkno, NULL);
 
 	desc->rootInfo.rootPageBlkno = OInvalidInMemoryBlkno;
 	desc->rootInfo.metaPageBlkno = OInvalidInMemoryBlkno;

--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -180,7 +180,7 @@ btree_try_merge_pages(BTreeDescr *desc,
 	CLEAN_DIRTY(desc->ppool, right_blkno);
 	O_PAGE_CHANGE_COUNT_INC(right);
 
-	ppool_free_page(desc->ppool, right_blkno, true);
+	(*desc->ppool->ops->free_page) (desc->ppool, right_blkno, true);
 
 	if (O_PAGE_IS(left, LEAF))
 		pg_atomic_fetch_sub_u32(&BTREE_GET_META(desc)->leafPagesNum, 1);

--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -53,7 +53,7 @@ btree_try_merge_pages(BTreeDescr *desc,
 					  OInMemoryBlkno parent_blkno, OFixedKey *parent_hikey,
 					  bool *merge_parent,
 					  OInMemoryBlkno left_blkno,
-					  BTreePageItemLocator right_loc,
+					  BTreePageItemLocator *right_loc,
 					  OInMemoryBlkno right_blkno,
 					  bool checkpoint)
 {
@@ -106,7 +106,7 @@ btree_try_merge_pages(BTreeDescr *desc,
 	/* deletes downlink to right page from the parent node */
 	page_block_reads(parent_blkno);
 
-	page_locator_delete_item(parent, &right_loc);
+	page_locator_delete_item(parent, right_loc);
 	MARK_DIRTY_EXTENDED(desc, parent_blkno, checkpoint);
 
 	/* unlocks the parent page */
@@ -239,7 +239,7 @@ btree_try_merge_and_unlock(BTreeDescr *desc, OInMemoryBlkno blkno,
 	/* Step 1: get all the information from the parent page */
 	level = PAGE_GET_LEVEL(target);
 
-	Assert(page_is_locked(blkno));
+	Assert(page_is_locked(blkno) || O_PAGE_IS_LOCAL(blkno));
 	Assert(desc->rootInfo.rootPageBlkno != blkno);
 	Assert(is_page_too_sparse(desc, target));
 	Assert(!O_PAGE_IS(target, LEFTMOST) || !O_PAGE_IS(target, RIGHTMOST));
@@ -301,7 +301,7 @@ btree_try_merge_and_unlock(BTreeDescr *desc, OInMemoryBlkno blkno,
 		/* Step 3: do all the checks with parent and target */
 		parent_change_count = find_context.items[find_context.index].pageChangeCount;
 		parent_blkno = find_context.items[find_context.index].blkno;
-		Assert(page_is_locked(parent_blkno));
+		Assert(page_is_locked(parent_blkno) || O_PAGE_IS_LOCAL(parent_blkno));
 		parent = O_GET_IN_MEMORY_PAGE(parent_blkno);
 
 		target_loc = find_context.items[find_context.index].locator;
@@ -395,7 +395,7 @@ btree_try_merge_and_unlock(BTreeDescr *desc, OInMemoryBlkno blkno,
 				{
 					merged = btree_try_merge_pages(desc, parent_blkno, &key,
 												   &merge_parent, target_blkno,
-												   right_loc, right_blkno,
+												   &right_loc, right_blkno,
 												   false);
 					if (!merged)
 						unlock_page(right_blkno);
@@ -469,7 +469,7 @@ btree_try_merge_and_unlock(BTreeDescr *desc, OInMemoryBlkno blkno,
 					merged = btree_try_merge_pages(desc, parent_blkno,
 												   &key, &merge_parent,
 												   left_blkno,
-												   target_loc, target_blkno,
+												   &target_loc, target_blkno,
 												   false);
 					if (!merged)
 						unlock_page(left_blkno);

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -171,7 +171,7 @@ retry:
 	blkno = pageFindContext->items[pageFindContext->index].blkno;
 	loc = pageFindContext->items[pageFindContext->index].locator;
 	page = O_GET_IN_MEMORY_PAGE(blkno);
-	Assert(page_is_locked(blkno));
+	Assert(page_is_locked(blkno) || O_PAGE_IS_LOCAL(blkno));
 
 	if (!BTREE_PAGE_LOCATOR_IS_VALID(page, &loc))
 		return o_btree_modify_handle_tuple_not_found(&context);
@@ -198,7 +198,7 @@ retry:
 			goto retry;
 	}
 
-	Assert(page_is_locked(blkno));
+	Assert(page_is_locked(blkno) || O_PAGE_IS_LOCAL(blkno));
 
 	if (context.cmp != 0)
 		return o_btree_modify_handle_tuple_not_found(&context);
@@ -231,7 +231,7 @@ retry:
 			goto retry;
 		}
 
-		Assert(page_is_locked(blkno));
+		Assert(page_is_locked(blkno) || O_PAGE_IS_LOCAL(blkno));
 
 		if (callbackInfo->modifyCallback || (action == BTreeOperationInsert ||
 											 action == BTreeOperationUpdate ||

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -390,8 +390,8 @@ unlock_release(BTreeModifyInternalContext *context, bool unlock)
 			release_undo_size(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType));
 	}
 	if (context->pagesAreReserved)
-		ppool_release_reserved(desc->ppool,
-							   PPOOL_KIND_GET_MASK(context->pageReserveKind));
+		(*desc->ppool->ops->release_reserved) (desc->ppool,
+											   PPOOL_KIND_GET_MASK(context->pageReserveKind));
 	if (context->hwLockMode != NoLock)
 		LockRelease(&context->hwLockTag, context->hwLockMode, false);
 }
@@ -1016,7 +1016,7 @@ o_btree_normal_modify(BTreeDescr *desc, BTreeOperationType action,
 		pageReserveKind = PPOOL_RESERVE_INSERT;
 
 	if (action != BTreeOperationDelete)
-		ppool_reserve_pages(desc->ppool, pageReserveKind, 2);
+		(*desc->ppool->ops->reserve_pages) (desc->ppool, pageReserveKind, 2);
 
 	init_page_find_context(&pageFindContext, desc, COMMITSEQNO_INPROGRESS,
 						   BTREE_PAGE_FIND_MODIFY | BTREE_PAGE_FIND_FIX_LEAF_SPLIT);
@@ -1046,7 +1046,7 @@ o_btree_normal_modify(BTreeDescr *desc, BTreeOperationType action,
 			if (GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType) != desc->undoType)
 				release_undo_size(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType));
 		}
-		ppool_release_reserved(desc->ppool, PPOOL_RESERVE_INSERT);
+		(*desc->ppool->ops->release_reserved) (desc->ppool, PPOOL_RESERVE_INSERT);
 		Assert(!have_locked_pages());
 		return OBTreeModifyResultInserted;
 	}
@@ -1193,7 +1193,7 @@ o_btree_insert_unique(BTreeDescr *desc, OTuple tuple, BTreeKeyType tupleType,
 	else
 		pageReserveKind = PPOOL_RESERVE_INSERT;
 
-	ppool_reserve_pages(desc->ppool, pageReserveKind, 2);
+	(*desc->ppool->ops->reserve_pages) (desc->ppool, pageReserveKind, 2);
 
 	init_page_find_context(&pageFindContext, desc, COMMITSEQNO_INPROGRESS,
 						   BTREE_PAGE_FIND_MODIFY |

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -355,8 +355,7 @@ init_new_btree_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint16 flags,
 	header->itemsCount = 0;
 	header->prevInsertOffset = MaxOffsetNumber;
 	header->maxKeyLen = 0;
-	(*desc->ppool->ops->ucm_change_usage) (desc->ppool, blkno,
-										   ((*desc->ppool->ops->ucm_get_epoch) (desc->ppool) + 2) % UCM_USAGE_LEVELS);
+	(*desc->ppool->ops->ucm_init) (desc->ppool, blkno);
 
 	memset(p + offsetof(BTreePageHeader, chunkDesc),
 		   0,

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -124,7 +124,7 @@ my_locked_page_get_state(OInMemoryBlkno blkno)
 static uint64
 lock_page_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum)
 {
-	UsageCountMap *ucm = &(get_ppool_by_blkno(blkno)->ucm);
+	PagePool   *ppool = get_ppool_by_blkno(blkno);
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	OrioleDBPageHeader *header = (OrioleDBPageHeader *) p;
 	uint64		state;
@@ -153,13 +153,13 @@ lock_page_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum)
 
 		if (!ucmUpdateTried)
 		{
-			newState = ucm_update_state(ucm, blkno, newState);
+			newState = (*ppool->ops->ucm_update_state) (ppool, blkno, newState);
 			ucmUpdateTried = true;
 		}
 
 		if (pg_atomic_compare_exchange_u64(&header->state, &state, newState))
 		{
-			ucm_after_update_state(ucm, blkno, state, newState);
+			(*ppool->ops->ucm_after_update_state) (ppool, blkno, state, newState);
 			break;
 		}
 	}
@@ -188,7 +188,7 @@ lock_page_or_queue_or_split_detect(BTreeDescr *desc, OInMemoryBlkno *blkno,
 								   OTuple tuple, uint64 *prevState,
 								   bool *keySerialized)
 {
-	UsageCountMap *ucm = &(get_ppool_by_blkno(*blkno)->ucm);
+	PagePool   *ppool = get_ppool_by_blkno(*blkno);
 	Page		p = O_GET_IN_MEMORY_PAGE(*blkno);
 	OrioleDBPageHeader *header = (OrioleDBPageHeader *) p;
 	OrioleDBPageHeader *imgHeader = (OrioleDBPageHeader *) img->img;
@@ -292,13 +292,13 @@ lock_page_or_queue_or_split_detect(BTreeDescr *desc, OInMemoryBlkno *blkno,
 
 		if (!ucmUpdateTried)
 		{
-			newState = ucm_update_state(ucm, *blkno, newState);
+			newState = (*ppool->ops->ucm_update_state) (ppool, *blkno, newState);
 			ucmUpdateTried = true;
 		}
 
 		if (pg_atomic_compare_exchange_u64(&header->state, &state, newState))
 		{
-			ucm_after_update_state(ucm, *blkno, state, newState);
+			(*ppool->ops->ucm_after_update_state) (ppool, *blkno, state, newState);
 			break;
 		}
 	}
@@ -352,7 +352,7 @@ static uint64
 state_changed_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum,
 					   uint64 oldState)
 {
-	UsageCountMap *ucm = &(get_ppool_by_blkno(blkno)->ucm);
+	PagePool   *ppool = get_ppool_by_blkno(blkno);
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	OrioleDBPageHeader *header = (OrioleDBPageHeader *) p;
 	uint64		state;
@@ -380,13 +380,13 @@ state_changed_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum,
 
 		if (!ucmUpdateTried)
 		{
-			newState = ucm_update_state(ucm, blkno, newState);
+			newState = (*ppool->ops->ucm_update_state) (ppool, blkno, newState);
 			ucmUpdateTried = true;
 		}
 
 		if (pg_atomic_compare_exchange_u64(&header->state, &state, newState))
 		{
-			ucm_after_update_state(ucm, blkno, state, newState);
+			(*ppool->ops->ucm_after_update_state) (ppool, blkno, state, newState);
 			break;
 		}
 	}
@@ -405,6 +405,10 @@ lock_page(OInMemoryBlkno blkno)
 	OPageWaiterShmemState *lockerState = &lockerStates[MYPROCNUMBER];
 	uint64		prevState;
 	int			extraWaits = 0;
+
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return;
 
 	Assert(get_my_locked_page_index(blkno) < 0);
 
@@ -454,6 +458,9 @@ lock_page_with_tuple(BTreeDescr *desc,
 	bool		keySerialized = false;
 	PageImg		img;
 
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return OLockPageWithTupleResultLocked;
 
 	img.load = false;
 	Assert(get_my_locked_page_index(*blkno) < 0);
@@ -527,6 +534,10 @@ page_wait_for_read_enable(OInMemoryBlkno blkno)
 	uint32		prevState;
 	int			extraWaits = 0;
 	OPageWaiterShmemState *lockerState = &lockerStates[MYPROCNUMBER];
+
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return;
 
 	while (true)
 	{
@@ -619,6 +630,10 @@ relock_page(OInMemoryBlkno blkno)
 {
 	uint64		state;
 
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return;
+
 	state = my_locked_page_get_state(blkno);
 	unlock_page(blkno);
 
@@ -634,9 +649,13 @@ relock_page(OInMemoryBlkno blkno)
 bool
 try_lock_page(OInMemoryBlkno blkno)
 {
-	UsageCountMap *ucm = &(get_ppool_by_blkno(blkno)->ucm);
+	PagePool   *ppool = get_ppool_by_blkno(blkno);
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	uint64		state;
+
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return true;
 
 	state = pg_atomic_fetch_or_u64(&(O_PAGE_HEADER(p)->state),
 								   PAGE_STATE_LOCKED_FLAG);
@@ -646,7 +665,7 @@ try_lock_page(OInMemoryBlkno blkno)
 
 	EA_LOCK_INC(blkno);
 	my_locked_page_add(blkno, state | PAGE_STATE_LOCKED_FLAG);
-	page_inc_usage_count(ucm, blkno);
+	(*ppool->ops->ucm_inc_usage) (ppool, blkno);
 
 	return true;
 }
@@ -659,15 +678,24 @@ delare_page_as_locked(OInMemoryBlkno blkno)
 {
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return;
+
 	my_locked_page_add(blkno, pg_atomic_read_u64(&(O_PAGE_HEADER(p)->state)));
 }
 
 /*
  * Check if page is locked.
  */
+/*  TODO: check uses and don't call if page is local */
 bool
 page_is_locked(OInMemoryBlkno blkno)
 {
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return false;
+
 	return (get_my_locked_page_index(blkno) >= 0);
 }
 
@@ -679,7 +707,13 @@ page_block_reads(OInMemoryBlkno blkno)
 {
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	uint64		state;
-	int			i = get_my_locked_page_index(blkno);
+	int			i;
+
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return;
+
+	i = get_my_locked_page_index(blkno);
 
 	Assert((myLockedPages[i].state & PAGE_STATE_CHANGE_NON_WAITERS_MASK) ==
 		   (pg_atomic_read_u64(&(O_PAGE_HEADER(p)->state)) & PAGE_STATE_CHANGE_NON_WAITERS_MASK));
@@ -697,6 +731,10 @@ get_waiters_with_tuples(BTreeDescr *desc,
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	uint32		pgprocnum;
 	int			count = 0;
+
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return 0;
 
 	pgprocnum = pg_atomic_read_u64(&(O_PAGE_HEADER(p)->state)) & PAGE_STATE_LIST_TAIL_MASK;
 
@@ -1006,6 +1044,10 @@ unlock_page_internal(OInMemoryBlkno blkno, bool split)
 void
 unlock_page(OInMemoryBlkno blkno)
 {
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return;
+
 	unlock_page_internal(blkno, false);
 }
 
@@ -1015,6 +1057,10 @@ unlock_page(OInMemoryBlkno blkno)
 void
 unlock_page_after_split(OInMemoryBlkno blkno)
 {
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(blkno))
+		return;
+
 	unlock_page_internal(blkno, true);
 }
 
@@ -1102,6 +1148,10 @@ btree_split_mark_finished(OInMemoryBlkno rightBlkno, bool use_lock, bool success
 	BTreePageHeader *rightHeader;
 	OrioleDBPageDesc *rightPageDesc = O_GET_IN_MEMORY_PAGEDESC(rightBlkno);
 	OInMemoryBlkno leftBlkno;
+
+	/* Local pages do not need locking */
+	if (O_PAGE_IS_LOCAL(rightBlkno))
+		use_lock = false;
 
 	leftBlkno = rightPageDesc->leftBlkno;
 	Assert(OInMemoryBlknoIsValid(leftBlkno));

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -124,7 +124,7 @@ my_locked_page_get_state(OInMemoryBlkno blkno)
 static uint64
 lock_page_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum)
 {
-	PagePool   *ppool = get_ppool_by_blkno(blkno);
+	OPagePool  *ppool = (OPagePool *) get_ppool_by_blkno(blkno);
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	OrioleDBPageHeader *header = (OrioleDBPageHeader *) p;
 	uint64		state;
@@ -132,6 +132,7 @@ lock_page_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum)
 	bool		ucmUpdateTried = false;
 
 	Assert(pgprocnum < max_procs);
+	Assert(!O_PAGE_IS_LOCAL(blkno));
 
 	state = pg_atomic_read_u64(&header->state);
 	while (true)
@@ -153,13 +154,13 @@ lock_page_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum)
 
 		if (!ucmUpdateTried)
 		{
-			newState = (*ppool->ops->ucm_update_state) (ppool, blkno, newState);
+			newState = ucm_update_state(&ppool->ucm, blkno, newState);
 			ucmUpdateTried = true;
 		}
 
 		if (pg_atomic_compare_exchange_u64(&header->state, &state, newState))
 		{
-			(*ppool->ops->ucm_after_update_state) (ppool, blkno, state, newState);
+			ucm_after_update_state(&ppool->ucm, blkno, state, newState);
 			break;
 		}
 	}
@@ -188,7 +189,7 @@ lock_page_or_queue_or_split_detect(BTreeDescr *desc, OInMemoryBlkno *blkno,
 								   OTuple tuple, uint64 *prevState,
 								   bool *keySerialized)
 {
-	PagePool   *ppool = get_ppool_by_blkno(*blkno);
+	OPagePool  *ppool = (OPagePool *) get_ppool_by_blkno(*blkno);
 	Page		p = O_GET_IN_MEMORY_PAGE(*blkno);
 	OrioleDBPageHeader *header = (OrioleDBPageHeader *) p;
 	OrioleDBPageHeader *imgHeader = (OrioleDBPageHeader *) img->img;
@@ -197,6 +198,7 @@ lock_page_or_queue_or_split_detect(BTreeDescr *desc, OInMemoryBlkno *blkno,
 	bool		ucmUpdateTried = false;
 
 	Assert(pgprocnum < max_procs);
+	Assert(!O_PAGE_IS_LOCAL(*blkno));
 
 	state = pg_atomic_read_u64(&header->state);
 	while (true)
@@ -292,13 +294,13 @@ lock_page_or_queue_or_split_detect(BTreeDescr *desc, OInMemoryBlkno *blkno,
 
 		if (!ucmUpdateTried)
 		{
-			newState = (*ppool->ops->ucm_update_state) (ppool, *blkno, newState);
+			newState = ucm_update_state(&ppool->ucm, *blkno, newState);
 			ucmUpdateTried = true;
 		}
 
 		if (pg_atomic_compare_exchange_u64(&header->state, &state, newState))
 		{
-			(*ppool->ops->ucm_after_update_state) (ppool, *blkno, state, newState);
+			ucm_after_update_state(&ppool->ucm, *blkno, state, newState);
 			break;
 		}
 	}
@@ -352,12 +354,14 @@ static uint64
 state_changed_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum,
 					   uint64 oldState)
 {
-	PagePool   *ppool = get_ppool_by_blkno(blkno);
+	OPagePool  *ppool = (OPagePool *) get_ppool_by_blkno(blkno);
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	OrioleDBPageHeader *header = (OrioleDBPageHeader *) p;
 	uint64		state;
 	OPageWaiterShmemState *lockerState = &lockerStates[pgprocnum];
 	bool		ucmUpdateTried = false;
+
+	Assert(!O_PAGE_IS_LOCAL(blkno));
 
 	state = pg_atomic_read_u64(&header->state);
 	while (true)
@@ -380,13 +384,13 @@ state_changed_or_queue(OInMemoryBlkno blkno, uint32 pgprocnum,
 
 		if (!ucmUpdateTried)
 		{
-			newState = (*ppool->ops->ucm_update_state) (ppool, blkno, newState);
+			newState = ucm_update_state(&ppool->ucm, blkno, newState);
 			ucmUpdateTried = true;
 		}
 
 		if (pg_atomic_compare_exchange_u64(&header->state, &state, newState))
 		{
-			(*ppool->ops->ucm_after_update_state) (ppool, blkno, state, newState);
+			ucm_after_update_state(&ppool->ucm, blkno, state, newState);
 			break;
 		}
 	}
@@ -459,7 +463,7 @@ lock_page_with_tuple(BTreeDescr *desc,
 	PageImg		img;
 
 	/* Local pages do not need locking */
-	if (O_PAGE_IS_LOCAL(blkno))
+	if (O_PAGE_IS_LOCAL(*blkno))
 		return OLockPageWithTupleResultLocked;
 
 	img.load = false;
@@ -688,7 +692,6 @@ delare_page_as_locked(OInMemoryBlkno blkno)
 /*
  * Check if page is locked.
  */
-/*  TODO: check uses and don't call if page is local */
 bool
 page_is_locked(OInMemoryBlkno blkno)
 {

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -53,6 +53,7 @@
 #include "btree/page_chunks.h"
 #include "btree/scan.h"
 #include "btree/undo.h"
+#include "tableam/descr.h"
 #include "transam/oxid.h"
 #include "tuple/slot.h"
 #include "utils/page_pool.h"
@@ -1810,7 +1811,7 @@ free_btree_seq_scan_internal(BTreeSeqScan *scan, bool fromResowner)
 
 		/* Complete deferred meta page free if this was the last scan. */
 		if (metaPage->toBeFreedOnSeqScanRelease && meta_page_get_num_seq_scans(desc->rootInfo.metaPageBlkno) == 0)
-			ppool_free_page(desc->ppool, desc->rootInfo.metaPageBlkno, false);
+			(*desc->ppool->ops->free_page) (desc->ppool, desc->rootInfo.metaPageBlkno, false);
 
 		scan->checkpointNumberSet = false;
 	}

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -33,6 +33,7 @@
 #include "utils/compress.h"
 #include "utils/planner.h"
 #include "utils/stopevent.h"
+#include "utils/page_pool.h"
 #include "workers/interrupt.h"
 
 #include "access/genam.h"
@@ -1514,8 +1515,13 @@ build_secondary_index(OTable *o_table, OTableDescr *descr, OIndexNumber ix_num,
 	idx = descr->indices[o_table->has_primary ? ix_num : ix_num + 1];
 	buildstate.btleader = NULL;
 
-	/* Attempt to launch parallel worker scan when required */
-	if (in_dedicated_recovery_worker || (ActiveSnapshotSet() && max_parallel_maintenance_workers > 0))
+	/*
+	 * Attempt to launch parallel worker scan when required. Parallel workers
+	 * cannot access data in temporary tables because they use a per-backend
+	 * local page pool.
+	 */
+	if ((in_dedicated_recovery_worker || (ActiveSnapshotSet() && max_parallel_maintenance_workers > 0)) &&
+		o_table->persistence != RELPERSISTENCE_TEMP)
 	{
 		int			parallel_workers = o_calculate_index_workers(&GET_PRIMARY(descr)->desc, false, 1);
 
@@ -1878,8 +1884,13 @@ rebuild_indices(OTable *old_o_table, OTableDescr *old_descr,
 
 	buildstate.btleader = NULL;
 
-	/* Attempt to launch parallel worker scan when required */
+	/*
+	 * Attempt to launch parallel worker scan when required. Parallel workers
+	 * cannot access data in temporary tables because they use a per-backend
+	 * local page pool.
+	 */
 	if ((in_dedicated_recovery_worker || (ActiveSnapshotSet() && max_parallel_maintenance_workers > 0)) &&
+		o_table->persistence != RELPERSISTENCE_TEMP &&
 		!descr->indices[PrimaryIndexNumber]->primaryIsCtid &&
 		!(descr->bridge && !old_descr->bridge))
 	{

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -728,9 +728,9 @@ sys_tree_init_if_needed(int i)
 
 		if (!header->initialized)
 		{
-			OPagePool  *pool = get_ppool(sysTreesMeta[i].poolType);
+			PagePool   *pool = get_ppool(sysTreesMeta[i].poolType);
 
-			ppool_reserve_pages(pool, PPOOL_RESERVE_META, 8);
+			(*pool->ops->reserve_pages) (pool, PPOOL_RESERVE_META, 8);
 			LWLockAcquire(&checkpoint_state->oSharedRootInfoInsertLocks[0],
 						  LW_EXCLUSIVE);
 			if (header->initialized)
@@ -745,7 +745,7 @@ sys_tree_init_if_needed(int i)
 			pg_write_barrier();
 			header->initialized = true;
 			LWLockRelease(&checkpoint_state->oSharedRootInfoInsertLocks[0]);
-			ppool_release_reserved(pool, PPOOL_RESERVE_META);
+			(*pool->ops->release_reserved) (pool, PPOOL_RESERVE_META);
 		}
 		else
 		{
@@ -766,7 +766,7 @@ sys_tree_init_if_needed(int i)
 static void
 sys_tree_init(int i, bool init_shmem)
 {
-	OPagePool  *pool;
+	PagePool   *pool;
 	SysTreeShmemHeader *header;
 	SysTreeMeta *meta;
 	BTreeDescr *descr;
@@ -781,8 +781,8 @@ sys_tree_init(int i, bool init_shmem)
 
 	if (init_shmem)
 	{
-		header->rootInfo.rootPageBlkno = ppool_get_page(pool, PPOOL_RESERVE_META);
-		header->rootInfo.metaPageBlkno = ppool_get_page(pool, PPOOL_RESERVE_META);
+		header->rootInfo.rootPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);
+		header->rootInfo.metaPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);
 		header->rootInfo.rootPageChangeCount = O_PAGE_GET_CHANGE_COUNT(O_GET_IN_MEMORY_PAGE(header->rootInfo.rootPageBlkno));
 	}
 	descr->rootInfo = header->rootInfo;

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -3209,7 +3209,7 @@ checkpoint_try_merge_page(BTreeDescr *descr, CheckpointState *state,
 	}
 
 	if (btree_try_merge_pages(descr, parentBlkno, NULL, &mergeParent,
-							  blkno, loc, rightBlkno, true))
+							  blkno, &loc, rightBlkno, true))
 	{
 		checkpoint_reserve_undo(descr->undoType, true);
 		return true;
@@ -4906,7 +4906,20 @@ checkpoint_tables_callback(OIndexType type, ORelOids treeOids,
 
 	descr = o_fetch_index_descr(treeOids, type, true, NULL);
 	if (descr != NULL)
+	{
+		/*
+		 * Skip temporary tables - they use a per-backend local page pool
+		 * which is not accessible from the checkpointer process.
+		 */
+		if (descr->desc.storageType == BTreeStorageTemporary)
+		{
+			o_tables_rel_unlock_extended(&treeOids, AccessShareLock, true);
+			MemoryContextSwitchTo(prev_context);
+			MemoryContextResetOnly(chkp_tree_context);
+			return;
+		}
 		loaded = o_btree_load_shmem_checkpoint(&descr->desc);
+	}
 	if (loaded)
 	{
 		BTreeDescr *td = &descr->desc;

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -1548,7 +1548,7 @@ checkpoint_init_new_seq_bufs(BTreeDescr *descr, int chkpNum)
 		return;
 	}
 
-	ppool_reserve_pages(descr->ppool, PPOOL_RESERVE_META, 4);
+	(*descr->ppool->ops->reserve_pages) (descr->ppool, PPOOL_RESERVE_META, 4);
 
 	init_seq_buf_pages(descr, &meta_page->tmpBuf[next_chkp_index]);
 
@@ -5099,8 +5099,8 @@ init_seq_buf_pages(BTreeDescr *desc, SeqBufDescShared *shared)
 	Assert(!OInMemoryBlknoIsValid(shared->pages[0]));
 	Assert(!OInMemoryBlknoIsValid(shared->pages[1]));
 
-	shared->pages[0] = ppool_get_page(desc->ppool, PPOOL_RESERVE_META);
-	shared->pages[1] = ppool_get_page(desc->ppool, PPOOL_RESERVE_META);
+	shared->pages[0] = (*desc->ppool->ops->alloc_page) (desc->ppool, PPOOL_RESERVE_META);
+	shared->pages[1] = (*desc->ppool->ops->alloc_page) (desc->ppool, PPOOL_RESERVE_META);
 
 	Assert(OInMemoryBlknoIsValid(shared->pages[0]));
 	Assert(OInMemoryBlknoIsValid(shared->pages[1]));

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -1096,20 +1096,20 @@ _PG_init(void)
 	EmitWarningsOnPlaceholders("pg_stat_statements");
 
 	memset(page_pools, 0, OPagePoolTypesCount * sizeof(OPagePool));
-	page_pools_size[OPagePoolFreeTree] = ppool_estimate_space(&page_pools[OPagePoolFreeTree],
-															  0,
-															  free_tree_buffers_count,
-															  debug_disable_pools_limit);
+	page_pools_size[OPagePoolFreeTree] = o_ppool_estimate_space(&page_pools[OPagePoolFreeTree],
+																0,
+																free_tree_buffers_count,
+																debug_disable_pools_limit);
 
-	page_pools_size[OPagePoolCatalog] = ppool_estimate_space(&page_pools[OPagePoolCatalog],
-															 free_tree_buffers_count,
-															 catalog_buffers_count,
-															 debug_disable_pools_limit);
+	page_pools_size[OPagePoolCatalog] = o_ppool_estimate_space(&page_pools[OPagePoolCatalog],
+															   free_tree_buffers_count,
+															   catalog_buffers_count,
+															   debug_disable_pools_limit);
 
-	page_pools_size[OPagePoolMain] = ppool_estimate_space(&page_pools[OPagePoolMain],
-														  main_buffers_offset,
-														  main_buffers_count,
-														  debug_disable_pools_limit);
+	page_pools_size[OPagePoolMain] = o_ppool_estimate_space(&page_pools[OPagePoolMain],
+															main_buffers_offset,
+															main_buffers_count,
+															debug_disable_pools_limit);
 
 	for (i = 0; i < OPagePoolTypesCount; i++)
 		page_pools_size[i] = CACHELINEALIGN(page_pools_size[i]);
@@ -1332,7 +1332,7 @@ ppools_shmem_init(Pointer ptr, bool found)
 	page_descs = (OrioleDBPageDesc *) ptr;
 
 	for (i = 0; i < OPagePoolTypesCount; i++)
-		ppool_shmem_init(&page_pools[i], page_pools_ptr[i], found);
+		o_ppool_shmem_init(&page_pools[i], page_pools_ptr[i], found);
 
 	if (!found)
 	{
@@ -1693,10 +1693,10 @@ orioledb_page_stats(PG_FUNCTION_ARGS)
 			values[0] = PointerGetDatum(cstring_to_text("free_tree"));
 		else if (i == OPagePoolCatalog)
 			values[0] = PointerGetDatum(cstring_to_text("catalog"));
-		num_free_pages = (int64) ppool_free_pages_count(&page_pools[i]);
+		num_free_pages = (int64) o_ppool_free_pages_count((PagePool *) &page_pools[i]);
 		values[1] = Int64GetDatum(total_num_pages - num_free_pages);
 		values[2] = Int64GetDatum(num_free_pages);
-		values[3] = Int64GetDatum((int64) ppool_dirty_pages_count(&page_pools[i]));
+		values[3] = Int64GetDatum((int64) o_ppool_dirty_pages_count((PagePool *) &page_pools[i]));
 		values[4] = Int64GetDatum(total_num_pages);
 		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);
 	}
@@ -1912,28 +1912,28 @@ orioledb_commit_hash(PG_FUNCTION_ARGS)
 /*
  * Returns a page pool by the type.
  */
-OPagePool *
+PagePool *
 get_ppool(OPagePoolType type)
 {
 	Assert((int) type < OPagePoolTypesCount);
-	return &page_pools[type];
+	return (PagePool *) &page_pools[type];
 }
 
 /*
  * Returns a page pool for the page number.
  */
-OPagePool *
+PagePool *
 get_ppool_by_blkno(OInMemoryBlkno blkno)
 {
 	Assert(blkno < orioledb_buffers_count);
 
 	if (blkno >= main_buffers_offset)
-		return &page_pools[OPagePoolMain];
+		return (PagePool *) &page_pools[OPagePoolMain];
 
 	if (blkno < free_tree_buffers_count)
-		return &page_pools[OPagePoolFreeTree];
+		return (PagePool *) &page_pools[OPagePoolFreeTree];
 
-	return &page_pools[OPagePoolCatalog];
+	return (PagePool *) &page_pools[OPagePoolCatalog];
 }
 
 /*
@@ -1946,7 +1946,7 @@ get_dirty_pages_count_sum(void)
 	int			i;
 
 	for (i = 0; i < OPagePoolTypesCount; i++)
-		result += ppool_dirty_pages_count(&page_pools[i]);
+		result += o_ppool_dirty_pages_count((PagePool *) &page_pools[i]);
 
 	return result;
 }

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -97,15 +97,19 @@ static Size main_buffers_offset;
 
 Pointer		o_shared_buffers = NULL;
 OrioleDBPageDesc *page_descs = NULL;
+Page	   *local_ppool_pages = NULL;
+OrioleDBPageDesc *local_ppool_page_descs = NULL;
 
 /* Custom GUC variables */
 static int	main_buffers_guc;
 static int	undo_buffers_guc;
 static int	xid_buffers_guc;
 static int	rewind_buffers_guc;
+static int	temp_buffers_guc;
 int			max_procs;
 Size		orioledb_buffers_size;
 Size		orioledb_buffers_count;
+Size		orioledb_temp_buffers_count;
 Size		page_descs_size;
 Size		undo_circular_buffer_size;
 uint32		undo_buffers_count;
@@ -180,6 +184,7 @@ MemoryContext btree_insert_context = NULL;
 MemoryContext btree_seqscan_context = NULL;
 
 OPagePool	page_pools[OPagePoolTypesCount];
+LocalPagePool local_ppool;
 
 static size_t page_pools_size[OPagePoolTypesCount];
 
@@ -524,6 +529,20 @@ _PG_init(void)
 							NULL,
 							NULL,
 							NULL);
+
+	DefineCustomIntVariable("orioledb.temp_buffers",
+							"Size of orioledb engine buffers for temporary tables.",
+							NULL,
+							&temp_buffers_guc,
+							PPOOL_MIN_SIZE * 8,
+							debug_disable_pools_limit ? 1 : PPOOL_MIN_SIZE,
+							INT_MAX,
+							PGC_POSTMASTER,
+							GUC_UNIT_BLOCKS,
+							NULL,
+							NULL,
+							NULL);
+
 
 	DefineCustomRealVariable("orioledb.regular_block_undo_circular_buffer_fraction",
 							 "Fraction of cirucular buffer for block-level undo of regular tables.",
@@ -1067,6 +1086,7 @@ _PG_init(void)
 	main_buffers_count = ((Size) main_buffers_guc * (Size) BLCKSZ) / ORIOLEDB_BLCKSZ;
 	free_tree_buffers_count = ((Size) free_tree_buffers_guc * (Size) BLCKSZ) / ORIOLEDB_BLCKSZ;
 	catalog_buffers_count = ((Size) catalog_buffers_guc * (Size) BLCKSZ) / ORIOLEDB_BLCKSZ;
+	orioledb_temp_buffers_count = ((Size) temp_buffers_guc * (Size) BLCKSZ) / ORIOLEDB_BLCKSZ;
 
 	main_buffers_offset = free_tree_buffers_count + catalog_buffers_count;
 
@@ -1113,6 +1133,8 @@ _PG_init(void)
 
 	for (i = 0; i < OPagePoolTypesCount; i++)
 		page_pools_size[i] = CACHELINEALIGN(page_pools_size[i]);
+
+	local_ppool_init(&local_ppool);
 
 	if (device_filename)
 	{
@@ -1347,12 +1369,7 @@ ppools_shmem_init(Pointer ptr, bool found)
 
 		for (i = 0; i < page_descs_size / sizeof(OrioleDBPageDesc); i++)
 		{
-			page_descs[i].fileExtent.len = InvalidFileExtentLen;
-			page_descs[i].fileExtent.off = InvalidFileExtentOff;
-			ORelOidsSetInvalid(page_descs[i].oids);
-			page_descs[i].ionum = -1;
-			page_descs[i].type = 0;
-			page_descs[i].flags = 0;
+			o_page_desc_init(&page_descs[i]);
 		}
 	}
 }
@@ -1438,6 +1455,17 @@ orioledb_shmem_startup(void)
 	LWLockRelease(AddinShmemInitLock);
 
 	shared_segment_initialized = true;
+}
+
+void
+o_page_desc_init(OrioleDBPageDesc *desc)
+{
+	desc->fileExtent.len = InvalidFileExtentLen;
+	desc->fileExtent.off = InvalidFileExtentOff;
+	ORelOidsSetInvalid(desc->oids);
+	desc->ionum = -1;
+	desc->type = 0;
+	desc->flags = 0;
 }
 
 uint64
@@ -1925,6 +1953,9 @@ get_ppool(OPagePoolType type)
 PagePool *
 get_ppool_by_blkno(OInMemoryBlkno blkno)
 {
+	if (O_PAGE_IS_LOCAL(blkno))
+		return (PagePool *) &local_ppool;
+
 	Assert(blkno < orioledb_buffers_count);
 
 	if (blkno >= main_buffers_offset)

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -1693,10 +1693,10 @@ orioledb_page_stats(PG_FUNCTION_ARGS)
 			values[0] = PointerGetDatum(cstring_to_text("free_tree"));
 		else if (i == OPagePoolCatalog)
 			values[0] = PointerGetDatum(cstring_to_text("catalog"));
-		num_free_pages = (int64) o_ppool_free_pages_count((PagePool *) &page_pools[i]);
+		num_free_pages = (int64) (*page_pools[i].base.ops->free_pages_count) ((PagePool *) &page_pools[i]);
 		values[1] = Int64GetDatum(total_num_pages - num_free_pages);
 		values[2] = Int64GetDatum(num_free_pages);
-		values[3] = Int64GetDatum((int64) o_ppool_dirty_pages_count((PagePool *) &page_pools[i]));
+		values[3] = Int64GetDatum((int64) (*page_pools[i].base.ops->dirty_pages_count) ((PagePool *) &page_pools[i]));
 		values[4] = Int64GetDatum(total_num_pages);
 		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);
 	}
@@ -1946,7 +1946,7 @@ get_dirty_pages_count_sum(void)
 	int			i;
 
 	for (i = 0; i < OPagePoolTypesCount; i++)
-		result += o_ppool_dirty_pages_count((PagePool *) &page_pools[i]);
+		result += (*page_pools[i].base.ops->dirty_pages_count) ((PagePool *) &page_pools[i]);
 
 	return result;
 }

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -57,7 +57,7 @@ typedef struct
 static OIndexDescr *get_index_descr(ORelOids ixOids, OIndexType ixType,
 									bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source);
 static void o_table_descr_fill_indices(OTableDescr *descr, OTable *table, OSnapshot *snapshot);
-static void init_shared_root_info(OPagePool *pool,
+static void init_shared_root_info(PagePool *pool,
 								  SharedRootInfo *sharedRootInfo);
 static bool o_tree_init_free_extents(BTreeDescr *desc);
 static OComparator *o_find_opclass_comparator(OOpclass *opclass, Oid collation);
@@ -142,7 +142,7 @@ OTableFetchContext default_table_fetch_context = {.snapshot = &o_non_deleted_sna
  * table_descr_init_tree function.
  */
 static SharedRootInfo *
-create_shared_root_info(OPagePool *pool, SharedRootInfoKey *key)
+create_shared_root_info(PagePool *pool, SharedRootInfoKey *key)
 {
 	SharedRootInfo *sharedRootInfo;
 
@@ -325,7 +325,7 @@ o_btree_load_shmem_internal(BTreeDescr *desc, bool checkpoint)
 		 * - 2 for tmp seq bufs
 		 * - 2 for free seq bufs
 		 */
-		ppool_reserve_pages(desc->ppool, PPOOL_RESERVE_META, 8);
+		(*desc->ppool->ops->reserve_pages) (desc->ppool, PPOOL_RESERVE_META, 8);
 		LWLockAcquire(&checkpoint_state->oSharedRootInfoInsertLocks[lockNo],
 					  LW_EXCLUSIVE);
 		hasLock = true;
@@ -337,7 +337,7 @@ o_btree_load_shmem_internal(BTreeDescr *desc, bool checkpoint)
 		if (hasLock)
 		{
 			LWLockRelease(&checkpoint_state->oSharedRootInfoInsertLocks[lockNo]);
-			ppool_release_reserved(desc->ppool, PPOOL_RESERVE_META);
+			(*desc->ppool->ops->release_reserved) (desc->ppool, PPOOL_RESERVE_META);
 		}
 		pfree(sharedRootInfo);
 		return false;
@@ -428,7 +428,7 @@ o_btree_load_shmem_internal(BTreeDescr *desc, bool checkpoint)
 	Assert(sharedRootInfo != NULL);
 	Assert(!sharedRootInfo->placeholder);
 	pfree(sharedRootInfo);
-	ppool_release_reserved(desc->ppool, PPOOL_RESERVE_META);
+	(*desc->ppool->ops->release_reserved) (desc->ppool, PPOOL_RESERVE_META);
 	return true;
 }
 
@@ -960,7 +960,7 @@ o_fetch_index_descr_extended(ORelOids oids, OIndexType type, bool lock,
 }
 
 static void
-init_shared_root_info(OPagePool *pool, SharedRootInfo *sharedRootInfo)
+init_shared_root_info(PagePool *pool, SharedRootInfo *sharedRootInfo)
 {
 	BTreeMetaPage *meta_page;
 	BTreeRootInfo *rootInfo = &sharedRootInfo->rootInfo;
@@ -968,8 +968,8 @@ init_shared_root_info(OPagePool *pool, SharedRootInfo *sharedRootInfo)
 				bufnum;
 
 	sharedRootInfo->placeholder = false;
-	rootInfo->rootPageBlkno = ppool_get_page(pool, PPOOL_RESERVE_META);;
-	rootInfo->metaPageBlkno = ppool_get_page(pool, PPOOL_RESERVE_META);;
+	rootInfo->rootPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);;
+	rootInfo->metaPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);;
 	rootInfo->rootPageChangeCount = O_PAGE_GET_CHANGE_COUNT(O_GET_IN_MEMORY_PAGE(rootInfo->rootPageBlkno));
 
 	Assert(OInMemoryBlknoIsValid(rootInfo->rootPageBlkno));

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -25,6 +25,7 @@
 #include "catalog/o_tables.h"
 #include "catalog/sys_trees.h"
 #include "recovery/recovery.h"
+#include "rewind/rewind.h"
 #include "tableam/toast.h"
 #include "tableam/tree.h"
 #include "tuple/slot.h"
@@ -968,8 +969,8 @@ init_shared_root_info(PagePool *pool, SharedRootInfo *sharedRootInfo)
 				bufnum;
 
 	sharedRootInfo->placeholder = false;
-	rootInfo->rootPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);;
-	rootInfo->metaPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);;
+	rootInfo->rootPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);
+	rootInfo->metaPageBlkno = (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);
 	rootInfo->rootPageChangeCount = O_PAGE_GET_CHANGE_COUNT(O_GET_IN_MEMORY_PAGE(rootInfo->rootPageBlkno));
 
 	Assert(OInMemoryBlknoIsValid(rootInfo->rootPageBlkno));
@@ -1184,6 +1185,10 @@ cleanup_btree(Oid datoid, Oid relnode, bool files, bool fsync)
 	if (shared)
 	{
 		bool		drop_result PG_USED_FOR_ASSERTS_ONLY;
+
+		/* Rewind worker will not see local pages */
+		if (is_rewind_worker() && O_PAGE_IS_LOCAL(shared->rootInfo.rootPageBlkno))
+			return;
 
 		drop_result = o_drop_shared_root_info(datoid, relnode);
 		Assert(drop_result);

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -116,7 +116,10 @@ index_btree_desc_init(BTreeDescr *desc, OCompress compress, int fillfactor,
 	desc->tmpBuf[0].file = -1;
 	desc->ppool = get_ppool(OPagePoolMain);
 	if (persistence == RELPERSISTENCE_TEMP)
+	{
+		desc->ppool = (PagePool *) &local_ppool;
 		desc->storageType = BTreeStorageTemporary;
+	}
 	else if (persistence == RELPERSISTENCE_UNLOGGED)
 		desc->storageType = BTreeStorageUnlogged;
 	else

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -2254,9 +2254,9 @@ undo_xact_callback(XactEvent event, void *arg)
 
 		for (i = 0; i < OPagePoolTypesCount; i++)
 		{
-			OPagePool  *pool = get_ppool((OPagePoolType) i);
+			PagePool   *pool = get_ppool((OPagePoolType) i);
 
-			ppool_release_reserved(pool, PPOOL_RESERVE_MASK_ALL);
+			(*pool->ops->release_reserved) (pool, PPOOL_RESERVE_MASK_ALL);
 		}
 
 		for (i = 0; i < (int) UndoLogsCount; i++)

--- a/src/utils/page_pool.c
+++ b/src/utils/page_pool.c
@@ -22,9 +22,14 @@
 #include "tableam/handler.h"
 #include "transam/undo.h"
 #include "utils/page_pool.h"
+#include "utils/elog.h"
+#include "utils/memutils.h"
+#include "utils/palloc.h"
 #include "utils/ucm.h"
 
 #include "utils/memdebug.h"
+
+#define LOCAL_PPOOL_INIT_SIZE 1024
 
 /* Shared memory based page pool operations */
 
@@ -37,16 +42,11 @@ void		o_ppool_release_reserved(PagePool *pool, uint32 mask);
 
 OInMemoryBlkno o_ppool_free_pages_count(PagePool *pool);
 OInMemoryBlkno o_ppool_dirty_pages_count(PagePool *pool);
-void		o_ppool_run_clock(PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
+void		o_ppool_run_maintenance(PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
 OInMemoryBlkno o_ppool_size(PagePool *pool);
 
 void		o_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno);
-void		o_ucm_change_usage(PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount);
-uint32		o_ucm_get_epoch(PagePool *pool);
-bool		o_ucm_epoch_needs_shift(PagePool *pool);
-void		o_ucm_epoch_shift(PagePool *pool);
-uint64		o_ucm_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 state);
-void		o_ucm_after_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState);
+void		o_ucm_init(PagePool *pool, OInMemoryBlkno blkno);
 
 /* PagePoolOps for a shared memory based page pool */
 static const PagePoolOps o_page_pool_ops = {
@@ -59,16 +59,46 @@ static const PagePoolOps o_page_pool_ops = {
 
 	.free_pages_count = o_ppool_free_pages_count,
 	.dirty_pages_count = o_ppool_dirty_pages_count,
-	.run_clock = o_ppool_run_clock,
+	.run_maintenance = o_ppool_run_maintenance,
 	.size = o_ppool_size,
 
 	.ucm_inc_usage = o_ucm_inc_usage,
-	.ucm_change_usage = o_ucm_change_usage,
-	.ucm_get_epoch = o_ucm_get_epoch,
-	.ucm_epoch_needs_shift = o_ucm_epoch_needs_shift,
-	.ucm_epoch_shift = o_ucm_epoch_shift,
-	.ucm_update_state = o_ucm_update_state,
-	.ucm_after_update_state = o_ucm_after_update_state,
+	.ucm_init = o_ucm_init,
+};
+
+/* Shared local memory based page pool operations */
+
+OInMemoryBlkno local_ppool_alloc_page(PagePool *pool, int kind);
+void		local_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock);
+
+void		local_ppool_reserve_pages(PagePool *pool, int kind, int count);
+void		local_ppool_release_reserved(PagePool *pool, uint32 mask);
+
+OInMemoryBlkno local_ppool_free_pages_count(PagePool *pool);
+OInMemoryBlkno local_ppool_dirty_pages_count(PagePool *pool);
+void		local_ppool_run_maintenance(PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
+OInMemoryBlkno local_ppool_size(PagePool *pool);
+
+void		local_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno);
+void		local_ucm_init(PagePool *pool, OInMemoryBlkno blkno);
+
+/* PagePoolOps for a local memory based page pool */
+static const PagePoolOps local_ppool_ops = {
+	.alloc_page = local_ppool_alloc_page,
+	/* This is intentional as implementation is the same for both pools */
+	.alloc_metapage = o_ppool_get_metapage,
+	.free_page = local_ppool_free_page,
+
+	.reserve_pages = local_ppool_reserve_pages,
+	.release_reserved = local_ppool_release_reserved,
+
+	.free_pages_count = local_ppool_free_pages_count,
+	.dirty_pages_count = local_ppool_dirty_pages_count,
+	.run_maintenance = local_ppool_run_maintenance,
+	.size = local_ppool_size,
+
+	.ucm_inc_usage = local_ucm_inc_usage,
+	.ucm_init = local_ucm_init,
 };
 
 /*
@@ -82,6 +112,7 @@ o_ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno si
 
 	if (!debug)
 		Assert(size >= PPOOL_MIN_SIZE);
+	/* TODO: check for ppool max size */
 
 	pool->offset = offset;
 	pool->size = size;
@@ -140,6 +171,7 @@ void
 o_ppool_reserve_pages(PagePool *pool, int kind, int count)
 {
 	bool		was_saving;
+	OPagePool  *o_pool = (OPagePool *) pool;
 
 	Assert(!have_locked_pages());
 
@@ -149,13 +181,13 @@ o_ppool_reserve_pages(PagePool *pool, int kind, int count)
 
 	was_saving = o_start_saving_inval_messages();
 
-	while (pg_atomic_sub_fetch_u64(pool->availablePagesCount, count) & (UINT64CONST(1) << 63))
+	while (pg_atomic_sub_fetch_u64(o_pool->availablePagesCount, count) & (UINT64CONST(1) << 63))
 	{
-		pg_atomic_add_fetch_u64(pool->availablePagesCount, count);
-		(*pool->ops->run_clock) (pool, true, NULL);
+		pg_atomic_add_fetch_u64(o_pool->availablePagesCount, count);
+		(*pool->ops->run_maintenance) (pool, true, NULL);
 	}
 
-	pool->numPagesReserved[kind] += count;
+	o_pool->numPagesReserved[kind] += count;
 
 	o_stop_saving_inval_messages(was_saving);
 }
@@ -312,8 +344,8 @@ o_ppool_dirty_pages_count(PagePool *pool)
  * GET_PAGE_LEVEL_UNDO_TYPE).  UndoLogRegular is not touched by merges.
  */
 void
-o_ppool_run_clock(PagePool *pool, bool evict,
-				  volatile sig_atomic_t *shutdown_requested)
+o_ppool_run_maintenance(PagePool *pool, bool evict,
+						volatile sig_atomic_t *shutdown_requested)
 {
 	uint64		blkno;
 	Size		undoRegularSize = get_reserved_undo_size(UndoLogRegularPageLevel);
@@ -379,6 +411,11 @@ o_ppool_run_clock(PagePool *pool, bool evict,
 		free_retained_undo_location(UndoLogRegularPageLevel);
 	if (!haveRetainSystemLoc)
 		free_retained_undo_location(UndoLogSystem);
+
+	if ((shutdown_requested == NULL || !*shutdown_requested) && ucm_epoch_needs_shift(&o_pool->ucm))
+	{
+		ucm_epoch_shift(&o_pool->ucm);
+	}
 }
 
 /*
@@ -401,49 +438,249 @@ o_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno)
 }
 
 void
-o_ucm_change_usage(PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount)
+o_ucm_init(PagePool *pool, OInMemoryBlkno blkno)
 {
 	OPagePool  *o_pool = (OPagePool *) pool;
 
-	page_change_usage_count(&o_pool->ucm, blkno, usageCount);
-}
-
-uint32
-o_ucm_get_epoch(PagePool *pool)
-{
-	OPagePool  *o_pool = (OPagePool *) pool;
-
-	return pg_atomic_read_u32(o_pool->ucm.epoch);
-}
-
-bool
-o_ucm_epoch_needs_shift(PagePool *pool)
-{
-	OPagePool  *o_pool = (OPagePool *) pool;
-
-	return ucm_epoch_needs_shift(&o_pool->ucm);
+	page_change_usage_count(&o_pool->ucm, blkno, (pg_atomic_read_u32(o_pool->ucm.epoch) + 2) % UCM_USAGE_LEVELS);
 }
 
 void
-o_ucm_epoch_shift(PagePool *pool)
+local_ppool_init(LocalPagePool *pool)
 {
-	OPagePool  *o_pool = (OPagePool *) pool;
+	local_ppool_pages = calloc(orioledb_temp_buffers_count, sizeof(Page));
+	local_ppool_page_descs = calloc(orioledb_temp_buffers_count, sizeof(OrioleDBPageDesc));
+	pool->usage_count = calloc(orioledb_temp_buffers_count, sizeof(uint32));
 
-	ucm_epoch_shift(&o_pool->ucm);
+	if (!local_ppool_pages || !local_ppool_page_descs || !pool->usage_count)
+		ereport(ERROR, errmsg("Failed to allocate memory for local page pool"));
+
+	for (int i = 0; i < orioledb_temp_buffers_count; i++)
+		o_page_desc_init(&local_ppool_page_descs[i]);
+
+	pool->size = orioledb_temp_buffers_count;
+	pool->alloc_current_slot = 0;
+	pool->availablePagesCount = orioledb_temp_buffers_count;
+	pool->dirtyPagesCount = 0;
+	for (int i = 0; i < PPOOL_RESERVE_COUNT; i++)
+		pool->numPagesReserved[i] = 0;
+	pool->slab_context = SlabContextCreate(TopMemoryContext, "oriole local page pool", ORIOLEDB_BLCKSZ * 16, ORIOLEDB_BLCKSZ);
+	/* This might lead to PANIC on allocation failure in critical section */
+	MemoryContextAllowInCriticalSection(pool->slab_context, true);
+	pool->base.ops = &local_ppool_ops;
 }
 
-uint64
-o_ucm_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 state)
+OInMemoryBlkno
+local_ppool_alloc_page(PagePool *pool, int kind)
 {
-	OPagePool  *o_pool = (OPagePool *) pool;
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
 
-	return ucm_update_state(&o_pool->ucm, blkno, state);
+	int			start = local_pool->alloc_current_slot;
+	int			i = start;
+
+	Assert(local_pool->numPagesReserved[kind] > 0);
+	local_pool->numPagesReserved[kind]--;
+
+	/* Iterate through local_pool_pages to find a free slot */
+	do
+	{
+		i++;
+		if (i >= local_pool->size)
+			i = 0;
+		if (local_ppool_pages[i] == NULL)
+		{
+			local_ppool_pages[i] = (Page) MemoryContextAllocZero(local_pool->slab_context, ORIOLEDB_BLCKSZ);
+			local_pool->alloc_current_slot = i;
+			/* Set the local page bit */
+			return i | BLKNO_LOCAL_BIT;
+		}
+	} while (i != start);
+
+	pg_unreachable();
 }
 
 void
-o_ucm_after_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState)
+local_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock)
 {
-	OPagePool  *o_pool = (OPagePool *) pool;
+	int			i = blkno & O_BLKNO_MASK;
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
 
-	ucm_after_update_state(&o_pool->ucm, blkno, oldState, newState);
+	pfree(local_ppool_pages[i]);
+	local_ppool_pages[i] = NULL;
+	local_pool->availablePagesCount++;
+}
+
+void
+local_ppool_reserve_pages(PagePool *pool, int kind, int count)
+{
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
+
+	count -= local_pool->numPagesReserved[kind];
+	if (count <= 0)
+		return;
+
+	local_pool->availablePagesCount -= count;
+	while (local_pool->availablePagesCount & ((uint32) 1 << 31))
+	{
+		(*pool->ops->run_maintenance) (pool, true, NULL);
+	}
+
+	local_pool->numPagesReserved[kind] += count;
+}
+
+void
+local_ppool_release_reserved(PagePool *pool, uint32 mask)
+{
+	int			sum = 0,
+				kind;
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
+
+	for (kind = 0; kind < PPOOL_RESERVE_COUNT; kind++)
+	{
+		if (mask & (1 << kind))
+		{
+			sum += local_pool->numPagesReserved[kind];
+			local_pool->numPagesReserved[kind] = 0;
+		}
+	}
+
+	local_pool->availablePagesCount += sum;
+}
+
+OInMemoryBlkno
+local_ppool_free_pages_count(PagePool *pool)
+{
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
+
+	return local_pool->availablePagesCount;
+}
+
+OInMemoryBlkno
+local_ppool_dirty_pages_count(PagePool *pool)
+{
+	return 0;
+}
+
+/*
+ * Run clock replacement algorithm until we evict at least one page.
+ *
+ * This can be called from any backend that needs pages (via
+ * ppool_reserve_pages).  Because the caller may
+ * already have undo space reserved for its own operation, we save and
+ * restore the undo reservation state around the eviction work.
+ *
+ * We save both the reserved undo sizes and whether
+ * transactionUndoRetainLocation was set for UndoLogRegularPageLevel and
+ * UndoLogSystem.  Page merges during walk_page() may set these via
+ * get_undo_record() → set_my_reserved_location().  After we're done, we
+ * restore the caller's original reservation and free any retain locations
+ * that we introduced (i.e., that weren't set before we entered).
+ *
+ * Note: we only manage UndoLogRegularPageLevel and UndoLogSystem here
+ * because page-level merges only write undo to these types (via
+ * GET_PAGE_LEVEL_UNDO_TYPE).  UndoLogRegular is not touched by merges.
+ */
+void
+local_ppool_run_maintenance(PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested)
+{
+	Size		undoRegularSize = get_reserved_undo_size(UndoLogRegularPageLevel);
+	Size		undoSystemSize = get_reserved_undo_size(UndoLogSystem);
+	bool		haveRetainRegularLoc = undo_type_has_retained_location(UndoLogRegularPageLevel);
+	bool		haveRetainSystemLoc = undo_type_has_retained_location(UndoLogSystem);
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
+	bool		merged_or_evicted = false;
+
+	/*
+	 * Shutdown can be requested only from the bgwriter. And bgwriter should
+	 * not be running maintenance on local page pool.
+	 */
+	Assert(shutdown_requested == NULL);
+	/* Only bgwriter sets evict to false */
+	Assert(evict);
+
+	/* We might need to merge pages */
+	reserve_undo_size(UndoLogRegularPageLevel, 2 * O_MERGE_UNDO_IMAGE_SIZE);
+	reserve_undo_size(UndoLogSystem, 2 * O_MERGE_UNDO_IMAGE_SIZE);
+
+	while (!merged_or_evicted)
+	{
+		OWalkPageResult result;
+
+		if (local_pool->evict_current_slot >= local_pool->size)
+		{
+			local_pool->evict_current_slot = 0;
+		}
+		if (local_pool->usage_count[local_pool->evict_current_slot] > 0)
+		{
+			local_pool->usage_count[local_pool->evict_current_slot]--;
+			local_pool->evict_current_slot++;
+			continue;
+		}
+		if (local_ppool_pages[local_pool->evict_current_slot] == NULL)
+		{
+			local_pool->evict_current_slot++;
+			continue;
+		}
+		result = walk_page(local_pool->evict_current_slot | BLKNO_LOCAL_BIT, evict);
+		switch (result)
+		{
+			case OWalkPageEvicted:
+			case OWalkPageMerged:
+				/* walk_page() should have freed the page */
+				merged_or_evicted = true;
+				break;
+			case OWalkPageWritten:
+				elog(ERROR, "Page should have been merged or evicted");
+				break;
+			case OWalkPageSkipped:
+				break;
+		}
+		local_pool->evict_current_slot++;
+	}
+
+
+	/*
+	 * The caller might have the undo location reserved.  We need to carefully
+	 * put the undo location back.
+	 */
+	if (undoRegularSize > 0)
+		reserve_undo_size(UndoLogRegularPageLevel, undoRegularSize);
+	else
+		release_undo_size(UndoLogRegularPageLevel);
+
+	if (undoSystemSize > 0)
+		reserve_undo_size(UndoLogSystem, undoSystemSize);
+	else
+		release_undo_size(UndoLogSystem);
+
+	if (!haveRetainRegularLoc)
+		free_retained_undo_location(UndoLogRegularPageLevel);
+	if (!haveRetainSystemLoc)
+		free_retained_undo_location(UndoLogSystem);
+}
+
+OInMemoryBlkno
+local_ppool_size(PagePool *pool)
+{
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
+
+	return local_pool->size;
+}
+
+void
+local_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno)
+{
+	int			i = blkno & O_BLKNO_MASK;
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
+
+	local_pool->usage_count[i]++;
+}
+
+void
+local_ucm_init(PagePool *pool, OInMemoryBlkno blkno)
+{
+	int			i = blkno & O_BLKNO_MASK;
+	LocalPagePool *local_pool = (LocalPagePool *) pool;
+
+	local_pool->usage_count[i] = 1;
 }

--- a/src/utils/page_pool.c
+++ b/src/utils/page_pool.c
@@ -26,12 +26,35 @@
 
 #include "utils/memdebug.h"
 
+/* PagePoolOps for a shared memory based page pool */
+static const PagePoolOps o_page_pool_ops = {
+	.alloc_page = o_ppool_get_page,
+	.alloc_metapage = o_ppool_get_metapage,
+	.free_page = o_ppool_free_page,
+
+	.reserve_pages = o_ppool_reserve_pages,
+	.release_reserved = o_ppool_release_reserved,
+
+	.free_pages_count = o_ppool_free_pages_count,
+	.dirty_pages_count = o_ppool_dirty_pages_count,
+	.run_clock = o_ppool_run_clock,
+	.size = o_ppool_size,
+
+	.ucm_inc_usage = o_ucm_inc_usage,
+	.ucm_change_usage = o_ucm_change_usage,
+	.ucm_get_epoch = o_ucm_get_epoch,
+	.ucm_epoch_needs_shift = o_ucm_epoch_needs_shift,
+	.ucm_epoch_shift = o_ucm_epoch_shift,
+	.ucm_update_state = o_ucm_update_state,
+	.ucm_after_update_state = o_ucm_after_update_state,
+};
+
 /*
  * Calculates shared memory space needed for a page pool. Be careful,
  * it prepares local memory structures to initialize.
  */
 Size
-ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno size, bool debug)
+o_ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno size, bool debug)
 {
 	Size		result = 0;
 
@@ -55,7 +78,7 @@ ppool_estimate_space(OPagePool *pool, OInMemoryBlkno offset, OInMemoryBlkno size
  * must be already called for the pool.
  */
 void
-ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found)
+o_ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found)
 {
 	pool->availablePagesCount = (pg_atomic_uint64 *) ptr;
 	ptr += CACHELINEALIGN(sizeof(pg_atomic_uint64));
@@ -75,6 +98,7 @@ ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found)
 	pool->location = pg_prng_uint64_range(&pool->prngSeed,
 										  pool->offset,
 										  pool->offset + pool->size - 1);
+	pool->base.ops = &o_page_pool_ops;
 }
 
 /*
@@ -91,13 +115,13 @@ ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found)
  * lock, and then allocate them using ucm_occupy_free_page().
  */
 void
-ppool_reserve_pages(OPagePool *pool, int kind, int count)
+o_ppool_reserve_pages(PagePool *pool, int kind, int count)
 {
 	bool		was_saving;
 
 	Assert(!have_locked_pages());
 
-	count -= pool->numPagesReserved[kind];
+	count -= o_pool->numPagesReserved[kind];
 	if (count <= 0)
 		return;
 
@@ -106,7 +130,7 @@ ppool_reserve_pages(OPagePool *pool, int kind, int count)
 	while (pg_atomic_sub_fetch_u64(pool->availablePagesCount, count) & (UINT64CONST(1) << 63))
 	{
 		pg_atomic_add_fetch_u64(pool->availablePagesCount, count);
-		ppool_run_clock(pool, true, NULL);
+		(*pool->ops->run_clock) (pool, true, NULL);
 	}
 
 	pool->numPagesReserved[kind] += count;
@@ -119,25 +143,26 @@ ppool_reserve_pages(OPagePool *pool, int kind, int count)
  * released in one call).
  */
 void
-ppool_release_reserved(OPagePool *pool, uint32 mask)
+o_ppool_release_reserved(PagePool *pool, uint32 mask)
 {
 	int			sum = 0,
 				kind;
+	OPagePool  *o_pool = (OPagePool *) pool;
 
 	for (kind = 0; kind < PPOOL_RESERVE_COUNT; kind++)
 	{
 		if (mask & (1 << kind))
 		{
-			sum += pool->numPagesReserved[kind];
-			pool->numPagesReserved[kind] = 0;
+			sum += o_pool->numPagesReserved[kind];
+			o_pool->numPagesReserved[kind] = 0;
 		}
 	}
 	if (sum != 0)
-		pg_atomic_add_fetch_u64(pool->availablePagesCount, sum);
+		pg_atomic_add_fetch_u64(o_pool->availablePagesCount, sum);
 }
 
 /*
- * Release all reserved pages in all the pools.
+ * Release all reserved pages in all the shared memory pools.
  */
 void
 ppool_release_all_pages(void)
@@ -146,9 +171,9 @@ ppool_release_all_pages(void)
 
 	for (i = 0; i < (int) OPagePoolTypesCount; i++)
 	{
-		OPagePool  *pool = get_ppool((OPagePoolType) i);
+		PagePool   *pool = get_ppool((OPagePoolType) i);
 
-		ppool_release_reserved(pool, PPOOL_RESERVE_MASK_ALL);
+		(*pool->ops->release_reserved) (pool, PPOOL_RESERVE_MASK_ALL);
 	}
 }
 
@@ -156,11 +181,12 @@ ppool_release_all_pages(void)
  * Reserves and allocate page for metadata. Metadata pages are typically
  * allocated without holding any page locks.
  */
+/*  THOUGHT: can be shared for both ppool impls */
 OInMemoryBlkno
-ppool_get_metapage(OPagePool *pool)
+o_ppool_get_metapage(PagePool *pool)
 {
-	ppool_reserve_pages(pool, PPOOL_RESERVE_META, 1);
-	return ppool_get_page(pool, PPOOL_RESERVE_META);
+	(*pool->ops->reserve_pages) (pool, PPOOL_RESERVE_META, 1);
+	return (*pool->ops->alloc_page) (pool, PPOOL_RESERVE_META);
 }
 
 /*
@@ -169,15 +195,16 @@ ppool_get_metapage(OPagePool *pool)
  * Free page should be previously reserved by o_pool_reserve_pages().
  */
 OInMemoryBlkno
-ppool_get_page(OPagePool *pool, int kind)
+o_ppool_get_page(PagePool *pool, int kind)
 {
+	OPagePool  *o_pool = (OPagePool *) pool;
 	OInMemoryBlkno result;
 
-	Assert(pool->numPagesReserved[kind] > 0);
-	pool->numPagesReserved[kind]--;
+	Assert(o_pool->numPagesReserved[kind] > 0);
+	o_pool->numPagesReserved[kind]--;
 
-	result = ucm_occupy_free_page(&pool->ucm);
-	Assert(pool->offset <= result && result < pool->offset + pool->size);
+	result = ucm_occupy_free_page(&o_pool->ucm);
+	Assert(o_pool->offset <= result && result < o_pool->offset + o_pool->size);
 
 	VALGRIND_CHECK_MEM_IS_DEFINED(O_GET_IN_MEMORY_PAGE(result), ORIOLEDB_BLCKSZ);
 
@@ -188,12 +215,13 @@ ppool_get_page(OPagePool *pool, int kind)
  * Return free page to the pool.
  */
 void
-ppool_free_page(OPagePool *pool, OInMemoryBlkno blkno, bool haveLock)
+o_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock)
 {
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	OrioleDBPageDesc *page_desc = O_GET_IN_MEMORY_PAGEDESC(blkno);
+	OPagePool  *o_pool = (OPagePool *) pool;
 
-	Assert(pool->offset <= blkno && blkno < pool->offset + pool->size);
+	Assert(o_pool->offset <= blkno && blkno < o_pool->offset + o_pool->size);
 
 	VALGRIND_CHECK_MEM_IS_DEFINED(p, ORIOLEDB_BLCKSZ);
 	Assert(!IS_DIRTY(blkno));
@@ -211,18 +239,19 @@ ppool_free_page(OPagePool *pool, OInMemoryBlkno blkno, bool haveLock)
 	page_desc->fileExtent.len = InvalidFileExtentLen;
 	unlock_page(blkno);
 
-	page_change_usage_count(&pool->ucm, blkno, UCM_FREE_PAGES_LEVEL);
+	page_change_usage_count(&o_pool->ucm, blkno, UCM_FREE_PAGES_LEVEL);
 
-	pg_atomic_add_fetch_u64(pool->availablePagesCount, 1);
+	pg_atomic_add_fetch_u64(o_pool->availablePagesCount, 1);
 }
 
 /*
  * Return count of free pages in the pool.
  */
 OInMemoryBlkno
-ppool_free_pages_count(OPagePool *pool)
+o_ppool_free_pages_count(PagePool *pool)
 {
-	uint64		count = pg_atomic_read_u64(pool->availablePagesCount);
+	OPagePool  *o_pool = (OPagePool *) pool;
+	uint64		count = pg_atomic_read_u64(o_pool->availablePagesCount);
 
 	if (count & (UINT64CONST(1) << 63))
 		return 0;
@@ -234,9 +263,11 @@ ppool_free_pages_count(OPagePool *pool)
  * Return count of dirty pages in the pool.
  */
 OInMemoryBlkno
-ppool_dirty_pages_count(OPagePool *pool)
+o_ppool_dirty_pages_count(PagePool *pool)
 {
-	return pg_atomic_read_u32(pool->dirtyPagesCount);
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	return pg_atomic_read_u32(o_pool->dirtyPagesCount);
 }
 
 /*
@@ -259,18 +290,19 @@ ppool_dirty_pages_count(OPagePool *pool)
  * GET_PAGE_LEVEL_UNDO_TYPE).  UndoLogRegular is not touched by merges.
  */
 void
-ppool_run_clock(OPagePool *pool, bool evict,
-				volatile sig_atomic_t *shutdown_requested)
+o_ppool_run_clock(PagePool *pool, bool evict,
+				  volatile sig_atomic_t *shutdown_requested)
 {
 	uint64		blkno;
 	Size		undoRegularSize = get_reserved_undo_size(UndoLogRegularPageLevel);
 	Size		undoSystemSize = get_reserved_undo_size(UndoLogSystem);
 	bool		haveRetainRegularLoc = undo_type_has_retained_location(UndoLogRegularPageLevel);
 	bool		haveRetainSystemLoc = undo_type_has_retained_location(UndoLogSystem);
+	OPagePool  *o_pool = (OPagePool *) pool;
 
-	blkno = pg_prng_uint64_range(&pool->prngSeed,
-								 pool->offset,
-								 pool->offset + pool->size - 1);
+	blkno = pg_prng_uint64_range(&o_pool->prngSeed,
+								 o_pool->offset,
+								 o_pool->offset + o_pool->size - 1);
 
 	/*
 	 * Shouldn't be called while holding a page lock: one should reserve the
@@ -282,7 +314,7 @@ ppool_run_clock(OPagePool *pool, bool evict,
 	reserve_undo_size(UndoLogRegularPageLevel, 2 * O_MERGE_UNDO_IMAGE_SIZE);
 	reserve_undo_size(UndoLogSystem, 2 * O_MERGE_UNDO_IMAGE_SIZE);
 
-	Assert(blkno >= pool->offset && blkno < pool->offset + pool->size);
+	Assert(blkno >= o_pool->offset && blkno < o_pool->offset + o_pool->size);
 	/* Our attempts to evict pages shouldn't themselves affect UCM */
 	set_skip_ucm();
 
@@ -291,9 +323,9 @@ ppool_run_clock(OPagePool *pool, bool evict,
 		if (shutdown_requested != NULL && *shutdown_requested)
 			break;
 
-		blkno = ucm_next_blkno(&pool->ucm, blkno, 1);
+		blkno = ucm_next_blkno(&o_pool->ucm, blkno, 1);
 
-		Assert(blkno >= pool->offset && blkno < pool->offset + pool->size);
+		Assert(blkno >= o_pool->offset && blkno < o_pool->offset + o_pool->size);
 		if (walk_page(blkno, evict) != OWalkPageSkipped)
 		{
 			Assert(!have_locked_pages());
@@ -301,8 +333,8 @@ ppool_run_clock(OPagePool *pool, bool evict,
 		}
 		Assert(!have_locked_pages());
 		blkno++;
-		if (blkno >= pool->offset + pool->size)
-			blkno = pool->offset;
+		if (blkno >= o_pool->offset + o_pool->size)
+			blkno = o_pool->offset;
 	}
 
 	unset_skip_ucm();
@@ -325,4 +357,71 @@ ppool_run_clock(OPagePool *pool, bool evict,
 		free_retained_undo_location(UndoLogRegularPageLevel);
 	if (!haveRetainSystemLoc)
 		free_retained_undo_location(UndoLogSystem);
+}
+
+/*
+ * Return the size of the page pool.
+ */
+OInMemoryBlkno
+o_ppool_size(PagePool *pool)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	return o_pool->size;
+}
+
+void
+o_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	page_inc_usage_count(&o_pool->ucm, blkno);
+}
+
+void
+o_ucm_change_usage(PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	page_change_usage_count(&o_pool->ucm, blkno, usageCount);
+}
+
+uint32
+o_ucm_get_epoch(PagePool *pool)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	return pg_atomic_read_u32(o_pool->ucm.epoch);
+}
+
+bool
+o_ucm_epoch_needs_shift(PagePool *pool)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	return ucm_epoch_needs_shift(&o_pool->ucm);
+}
+
+void
+o_ucm_epoch_shift(PagePool *pool)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	ucm_epoch_shift(&o_pool->ucm);
+}
+
+uint64
+o_ucm_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 state)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	return ucm_update_state(&o_pool->ucm, blkno, state);
+}
+
+void
+o_ucm_after_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState)
+{
+	OPagePool  *o_pool = (OPagePool *) pool;
+
+	ucm_after_update_state(&o_pool->ucm, blkno, oldState, newState);
 }

--- a/src/utils/page_pool.c
+++ b/src/utils/page_pool.c
@@ -26,6 +26,28 @@
 
 #include "utils/memdebug.h"
 
+/* Shared memory based page pool operations */
+
+OInMemoryBlkno o_ppool_get_page(PagePool *pool, int kind);
+OInMemoryBlkno o_ppool_get_metapage(PagePool *pool);
+void		o_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock);
+
+void		o_ppool_reserve_pages(PagePool *pool, int kind, int count);
+void		o_ppool_release_reserved(PagePool *pool, uint32 mask);
+
+OInMemoryBlkno o_ppool_free_pages_count(PagePool *pool);
+OInMemoryBlkno o_ppool_dirty_pages_count(PagePool *pool);
+void		o_ppool_run_clock(PagePool *pool, bool evict, volatile sig_atomic_t *shutdown_requested);
+OInMemoryBlkno o_ppool_size(PagePool *pool);
+
+void		o_ucm_inc_usage(PagePool *pool, OInMemoryBlkno blkno);
+void		o_ucm_change_usage(PagePool *pool, OInMemoryBlkno blkno, uint32 usageCount);
+uint32		o_ucm_get_epoch(PagePool *pool);
+bool		o_ucm_epoch_needs_shift(PagePool *pool);
+void		o_ucm_epoch_shift(PagePool *pool);
+uint64		o_ucm_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 state);
+void		o_ucm_after_update_state(PagePool *pool, OInMemoryBlkno blkno, uint64 oldState, uint64 newState);
+
 /* PagePoolOps for a shared memory based page pool */
 static const PagePoolOps o_page_pool_ops = {
 	.alloc_page = o_ppool_get_page,

--- a/src/workers/bgwriter.c
+++ b/src/workers/bgwriter.c
@@ -139,7 +139,8 @@ bgwriter_main(Datum main_arg)
 
 					while (need_eviction || need_write)
 					{
-						(*pool->ops->run_clock) (pool, need_eviction, &ShutdownRequestPending);
+						/* Should not run maintenance for local page pool */
+						(*pool->ops->run_maintenance) (pool, need_eviction, &ShutdownRequestPending);
 						i++;
 
 						if (i >= bgwriter_lru_maxpages * (BLCKSZ / ORIOLEDB_BLCKSZ))
@@ -156,11 +157,6 @@ bgwriter_main(Datum main_arg)
 					MemoryContextReset(TopTransactionContext);
 				}
 
-				if (!ShutdownRequestPending && (*pool->ops->ucm_epoch_needs_shift) (pool))
-				{
-					if ((*pool->ops->ucm_epoch_needs_shift) (pool))
-						(*pool->ops->ucm_epoch_shift) (pool);
-				}
 			}
 
 			for (j = 0; j < (int) UndoLogsCount; j++)

--- a/test/t/eviction_test.py
+++ b/test/t/eviction_test.py
@@ -598,24 +598,20 @@ class EvictionTest(BaseTest):
 		node = self.node
 		node.append_conf(
 		    'postgresql.conf', "shared_preload_libraries = orioledb\n"
-		    "orioledb.main_buffers = 8MB\n"
 		    "checkpoint_timeout = 86400\n"
 		    "max_wal_size = 1GB\n"
+		    "orioledb.temp_buffers = 1MB\n"
+		    "orioledb.debug_disable_pools_limit = true\n"
 		    "orioledb.debug_disable_bgwriter = true\n")
 		node.start()
 
 		node.safe_psql("""
 			CREATE EXTENSION orioledb;
-			CREATE TABLE o_test (
-				key SERIAL NOT NULL,
-				val int NOT NULL,
-				PRIMARY KEY (key)
-			) USING orioledb;
-			CREATE UNIQUE INDEX o_test_ix2 ON o_test (key);
-			CREATE UNIQUE INDEX o_test_ix3 ON o_test (key);
-			CREATE UNIQUE INDEX o_test_ix4 ON o_test (key);
 		""")
 		con1 = node.connect()
+
+		# Create o_evicted tables FIRST so their pages are older
+		# and will be evicted first by the clock sweep algorithm
 		con1.execute("""
 			CREATE TEMP TABLE o_evicted (
 				key SERIAL NOT NULL,
@@ -636,33 +632,69 @@ class EvictionTest(BaseTest):
 		)
 		con1.commit()
 
+		# Verify initial data - but note this touches o_evicted pages
 		self.assertEqual(
 		    con1.execute("SELECT count(*) FROM o_evicted;")[0][0], 500)
 		self.assertEqual(
 		    con1.execute("SELECT count(*) FROM o_evicted_empty;")[0][0], 0)
+		con1.commit()
 
-		n = 250000
+		# Create o_test AFTER o_evicted so o_evicted pages have lower usage counts
+		con1.execute("""
+			CREATE TEMP TABLE o_test (
+				key SERIAL NOT NULL,
+				val int NOT NULL,
+				PRIMARY KEY (key)
+			) USING orioledb;
+			CREATE UNIQUE INDEX o_test_ix2 ON o_test (key);
+			CREATE UNIQUE INDEX o_test_ix3 ON o_test (key);
+			CREATE UNIQUE INDEX o_test_ix4 ON o_test (key);
+		""")
+		con1.commit()
+
+		# Helper to check if a table is evicted
+		# Note: checking orioledb_tbl_structure may reload the table
+		def is_evicted(rel):
+			result = con1.execute(
+			    f"SELECT orioledb_tbl_structure('{rel}'::regclass, 'e');"
+			)[0][0]
+			# Check if "not loaded" appears anywhere in the output
+			return INDEX_NOT_LOADED_TMPLT.format(relname=rel) in result
+
+		# For local page pool, eviction happens synchronously during INSERT.
+		# Insert data until both tables are evicted. For o_evicted (which has
+		# data), the root page can only be evicted after all leaf pages are
+		# written to disk, so we need many eviction cycles.
 		step = 1000
-		for i in range(1, n, step):
+		max_iterations = 2000  # Safety limit
+		i = 0
+		evicted = False
+		while not evicted and i < max_iterations:
 			con1.execute(
 			    "INSERT INTO o_test (val)\n"
 			    " (SELECT val FROM generate_series(%d, %d, 1) val);\n" %
-			    (i, i + step - 1))
+			    (i * step + 1, (i + 1) * step))
 			con1.commit()
+			i += 1
+			# Check every 100 iterations to avoid overhead
+			if i % 100 == 0:
+				evicted = is_evicted('o_evicted') and is_evicted(
+				    'o_evicted_empty')
 
-		self.assertTrue(
-		    self.wait_eviction(
-		        con1,
-		        "SELECT COUNT(*) FROM (SELECT * FROM o_test ORDER BY key) x;",
-		        ('o_evicted', 'o_evicted_empty')))
+		# Final check
+		evicted = is_evicted('o_evicted') and is_evicted('o_evicted_empty')
+		self.assertTrue(evicted,
+		                "Tables should be evicted after filling the pool")
 
 		try:
+			# Verify data is still accessible (will reload from disk)
 			self.assertEqual(
 			    con1.execute("SELECT count(*) FROM o_evicted;")[0][0], 500)
 			self.assertEqual(
 			    con1.execute("SELECT count(*) FROM o_evicted_empty;")[0][0], 0)
 			con1.commit()
 
+			# After reloading, tables should no longer show as "not loaded"
 			self.assertNotEqual(
 			    con1.execute(
 			        "SELECT orioledb_tbl_structure('o_evicted'::regclass, 'e');"
@@ -674,17 +706,23 @@ class EvictionTest(BaseTest):
 			    )[0][0].split('\n')[0],
 			    INDEX_NOT_LOADED_TMPLT.format(relname='o_evicted_empty'))
 
-			con1.execute(
-			    "INSERT INTO o_test (val)\n"
-			    " (SELECT val FROM generate_series(%d, %d, 1) val);\n" %
-			    (1, n))
-			con1.commit()
+			# Insert more to trigger eviction again
+			i = 0
+			evicted = False
+			while not evicted and i < max_iterations:
+				con1.execute(
+				    "INSERT INTO o_test (val)\n"
+				    " (SELECT val FROM generate_series(%d, %d, 1) val);\n" %
+				    (i * step + 1, (i + 1) * step))
+				con1.commit()
+				i += 1
+				if i % 100 == 0:
+					evicted = is_evicted('o_evicted') and is_evicted(
+					    'o_evicted_empty')
 
-			self.assertTrue(
-			    self.wait_eviction(
-			        con1,
-			        "SELECT COUNT(*) FROM (SELECT * FROM o_test ORDER BY key) x;",
-			        ('o_evicted', 'o_evicted_empty')))
+			# Final check
+			evicted = is_evicted('o_evicted') and is_evicted('o_evicted_empty')
+			self.assertTrue(evicted, "Tables should be evicted again")
 		finally:
 			con1.close()
 


### PR DESCRIPTION
Introduces local page pool for temporary tables. Temporary tables are now always created on local page pool instead of shared. Eviction is supported and works similar to vanilla postgres.

Closes https://github.com/orioledb/orioledb/issues/685

Previous PR: https://github.com/orioledb/orioledb/pull/686

Generally the implementation follows the plan in the issue, but instead of small allocator it uses postgres' slab.

Performance improvements are significant: better latency and TPS after 8 connections and the difference only increases with the number of connections.
<img width="930" height="1126" alt="image" src="https://github.com/user-attachments/assets/8fed2181-b5b9-498d-a1df-ae78b242ae90" />

