### PR TITLE
Fix pg isolation tests added to eval-plan-qual by 0fb06e893331 if run…

### DIFF
--- a/ci/filter_isolation_diff.py
+++ b/ci/filter_isolation_diff.py
@@ -34,6 +34,7 @@ allowedRegexes = {
 	r"ERROR:  orioledb does not support SERIALIZABLE isolation level": ["*"],
 	r"ERROR:  tuple to be locked has its primary key changed due to concurrent update": ["*"],
 	r"ERROR:  Not implemented: orioledb_tuple_tid_valid": ["*"],
+	r"ERROR:  Not implemented: orioledb_set_tidrange": ["*"],
 	r"ERROR:  REINDEX CONCURRENTLY is not supported for orioledb tables yet": ["*"],
 	r"ERROR:  orioledb tables does not support CLUSTER": ["*"],
 	r"ERROR:  orioledb table \"[a-z0-9_]+\" does not support VACUUM FULL": ["*"],

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -341,6 +341,21 @@ orioledb_tuple_tid_valid(TableScanDesc scan, ItemPointer tid)
 	return false;
 }
 
+static void
+orioledb_set_tidrange(TableScanDesc sscan, ItemPointer mintid, ItemPointer maxtid)
+{
+	elog(ERROR, "Not implemented: %s", PG_FUNCNAME_MACRO);
+}
+
+/* Just to be safe. Normally this function should not be called before orioledb_set_tidrange. */
+static bool
+orioledb_getnextslot_tidrange(TableScanDesc sscan, ScanDirection direction,
+							  TupleTableSlot *slot)
+{
+	elog(ERROR, "Not implemented: %s", PG_FUNCNAME_MACRO);
+	return false;
+}
+
 static bool
 orioledb_tuple_satisfies_snapshot(Relation rel, TupleTableSlot *slot,
 								  Snapshot snapshot)
@@ -2303,6 +2318,9 @@ static const TableAmRoutine orioledb_am_methods = {
 	.scan_end = orioledb_endscan,
 	.scan_rescan = orioledb_rescan,
 	.scan_getnextslot = orioledb_getnextslot,
+
+	.scan_set_tidrange = orioledb_set_tidrange,
+	.scan_getnextslot_tidrange = orioledb_getnextslot_tidrange,
 
 	.parallelscan_estimate = orioledb_parallelscan_estimate,
 	.parallelscan_initialize = orioledb_parallelscan_initialize,


### PR DESCRIPTION
… on OrioleDB table

Orioledb can't determine tuple visibility by ctid, so it can't do tid range scan. Add error that tid tange scan is not supported.