### PR TITLE
Add origin tracking

### DIFF
--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -200,13 +200,21 @@ typedef struct
  * WAL_CONTAINER_HAS_* flags.
  */
 
-#define WAL_CONTAINER_HAS_XACT_INFO	(1U << 0)
+#define WAL_CONTAINER_HAS_XACT_INFO		(1U << 0)
+#define WAL_CONTAINER_HAS_ORIGIN_INFO	(1U << 1)
 
 typedef struct
 {
 	uint8		xactTime[sizeof(TimestampTz)];
 	uint8		xid[sizeof(TransactionId)];
 } WALRecXactInfo;
+
+typedef struct
+{
+	uint8		origin_id[sizeof(RepOriginId)];
+	uint8		origin_lsn[sizeof(XLogRecPtr)];
+} WALRecOriginInfo;
+
 
 #define LOCAL_WAL_BUFFER_SIZE	(8192)
 #define ORIOLEDB_WAL_PREFIX	"o_wal"
@@ -288,5 +296,7 @@ extern void set_local_wal_has_material_changes(bool value);
 
 extern Pointer wal_container_read_header(Pointer ptr, uint16 *version,
 										 uint8 *flags);
+extern Pointer wal_parse_container_origin_info(Pointer ptr, RepOriginId *origin_id,
+											   XLogRecPtr *origin_lsn);
 
 #endif							/* __WAL_H__ */

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -3055,6 +3055,11 @@ replay_container(Pointer startPtr, Pointer endPtr,
 	else
 		recoveryHeapTransactionId = InvalidTransactionId;
 
+	if (wal_flags & WAL_CONTAINER_HAS_ORIGIN_INFO)
+	{
+		ptr = wal_parse_container_origin_info(ptr, NULL, NULL);
+	}
+
 	while (ptr < endPtr)
 	{
 		const char *rec_type_str;

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -1950,7 +1950,7 @@ undo_xact_callback(XactEvent event, void *arg)
 		IsInParallelMode();
 
 	/*
-	 * Cleanup EXPLAY ANALYZE counters pointer to handle case when execution
+	 * Cleanup EXPLAIN ANALYZE counters pointer to handle case when execution
 	 * of node was interrupted by exception.
 	 */
 	ea_counters = NULL;


### PR DESCRIPTION
- Added origin info to the header of WAL container if the change was done within the Apply Worker
- Modified the orioledb_decode to parse and filter based on the origin filtering of the logical decoding context

TODO: In the vanilla postgres the origin info is stored on a per-row basis which makes sense in cascading replication contexts and more complicated logical replication setups. Our current implementation packs the origin info into the container header which doesn't support that level of granularity but is consistent with the existing features in native postgres logical replication. We should remember to add per-row origin info when more advanced filtering is implemented in postgres.