### PR TITLE
Further logical replication tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,8 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/trigger_test.py \
 						test/t/unlogged_test.py \
 						test/t/vacuum_test.py
-TESTGRESCHECKS_PART_3 = test/t/rewind_time_test.py
+TESTGRESCHECKS_PART_3 = test/t/rewind_time_test.py \
+						test/t/logical_streaming_test.py
 
 PG_REGRESS_ARGS=--no-locale --inputdir=test --outputdir=test --temp-instance=./test/tmp_check
 PG_ISOLATION_REGRESS_ARGS=--no-locale --inputdir=test --outputdir=test/output_iso --temp-instance=./test/tmp_check_iso

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -116,7 +116,7 @@ class BaseTest(unittest.TestCase):
 
 		return self.replica
 
-	def getSubsriber(self) -> testgres.PostgresNode:
+	def getSubscriber(self) -> testgres.PostgresNode:
 		if self.subscriber is None:
 			(test_path, t) = os.path.split(
 			    os.path.dirname(inspect.getfile(self.__class__)))

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -134,6 +134,40 @@ class BaseTest(unittest.TestCase):
 			self.subscriber = subscriber
 		return self.subscriber
 
+	def wait_ready(self, node):
+		# Wait on subscriber until it becomes ready (r state)
+		# pg_subscription_rel.srsubstate means synchronization state on subscriber
+		#
+		# i — initializing
+		#	NO tablesync worker
+		#	NO initial copy
+		#
+		# d — data copy
+		#	tablesync worker in progress (`COPY public.table FROM STDIN`)
+		#
+		# s — sync
+		#	initial copy done
+		#	tablesync worker is applying WAL
+		#	NO apply worker
+		#
+		# r — ready
+		#	initial copy done
+		#	catch-up done
+		#	apply worker in progress
+		#
+		with node.connect() as con:
+			con.execute(f"""
+				DO $$
+				BEGIN
+				WHILE EXISTS (
+					SELECT 1 FROM pg_subscription_rel WHERE srsubstate <> 'r'
+				)
+				LOOP
+					PERFORM pg_sleep(0.1);
+				END LOOP;
+				END $$;
+			""")
+
 	def restoreNode(self, port: int, filename: str) -> testgres.PostgresNode:
 		self.assertIsNone(self.restoredNode)
 

--- a/test/t/logical_streaming_test.py
+++ b/test/t/logical_streaming_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+
+class LogicalStreamingTest(BaseTest):
+
+	o_relname = "o_data"
+
+	setup_sql = f"""
+		CREATE EXTENSION IF NOT EXISTS orioledb;
+		CREATE TABLE {o_relname}(id serial primary key, data text) USING orioledb;
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.node.append_conf('postgresql.conf', "wal_level = logical\n")
+		self.node.append_conf('postgresql.conf', "logical_decoding_work_mem = 64kB\n")
+
+	def test_streaming_on_large_transaction(self):
+		"""
+		Tests PostgreSQL logical replication with streaming = on.
+		Demonstrates that changes from a large transaction arrive to
+		the subscriber.
+		"""
+
+		o_relname = self.o_relname
+		setup_sql = self.setup_sql
+
+		with self.node as publisher:
+			publisher.start()
+
+			subscriber = self.getSubscriber()
+			with subscriber.start() as subscriber:
+
+				publisher.safe_psql(setup_sql)
+				subscriber.safe_psql(setup_sql)
+
+				pub = publisher.publish('test_pub', tables=[f'{o_relname}'])
+				sub = subscriber.subscribe(pub, 'test_sub', streaming='on')
+				self.wait_ready(subscriber)
+
+				with publisher.connect() as pub1:
+					with publisher.connect() as pub2:
+						# Insert 10k rows with each tuple ~672 bytes
+						# This should easily put us over 64kB work_mem
+						pub1.begin()
+						pub1.execute(f"""
+							insert into {o_relname}(data)
+								select repeat(md5(a::text), 20)
+									from generate_series(1, 10000) f(a);
+						""")
+
+						pub2.begin()
+						pub2.execute(f"""
+							insert into {o_relname}(data)
+								select repeat(md5(a::text), 20)
+									from generate_series(1, 10000) f(a);
+						""")
+						pub2.commit()
+
+						# Make sure the two transactions are interlaced
+						pub1.execute(f"""
+							insert into {o_relname}(data)
+								select repeat(md5(a::text), 20)
+									from generate_series(1, 100) f(a);
+						""")
+
+						pub1.commit()
+
+
+				# wait until changes apply on subscriber and check them
+				sub.catchup()
+
+				with subscriber.connect() as con:
+					output = con.execute(f"""select count(*) from {o_relname};""")
+					tup = output[0][0]
+					self.assertEqual(tup, 20100)
+

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -367,7 +367,7 @@ class LogicalTest(BaseTest):
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 			with subscriber.start() as subscriber:
 
 				publisher.safe_psql(setup_sql)
@@ -588,7 +588,7 @@ class LogicalTest(BaseTest):
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 			with subscriber.start() as subscriber:
 
 				publisher.safe_psql(setup_sql)
@@ -675,7 +675,7 @@ class LogicalTest(BaseTest):
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 			with subscriber.start() as subscriber:
 
 				publisher.safe_psql(setup_sql)
@@ -1069,7 +1069,7 @@ class LogicalTest(BaseTest):
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 			with subscriber.start() as subscriber:
 				create_sql = f"""
 					CREATE EXTENSION IF NOT EXISTS orioledb;
@@ -1704,7 +1704,7 @@ COMMIT\n""")
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 			with subscriber.start() as subscriber:
 				create_sql = """
 					CREATE EXTENSION IF NOT EXISTS orioledb;
@@ -1810,7 +1810,7 @@ COMMIT\n""")
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 
 			with subscriber.start() as subscriber:
 				create_sql = """
@@ -2017,7 +2017,7 @@ COMMIT\n""")
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 
 			with subscriber.start() as subscriber:
 				create_sql = """
@@ -2101,7 +2101,7 @@ COMMIT\n""")
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 
 			with subscriber.start() as subscriber:
 				create_sql = """
@@ -2376,7 +2376,7 @@ COMMIT\n""")
 		with self.node as publisher:
 			publisher.start()
 
-			subscriber = self.getSubsriber()
+			subscriber = self.getSubscriber()
 
 			with subscriber.start() as subscriber:
 				create_sql = """

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -41,42 +41,6 @@ def node_prepare_orel(node, table):
 	    "SELECT * FROM pg_create_logical_replication_slot('regression_slot', 'test_decoding', false, true);\n"
 	)
 
-
-def wait_ready(subscriber):
-	# Wait on subscriber until it becomes ready (r state)
-	# pg_subscription_rel.srsubstate means synchronization state on subscriber
-	#
-	# i — initializing
-	#	NO tablesync worker
-	#	NO initial copy
-	#
-	# d — data copy
-	#	tablesync worker in progress (`COPY public.table FROM STDIN`)
-	#
-	# s — sync
-	#	initial copy done
-	#	tablesync worker is applying WAL
-	#	NO apply worker
-	#
-	# r — ready
-	#	initial copy done
-	#	catch-up done
-	#	apply worker in progress
-	#
-	with subscriber.connect() as con:
-		con.execute(f"""
-			DO $$
-			BEGIN
-			WHILE EXISTS (
-				SELECT 1 FROM pg_subscription_rel WHERE srsubstate <> 'r'
-			)
-			LOOP
-				PERFORM pg_sleep(0.1);
-			END LOOP;
-			END $$;
-		""")
-
-
 class LogicalTest(BaseTest):
 
 	o_relname = "o_data"
@@ -375,7 +339,7 @@ class LogicalTest(BaseTest):
 
 				pub = publisher.publish('test_pub', tables=[f'{o_relname}'])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					con1.begin()
@@ -596,7 +560,7 @@ class LogicalTest(BaseTest):
 
 				pub = publisher.publish('test_pub', tables=[f'{o_relname}'])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					con1.begin()
@@ -683,7 +647,7 @@ class LogicalTest(BaseTest):
 
 				pub = publisher.publish('test_pub', tables=[f'{o_relname}'])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					con1.begin()
@@ -1080,7 +1044,7 @@ class LogicalTest(BaseTest):
 
 				pub = publisher.publish('test_pub', tables=[f'{o_relname}'])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					con1.begin()
@@ -1722,7 +1686,7 @@ COMMIT\n""")
 
 				pub = publisher.publish('test_pub', tables=['o_test1'])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 				a, *b = (subscriber.execute(
 				    'postgres', 'select pg_current_xact_id();\n'))[0]
 				xids1 = int(a)
@@ -1880,7 +1844,7 @@ COMMIT\n""")
 				                            'o_test_bridge_secondary'
 				                        ])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					with publisher.connect() as con2:
@@ -2038,7 +2002,7 @@ COMMIT\n""")
 				    'test_pub',
 				    tables=['o_test', 'o_test_ctid', 'o_test_secondary'])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					with publisher.connect() as con2:
@@ -2175,7 +2139,7 @@ COMMIT\n""")
 				        'o_test_secondary_2', 'o_test_ctid_secondary_2'
 				    ])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					with publisher.connect() as con2:
@@ -2425,7 +2389,7 @@ COMMIT\n""")
 				                            'o_test_toasted_update'
 				                        ])
 				sub = subscriber.subscribe(pub, 'test_sub')
-				wait_ready(subscriber)
+				self.wait_ready(subscriber)
 
 				with publisher.connect() as con1:
 					with publisher.connect() as con2:


### PR DESCRIPTION
For beta14 we decided to implement a temporary workaround for #663 and #664 by disabling streaming in PR #713.

This PR adds tests for both changes in the #713 as well as fixes a small typo in `base_test.py`:

```
getSubsriber renamed to 
getSubscriber
```

TODO: Origin tracking test is not yet here.