### PR TITLE
Fix partitioned tables: build TOAST table during bridge index configuring 

### DIFF
--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -118,6 +118,7 @@ List	   *reindex_list = NIL;
 Query	   *savedDataQuery = NULL;
 IndexBuildResult o_pkey_result = {0};
 bool		o_in_add_column = false;
+static CreateStmt *create_stmt = NULL;
 
 static void orioledb_utility_command(PlannedStmt *pstmt,
 									 const char *queryString,
@@ -1329,6 +1330,10 @@ orioledb_utility_command(PlannedStmt *pstmt,
 
 		o_find_collation_dependencies(collOid);
 	}
+	else if (IsA(pstmt->utilityStmt, CreateStmt))
+	{
+		create_stmt = (CreateStmt *) pstmt->utilityStmt;
+	}
 #if PG_VERSION_NUM >= 170000
 	else if (IsA(pstmt->utilityStmt, CreateTableAsStmt))
 	{
@@ -1480,6 +1485,10 @@ orioledb_utility_command(PlannedStmt *pstmt,
 			list_free(alter_type_exprs);
 			alter_type_exprs = NIL;
 		}
+	}
+	else if (IsA(pstmt->utilityStmt, CreateStmt))
+	{
+		create_stmt = NULL;
 	}
 
 	free_parsestate(pstate);
@@ -2498,7 +2507,7 @@ add_bridge_index(Relation tbl, OTable *o_table, bool manually, Oid amoid)
 		o_add_invalidate_undo_item(index->oids, O_INVALIDATE_OIDS_ON_ABORT);
 	}
 	o_tables_update(o_table, oxid, oSnapshot.csn);
-	o_tables_rel_meta_unlock(tbl, InvalidOid);
+	o_tables_rel_meta_unlock(tbl, old_o_table->oids.relnode);
 	o_invalidate_oids(o_table->bridge_oids);
 	o_add_invalidate_undo_item(o_table->bridge_oids, O_INVALIDATE_OIDS_ON_ABORT);
 	o_invalidate_oids(o_table->oids);
@@ -2552,7 +2561,7 @@ drop_bridge_index(Relation tbl, OTable *o_table)
 		o_add_invalidate_undo_item(index->oids, O_INVALIDATE_OIDS_ON_ABORT);
 	}
 	o_tables_update(o_table, oxid, oSnapshot.csn);
-	o_tables_rel_meta_unlock(tbl, InvalidOid);
+	o_tables_rel_meta_unlock(tbl, old_o_table->oids.relnode);
 	o_invalidate_oids(old_o_table->bridge_oids);
 	o_add_invalidate_undo_item(old_o_table->bridge_oids, O_INVALIDATE_OIDS_ON_ABORT);
 	o_invalidate_oids(o_table->oids);
@@ -3202,7 +3211,50 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 						}
 
 						if (add_bridging)
+						{
+							/*
+							 * Ensure the table has a toast relation before
+							 * adding the bridge index.  The bridge rebuild
+							 * path recreates all indices including the toast
+							 * tree, so the toast OIDs must already be set.
+							 * During CREATE TABLE the toast table may not
+							 * exist yet if table inherits indices from parent
+							 * table.
+							 */
+							if (!ORelOidsIsValid(o_table->toast_oids))
+							{
+								Datum		toast_options;
+								static char *validnsps[] = HEAP_RELOPT_NAMESPACES;
+
+								Assert(create_stmt != NULL);
+
+								toast_options = transformRelOptions((Datum) 0,
+																	create_stmt->options,
+																	"toast",
+																	validnsps,
+																	true, false);
+								(void) heap_reloptions(RELKIND_TOASTVALUE,
+													   toast_options,
+													   true);
+
+								relation_close(tbl, AccessShareLock);
+
+								/*
+								 * NewRelationCreateToastTable ends with
+								 * CommandCounterIncrement(), so that the
+								 * TOAST table will be visible for
+								 * add_bridge_index().
+								 */
+								NewRelationCreateToastTable(rel->rd_index->indrelid, toast_options);
+
+								tbl = relation_open(rel->rd_index->indrelid, AccessShareLock);
+
+								ORelOidsSetFromRel(table_oids, tbl);
+								o_table_free(o_table);
+								o_table = o_tables_get(table_oids);
+							}
 							add_bridge_index(tbl, o_table, false, rel->rd_rel->relam);
+						}
 						else
 							o_table_free(o_table);
 					}
@@ -4154,4 +4206,5 @@ o_ddl_cleanup(void)
 	in_rewrite = false;
 	o_alter_generated_column_id = NIL;
 	o_in_add_column = false;
+	create_stmt = NULL;
 }

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -4405,6 +4405,29 @@ WHERE tags @> '{814}';
 (1 row)
 
 COMMIT;
+-- Test partitioned with bridge index (brin). Test checks that bridge index can
+-- be safely added before full building the concrete partition
+CREATE TABLE tab1 (
+	c text,
+	a int PRIMARY KEY,
+	b text
+) PARTITION BY LIST (a);
+CREATE INDEX tab1_c_brin_idx ON tab1 USING brin (c);
+CREATE TABLE tab1_2_2 PARTITION OF tab1
+	FOR VALUES IN (4, 6) USING orioledb;
+NOTICE:  index bridging is enabled for orioledb table 'tab1_2_2'
+DETAIL:  index access method 'brin' is supported only via index bridging for OrioleDB table
+INSERT INTO tab1 (c, a, b) VALUES
+	('c1', 4, 'b1'),
+	('c2', 6, 'b2');
+SELECT * FROM tab1 ORDER BY a, b;
+ c  | a | b  
+----+---+----
+ c1 | 4 | b1
+ c2 | 6 | b2
+(2 rows)
+
+DROP TABLE tab1;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 17 other objects

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -891,6 +891,25 @@ FROM gin_test_table
 WHERE tags @> '{814}';
 COMMIT;
 
+-- Test partitioned with bridge index (brin). Test checks that bridge index can
+-- be safely added before full building the concrete partition
+CREATE TABLE tab1 (
+	c text,
+	a int PRIMARY KEY,
+	b text
+) PARTITION BY LIST (a);
+CREATE INDEX tab1_c_brin_idx ON tab1 USING brin (c);
+CREATE TABLE tab1_2_2 PARTITION OF tab1
+	FOR VALUES IN (4, 6) USING orioledb;
+
+INSERT INTO tab1 (c, a, b) VALUES
+	('c1', 4, 'b1'),
+	('c2', 6, 'b2');
+
+SELECT * FROM tab1 ORDER BY a, b;
+
+DROP TABLE tab1;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;


### PR DESCRIPTION
For now such sql code leads to SEGFAULT:

```
CREATE TABLE tab1 (c text, a int PRIMARY KEY, b text) PARTITION BY LIST (a);
CREATE INDEX tab1_c_brin_idx ON tab1 USING brin (c);
CREATE TABLE tab1_2_2 PARTITION OF tab1 FOR VALUES IN (4, 6);
```

That happens because, during the creation of a concrete partition, indices are inherited from the parent table before the creation of toast tables. In that example, a bridge index is required to build a brin index, and a bridge itself rebuilds the entire relation, including the toast table. However, the table is not completely built in this example.
So we need to add explicit toast table building in such case.