### PR TITLE
Implementation of concurrent creation algorithm for secondary indexes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MODULE_big = orioledb
 EXTENSION = orioledb
 PGFILEDESC = "orioledb - orioledb transactional storage engine via TableAm"
 SHLIB_LINK += -lzstd -lcurl -lssl -lcrypto
-
+IS_DEV=1
 DATA_built = $(patsubst %_prod.sql,%.sql,$(wildcard sql/*_prod.sql))
 DATA = $(filter-out $(wildcard sql/*_*.sql) $(DATA_built), $(wildcard sql/*sql))
 
@@ -96,46 +96,10 @@ OBJS = src/btree/btree.o \
 	   src/utils/ucm.o \
 	   $(WIN32RES)
 
-REGRESSCHECKS = btree_sys_check \
-				alter_type \
-				alter_storage \
-				bitmap_scan \
-				btree_compression \
-				btree_print \
-				createas \
-				database \
-				ddl \
-				exclude \
-				explain \
-				fillfactor \
-				foreign_keys \
-				generated \
-				getsomeattrs \
-				index_bridging \
-				indices \
-				indices_build \
-				inherits \
-				ioc \
-				joins \
-				nulls \
-				opclass \
-				parallel_scan \
-				partial \
-				partition \
-				primary_key \
-				row_level_locks \
-				row_security \
-				sanitizers \
-				stats \
-				subquery \
-				subtransactions \
-				tableam \
-				tablespace \
-				temp \
-				toast \
-				trigger \
-				types \
-				rewind
+REGRESSCHECKS = index_concurrently \
+				index_concurrently_unique \
+				reindex_concurrently_content \
+				reindex_concurrently_insert
 ISOLATIONCHECKS = bitmap_hist_scan \
 				  btree_iterate \
 				  btree_print_backend_id \

--- a/ci/filter_isolation_diff.py
+++ b/ci/filter_isolation_diff.py
@@ -35,7 +35,7 @@ allowedRegexes = {
 	r"ERROR:  tuple to be locked has its primary key changed due to concurrent update": ["*"],
 	r"ERROR:  Not implemented: orioledb_tuple_tid_valid": ["*"],
 	r"ERROR:  Not implemented: orioledb_set_tidrange": ["*"],
-	r"ERROR:  REINDEX CONCURRENTLY is not supported for orioledb tables yet": ["*"],
+	r"ERROR:  REINDEX CONCURRENTLY is not supported for orioledb PK": ["*"],
 	r"ERROR:  orioledb tables does not support CLUSTER": ["*"],
 	r"ERROR:  orioledb table \"[a-z0-9_]+\" does not support VACUUM FULL": ["*"],
 	r"ERROR:  cannot use PREPARE TRANSACTION in transaction that uses orioledb table": ["*"],
@@ -49,7 +49,6 @@ allowedRegexes = {
 	r"setup failed: ERROR:  function \"[a-z0-9_]+\" cannot be used here": ['insert-conflict-specconflict'],
 	r"  3|setup1 updated by merge1 source not matched by merge2a": ['merge-update'],
 	r"  2|setup1 updated by merge1": ['merge-update'],
-	r"ERROR:  concurrent index creation is not supported for orioledb tables yet": ['*'],
 	r"ERROR:  REFRESH MATERIALIZED VIEW CONCURRENTLY is not supported for orioledb tables yet": ['*'],
 	r"ERROR:  could not serialize access due to concurrent delete": ['partition-key-update-3'],
 }

--- a/include/btree/btree.h
+++ b/include/btree/btree.h
@@ -380,4 +380,16 @@ extern Jsonb *btree_page_stopevent_params(BTreeDescr *desc, Page p);
 extern Jsonb *btree_downlink_stopevent_params(BTreeDescr *desc, Page p,
 											  BTreePageItemLocator *loc);
 
+extern Size btree_validation_shmem_needs(void);
+extern void btree_validation_shmem_init(Pointer ptr, bool found);
+
+/* Concurrent index build validation boundary functions */
+extern void btree_set_validation_boundary(OIndexDescr *idx, OTuple boundary);
+extern bool btree_get_validation_boundary(BTreeDescr *desc, OTuple *boundary);
+extern uint16 btree_is_validation_boundary_get_len(BTreeDescr *desc);
+extern void btree_set_validation_boundary_full_visible(OIndexDescr *idx);
+extern void btree_set_validation_boundary_non_visible(OIndexDescr *idx);
+extern bool btree_pk_satisfies_validation_boundary(BTreeDescr *desc, OTuple pk);
+extern bool btree_index_is_ready_not_valid(Oid indexRelOid);
+extern void btree_remove_validation_boundary(OIndexDescr *idx);
 #endif							/* __BTREE_H__ */

--- a/include/btree/iterator.h
+++ b/include/btree/iterator.h
@@ -71,13 +71,26 @@ extern OTuple o_btree_iterator_fetch(BTreeIterator *it,
 									 BTreeLocationHint *hint);
 extern OTuple btree_iterate_raw(BTreeIterator *it, void *end,
 								BTreeKeyType endKind, bool endInclude,
-								bool *scanEnd, BTreeLocationHint *hint);
+								bool *scanEnd, BTreeLocationHint *hint, BTreeLeafTuphdr **tupHdr);
 extern OTuple btree_iterate_all(BTreeIterator *it, void *end,
 								BTreeKeyType endKind, bool endInclude,
 								bool *scanEnd, BTreeLocationHint *hint,
 								BTreeLeafTuphdr **tupHdr);
+extern void o_btree_iterator_set_undo_chain_walking(BTreeIterator *it,
+													bool enable);
+extern BTreeIterator *o_btree_iterator_create_with_flags(BTreeDescr *desc,
+														 void *key,
+														 BTreeKeyType kind,
+														 OSnapshot *o_snapshot,
+														 ScanDirection scanDir,
+														 uint16 flags);
+extern BTreeLeafTuphdr o_btree_iterator_get_current_header(BTreeIterator *it);
+extern OTuple validate_iterator_fetch(BTreeIterator *it,
+									  bool *scanEnd,
+									  BTreeLocationHint *hint,
+									  BTreeLeafTuphdr **tupHdr,
+									  OInMemoryBlkno *rightMostBlock);
 extern void btree_iterator_free(BTreeIterator *it);
-
 extern OTuple o_btree_find_tuple_by_key_cb(BTreeDescr *desc, void *key,
 										   BTreeKeyType kind,
 										   OSnapshot *read_o_snapshot,
@@ -87,7 +100,6 @@ extern OTuple o_btree_find_tuple_by_key_cb(BTreeDescr *desc, void *key,
 										   bool *deleted,
 										   TupleFetchCallback cb,
 										   void *arg);
-
 extern OTuple o_find_tuple_version(BTreeDescr *desc, Page p,
 								   BTreePageItemLocator *loc,
 								   OSnapshot *oSnapshot,

--- a/include/btree/modify.h
+++ b/include/btree/modify.h
@@ -88,4 +88,6 @@ extern OBTreeModifyResult o_btree_insert_unique(BTreeDescr *desc,
 												BTreeModifyCallbackInfo *callbackInfo,
 												IndexUniqueCheck checkUnique);
 
+extern bool o_get_last_pk_satisfies_boundary(void);
+
 #endif							/* __BTREE_MODIFY_H__ */

--- a/include/btree/page_contents.h
+++ b/include/btree/page_contents.h
@@ -316,6 +316,20 @@ typedef struct
 	char		fixedData[O_BTREE_MAX_KEY_SIZE];
 } OFixedKey;
 
+
+/*
+ * Concurrent index build validation boundary hash table.
+ * Hash key: primary index OIDs
+ * Hash value: validation boundary tuple
+ */
+typedef struct
+{
+	ORelOids	key;								/* Hash key: PK index OIDs */
+	uint16		tupleLen;							/* Length of boundary tuple */
+	uint8		formatFlags;						/* Format flags of boundary tuple */
+	char		tupleData[O_BTREE_MAX_KEY_SIZE];	/* Boundary tuple data */
+} ValidationBoundaryEntry;
+
 /*
  * Fixed structure for storage of B-tree key.  Separate key length field,
  * saves us from getting length of inconsistent key.

--- a/include/btree/scan.h
+++ b/include/btree/scan.h
@@ -51,7 +51,7 @@ extern OTuple btree_seq_scan_getnext(BTreeSeqScan *scan, MemoryContext mctx,
 									 CommitSeqNo *tupleCsn,
 									 BTreeLocationHint *hint);
 extern OTuple btree_seq_scan_getnext_raw(BTreeSeqScan *scan, MemoryContext mctx,
-										 bool *end, BTreeLocationHint *hint);
+										 bool *end, BTreeLocationHint *hint, BTreeLeafTuphdr ** tupHdr);
 extern void free_btree_seq_scan(BTreeSeqScan *scan);
 extern void seq_scans_cleanup(void);
 

--- a/include/catalog/indices.h
+++ b/include/catalog/indices.h
@@ -21,6 +21,8 @@
 #include "catalog/o_tables.h"
 #include "tableam/descr.h"
 
+#define InvalidCSN				 (UINT64_MAX)
+
 #define recovery_first_worker 	 (0)
 #define recovery_last_worker 	 (recovery_pool_size_guc - 1)
 #define recovery_workers		 (recovery_pool_size_guc)
@@ -133,4 +135,6 @@ extern void _o_index_parallel_build_inner(dsm_segment *seg, shm_toc *toc,
 										  OTable *recovery_o_table, OTable *recovery_old_o_table);
 extern Size _o_index_parallel_estimate_shared(Size o_table_size);
 extern void drop_primary_index(Relation rel, OTable *o_table);
+extern void  check_secondary_index_unique(OTable *o_table, OTableDescr *descr, OIndexNumber ix_num,
+							 IndexBuildResult *result);
 #endif							/* __INDICES_H__ */

--- a/include/tableam/handler.h
+++ b/include/tableam/handler.h
@@ -130,6 +130,8 @@ extern bool o_drop_shared_root_info(Oid datoid, Oid relnode);
 extern void o_tableam_descr_init(void);
 extern void o_invalidate_descrs(Oid datoid, Oid reloid, Oid relfilenode);
 extern void init_print_options(BTreePrintOptions *printOptions, VarChar *optionsArg);
+extern void idx_tup_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg);
+extern void idx_key_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg);
 extern void orioledb_free_rd_amcache(Relation rel);
 extern OTableDescr *relation_get_descr(Relation rel);
 extern void table_descr_inc_refcnt(OTableDescr *descr);
@@ -220,5 +222,38 @@ typedef struct ParallelOScanDescData
 typedef ParallelOScanDescData *ParallelOScanDesc;
 
 extern bool in_nontransactional_truncate;
+
+/*
+ * Cleanup old concurrent index structure after validation
+ */
+extern void orioledb_index_validate_cleanup_old_concurrent(Relation heapRelation,
+														   Relation indexRelation);
+extern void orioledb_reindex_concurrent_swap(Oid newIndex,
+												Oid oldIndex,
+												Relation heapRelation,
+												const char *oldName);
+extern void 
+debug_print_validate_tuple(OTuple tuple, OIndexDescr *idx, bool key, OXid oxid);								 
+/*
+ * State for orioledb index validation
+ * Extends PostgreSQL's ValidateIndexState with orioledb-specific fields
+ */
+typedef struct OValidateIndexState
+{
+	/* Fields matching PostgreSQL's ValidateIndexState */
+	Tuplesortstate *tuplesort;
+	double		htups;			/* # heap tuples processed */
+	double		itups;			/* # index tuples from ambulkdelete */
+	double		tups_inserted;	/* # missing tuples inserted */
+	double		tups_deleted;	/* # spurious tuples deleted */
+	
+	/* Orioledb-specific field */
+	OTuple		current_tuple;	/* Current tuple being processed by ambulkdelete */
+	OIndexDescr *index_descr;	/* Index descriptor for extracting PK from tuples */
+	OTableDescr *table_descr;	/* Table descriptor for the table being indexed */
+	ORelOids	index_oids;		/* Index OIDs for finding index number */
+	BTreeLeafTuphdr header;			/* Header for leaf tuples, used for extracting PK */
+} OValidateIndexState;
+
 
 #endif

--- a/include/tableam/operations.h
+++ b/include/tableam/operations.h
@@ -155,5 +155,10 @@ extern bool o_is_index_predicate_satisfied(OIndexDescr *idx,
 extern void o_truncate_table(ORelOids oids, bool missingOK);
 extern void o_apply_new_bridge_index_ctid(OTableDescr *descr, Relation relation, TupleTableSlot *slot, CommitSeqNo csn);
 extern int	o_exclusion_cmp(OIndexDescr *id, OBTreeKeyBound *key1, OTuple *tuple2);
+extern bool am_validate_process;
+extern OXid o_validate_process_current_oxid;
 
+#define IS_VALIDATE_PROCESS() (am_validate_process)
+#define SET_VALIDATE_PROCESS_OXID(oxid) (o_validate_process_current_oxid = oxid)
+#define GET_VALIDATE_PROCESS_OXID() (o_validate_process_current_oxid)
 #endif

--- a/include/tableam/tree.h
+++ b/include/tableam/tree.h
@@ -22,6 +22,9 @@ extern void index_btree_desc_init(BTreeDescr *desc, OCompress compress, int fill
 								  ORelOids oids, OIndexType type,
 								  char persistence, OXid createOxid,
 								  void *arg);
+OTuple o_tuple_make_key(BTreeDescr *desc, OTuple tuple,
+							   Pointer data, bool keep_version,
+							   bool *allocated);
 extern uint32 o_hash_iptr(OIndexDescr *idx, ItemPointer iptr);
 extern void o_fill_key_bound(OIndexDescr *id, OTuple tuple,
 							 BTreeKeyType keyType, OBTreeKeyBound *bound);

--- a/include/tuple/sort.h
+++ b/include/tuple/sort.h
@@ -20,6 +20,12 @@ extern Tuplesortstate *tuplesort_begin_orioledb_index(OIndexDescr *idx,
 													  int workMem,
 													  bool randomAccess,
 													  SortCoordinate coordinate);
+extern Tuplesortstate *tuplesort_begin_orioledb_index_secondary_pk(OIndexDescr *secondary,
+																   OIndexDescr *primary,
+																   int workMem,
+																   bool randomAccess,
+																   SortCoordinate coordinate);
+																   
 extern Tuplesortstate *tuplesort_begin_orioledb_toast(OIndexDescr *toast,
 													  OIndexDescr *primary,
 													  int workMem,

--- a/src/btree/btree.c
+++ b/src/btree/btree.c
@@ -15,6 +15,7 @@
 
 #include "orioledb.h"
 
+#include "catalog/pg_index.h"
 #include "btree/find.h"
 #include "btree/insert.h"
 #include "btree/io.h"
@@ -35,6 +36,15 @@
 #include "miscadmin.h"
 #include "utils/fmgrprotos.h"
 #include "utils/numeric.h"
+#include "utils/syscache.h"
+#include "utils/hsearch.h"
+
+/* Shared memory hash table for validation boundaries */
+static HTAB *validation_boundary_htab = NULL;
+static LWLock *validation_boundary_lock = NULL;
+#define VALIDATION_BOUNDARY_NON  0x0000	/* Minimum value of the first byte of serialized PK tuple for validation boundary */
+#define VALIDATION_BOUNDARY_FULL 0xFFFF	/* Maximum value of the first byte of serialized PK tuple for validation boundary */
+
 
 LWLockPadded *unique_locks;
 int			num_unique_locks;
@@ -410,4 +420,302 @@ btree_downlink_stopevent_params(BTreeDescr *desc, Page p, BTreePageItemLocator *
 	MemoryContextSwitchTo(mctx);
 
 	return res;
+}
+
+/*
+ * Calculate shared memory needed for validation boundary hash table.
+ */
+Size
+btree_validation_shmem_needs(void)
+{
+	Size		size;
+
+	/* Size for hash table: 128 concurrent index builds should be enough */
+	size = hash_estimate_size(128, sizeof(ValidationBoundaryEntry));
+	
+	return size;
+}
+
+/*
+ * Initialize shared memory for validation boundary hash table.
+ */
+void
+btree_validation_shmem_init(Pointer ptr, bool found)
+{
+	HASHCTL		info;
+
+	if (!found)
+	{
+		/* Initialize hash table */
+		memset(&info, 0, sizeof(info));
+		info.keysize = sizeof(ORelOids);
+		info.entrysize = sizeof(ValidationBoundaryEntry);
+		
+		validation_boundary_htab = ShmemInitHash("Validation Boundary Hash",
+												 128, 128,
+												 &info,
+												 HASH_ELEM | HASH_BLOBS);
+	}
+	else
+	{
+		/* Attach to existing hash table */
+		validation_boundary_htab = (HTAB *) ptr;
+	}
+	
+	/* Get the single lock for the hash table */
+	validation_boundary_lock = &(GetNamedLWLockTranche("orioledb_validation_boundary")->lock);
+}
+
+/*
+ * Set the validation boundary for concurrent index builds.
+ * The boundary is stored as an OBTreeKeyBound in the meta page.
+ */
+void
+btree_set_validation_boundary(OIndexDescr *idx, OTuple heapTuple)
+{
+	ValidationBoundaryEntry *entry;
+	int			boundaryLen;
+	BTreeDescr *desc = &idx->desc;
+	bool allocated = false;
+	bool		found;
+
+	Assert(desc != NULL);
+	Assert(!O_TUPLE_IS_NULL(heapTuple));
+	
+	OTuple boundary = o_tuple_make_key(desc, heapTuple, NULL, false, &allocated);
+
+	boundaryLen = o_btree_len(desc, boundary, OTupleLength);
+	if (boundaryLen > O_BTREE_MAX_KEY_SIZE)
+		elog(ERROR, "validation boundary tuple too large: %d bytes (maximum: %ld bytes)",
+			 boundaryLen, O_BTREE_MAX_KEY_SIZE);
+
+	/* Acquire single global lock */
+	LWLockAcquire(validation_boundary_lock, LW_EXCLUSIVE);
+	/* Insert or update entry in hash table */
+	entry = (ValidationBoundaryEntry *) hash_search(validation_boundary_htab,
+													&desc->oids,
+													HASH_ENTER,
+													&found);
+	memcpy(entry->tupleData, boundary.data, boundaryLen);
+	entry->tupleLen = boundaryLen;
+	entry->formatFlags = boundary.formatFlags;
+	LWLockRelease(validation_boundary_lock);
+}
+
+/*
+ * Get the current validation boundary.
+ * Returns true if a boundary is set, false otherwise.
+ * The boundary OTuple will be allocated in the current memory context.
+ */
+bool
+btree_get_validation_boundary(BTreeDescr *desc, OTuple *boundary)
+{
+	char	   *data;
+	ValidationBoundaryEntry *entry;
+
+	Assert(desc != NULL);
+	Assert(boundary != NULL);
+	Assert(validation_boundary_htab != NULL);
+	
+	/* Acquire shared lock for reading */
+	LWLockAcquire(validation_boundary_lock, LW_SHARED);
+
+	/* Look up entry in hash table */
+	entry = (ValidationBoundaryEntry *) hash_search(validation_boundary_htab,
+													&desc->oids,
+													HASH_FIND,
+													NULL);
+
+	if (entry == NULL)
+	{
+		O_TUPLE_SET_NULL(*boundary);
+		LWLockRelease(validation_boundary_lock);
+		return false;
+	}
+
+	/* Allocate and copy the boundary tuple */
+	data = (char *) palloc(entry->tupleLen);
+	memcpy(data, entry->tupleData, entry->tupleLen);
+	
+	boundary->data = data;
+	boundary->formatFlags = entry->formatFlags;
+	
+	LWLockRelease(validation_boundary_lock);
+	return true;
+}
+
+uint16
+btree_is_validation_boundary_get_len(BTreeDescr *desc)
+{
+	uint16		len;
+	ValidationBoundaryEntry *entry;
+
+	Assert(desc != NULL);
+	
+	LWLockAcquire(validation_boundary_lock, LW_SHARED);
+
+	/* Look up entry in hash table */
+	entry = (ValidationBoundaryEntry *) hash_search(validation_boundary_htab,
+													&desc->oids,
+													HASH_FIND,
+													NULL);
+													
+	len = entry->tupleLen;
+	
+	LWLockRelease(validation_boundary_lock);
+
+	return len;
+}
+
+/*
+ * Set validation boundary to non visible.
+ */
+void
+btree_set_validation_boundary_non_visible(OIndexDescr *idx)
+{
+	ValidationBoundaryEntry *entry;
+	BTreeDescr *desc = &idx->desc;
+	bool found;
+
+	Assert(desc != NULL);
+	
+	LWLockAcquire(validation_boundary_lock, LW_EXCLUSIVE);
+
+	/* Insert or update entry in hash table */
+	entry = (ValidationBoundaryEntry *) hash_search(validation_boundary_htab,
+													&desc->oids,
+													HASH_ENTER,
+													&found);
+	entry->tupleLen = VALIDATION_BOUNDARY_NON;
+	
+	LWLockRelease(validation_boundary_lock);
+}
+
+/*
+ * Set validation boundary to full visible (no boundary).
+ */
+void
+btree_set_validation_boundary_full_visible(OIndexDescr *idx)
+{
+	ValidationBoundaryEntry *entry;
+	BTreeDescr *desc = &idx->desc;
+
+	Assert(desc != NULL);
+	
+	LWLockAcquire(validation_boundary_lock, LW_EXCLUSIVE);
+	/* Insert or update entry in hash table */
+	entry = (ValidationBoundaryEntry *) hash_search(validation_boundary_htab,
+													&desc->oids,
+													HASH_ENTER,
+													NULL);
+	entry->tupleLen = VALIDATION_BOUNDARY_FULL;
+	
+	LWLockRelease(validation_boundary_lock);
+}
+
+void
+btree_remove_validation_boundary(OIndexDescr *idx)
+{
+	BTreeDescr *desc = &idx->desc;
+
+	Assert(desc != NULL);
+	
+	LWLockAcquire(validation_boundary_lock, LW_EXCLUSIVE);
+
+	/* Remove entry from hash table */
+	hash_search(validation_boundary_htab, &desc->oids, HASH_REMOVE, NULL);
+	
+	LWLockRelease(validation_boundary_lock);
+}
+
+/*
+ * Check if a primary key satisfies the validation boundary.
+ * Returns true if:
+ * - No validation is in progress (boundary not set), OR
+ * - The PK is less than or equal to the boundary
+ * Returns false if PK is greater than the boundary.
+ */
+bool
+btree_pk_satisfies_validation_boundary(BTreeDescr *desc, OTuple pk)
+{
+	OTuple		boundary;
+	ValidationBoundaryEntry *entry;
+	char		boundaryData[O_BTREE_MAX_KEY_SIZE];
+	int			cmp;
+
+	Assert(desc != NULL);
+	Assert(!O_TUPLE_IS_NULL(pk));
+		
+	LWLockAcquire(validation_boundary_lock, LW_SHARED);
+	
+	/* Look up entry in hash table */
+	entry = (ValidationBoundaryEntry *) hash_search(validation_boundary_htab,
+													&desc->oids,
+													HASH_FIND,
+													NULL);
+	if (entry == NULL)
+	{
+		LWLockRelease(validation_boundary_lock);
+		/* No boundary set, so PK satisfies it */
+		return true;
+	}
+										
+	if (entry->tupleLen == VALIDATION_BOUNDARY_NON)
+	{
+		LWLockRelease(validation_boundary_lock);
+		/* Boundary is non visible, so PK does not satisfy it */
+		return false;
+	}
+	else if (entry->tupleLen == VALIDATION_BOUNDARY_FULL)
+	{
+		LWLockRelease(validation_boundary_lock);
+		/* Boundary is full visible, so PK satisfies it */
+		return true;
+	}
+	
+	memcpy(boundaryData, entry->tupleData, entry->tupleLen);
+
+	boundary.data = boundaryData;
+	boundary.formatFlags = entry->formatFlags;
+	
+	LWLockRelease(validation_boundary_lock);
+
+	/* Compare PK with boundary */
+	cmp = o_btree_cmp(desc, &pk, BTreeKeyNonLeafKey,
+					  &boundary, BTreeKeyNonLeafKey);
+	
+	/* Return true if PK <= boundary */
+	return (cmp <= 0);
+}
+
+/*
+ * Check if an index is "ready but not valid" by querying pg_index.
+ * This indicates the index is being built concurrently.
+ *
+ * Returns true if indisready=true and indisvalid=false, false otherwise.
+ */
+bool
+btree_index_is_ready_not_valid(Oid indexRelOid)
+{
+	HeapTuple	indexTuple;
+	Form_pg_index indexForm;
+	bool		result;
+	
+	/* Get the index tuple from pg_index */
+	indexTuple = SearchSysCache1(INDEXRELID, indexRelOid);
+	
+	if (!HeapTupleIsValid(indexTuple))
+	{
+		/* Index not found in pg_index */
+		return false;
+	}
+
+	indexForm = (Form_pg_index) GETSTRUCT(indexTuple);
+
+	/* Check if index is ready but not valid */
+	result = (indexForm->indisready && !indexForm->indisvalid);
+
+	ReleaseSysCache(indexTuple);
+
+	return result;
 }

--- a/src/btree/build.c
+++ b/src/btree/build.c
@@ -279,11 +279,13 @@ put_tuple_to_stack(BTreeDescr *desc, OIndexBuildStackItem *stack,
 {
 	BTreeLeafTuphdr leaf_header = {0};
 	int			tuplesize;
+	OXid 		oxid;
 
 	leaf_header.deleted = BTreeLeafTupleNonDeleted;
 	leaf_header.undoLocation = InvalidUndoLocation;
-	leaf_header.xactInfo = OXID_GET_XACT_INFO(BootstrapTransactionId, RowLockUpdate, false);
 	tuplesize = o_btree_len(desc, tuple, OTupleLength);
+	oxid = *((OXid *)(tuple.data + tuplesize));
+	leaf_header.xactInfo = OXID_GET_XACT_INFO(oxid, RowLockUpdate, false);
 	return put_item_to_stack(desc, stack, 0,
 							 tuple, tuplesize, (Pointer) &leaf_header,
 							 sizeof(leaf_header), root_level, metaPage);

--- a/src/btree/fastpath.c
+++ b/src/btree/fastpath.c
@@ -22,8 +22,11 @@
 
 #include "orioledb.h"
 
+#include "catalog/sys_trees.h"
 #include "btree/btree.h"
+#include "tableam/descr.h"
 #include "btree/fastpath.h"
+#include "tuple/format.h"
 #include "btree/find.h"
 #include "postgres_ext.h"
 #include "storage/itemptr.h"

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -65,6 +65,8 @@ struct BTreeIterator
 	/* callback for fetching tuple version */
 	TupleFetchCallback fetchCallback;
 	void	   *fetchCallbackArg;
+	
+	BTreeLeafTuphdr header;
 #ifdef USE_ASSERT_CHECKING
 	/* additional check for iteration order */
 	OFixedTuple prevTuple;
@@ -484,8 +486,9 @@ o_find_tuple_version(BTreeDescr *desc, Page p, BTreePageItemLocator *loc,
 }
 
 BTreeIterator *
-o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
-						OSnapshot *o_snapshot, ScanDirection scanDir)
+o_btree_iterator_create_with_flags(BTreeDescr *desc, void *key, BTreeKeyType kind,
+								   OSnapshot *o_snapshot, ScanDirection scanDir,
+								   uint16 flags)
 {
 	BTreeIterator *it;
 	uint16		findFlags = BTREE_PAGE_FIND_IMAGE;
@@ -507,7 +510,8 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 
 	if (IT_IS_BACKWARD(it))
 		findFlags |= BTREE_PAGE_FIND_KEEP_LOKEY;
-
+	
+	findFlags |= flags;
 	init_page_find_context(&it->context, desc,
 						   it->combinedResult ? COMMITSEQNO_INPROGRESS : o_snapshot->csn, findFlags);
 
@@ -555,6 +559,14 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 						kind != BTreeKeyRightmost ? kind : BTreeKeyNone);
 
 	return it;
+}
+
+BTreeIterator *
+o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
+						OSnapshot *o_snapshot, ScanDirection scanDir)
+{
+	return o_btree_iterator_create_with_flags(desc, key, kind,
+											  o_snapshot, scanDir, 0);
 }
 
 void
@@ -782,7 +794,12 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
 					UNDO_IT_NEXT_OFFSET(&it->undoIt, &it->undoLoc);
 
 				if (!O_TUPLE_IS_NULL(result))
+				{
+					BTreeLeafTuphdr *tupHdr;
+					tupHdr = (BTreeLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(img, &leaf_item->locator);
+					it->header = *tupHdr;
 					return result;
+				}
 			}
 			else
 			{
@@ -796,7 +813,12 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
 				UNDO_IT_NEXT_OFFSET(&it->undoIt, &it->undoLoc);
 
 				if (!O_TUPLE_IS_NULL(result))
+				{
+					BTreeLeafTuphdr *tupHdr;
+					tupHdr = (BTreeLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(hImg, &it->undoLoc);
+					it->header = *tupHdr;
 					return result;
+				}
 			}
 		}
 		else
@@ -811,12 +833,35 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
 			IT_NEXT_OFFSET(it, &leaf_item->locator);
 
 			if (!O_TUPLE_IS_NULL(result))
+			{
+				BTreeLeafTuphdr *tupHdr;
+				OBTreeFindPageContext *ctx = &it->context;
+				OBtreePageFindItem *item = &ctx->items[ctx->index];
+				
+				/* Need to get tuple header - back up locator to get it */
+				BTreePageItemLocator tempLoc = item->locator;
+				if (IT_IS_FORWARD(it))
+					BTREE_PAGE_LOCATOR_PREV(img, &tempLoc);
+				else
+					BTREE_PAGE_LOCATOR_NEXT(img, &tempLoc);
+					
+				tupHdr = (BTreeLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(img, &tempLoc);
+	
+				it->header = *tupHdr;
+				
 				return result;
+			}
 		}
 	}
 
 	O_TUPLE_SET_NULL(result);
 	return result;				/* unreachable */
+}
+
+BTreeLeafTuphdr
+o_btree_iterator_get_current_header(BTreeIterator *it)
+{
+	return it->header;
 }
 
 /*
@@ -998,6 +1043,7 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 
 		if (BTREE_PAGE_LOCATOR_IS_VALID(img, loc))
 		{
+			
 			BTREE_PAGE_READ_LEAF_ITEM(*tupHdr, result, context->img, loc);
 			IT_NEXT_OFFSET(it, loc);
 
@@ -1060,6 +1106,87 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 	return result;				/* unreachable */
 }
 
+OTuple
+validate_iterator_fetch(BTreeIterator *it, bool *scanEnd,
+						BTreeLocationHint *hint, BTreeLeafTuphdr **tupHdr, OInMemoryBlkno *rightMostBlock)
+{
+	OBTreeFindPageContext *context = &it->context;
+	BTreeDescr *desc = context->desc;
+	BTreeLeafTuphdr *localTupHdr;
+	OTuple		result;
+	OFixedKey	key_buf;
+
+	Assert(BTREE_PAGE_FIND_IS(context, MODIFY));
+	Assert(IT_IS_FORWARD(it));
+
+	if (!tupHdr)
+		tupHdr = &localTupHdr;
+
+	*scanEnd = false;
+	while (true)
+	{
+		BTreePageItemLocator *loc = &context->items[context->index].locator;
+		OInMemoryBlkno blkno = context->items[context->index].blkno;
+		Page		img = O_GET_IN_MEMORY_PAGE(blkno);
+
+		if (BTREE_PAGE_LOCATOR_IS_VALID(img, loc))
+		{
+			BTREE_PAGE_READ_LEAF_ITEM(*tupHdr, result, img, loc);
+			BTREE_PAGE_LOCATOR_NEXT(img, loc);
+
+			if (hint)
+			{
+				hint->blkno = blkno;
+				hint->pageChangeCount = context->items[context->index].pageChangeCount;
+			}
+			
+			*rightMostBlock = OInvalidInMemoryBlkno;
+			return result;
+		}
+
+		if (O_PAGE_IS(img, RIGHTMOST))
+		{
+			/* Keep the lock */
+			*rightMostBlock = blkno;
+			*scanEnd = true;
+			O_TUPLE_SET_NULL(result);
+			return result;
+		}
+
+		{
+			uint64		rightlink = BTREE_PAGE_GET_RIGHTLINK(img);
+			OInMemoryBlkno nextBlkno = RIGHTLINK_GET_BLKNO(rightlink);
+			uint32		nextChangeCount = RIGHTLINK_GET_CHANGECOUNT(rightlink);
+
+			if (OInMemoryBlknoIsValid(nextBlkno))
+			{
+				Page		nextImg;
+
+				lock_page(nextBlkno);
+				nextImg = O_GET_IN_MEMORY_PAGE(nextBlkno);
+				if (O_PAGE_GET_CHANGE_COUNT(nextImg) == nextChangeCount)
+				{
+					context->items[context->index].blkno = nextBlkno;
+					context->items[context->index].pageChangeCount = nextChangeCount;
+					BTREE_PAGE_LOCATOR_FIRST(nextImg, loc);
+					unlock_page(blkno);
+					continue;
+				}
+				unlock_page(nextBlkno);
+			}
+		}
+
+		copy_fixed_hikey(desc, &key_buf, img);
+		unlock_page(blkno);
+
+		if (O_TUPLE_IS_NULL(key_buf.tuple) ||
+			find_page(context, &key_buf, BTreeKeyNonLeafKey, 0) != OFindPageResultSuccess)
+		{
+			elog(ERROR, "failed to find next page for validate iterator");
+		}
+	}
+}
+
 /*
  * Iterate over leaf page tuples without considering undo log.  Deleted tuples
  * are reported as NULLs.  So, the separate `*end` flag indicates finish of
@@ -1067,10 +1194,10 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
  */
 OTuple
 btree_iterate_raw(BTreeIterator *it, void *end, BTreeKeyType endKind,
-				  bool endInclude, bool *scanEnd, BTreeLocationHint *hint)
+				  bool endInclude, bool *scanEnd, BTreeLocationHint *hint, BTreeLeafTuphdr **tupHdr)
 {
 	return btree_iterate_raw_internal(it, end, endKind, endInclude, scanEnd,
-									  hint, true, NULL);
+									  hint, true, tupHdr);
 }
 
 /*

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -23,6 +23,7 @@
 #include "btree/page_chunks.h"
 #include "btree/undo.h"
 #include "catalog/o_tables.h"
+#include "tableam/operations.h"
 #include "recovery/recovery.h"
 #include "recovery/wal.h"
 #include "transam/undo.h"
@@ -33,6 +34,15 @@
 #include "miscadmin.h"
 
 #define IsRelationTree(desc) (ORelOidsIsValid(desc->oids) && !IS_SYS_TREE_OIDS(desc->oids))
+
+/*
+ * Global variable to pass boundary check result from PK modification to
+ * secondary index undo record creation. Since secondary index operations
+ * always follow PK operations and only one PK can be modified at a time,
+ * this simple approach works correctly.
+ */
+static bool g_last_pk_satisfies_boundary = true;
+
 
 /*
  * Context for o_btree_modify_internal()
@@ -62,6 +72,7 @@ typedef struct
 	BTreeKeyType keyType;
 	UndoLocation savepointUndoLocation;
 	BTreeModifyCallbackInfo *callbackInfo;
+	bool pkSatisfiesBoundary;
 } BTreeModifyInternalContext;
 
 typedef enum ConflictResolution
@@ -142,6 +153,7 @@ o_btree_modify_internal(OBTreeFindPageContext *pageFindContext,
 	context.savepointUndoLocation = get_subxact_undo_location(desc->undoType);
 	context.pageReserveKind = pageReserveKind;
 	context.callbackInfo = callbackInfo;
+	context.pkSatisfiesBoundary = true;
 
 	Assert(callbackInfo);
 	Assert((action != BTreeOperationInsert) || (tupleType == BTreeKeyLeafTuple));
@@ -696,6 +708,25 @@ o_btree_modify_insert_update(BTreeModifyInternalContext *context)
 	BTreeDescr *desc = pageFindContext->desc;
 	int			tuplen;
 
+	/*
+	 * For primary index modification during concurrent secondary index build,
+	 * check if the PK satisfies the validation boundary WHILE HOLDING PAGE LOCK.
+	 * Store the result in the callback arg for use by secondary index operations.
+	 */
+	if (desc->type == oIndexPrimary && !IS_SYS_TREE_OIDS(desc->oids))
+	{
+		bool		pkSatisfiesBoundary;
+		
+		/* Check validation boundary while holding the page lock on primary */
+		pkSatisfiesBoundary = btree_pk_satisfies_validation_boundary(desc, context->tuple);
+
+		/* Store result for use by secondary index operations */
+		context->pkSatisfiesBoundary = pkSatisfiesBoundary;
+		
+		/* Store in global variable for undo record creation */
+		g_last_pk_satisfies_boundary = pkSatisfiesBoundary;
+	}
+	
 	if (context->undoIsReserved && context->needsUndo)
 	{
 		o_btree_modify_add_undo_record(context);
@@ -793,6 +824,26 @@ o_btree_modify_delete(BTreeModifyInternalContext *context)
 	page = O_GET_IN_MEMORY_PAGE(blkno);
 
 	BTREE_PAGE_READ_LEAF_ITEM(tuphdr, curTuple, page, &loc);
+	
+	/*
+	 * For primary index modification during concurrent secondary index build,
+	 * check if the PK satisfies the validation boundary WHILE HOLDING PAGE LOCK.
+	 * Store the result in the callback arg for use by secondary index operations.
+	 */
+	if (desc->type == oIndexPrimary && !IS_SYS_TREE_OIDS(desc->oids))
+	{
+		// OTableDescr *tableDescr = (OTableDescr *) desc->arg;
+		bool		pkSatisfiesBoundary;
+		
+		/* Check validation boundary while holding the page lock on primary */
+		pkSatisfiesBoundary = btree_pk_satisfies_validation_boundary(desc, curTuple);
+		
+		/* Store result for use by secondary index operations */
+		context->pkSatisfiesBoundary = pkSatisfiesBoundary;
+		
+		/* Store in global variable for undo record creation */
+		g_last_pk_satisfies_boundary = pkSatisfiesBoundary;
+	}
 
 	if (!context->needsUndo)
 	{
@@ -1051,6 +1102,23 @@ o_btree_normal_modify(BTreeDescr *desc, BTreeOperationType action,
 		return OBTreeModifyResultInserted;
 	}
 	Assert(findResult == OFindPageResultSuccess);
+	
+	if (desc->type == oIndexRegular && !o_get_last_pk_satisfies_boundary() && btree_index_is_ready_not_valid(desc->oids.reloid))
+	{
+		/* For regular index, if the last inserted PK does not satisfy the validation boundary, then we know for sure that the tuple to be modified also does not satisfy the boundary. So, we can skip the modification. */
+		ppool_release_reserved(desc->ppool, pageReserveKind);
+		
+		unlock_page(pageFindContext.items[pageFindContext.index].blkno);
+		//
+		if (action == BTreeOperationInsert)
+			return OBTreeModifyResultInserted;
+		else if (action == BTreeOperationDelete)
+			return OBTreeModifyResultDeleted;
+		else if (action == BTreeOperationLock)
+			return OBTreeModifyResultLocked;
+		else
+			elog(ERROR, "unexpected action: %d", action);
+	}
 
 	return o_btree_modify_internal(&pageFindContext, action, tuple, tupleType,
 								   key, keyType, opOxid, opCsn,
@@ -1595,4 +1663,15 @@ o_btree_autonomous_delete(BTreeDescr *desc, OTuple key, BTreeKeyType keyType,
 	}
 
 	return (result == OBTreeModifyResultDeleted);
+}
+
+/*
+ * Get the last boundary check result from primary index modification.
+ * This is used when creating undo records for secondary index operations
+ * to determine if the operation should be marked as actuallyPerformed.
+ */
+bool
+o_get_last_pk_satisfies_boundary(void)
+{
+	return g_last_pk_satisfies_boundary;
 }

--- a/src/btree/print.c
+++ b/src/btree/print.c
@@ -366,7 +366,7 @@ print_page_contents_recursive(BTreeDescr *desc, OInMemoryBlkno blkno,
 
 				BTREE_PAGE_READ_LEAF_ITEM(pageTuphdr, tuple, p, &loc);
 				tuphdr = *pageTuphdr;
-				appendStringInfo(outbuf, "    Item %i: ", i);
+				appendStringInfo(outbuf, "    Oxid %ld  Item %i: ", XACT_INFO_GET_OXID(tuphdr.xactInfo), i);
 
 				while (true)
 				{

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -49,8 +49,11 @@
 #include "btree/iterator.h"
 #include "btree/page_chunks.h"
 #include "btree/scan.h"
+#include "checkpoint/checkpoint.h"
 #include "btree/undo.h"
+#include "tableam/handler.h"
 #include "transam/oxid.h"
+#include "tableam/descr.h"
 #include "tuple/slot.h"
 #include "utils/sampling.h"
 #include "utils/stopevent.h"
@@ -1555,16 +1558,17 @@ btree_seq_scan_getnext(BTreeSeqScan *scan, MemoryContext mctx,
 static OTuple
 btree_seq_scan_get_tuple_from_iterator_raw(BTreeSeqScan *scan,
 										   bool *end,
-										   BTreeLocationHint *hint)
+										   BTreeLocationHint *hint,
+										   BTreeLeafTuphdr **tupHdr)
 {
 	OTuple		result;
 
 	if (!O_TUPLE_IS_NULL(scan->iterEnd))
 		result = btree_iterate_raw(scan->iter, &scan->iterEnd, BTreeKeyNonLeafKey,
-								   false, end, hint);
+								   false, end, hint, tupHdr);
 	else
 		result = btree_iterate_raw(scan->iter, NULL, BTreeKeyNone,
-								   false, end, hint);
+								   false, end, hint, tupHdr);
 
 	if (*end)
 	{
@@ -1577,16 +1581,19 @@ btree_seq_scan_get_tuple_from_iterator_raw(BTreeSeqScan *scan,
 
 static OTuple
 btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
-									BTreeLocationHint *hint)
+									BTreeLocationHint *hint, BTreeLeafTuphdr **tupHdr)
 {
-	BTreeLeafTuphdr *tupHdr;
+	BTreeLeafTuphdr *localtupHdr;
 	OTuple		tuple;
+	
+	if (tupHdr == NULL)
+		tupHdr = &localtupHdr;
 
 	if (scan->iter)
 	{
 		bool		end;
 
-		tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint);
+		tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint, tupHdr);
 		if (!end)
 			return tuple;
 	}
@@ -1602,7 +1609,7 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 				{
 					bool		end;
 
-					tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint);
+					tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint, tupHdr);
 					if (!end)
 						return tuple;
 				}
@@ -1623,10 +1630,10 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 		}
 	}
 
-	BTREE_PAGE_READ_LEAF_ITEM(tupHdr, tuple, scan->leafImg, &scan->leafLoc);
+	BTREE_PAGE_READ_LEAF_ITEM(*tupHdr, tuple, scan->leafImg, &scan->leafLoc);
 	BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
 
-	if (!tupHdr->deleted)
+	if (!(*tupHdr)->deleted)
 	{
 		if (hint)
 			*hint = scan->hint;
@@ -1642,7 +1649,7 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 OTuple
 btree_seq_scan_getnext_raw(BTreeSeqScan *scan, MemoryContext mctx,
-						   bool *end, BTreeLocationHint *hint)
+						   bool *end, BTreeLocationHint *hint, BTreeLeafTuphdr **tupHdr)
 {
 	OTuple		tuple;
 
@@ -1652,7 +1659,7 @@ btree_seq_scan_getnext_raw(BTreeSeqScan *scan, MemoryContext mctx,
 	if (scan->status == BTreeSeqScanInMemory ||
 		scan->status == BTreeSeqScanDisk)
 	{
-		tuple = btree_seq_scan_getnext_raw_internal(scan, mctx, hint);
+		tuple = btree_seq_scan_getnext_raw_internal(scan, mctx, hint, tupHdr);
 		if (scan->status == BTreeSeqScanInMemory ||
 			scan->status == BTreeSeqScanDisk)
 		{

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -22,6 +22,7 @@
 #include "btree/undo.h"
 #include "catalog/o_sys_cache.h"
 #include "recovery/recovery.h"
+#include "tableam/operations.h"
 #include "rewind/rewind.h"
 #include "tableam/descr.h"
 #include "transam/oxid.h"
@@ -30,7 +31,7 @@
 #include "utils/palloc.h"
 #include "utils/stopevent.h"
 #include "utils/page_pool.h"
-
+#include "tuple/slot.h"
 #include "access/transam.h"
 #include "miscadmin.h"
 #include "utils/inval.h"

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -487,7 +487,7 @@ get_all_vacuum_rels(int options)
 
 /* Based on postgres function ReindexMultipleTables */
 static bool
-check_multiple_tables(const char *objectName, ReindexObjectType objectKind, bool concurrently)
+check_multiple_tables(const char *objectName, ReindexObjectType objectKind, bool concurrently, bool *has_pk)
 {
 	Oid			objectOid;
 	Relation	relationRelation;
@@ -656,6 +656,8 @@ check_multiple_tables(const char *objectName, ReindexObjectType objectKind, bool
 				if (ind->rd_rel->relam == BTREE_AM_OID && !(options && !options->orioledb_index))
 				{
 					String	   *ix_name = makeString(pstrdup(ind->rd_rel->relname.data));
+					
+					*has_pk |= ind->rd_index->indisprimary;
 
 					reindex_list = list_append_unique(reindex_list, ix_name);
 				}
@@ -820,7 +822,7 @@ create_ctas_nodata(List *tlist, IntoClause *into)
 #endif
 
 static bool
-ReindexPartitions(Oid relid, bool concurrently)
+ReindexPartitions(Oid relid, bool concurrently, bool *has_pk)
 {
 	List	   *inhoids;
 	ListCell   *lc;
@@ -853,10 +855,28 @@ ReindexPartitions(Oid relid, bool concurrently)
 				is_orioledb_rel(part_rel))
 			{
 				has_orioledb = true;
+				
+				ListCell   *index;
+				
+				foreach(index, RelationGetIndexList(part_rel))
+				{
+					Oid			indexOid = lfirst_oid(index);
+					Relation	ind = relation_open(indexOid, AccessShareLock);
+					OBTOptions *options = (OBTOptions *) ind->rd_options;
+
+					if (ind->rd_rel->relam == BTREE_AM_OID && !(options && !options->orioledb_index))
+					{
+						*has_pk |= ind->rd_index->indisprimary;
+					}
+
+					relation_close(ind, AccessShareLock);
+				}
 			}
 			else if (part_rel->rd_rel->relkind == RELKIND_INDEX)
 			{
 				Relation	tbl;
+				
+				*has_pk |= part_rel->rd_index->indisprimary;
 
 				tbl = relation_open(part_rel->rd_index->indrelid, AccessShareLock);
 
@@ -1169,6 +1189,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 		char	   *tablespacename = NULL;
 		bool		concurrently = false;
 		bool		has_orioledb = false;
+		bool		has_pk = false;
 		ListCell   *lc;
 
 		foreach(lc, stmt->params)
@@ -1212,7 +1233,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 
 					if (get_rel_relkind(indOid) == RELKIND_PARTITIONED_INDEX)
 					{
-						has_orioledb = ReindexPartitions(indOid, concurrently);
+						has_orioledb = ReindexPartitions(indOid, concurrently, &has_pk);
 						break;
 					}
 
@@ -1228,6 +1249,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 
 						ix_name = makeString(pstrdup(iRel->rd_rel->relname.data));
 						reindex_list = list_append_unique(reindex_list, ix_name);
+						has_pk |= iRel->rd_index->indisprimary;
 						if (concurrently)
 							has_orioledb = true;
 					}
@@ -1244,7 +1266,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 
 					if (get_rel_relkind(tblOid) == RELKIND_PARTITIONED_TABLE)
 					{
-						has_orioledb = ReindexPartitions(tblOid, concurrently);
+						has_orioledb = ReindexPartitions(tblOid, concurrently, &has_pk);
 						break;
 					}
 					tbl = relation_open(tblOid, AccessShareLock);
@@ -1262,6 +1284,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 							{
 								String	   *ix_name = makeString(pstrdup(ind->rd_rel->relname.data));
 
+								has_pk |= ind->rd_index->indisprimary;
 								reindex_list = list_append_unique(reindex_list, ix_name);
 							}
 							relation_close(ind, AccessShareLock);
@@ -1275,7 +1298,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 			case REINDEX_OBJECT_SCHEMA:
 			case REINDEX_OBJECT_SYSTEM:
 			case REINDEX_OBJECT_DATABASE:
-				has_orioledb = check_multiple_tables(stmt->name, stmt->kind, concurrently);
+				has_orioledb = check_multiple_tables(stmt->name, stmt->kind, concurrently, &has_pk);
 				break;
 			default:
 				elog(ERROR, "unrecognized object type: %d",
@@ -1296,17 +1319,19 @@ orioledb_utility_command(PlannedStmt *pstmt,
 									get_tablespace_name(tablespaceOid))));
 			}
 
-			if (orioledb_strict_mode)
-				elog(ERROR, "REINDEX CONCURRENTLY is not supported for orioledb tables yet");
-			else
-				elog(WARNING, "REINDEX CONCURRENTLY is not supported for orioledb tables yet, using a plain REINDEX instead");
-
-			foreach(lc, stmt->params)
+			if (has_pk)
 			{
-				DefElem    *opt = (DefElem *) lfirst(lc);
+				if (orioledb_strict_mode)
+					elog(ERROR, "REINDEX CONCURRENTLY is not supported for orioledb PK");
+				else
+					elog(WARNING, "REINDEX CONCURRENTLY is not supported for orioledb PK, using a plain REINDEX instead");
 
-				if (strcmp(opt->defname, "concurrently") == 0)
-					stmt->params = foreach_delete_current(stmt->params, lc);
+				foreach(lc, stmt->params)
+				{
+					DefElem    *opt = (DefElem *) lfirst(lc);
+					if (strcmp(opt->defname, "concurrently") == 0)
+						stmt->params = foreach_delete_current(stmt->params, lc);
+				}
 			}
 		}
 	}
@@ -1411,27 +1436,16 @@ orioledb_utility_command(PlannedStmt *pstmt,
 
 		if (stmt->concurrent)
 		{
-			Oid			relid;
-			Relation	rel;
 			LOCKMODE	lockmode;
 
 			PreventInTransactionBlock(context == PROCESS_UTILITY_TOPLEVEL,
 									  "CREATE INDEX CONCURRENTLY");
 
 			lockmode = ShareUpdateExclusiveLock;
-			relid =
-				RangeVarGetRelidExtended(stmt->relation, lockmode,
+			RangeVarGetRelidExtended(stmt->relation, lockmode,
 										 0,
 										 RangeVarCallbackOwnsRelation,
 										 NULL);
-			rel = table_open(relid, lockmode);
-
-			if (is_orioledb_rel(rel))
-			{
-				table_close(rel, lockmode);
-				elog(ERROR, "concurrent index creation is not supported for orioledb tables yet");
-			}
-			table_close(rel, lockmode);
 		}
 	}
 	else if (IsA(pstmt->utilityStmt, CreatedbStmt))

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -1329,6 +1329,36 @@ scan_getnextslot_allattrs(BTreeSeqScan *scan, OTableDescr *descr,
 	return true;
 }
 
+
+static inline
+bool
+scan_getnextslot_allattrs_ext(BTreeSeqScan *scan, OTableDescr *descr,
+						  	TupleTableSlot *slot, double *ntuples, BTreeLeafTuphdr **tupHdr)
+{
+	OTuple		tup;
+	BTreeLocationHint hint;
+	CommitSeqNo tupleCsn;
+	bool end;
+	
+	while (true)
+	{
+		tup = btree_seq_scan_getnext_raw(scan, slot->tts_mcxt, &end, &hint, tupHdr);
+		tupleCsn = InvalidCSN;
+		
+		if (end)
+			return false;
+		
+		if (!O_TUPLE_IS_NULL(tup))
+			break;
+	}
+
+	tts_orioledb_store_tuple(slot, tup, descr, tupleCsn,
+							 PrimaryIndexNumber, false , &hint);
+	slot_getallattrs(slot);
+	(*ntuples)++;
+	return true;
+}
+
 /*
  * Make a local heapscan in a worker, in a leader, or sequentially
  * for building secomndary index. Put result into provided sortstate
@@ -1342,13 +1372,18 @@ build_secondary_index_worker_heap_scan(OTableDescr *descr, OIndexDescr *idx,
 {
 	void	   *sscan;
 	TupleTableSlot *primarySlot;
+	OXid oxid;
+	OSnapshot snap;
+	BTreeLeafTuphdr *tupHdr;
+	
+	fill_current_oxid_osnapshot(&oxid, &snap);
 
-	sscan = make_btree_seq_scan(&GET_PRIMARY(descr)->desc, &o_in_progress_snapshot, poscan);
+	sscan = make_btree_seq_scan(&GET_PRIMARY(descr)->desc, &snap, poscan);
 	primarySlot = MakeSingleTupleTableSlot(descr->tupdesc, &TTSOpsOrioleDB);
 
 	*heap_tuples = 0;
 	*index_tuples[0] = 0;
-	while (scan_getnextslot_allattrs(sscan, descr, primarySlot, heap_tuples))
+	while (scan_getnextslot_allattrs_ext(sscan, descr, primarySlot, heap_tuples, &tupHdr))
 	{
 		OTuple		secondaryTup;
 
@@ -1357,14 +1392,23 @@ build_secondary_index_worker_heap_scan(OTableDescr *descr, OIndexDescr *idx,
 			secondaryTup = tts_orioledb_make_secondary_tuple(primarySlot,
 															 idx, true);
 			(*index_tuples[0])++;
-
+			
 			o_btree_check_size_of_tuple(o_tuple_size(secondaryTup,
-													 &idx->leafSpec),
-										idx->name.data, true);
-			tuplesort_putotuple(sortstates[0], secondaryTup);
+											&idx->leafSpec),
+							idx->name.data, true);
+			
+			OXid tup_oxid = XACT_INFO_GET_OXID(tupHdr->xactInfo);
+			OTuple new_tuple;
+			new_tuple.formatFlags = secondaryTup.formatFlags;
+			Size len = o_btree_len(&idx->desc, secondaryTup, OTupleLength);
+			new_tuple.data = palloc0(len + sizeof(OXid));
+			memcpy(new_tuple.data, secondaryTup.data, len);
+			/* Store OXid at the end of the tuple */
+			memcpy(new_tuple.data + len, &tup_oxid, sizeof(OXid));
+			tuplesort_putotuple(sortstates[0], new_tuple);
 			pfree(secondaryTup.data);
-		}
-
+			pfree(new_tuple.data);
+		}	
 		ExecClearTuple(primarySlot);
 	}
 	ExecDropSingleTupleTableSlot(primarySlot);
@@ -1629,6 +1673,102 @@ build_secondary_index(OTable *o_table, OTableDescr *descr, OIndexNumber ix_num,
 		CommandCounterIncrement();
 		table_close(tableRelation, AccessExclusiveLock);
 		index_close(indexRelation, AccessExclusiveLock);
+	}
+
+	pfree(index_tuples);
+}
+
+void
+check_secondary_index_unique(OTable *o_table, OTableDescr *descr, OIndexNumber ix_num,
+							 IndexBuildResult *result)
+{
+	Tuplesortstate **sortstates;
+
+	/* Infrastructure for parallel build corresponds to _bt_spools_heapscan */
+	oIdxSpool  *btspool = NULL;
+	oIdxBuildState buildstate = {0};
+	SortCoordinate coordinate = NULL;
+	double		heap_tuples;
+	double	   *index_tuples;
+	OIndexDescr *idx;
+
+	index_tuples = palloc0(sizeof(double));
+	idx = descr->indices[o_table->has_primary ? ix_num : ix_num + 1];
+	buildstate.btleader = NULL;
+
+	/* Attempt to launch parallel worker scan when required */
+	{
+		int			parallel_workers = o_calculate_index_workers(&GET_PRIMARY(descr)->desc, false, 1);
+
+		if (parallel_workers > 0)
+		{
+			btspool = (oIdxSpool *) palloc0(sizeof(oIdxSpool));
+			btspool->o_table = o_table;
+			btspool->descr = descr;
+
+			buildstate.worker_heap_sort_fn = &build_secondary_index_worker_sort;
+			buildstate.ix_num = ix_num;
+			buildstate.spool = btspool;
+			buildstate.isrebuild = false;
+
+			elog(DEBUG4, "Parallel index build by %d workers", parallel_workers);
+			_o_index_begin_parallel(&buildstate, false, parallel_workers);
+		}
+	}
+
+	if (buildstate.btleader)
+		elog(DEBUG1, "parallel index build: table (%u, %u, %u), ix_num %u",
+			 o_table->oids.datoid, o_table->oids.reloid, o_table->oids.relnode,
+			 ix_num);
+	else
+		elog(DEBUG1, "serial index build: table (%u, %u, %u), ix_num %u",
+			 o_table->oids.datoid, o_table->oids.reloid, o_table->oids.relnode,
+			 ix_num);
+
+	/*
+	 * If parallel build requested and at least one worker process was
+	 * successfully launched, set up coordination state
+	 */
+	if (buildstate.btleader)
+	{
+		coordinate = (SortCoordinate) palloc0(sizeof(SortCoordinateData));
+		coordinate->isWorker = false;
+		coordinate->nParticipants =
+			buildstate.btleader->nparticipanttuplesorts;
+		coordinate->sharedsort = buildstate.btleader->sharedsort[0];
+	}
+
+	/* Begin serial/leader tuplesort */
+	sortstates = (Tuplesortstate **) palloc0(sizeof(Pointer));
+	sortstates[0] = tuplesort_begin_orioledb_index(idx, maintenance_work_mem, false, coordinate);
+
+	/* Fill spool using either serial or parallel heap scan */
+	if (!buildstate.btleader)
+	{
+		/* Serial build */
+		build_secondary_index_worker_heap_scan(descr, idx, NULL, sortstates,
+											   false, &heap_tuples, &index_tuples);
+	}
+	else
+	{
+		/* We are on leader. Wait until workers end their scans */
+		_o_index_parallel_heapscan(&buildstate);
+		index_tuples[0] = buildstate.btleader->btshared->indtuples[0];
+		heap_tuples = buildstate.btleader->btshared->reltuples;
+	}
+
+	o_set_syscache_hooks();
+	tuplesort_performsort(sortstates[0]);
+	o_unset_syscache_hooks();
+	
+	/* End serial/leader sort */
+	tuplesort_end(sortstates[0]);
+	pfree((void *) sortstates);
+
+	if (buildstate.btleader)
+	{
+		pfree(btspool);
+		_o_index_end_parallel(buildstate.btleader);
 	}
 
 	pfree(index_tuples);

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -1910,7 +1910,7 @@ orioledb_index_rows(PG_FUNCTION_ARGS)
 	{
 		bool		end;
 		OTuple		tup = btree_iterate_raw(it, NULL, BTreeKeyNone,
-											false, &end, NULL);
+											false, &end, NULL, NULL);
 
 		if (end)
 			break;

--- a/src/catalog/o_sys_cache.c
+++ b/src/catalog/o_sys_cache.c
@@ -1057,7 +1057,7 @@ o_sys_cache_delete_by_lsn(OSysCache *sys_cache, XLogRecPtr lsn)
 		bool		end;
 		BTreeLocationHint hint;
 		OTuple		tup = btree_iterate_raw(it, NULL, BTreeKeyNone,
-											false, &end, &hint);
+											false, &end, &hint, NULL);
 		OSysCacheKey *sys_cache_key;
 		OTuple		key_tup;
 

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -35,6 +35,7 @@
 #include "commands/progress.h"
 #include "commands/vacuum.h"
 #include "nodes/pathnodes.h"
+#include "btree/iterator.h"
 #include "optimizer/optimizer.h"
 #include "parser/parsetree.h"
 #include "utils/fmgroids.h"
@@ -43,6 +44,8 @@
 #include "utils/syscache.h"
 #include "utils/lsyscache.h"
 #include "nodes/pg_list.h"
+#include "tuple/format.h"
+#include "executor/executor.h"
 
 #include <math.h>
 
@@ -303,7 +306,13 @@ orioledb_ambuild(Relation heap, Relation index, IndexInfo *indexInfo)
 
 	result->heap_tuples = 0.0;
 	result->index_tuples = 0.0;
-
+	
+	{
+		OTableDescr *descr;
+		descr = relation_get_descr(heap);
+		o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
+		btree_set_validation_boundary_non_visible(GET_PRIMARY(descr));
+	}
 
 	if (in_nontransactional_truncate || !OidIsValid(o_saved_relrewrite))
 	{
@@ -324,9 +333,9 @@ orioledb_ambuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			if (!in_nontransactional_truncate)
 				o_define_index_validate(tbl_oids, index, indexInfo, NULL);
 			o_define_index(heap, index, InvalidOid, reindex, InvalidIndexNumber, false, result);
-		}
+		}		
 	}
-
+			
 	return result;
 }
 
@@ -638,7 +647,10 @@ orioledb_aminsert(Relation rel, Datum *values, bool *isnull,
 	callbackInfo.arg = slot;
 
 	fill_current_oxid_osnapshot(&oxid, &o_snapshot);
-
+	
+	if (IS_VALIDATE_PROCESS())
+		oxid = GET_VALIDATE_PROCESS_OXID();
+	
 	iresult = o_tbl_index_insert(descr, descr->indices[ix_num], &tuple, slot,
 								 oxid, o_snapshot.csn, &callbackInfo,
 								 checkUnique);
@@ -966,16 +978,116 @@ orioledb_amdelete(Relation rel, Datum *values, bool *isnull,
 	return result.success;
 }
 
+
+/*
+ * orioledb_ambulkdelete() -- bulk deletion of index entries
+ *
+ * Note: This function does NOT actually delete any tuples from the index.
+ * It is primarily used during concurrent index creation validation phase,
+ * where the callback gathers primary key tuples from the index and always
+ * returns false (meaning "do not delete").
+ *
+ * For orioledb, instead of passing ItemPointers like vanilla PostgreSQL,
+ * we pass the actual primary key tuples to the callback by storing them
+ * in the callback_state. The callback (e.g., validate_index_callback) can
+ * then collect these tuples into a tuplesort for later validation.
+ *
+ * If the callback returns true (requesting deletion), we throw an error since
+ * deletion is not supported.
+ */
 IndexBulkDeleteResult *
 orioledb_ambulkdelete(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 					  IndexBulkDeleteCallback callback, void *callback_state)
 {
 	OBTOptions *options = (OBTOptions *) info->index->rd_options;
-
+	ORelOids	oids;
+	OIndexDescr *index_descr;
+	OTableDescr *descr;
+	BTreeIterator *it;
+	OSnapshot	oSnapshot;
+	OTuple		tuple;
+	double		num_tuples = 0;
+	ItemPointerData	itemptr;
+	bool		should_delete;
+	
 	if (options && !options->orioledb_index)
 		return btbulkdelete(info, stats, callback, callback_state);
 
-	elog(ERROR, "Not implemented: %s", PG_FUNCNAME_MACRO);
+	/* Get index descriptor */
+	ORelOidsSetFromRel(oids, info->index);
+	index_descr = o_fetch_index_descr(oids, oIndexInvalid, false, NULL);
+	if (index_descr == NULL)
+		elog(ERROR, "index descriptor not found for index %u", info->index->rd_id);
+	
+	descr = o_fetch_table_descr(index_descr->tableOids);
+	if (descr == NULL)
+		elog(ERROR, "table descriptor not found for index %u", info->index->rd_id);
+
+	/* Initialize snapshot for iteration */
+	oSnapshot = o_in_progress_snapshot;
+
+	/* Create iterator to scan all tuples in the index */
+	o_btree_load_shmem(&index_descr->desc);
+	it = o_btree_iterator_create(&index_descr->desc, NULL, BTreeKeyNone,
+								 &oSnapshot, ForwardScanDirection);
+
+	/* Iterate through all tuples in the index */
+	while (true)
+	{
+		CommitSeqNo tupleCsn;
+		
+		/* Fetch next tuple */
+		tuple = o_btree_iterator_fetch(it, &tupleCsn, NULL, BTreeKeyNone, false, NULL);
+		
+		if (O_TUPLE_IS_NULL(tuple))
+			break;
+
+		num_tuples++;
+
+		/*
+		 * For orioledb, we pass the primary key tuple itself to the callback
+		 * instead of just an ItemPointer. The callback can then collect these
+		 * tuples (e.g., into a tuplesort) for validation purposes.
+		 * 
+		 * We store the tuple in callback_state for the callback to access.
+		 */
+		if (callback_state)
+		{
+			((OValidateIndexState *) callback_state)->current_tuple = tuple;
+			((OValidateIndexState *) callback_state)->header = o_btree_iterator_get_current_header(it);
+		}
+
+		/* Call the callback with a dummy ItemPointer */
+		ItemPointerSetInvalid(&itemptr);
+		should_delete = callback(&itemptr, callback_state);
+
+		/*
+		 * If callback returns true (requesting deletion), throw an error.
+		 * Deletion is not supported in orioledb_ambulkdelete.
+		 */
+		if (should_delete)
+		{
+			/* Clean up before erroring out */
+			btree_iterator_free(it);
+			
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("bulk deletion is not supported for orioledb indexes"),
+					 errdetail("Index: %s", RelationGetRelationName(info->index))));
+		}
+	}
+
+	/* Clean up */
+	btree_iterator_free(it);
+
+	/* Allocate and initialize stats if not provided */
+	if (stats == NULL)
+		stats = (IndexBulkDeleteResult *) palloc0(sizeof(IndexBulkDeleteResult));
+
+	/* Update statistics */
+	stats->num_index_tuples = num_tuples;
+	stats->estimated_count = false;
+
 	return stats;
 }
 

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -205,6 +205,7 @@ static ShmemItem shmemItems[] = {
 	{o_proc_shmem_needs, o_proc_shmem_init},
 	{ppools_shmem_needs, ppools_shmem_init},
 	{btree_scan_shmem_needs, btree_scan_init_shmem},
+	{btree_validation_shmem_needs, btree_validation_shmem_init},
 	{s3_queue_shmem_needs, s3_queue_init_shmem},
 	{s3_workers_shmem_needs, s3_workers_init_shmem},
 	{s3_headers_shmem_needs, s3_headers_shmem_init},
@@ -1340,6 +1341,7 @@ orioledb_shmem_request(void)
 	RequestAddinShmemSpace(orioledb_memsize());
 	request_btree_io_lwlocks();
 	RequestNamedLWLockTranche("orioledb_unique_locks", max_procs * 4);
+	RequestNamedLWLockTranche("orioledb_validation_boundary", 1);
 }
 
 /*

--- a/src/tableam/concurrent_index_build.md
+++ b/src/tableam/concurrent_index_build.md
@@ -1,0 +1,241 @@
+# Concurrent Secondary Index Creation in OrioleDB
+
+The procedure is conceptually similar to PostgreSQL’s concurrent index build, but introduces additional mechanisms required by:
+
+* Undo-based MVCC
+* MVCC-aware indexes
+* Visibility constraints
+* Absence of undo logging during validation
+
+The algorithm performs **two passes over the table**, with a validation phase that ensures index consistency without blocking OLTP workloads.
+
+---
+
+## High-Level Algorithm
+
+Concurrent index creation consists of the following stages:
+
+1. **Initial index build using a snapshot**
+2. **Collection of index contents**
+3. **Validation scan of the table**
+4. **Boundary-controlled insertion logic**
+5. **Finalization and index activation**
+
+---
+
+## Stage 1 — Initial Build (Snapshot Scan)
+
+During the first pass:
+
+* The table is scanned using a specific snapshot.
+* A secondary index is built from tuples visible in that snapshot.
+
+This snapshot guarantees consistency of the initial index contents.
+
+Unlike PostgreSQL, the resulting index is:
+
+* Not immediately valid for queries
+* Not fully synchronized with concurrent modifications
+
+At this stage, the index is marked as **ready for inserts with restrictions** (see boundary rules below).
+
+---
+
+## Stage 2 — Collecting Index Contents
+
+After the initial build:
+
+* The system scans the newly created secondary index.
+* For each index entry, it collects:
+
+```
+(primary_key, secondary_key, xid)
+```
+
+Where:
+
+* **primary_key** — identifies the row
+* **secondary_key** — index key
+* **xid** — transaction ID that committed the tuple
+
+This dataset represents what the index currently contains.
+
+---
+
+## Stage 3 — Validation Scan (Second Table Pass)
+
+A second scan of the table is performed.
+
+Using the collected index contents, the system determines:
+
+### Missing in Index
+
+Tuples present in the table but absent from the index → **must be inserted**
+
+### Stale in Index
+
+Entries present in the index but absent from the table → **must be deleted**
+
+This reconciles the index with the actual table state.
+
+---
+
+## OrioleDB-Specific Behavior (Undo-Based MVCC)
+
+Because OrioleDB uses **undo-based MVCC** and **MVCC-aware indexes**, additional constraints apply.
+
+### No Undo Logging During Validation
+
+Adding undo records to the secondary index during validation would be too complex.
+
+Therefore:
+
+> The validation process inserts only tuples that are **visible to all transactions**.
+
+#### Procedure:
+
+1. When encountering a tuple:
+
+   * Wait until it becomes globally visible
+   * Only then insert it into the secondary index
+
+This guarantees:
+
+* No undo logs are needed
+* Only final tuple versions are indexed
+
+---
+
+## Validation Boundary Mechanism
+
+### Global Constraint
+
+Only **one concurrent index build** may run per table.
+
+### Boundary Tracking
+
+For each index build, a shared hash table stores:
+
+```
+validation_boundary = highest primary key validated
+```
+
+As validation progresses, the boundary increases.
+
+### Boundary Stability Guarantee
+
+Boundary correctness relies on page-level synchronization:
+
+> During boundary checking, both the inserting transaction and the validation worker hold a lock on the corresponding page.
+> Because of this, tuple boundaries cannot move while the procedure is in progress.
+
+This ensures that:
+
+* The validator observes a stable ordering of tuples
+* Inserts cannot shift tuples across the boundary while it is being evaluated
+* No race conditions occur between OLTP inserts and validation logic
+
+---
+
+## Insert Behavior During Validation
+
+After the initial build, the index becomes **insert-ready with boundary rules**.
+
+### Rule 1 — Inserts Before Boundary
+
+If a transaction inserts a tuple with:
+
+```
+primary_key <= validation_boundary
+```
+
+Then:
+
+* The inserting transaction must insert the tuple into the secondary index.
+
+Reason:
+
+The validator has already passed this region and will not revisit it.
+
+---
+
+### Rule 2 — Inserts After Boundary
+
+If:
+
+```
+primary_key > validation_boundary
+```
+
+Then:
+
+* The transaction does NOT insert into the secondary index.
+
+Reason:
+
+The validator will encounter and insert these tuples later.
+
+---
+
+## Tuple Movement Procedure
+
+When the validator moves a tuple from primary storage to the secondary index:
+
+1. Wait until old transactions that could observe the previous state finish
+2. Insert the globally visible tuple into the secondary index
+
+This ensures:
+
+* No inconsistent visibility
+* No undo records required
+* Correct MVCC semantics
+
+---
+
+## Delete Handling
+
+If an entry exists in the secondary index but not in the table:
+
+* It is deleted directly from the index page.
+
+Safe because:
+
+* The index was built from a valid snapshot
+* Each tuple appears only once
+* No undo chains exist in the index
+
+---
+
+## Visibility and Consistency Checks
+
+During validation, tuples are compared using:
+
+* Commit sequence numbers (CSN)
+* Transaction IDs (XID)
+* Tuple identifiers
+
+This guarantees that:
+
+* No modifications occurred unnoticed
+* Tuple contents are unchanged
+
+---
+
+## Finalization
+
+After validation completes:
+
+1. The boundary reaches the end of the table
+2. All tuples are synchronized
+3. Insert restrictions are lifted
+4. The index is marked:
+
+```
+VALID
+```
+
+At this point:
+
+* Queries may use the index
+* Normal OLTP operations resume
+* Inserts can occur anywhere

--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -112,7 +112,7 @@ o_tuple_print(TupleDesc tupDesc, OTupleFixedFormatSpec *spec,
 	appendStringInfo(buf, ")");
 }
 
-static void
+void
 idx_key_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg)
 {
 	TuplePrintOpaque *opaque = (TuplePrintOpaque *) arg;
@@ -122,7 +122,7 @@ idx_key_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg)
 				  opaque->truncateValues);
 }
 
-static void
+void
 idx_tup_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg)
 {
 	TuplePrintOpaque *opaque = (TuplePrintOpaque *) arg;

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -24,9 +24,12 @@
 #include "btree/undo.h"
 #include "catalog/indices.h"
 #include "catalog/o_indices.h"
+#include "btree/page_chunks.h"
+#include "utils/page_pool.h"
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
 #include "recovery/wal.h"
+#include "tuple/sort.h"
 #include "tableam/descr.h"
 #include "tableam/handler.h"
 #include "tableam/operations.h"
@@ -71,8 +74,12 @@
 #include "utils/lsyscache.h"
 #include "utils/sampling.h"
 #include "utils/syscache.h"
+#include "access/genam.h"
+#include "storage/itemptr.h"
+#include "utils/tuplesort.h"
 
 bool		in_nontransactional_truncate = false;
+bool		debug_print_index_validate = false;
 
 typedef struct OScanDescData
 {
@@ -91,7 +98,13 @@ static void get_keys_from_rowid(OIndexDescr *primary, Datum pkDatum, OBTreeKeyBo
 								BTreeLocationHint *hint, CommitSeqNo *csn,
 								uint32 *version, ItemPointer *bridge_ctid);
 static void rowid_set_csn(OIndexDescr *id, Datum pkDatum, CommitSeqNo csn);
+static void orioledb_index_validate_scan(Relation heapRelation,
+										 Relation indexRelation,
+										 IndexInfo *indexInfo,
+										 Snapshot snapshot,
+										 OValidateIndexState *state);
 
+static bool validate_index_callback(ItemPointer itemptr, void *callback_state);
 
 /* ------------------------------------------------------------------------
  * Slot related callbacks for heap AM
@@ -1056,7 +1069,7 @@ orioledb_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
 
 	while (true)
 	{
-		tuple = btree_seq_scan_getnext_raw(oscan->scan, slot->tts_mcxt, &end, &hint);
+		tuple = btree_seq_scan_getnext_raw(oscan->scan, slot->tts_mcxt, &end, &hint, NULL);
 
 		if (end || ItemPointerGetOffsetNumber(&oscan->iptr) > NUM_TUPLES_PER_BLOCK)
 			return false;
@@ -1181,14 +1194,1180 @@ orioledb_index_build_range_scan(Relation heapRelation,
 	return 0.0;
 }
 
+/*
+ * orioledb_index_validate - Validate an index for orioledb tables
+ *
+ * This function implements index validation for orioledb tables, similar to
+ * PostgreSQL's validate_index but adapted for rowid-based tuple identification.
+ * It performs the following steps:
+ * 1. Calls index_bulk_delete (which invokes orioledb_ambulkdelete) with a callback
+ *    that collects all primary key tuples from the index into a tuplesort
+ * 2. Sorts the collected tuples in primary key order
+ * 3. Scans the heap and performs a merge join with sorted index tuples
+ * 4. Inserts any missing tuples into the index
+ * 
+ * As orioledb uses undo based mvcc, and indexes are mvcc-aware, procedure is
+ * quite different from PostgreSQL's validate_index, for more details see the
+ * concurrent_index_build.md
+ */
+static void
+orioledb_index_validate(Relation heapRelation,
+					   Relation indexRelation,
+					   Snapshot snapshot)
+{
+	IndexInfo  *indexInfo;
+	IndexVacuumInfo ivinfo;
+	OValidateIndexState state;
+	Oid			save_userid;
+	int			save_sec_context;
+	int			save_nestlevel;
+	OTableDescr *descr; 
+	
+	{
+		const int	progress_index[] = {
+			PROGRESS_CREATEIDX_PHASE,
+			PROGRESS_CREATEIDX_TUPLES_DONE,
+			PROGRESS_CREATEIDX_TUPLES_TOTAL,
+			PROGRESS_SCAN_BLOCKS_DONE,
+			PROGRESS_SCAN_BLOCKS_TOTAL
+		};
+		const int64 progress_vals[] = {
+			PROGRESS_CREATEIDX_PHASE_VALIDATE_IDXSCAN,
+			0, 0, 0, 0
+		};
+
+		pgstat_progress_update_multi_param(5, progress_index, progress_vals);
+	}
+
+	/*
+	 * Switch to the table owner's userid, so that any index functions are run
+	 * as that user.  Also lock down security-restricted operations and
+	 * arrange to make GUC variable changes local to this command.
+	 */
+	GetUserIdAndSecContext(&save_userid, &save_sec_context);
+	SetUserIdAndSecContext(heapRelation->rd_rel->relowner,
+						   save_sec_context | SECURITY_RESTRICTED_OPERATION);
+	save_nestlevel = NewGUCNestLevel();
+	RestrictSearchPath();
+
+	/*
+	 * Fetch info needed for index_insert.
+	 */
+	indexInfo = BuildIndexInfo(indexRelation);
+
+	/* mark build is concurrent just for consistency */
+	indexInfo->ii_Concurrent = true;
+
+	/*
+	 * Get table descriptor to access primary index descriptor
+	 */
+	descr = relation_get_descr(heapRelation);
+	Assert(descr != NULL);
+
+	ORelOids index_oids;
+	ORelOidsSetFromRel(index_oids, indexRelation);
+	OIndexType ix_type = o_index_rel_get_ix_type(indexRelation);
+	OIndexDescr * index_descr = o_fetch_index_descr(index_oids, ix_type, false, NULL);
+	
+	
+	o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
+	o_btree_load_shmem(&index_descr->desc);
+	state.tuplesort = tuplesort_begin_orioledb_index_secondary_pk(index_descr,
+															GET_PRIMARY(descr),
+															maintenance_work_mem,
+															true,
+															NULL);
+	state.htups = state.itups = state.tups_inserted = state.tups_deleted = 0;
+	state.current_tuple.data = NULL; /* Initialize */
+	state.index_descr = index_descr; /* Will be set by ambulkdelete */
+	state.table_descr = descr;
+	state.index_oids.datoid = MyDatabaseId;
+	state.index_oids.reloid = indexRelation->rd_rel->oid;
+	state.index_oids.relnode = indexRelation->rd_rel->relfilenode;
+	
+	/*
+	 * Scan the index and gather up all the primary key tuples into a tuplesort object.
+	 * This is done by calling index_bulk_delete with validate_index_callback,
+	 * which collects tuples instead of deleting them.
+	 */
+	ivinfo.index = indexRelation;
+	ivinfo.heaprel = heapRelation;
+	ivinfo.analyze_only = false;
+	ivinfo.report_progress = true;
+	ivinfo.estimated_count = true;
+	ivinfo.message_level = DEBUG2;
+	ivinfo.num_heap_tuples = heapRelation->rd_rel->reltuples;
+	ivinfo.strategy = NULL;
+
+	/* ambulkdelete updates progress metrics and collects tuples via callback */
+	(void) index_bulk_delete(&ivinfo, NULL,
+							 validate_index_callback, (void *) &state);
+	
+	/* Execute the sort */
+	{
+		const int	progress_index[] = {
+			PROGRESS_CREATEIDX_PHASE,
+			PROGRESS_SCAN_BLOCKS_DONE,
+			PROGRESS_SCAN_BLOCKS_TOTAL
+		};
+		const int64 progress_vals[] = {
+			PROGRESS_CREATEIDX_PHASE_VALIDATE_SORT,
+			0, 0
+		};
+
+		pgstat_progress_update_multi_param(3, progress_index, progress_vals);
+	}
+	tuplesort_performsort(state.tuplesort);
+
+	/*
+	 * Now scan the heap and "merge" it with the index
+	 */
+	pgstat_progress_update_param(PROGRESS_CREATEIDX_PHASE,
+								 PROGRESS_CREATEIDX_PHASE_VALIDATE_TABLESCAN);
+	orioledb_index_validate_scan(heapRelation,
+								 indexRelation,
+								 indexInfo,
+								 snapshot,
+								 &state);
+
+	/* Done with tuplesort object */
+	tuplesort_end(state.tuplesort);
+
+	/* Make sure to release resources cached in indexInfo (if needed). */
+	index_insert_cleanup(indexRelation, indexInfo);
+
+	elog(DEBUG2,
+		 "orioledb_index_validate found %.0f heap tuples, %.0f index tuples; inserted %.0f missing tuples, deleted %.0f spurious tuples",
+		 state.htups, state.itups, state.tups_inserted, state.tups_deleted);
+
+	/* Roll back any GUC changes executed by index functions */
+	AtEOXact_GUC(false, save_nestlevel);
+
+	/* Restore userid and security context */
+	SetUserIdAndSecContext(save_userid, save_sec_context);
+}
+
+/*
+ * orioledb_index_validate_cleanup_old_concurrent - Cleanup old concurrent index
+ *
+ * During concurrent index creation (REINDEX CONCURRENTLY), PostgreSQL creates
+ * a new index with a temporary name suffix (_ccnew). After validation succeeds,
+ * the new index gets the original relfilenode and the old index structure should
+ * be removed. However, orioledb maintains its own index structures that need
+ * explicit cleanup.
+ *
+ * This function finds and removes the old index structure that has a different
+ * relfilenode than what's currently in pg_class. It should be called after
+ * index validation completes successfully.
+ *
+ * Parameters:
+ *   heapRelation - The table relation
+ *   indexRelation - The new (validated) index relation with updated relfilenode
+ */
+void
+orioledb_index_validate_cleanup_old_concurrent(Relation heapRelation,
+											   Relation indexRelation)
+{
+	OTableDescr *descr;
+	ORelOids	old_idx_oids;
+	OTable	   *o_table;
+	
+	elog(DEBUG2, "orioledb: starting cleanup of old concurrent index structure "
+		 "for index %s", NameStr(indexRelation->rd_rel->relname));
+
+	/* Get the table descriptor */
+	descr = relation_get_descr(heapRelation);
+	if (descr == NULL)
+		return; /* Not an orioledb table */
+		
+	ORelOidsSetFromRel(old_idx_oids, indexRelation);
+	
+	ORelOids table_oids;
+	ORelOidsSetFromRel(table_oids, heapRelation);
+	o_table = o_tables_get(table_oids);
+	
+	/*
+	 * Scan through all indices in the table descriptor to find any index
+	 * with the same reloid but different relfilenode. This would be the
+	 * old concurrent index structure that needs cleanup.
+	 */
+	for (int ix_num = 0; ix_num < o_table->nindices; ix_num++)
+	{
+		OTableIndex *index = &o_table->indices[ix_num];
+
+		if (ORelOidsIsEqual(index->oids, old_idx_oids))
+		{
+			/* Drop the old index structure */
+			o_index_drop(heapRelation, ix_num);
+			
+			elog(DEBUG2, "orioledb: cleaning up old concurrent index structure "
+				 "for index %s (old relfilenode %u)",
+				 NameStr(indexRelation->rd_rel->relname),
+				 index->oids.relnode);
+			break;
+		}
+	}
+		
+}
+
+/*
+ * orioledb_reindex_concurrent_swap
+ *
+ * Convenience wrapper for stage 2: swap relfilenodes
+ * Call this AFTER PostgreSQL has swapped the relfilenodes in pg_class
+ */
+void
+orioledb_reindex_concurrent_swap(Oid newIndex,
+								 Oid oldIndex,
+								 Relation heapRelation,
+								 const char *oldName)
+{
+	Relation	oldIndexRel;
+	Relation	newIndexRel;
+	
+	elog(DEBUG2, "orioledb_reindex_concurrent_swap: Swapping relfilenodes "
+			"between old index OID %u and new index OID %u",
+			oldIndex, newIndex);
+	
+	/* Open relations for old and new index */
+	oldIndexRel = relation_open(oldIndex, AccessShareLock);
+	newIndexRel = relation_open(newIndex, AccessShareLock);
+	
+	int			old_ix_num = InvalidIndexNumber;
+	int 		new_ix_num = InvalidIndexNumber;
+	OSnapshot	oSnapshot;
+	OXid		oxid;
+	ORelOids	old_idx_oids;
+	ORelOids	new_idx_oids;
+	OTable	   *o_table;
+
+	ORelOidsSetFromRel(old_idx_oids, oldIndexRel);
+	ORelOidsSetFromRel(new_idx_oids, newIndexRel);
+	CommandCounterIncrement();
+	
+	ORelOids table_oids;
+	ORelOidsSetFromRel(table_oids, heapRelation);
+	o_table = o_tables_get(table_oids);
+	
+	for (int ix_num = 0; ix_num < o_table->nindices; ix_num++)
+	{
+		OTableIndex *index = &o_table->indices[ix_num];
+
+		if (ORelOidsIsEqual(index->oids, old_idx_oids))
+		{
+			old_ix_num = ix_num;
+			continue;
+		}
+		
+		if (ORelOidsIsEqual(index->oids, new_idx_oids))
+		{
+			new_ix_num = ix_num;
+			continue;
+		}
+	}
+	
+	int			ctid_idx_off;
+	ctid_idx_off = o_table->has_primary ? 0 : 1;
+	
+	Assert(old_ix_num < o_table->nindices);
+	Assert(new_ix_num < o_table->nindices);
+	
+	/* swap the names */
+	namestrcpy(&o_table->indices[new_ix_num].name, NameStr(o_table->indices[old_ix_num].name));
+	namestrcpy(&o_table->indices[old_ix_num].name, oldName);	 
+	
+	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
+	o_tables_rel_meta_lock(heapRelation);
+	o_tables_update(o_table, oxid, oSnapshot.csn);
+	o_indices_update(o_table, old_ix_num + ctid_idx_off, oxid, oSnapshot.csn);
+	o_indices_update(o_table, new_ix_num + ctid_idx_off, oxid, oSnapshot.csn);
+	o_tables_rel_meta_unlock(heapRelation, InvalidOid);
+	o_invalidate_oids(old_idx_oids);
+	o_invalidate_oids(new_idx_oids);
+	o_add_invalidate_undo_item(old_idx_oids,
+								O_INVALIDATE_OIDS_ON_ABORT);
+	o_add_invalidate_undo_item(new_idx_oids,
+								O_INVALIDATE_OIDS_ON_ABORT);
+	o_invalidate_oids(table_oids);
+	o_add_invalidate_undo_item(table_oids,
+									O_INVALIDATE_OIDS_ON_ABORT);
+	o_table_free(o_table);
+					  
+	/* Close relations */
+	relation_close(oldIndexRel, AccessShareLock);
+	relation_close(newIndexRel, AccessShareLock);
+}
+
+
+/*
+ * debug_print_validate_tuple - Debug helper to print tuples added to validation tuplesort
+ *
+ * Prints the secondary index tuple being added to tuplesort during validation.
+ * Shows both the secondary key fields and primary key fields.
+ */
+static void
+debug_print_validate_doubletuple(OTuple tuple, OTableDescr *table_descr, OIndexDescr *index_descr, OXid oxid)
+{
+	StringInfoData buf;
+	BTreeDescr *desc = &index_descr->desc;
+	int			nKeyFields = index_descr->nKeyFields;
+	int			i;
+
+	initStringInfo(&buf);
+	appendStringInfo(&buf, "validate tuple: index=%u.%u.%u",
+					 desc->oids.datoid, desc->oids.reloid, desc->oids.relnode);
+
+	/* Print each field in the tuple */
+	for (i = 1; i <= index_descr->nFields; i++)
+	{
+		Datum		value;
+		bool		isnull;
+		Oid			typid;
+		Oid			typoutput;
+		bool		typisvarlena;
+		char	   *value_str;
+
+		/* Determine if this is a secondary key field or PK field */
+		if (i <= nKeyFields)
+			appendStringInfo(&buf, ", SK_field_%d: ", i);
+		else
+			appendStringInfo(&buf, ", PK_field_%d: ", i - nKeyFields);
+
+		/* Get field info */
+		typid = index_descr->leafTupdesc->attrs[i - 1].atttypid;
+		value = o_fastgetattr(tuple, i, index_descr->leafTupdesc, &index_descr->leafSpec, &isnull);
+
+		if (isnull)
+		{
+			appendStringInfo(&buf, "NULL");
+		}
+		else
+		{
+			/* Get the output function for this type */
+			getTypeOutputInfo(typid, &typoutput, &typisvarlena);
+			value_str = OidOutputFunctionCall(typoutput, value);
+			appendStringInfo(&buf, "%s (type=%u)", value_str, typid);
+			pfree(value_str);
+		}
+	}
+
+	elog(WARNING, "%s : oxid %ld", buf.data, oxid);
+	pfree(buf.data);
+}
+
+/*
+ * debug_print_validate_tuple - Debug function to print tuple before adding to tuplesort
+ *
+ * This function prints the tuple data in readable format for debugging purposes 
+ * during index validation, similar to tss_orioledb_print_idx_key.
+ */
+void
+debug_print_validate_tuple(OTuple tuple, OIndexDescr *idx, bool key, OXid oxid)
+{
+	StringInfoData buf;
+
+	TuplePrintOpaque opaque;
+	int i;
+	
+	// create a temporary memory context for this debug print to avoid bloating the main context
+	MemoryContext newctx = AllocSetContextCreate(TopMemoryContext,
+											 "DebugPrintValidateTupleContext",
+											 ALLOCSET_DEFAULT_SIZES);
+	MemoryContext oldContext = MemoryContextSwitchTo(newctx);
+
+	opaque.desc = idx->leafTupdesc;
+	opaque.spec = &idx->leafSpec;
+	opaque.keyDesc = idx->nonLeafTupdesc;
+	opaque.keySpec = &idx->nonLeafSpec;
+	opaque.values = (Datum *) palloc(sizeof(Datum) * opaque.desc->natts);
+	opaque.nulls = (bool *) palloc(sizeof(bool) * opaque.desc->natts);
+	opaque.outputFns = (FmgrInfo *) palloc(sizeof(FmgrInfo) * opaque.desc->natts);
+	opaque.keyOutputFns = (FmgrInfo *) palloc(sizeof(FmgrInfo) * opaque.keyDesc->natts);
+	opaque.printRowVersion = true;
+
+	for (i = 0; i < opaque.desc->natts; i++)
+	{
+		Oid			output;
+		bool		varlena;
+
+		getTypeOutputInfo(opaque.desc->attrs[i].atttypid, &output, &varlena);
+		fmgr_info(output, &opaque.outputFns[i]);
+	}
+
+	for (i = 0; i < opaque.keyDesc->natts; i++)
+	{
+		Oid			output;
+		bool		varlena;
+
+		getTypeOutputInfo(opaque.keyDesc->attrs[i].atttypid, &output, &varlena);
+		fmgr_info(output, &opaque.keyOutputFns[i]);
+	}
+	
+	initStringInfo(&buf);
+	if (key)
+	{
+		idx_key_print(&idx->desc, &buf, tuple, (Pointer)&opaque);
+		elog(WARNING, "key: %s : oxid %ld", buf.data, oxid);
+	}
+	else
+	{
+		idx_tup_print(&idx->desc, &buf, tuple, (Pointer)&opaque);
+		elog(WARNING, "tuple: %s : oxid %ld", buf.data, oxid);
+	}
+	
+	MemoryContextSwitchTo(oldContext);
+	MemoryContextDelete(newctx);
+}
+
+/*
+ * Convert a secondary index tuple into (secondary_key_fields, pk_fields) format
+ * for validation tuplesort.
+ * 
+ * Secondary index tuples may have:
+ * - Key fields (secondary key attributes)
+ * - Primary key fields (at the end of the key)
+ * - INCLUDE fields (non-key attributes that we don't need for validation)
+ * 
+ * This function extracts only the key fields (secondary + PK) and converts them
+ * into a tuple formatted for the specialized tuplesort that has:
+ *   [secondary_key_field_1, ..., secondary_key_field_N, pk_field_1, ..., pk_field_M]
+ * 
+ * Most of the time we can pass the secondary index tuple directly (if it has no
+ * INCLUDE fields), but when INCLUDE fields exist, we need to extract only the
+ * key portion.
+ * 
+ * Returns: A new OTuple in the format (secondary_key_fields, pk_fields).
+ *          Caller must pfree the returned tuple data.
+ */
+static OTuple
+convert_secondary_tuple_for_validation(OTuple secTuple, OIndexDescr *secIndex, BTreeLeafTuphdr header)
+{
+	BTreeDescr *secDesc = &secIndex->desc;
+	int			nKeyFields = secIndex->nKeyFields;
+	int			nFields = secIndex->nFields;
+	int			nPrimaryFields = secIndex->nPrimaryFields;
+	OTuple		result;
+	Pointer		oxidPtr;
+	OXid		oxid = XACT_INFO_GET_OXID(header.xactInfo);
+	
+	/*
+	 * If secondary index has no INCLUDE fields (nFields == nKeyFields),
+	 * we can use the tuple directly since it already has the correct format:
+	 * (secondary_key_fields, pk_fields).
+	 */
+	if (nKeyFields + nPrimaryFields == nFields)
+	{
+		/* Make a copy of the tuple */
+		Size tupleLen = o_btree_len(secDesc, secTuple, OTupleLength);
+		Size totalLen = tupleLen + sizeof(OXid);
+		result.data = (Pointer) palloc(totalLen);
+		memcpy(result.data, secTuple.data, tupleLen);
+		result.formatFlags = secTuple.formatFlags;
+		/* Append oxid at the end */
+		oxidPtr = result.data + tupleLen;
+		memcpy(oxidPtr, &oxid, sizeof(OXid));
+		return result;
+	}
+	
+	/*
+	 * Secondary index has INCLUDE fields that we need to exclude.
+	 * Extract only the key fields (secondary key + PK) and create a new tuple.
+	 */
+	{
+		Datum		values[2 * INDEX_MAX_KEYS];
+		bool		isnull[2 * INDEX_MAX_KEYS];
+		uint32		version = o_tuple_get_version(secTuple);
+		int			i;
+		Size		len;
+		TupleDesc	secnonLeafTupdesc = secIndex->nonLeafTupdesc;
+		OTupleFixedFormatSpec *secnonLeafSpec = &secIndex->nonLeafSpec;
+		
+		/* Extract all key fields (secondary key fields + PK fields) */
+		for (i = 0; i < nKeyFields + nPrimaryFields; i++)
+		{
+			values[i] = o_fastgetattr(secTuple, i + 1, secnonLeafTupdesc, secnonLeafSpec, &isnull[i]);
+		}
+
+		/*
+		 * Create a new tuple with only the key fields.
+		 * We use the secondary index's leafTupdesc/leafSpec for extraction,
+		 * but create the tuple in a format suitable for validation tuplesort.
+		 */
+		len = o_new_tuple_size(secnonLeafTupdesc, secnonLeafSpec, NULL, NULL, version, values, isnull, NULL);
+		Size totalLen = len + sizeof(OXid);
+		result.data = (Pointer) palloc0(totalLen);
+		o_tuple_fill(secnonLeafTupdesc, secnonLeafSpec, &result, len, NULL, NULL, version, values, isnull, NULL);
+		
+		/* Append oxid at the end */
+		oxidPtr = result.data + len;
+		memcpy(oxidPtr, &oxid, sizeof(OXid));
+		
+		return result;
+	}
+}
+
+/*
+ * Extract PK tuple from a validation tuplesort tuple.
+ * 
+ * Validation tuples from tuplesort are in format: (secondary_key_fields, pk_fields).
+ * This function extracts just the PK portion for comparison with primary index tuples.
+ * 
+ * Returns: A new OTuple containing only PK fields. Caller must pfree the returned tuple data.
+ */
+static OTuple
+extract_pk_from_validation_tuple(OTuple validationTuple, OIndexDescr *secIndex, OIndexDescr *pkIndex)
+{
+	Datum		pkValues[INDEX_MAX_KEYS];
+	bool		pkIsnull[INDEX_MAX_KEYS];
+	uint32		version = o_tuple_get_version(validationTuple);
+	int			i;
+	Size		len;
+	OTuple		result;
+	int			nSecKeyFields = secIndex->nKeyFields;
+	
+	/*
+	 * Extract PK fields from the validation tuple.
+	 * PK fields start at position (nSecKeyFields + 1) in the tuple.
+	 */
+	for (i = 0; i < secIndex->nPrimaryFields; i++)
+	{
+		pkValues[i] = o_fastgetattr(validationTuple, nSecKeyFields + i + 1,
+									secIndex->nonLeafTupdesc, &secIndex->nonLeafSpec,
+									&pkIsnull[i]);
+	}
+	
+	/*
+	 * Create a new tuple with PK fields using the PK descriptor.
+	 */
+	len = o_new_tuple_size(pkIndex->nonLeafTupdesc, &pkIndex->nonLeafSpec, NULL, NULL,
+						   version, pkValues, pkIsnull, NULL);
+	result.data = (Pointer) palloc0(len);
+	o_tuple_fill(pkIndex->nonLeafTupdesc, &pkIndex->nonLeafSpec, &result, len, NULL, NULL,
+				 version, pkValues, pkIsnull, NULL);
+	
+	return result;
+}
+
+/*
+ * validate_index_callback - Callback for index validation
+ *
+ * This callback is invoked by orioledb_ambulkdelete for each tuple in the index.
+ * It stores the FULL secondary index tuple into the tuplesort for later comparison
+ * with heap tuples. The tuplesort will sort by primary key for merge-join validation.
+ */
+static bool
+validate_index_callback(ItemPointer itemptr, void *callback_state)
+{
+	OValidateIndexState *state = (OValidateIndexState *) callback_state;
+	OIndexDescr *id = state->index_descr;
+
+	/*
+	 * For orioledb, the actual tuple is stored in state->current_tuple
+ 	 * by orioledb_ambulkdelete. For validation with deletion support, we need
+	 * to store the FULL secondary index tuple (not just PK) so we can later
+	 * delete entries that don't correspond to any primary tuple.
+	 *
+	 * The tuplesort will sort these tuples by PK (using a custom comparator),
+	 * enabling efficient merge-join with the primary index scan.
+	 */
+	if (!O_TUPLE_IS_NULL(state->current_tuple))
+	{
+		/* 
+		 * Put the FULL secondary index tuple into tuplesort.
+		 * The tuplesort comparator will extract and compare PK fields for sorting.
+		 */
+		OTuple fullIndexTuple;
+		/* Convert secondary tuple to (secondary_key_fields, pk_fields) format */
+		fullIndexTuple = convert_secondary_tuple_for_validation(state->current_tuple, id, state->header);
+		
+		tuplesort_putotuple(state->tuplesort, fullIndexTuple);
+
+		if(0)debug_print_validate_doubletuple(fullIndexTuple, state->table_descr, id, XACT_INFO_GET_OXID(state->header.xactInfo));
+		
+		pfree(fullIndexTuple.data);
+		state->itups++;
+		
+	}
+
+	/* Return false to indicate we don't want to delete this tuple during the scan */
+	return false;
+}
+
+
+static bool
+orioledb_validate_next_index_tid(OIndexDescr *index_descr,
+								 Tuplesortstate *tuplesort,
+								 OTuple *indexTuple,
+								 OXid *oxid)
+{
+	*indexTuple = tuplesort_getotuple(tuplesort, true);
+	
+	if (O_TUPLE_IS_NULL(*indexTuple))
+		return false;
+		
+	*oxid = *((OXid *) ((*indexTuple).data + o_btree_len(&index_descr->desc, *indexTuple, OTupleLength)));
+ 
+	return true;
+}
+
+static void
+orioledb_validate_tuple_backoff(Tuplesortstate *tuplesort)
+{
+	tuplesort_getotuple(tuplesort, false);
+}
+
+static void
+orioledb_fake_index_validate_scan(Relation tableRelation,
+						 Relation indexRelation,
+						 IndexInfo *indexInfo,
+						 Snapshot snapshot,
+						 ValidateIndexState *state)
+{
+	elog(ERROR, "fake_index_build_range_scan not implemented");
+}
+
+bool am_validate_process = false;
+OXid o_validate_process_current_oxid = InvalidOXid;
+
+static BTreeIterator *
+create_validate_iterator(BTreeDescr *desc, void *key, BTreeKeyType kind,
+						OSnapshot *o_snapshot, ScanDirection scanDir)
+{
+	return o_btree_iterator_create_with_flags(desc,
+											  key,
+											  kind,
+											  o_snapshot,
+											  scanDir,
+											  BTREE_PAGE_FIND_MODIFY);
+}
+
+static void
+wait_tuple_finished_for_everybody(BTreeLeafTuphdr *tupHdr)
+{
+	OXid		tupleOxid = XACT_INFO_GET_OXID(tupHdr->xactInfo);
+
+	while (true)
+	{
+		if (xid_is_finished(tupleOxid))
+			break;
+
+		CHECK_FOR_INTERRUPTS();
+		wait_for_oxid(tupleOxid, false);
+	}
+
+	while (!xid_is_finished_for_everybody(tupleOxid))
+	{
+		OXid		runXmin = pg_atomic_read_u64(&xid_meta->runXmin);
+		OXid		waitOxid;
+
+		CHECK_FOR_INTERRUPTS();
+		if (runXmin > tupleOxid)
+			continue;
+
+		waitOxid = runXmin;
+		while (true)
+		{
+			while (!wait_for_oxid(waitOxid, true))
+				CHECK_FOR_INTERRUPTS();
+			if (waitOxid == tupleOxid)
+				break;
+			if (waitOxid == UINT64_MAX)
+				break;
+			waitOxid++;
+		}
+	}
+}
+
+static OTuple
+validate_fetch_heap_tuple(BTreeIterator *iterator, OSnapshot *oSnapshot, OTableDescr *descr, CommitSeqNo *tupleCsn, BTreeLocationHint *hint, BTreeLeafTuphdr **tupHdr, bool *scanEnd, OTuple *PrevBoundary, OInMemoryBlkno *rightMostBlock)
+{
+	OTuple heapTuple;
+	BTreeLeafTuphdr tupHdr_old;
+retry_heap_fetch:
+	heapTuple = validate_iterator_fetch(iterator, scanEnd, hint, tupHdr, rightMostBlock);
+
+	if (*scanEnd)
+	{
+		O_TUPLE_SET_NULL(heapTuple);
+		*tupleCsn = InvalidCSN;
+		return heapTuple;
+	}
+	
+	/* If tuple is the same as the last boundary tuple, we have already validated it and can skip to the next one */
+	if (!O_TUPLE_IS_NULL(*PrevBoundary) && o_idx_cmp(&GET_PRIMARY(descr)->desc, &heapTuple, BTreeKeyNonLeafKey, PrevBoundary, BTreeKeyNonLeafKey) == 0)
+		goto retry_heap_fetch;
+
+	if (!XACT_INFO_FINISHED_FOR_EVERYBODY((*tupHdr)->xactInfo))
+	{
+		
+		/* Make a copy of tuple header to use for waiting and re-fetching */
+		tupHdr_old = **tupHdr;
+		
+		/* Unlock the page so that the transaction holding the tuple can finish */
+		unlock_page(hint->blkno);
+		
+		/* Wait for the transaction that is modifying this tuple to finish, so we can see the final state of the tuple */
+		wait_tuple_finished_for_everybody(&tupHdr_old);
+
+		 /* After waiting, we need to re-fetch the tuple to see its final state */
+		btree_iterator_free(iterator);
+		
+		if (!O_TUPLE_IS_NULL(*PrevBoundary))
+		{
+			iterator = create_validate_iterator(&GET_PRIMARY(descr)->desc,
+												PrevBoundary,
+												BTreeKeyLeafTuple,
+												oSnapshot, ForwardScanDirection);
+		}
+		else
+		{
+			iterator = create_validate_iterator(&GET_PRIMARY(descr)->desc,
+												NULL,
+												BTreeKeyNone,
+												oSnapshot, ForwardScanDirection);
+		}
+
+		goto retry_heap_fetch;
+	}
+	
+	*tupleCsn = XACT_INFO_MAP_CSN((*tupHdr)->xactInfo);
+	return heapTuple;
+}
+
 static void
 orioledb_index_validate_scan(Relation heapRelation,
 							 Relation indexRelation,
 							 IndexInfo *indexInfo,
 							 Snapshot snapshot,
-							 ValidateIndexState *state)
+							 OValidateIndexState *state)
 {
-	elog(ERROR, "Not implemented: %s", PG_FUNCNAME_MACRO);
+	OTableDescr *descr;
+	BTreeIterator *iterator;
+	TupleTableSlot *primarySlot;
+	BTreeLocationHint hint;
+	CommitSeqNo tupleCsn = InvalidCSN;
+	ExprState  *predicate;
+	EState	   *estate;
+	OTuple		heapLastBoundary;
+	ExprContext *econtext;
+	Datum		values[INDEX_MAX_KEYS];
+	bool		isnull[INDEX_MAX_KEYS];
+	OTuple		indexTuple = {0};
+	OTuple		heapTuple;
+	IndexUniqueCheck checkUnique;
+	OSnapshot	oSnapshot;
+	Datum		heapRowIdDatum;
+	bool		rowIdIsNull;
+	OXid IndexTupleOxid = InvalidOXid;
+	BTreeLeafTuphdr *tupHdr = NULL;
+	bool		tupleDeleted;
+	OIndexDescr *secIndex = state->index_descr;
+	BTreeDescr *secondaryDesc = &secIndex->desc;
+	ORelOids secIndexOids = secIndex->oids;
+	bool validationHaveHeapTuple = false;
+	bool validationHaveIndexTuple = false;
+	bool validationEndedHeapScan = false;
+	bool validationEndedIndexScan = false;
+	OInMemoryBlkno rightMostBlock = OInvalidInMemoryBlkno;
+	
+	O_TUPLE_SET_NULL(heapLastBoundary);
+	
+	am_validate_process = true;
+
+	Assert(state != NULL);
+	Assert(state->tuplesort != NULL);
+
+	estate = CreateExecutorState();
+	econtext = GetPerTupleExprContext(estate);
+	predicate = ExecPrepareQual(indexInfo->ii_Predicate, estate);
+
+	descr = relation_get_descr(heapRelation);
+	Assert(descr != NULL);
+
+	/*
+	 * Use SnapshotAny to see ALL tuples including in-progress ones.
+	 * This is necessary for validation to properly handle concurrent modifications
+	 * and ensure we see all tuples that might exist in secondary indexes.
+	 */
+	oSnapshot = o_in_progress_snapshot;
+	/* 
+	 * Use iterator instead of sequential scan to ensure tuples are returned
+	 * in primary key order. This is essential for the merge join algorithm.
+	 * The validation boundary starts unset (validationBoundaryLen == 0) and
+	 * will be updated as we progress through the scan.
+	 */
+	o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
+	/* Load shared memory for secondary index */
+	o_btree_load_shmem(secondaryDesc);
+	iterator = create_validate_iterator(&GET_PRIMARY(descr)->desc, NULL, BTreeKeyNone, &oSnapshot, ForwardScanDirection);
+	primarySlot = MakeSingleTupleTableSlot(descr->tupdesc, &TTSOpsOrioleDB);
+	econtext->ecxt_scantuple = primarySlot;
+
+	checkUnique = indexInfo->ii_Unique ? UNIQUE_CHECK_YES : UNIQUE_CHECK_NO;
+	
+	while (!validationEndedHeapScan || !validationEndedIndexScan)
+	{
+		int cmp;
+
+		if (!validationHaveHeapTuple && !validationEndedHeapScan)
+		{
+			heapTuple = validate_fetch_heap_tuple(iterator, &oSnapshot, descr, &tupleCsn, &hint, &tupHdr, &validationEndedHeapScan, &heapLastBoundary, &rightMostBlock);
+			
+			if (!validationEndedHeapScan)
+			{
+				tupleDeleted = (tupHdr->deleted != BTreeLeafTupleNonDeleted);
+				if (tupleDeleted)
+				{
+					/* tuple is deleted, just set the new boundary and continue */
+					btree_set_validation_boundary(GET_PRIMARY(descr), heapTuple);
+					continue;
+				}
+				
+				tts_orioledb_store_tuple(primarySlot, heapTuple, descr, tupleCsn, PrimaryIndexNumber, false, &hint);
+				slot_getallattrs(primarySlot);
+			
+				if (predicate != NULL)
+				{
+					if (!ExecQual(predicate, econtext))
+					{
+						/* Tuple doesn't satisfy the index predicate, skip it */
+						btree_set_validation_boundary(GET_PRIMARY(descr), heapTuple);
+						
+						/* Clean up the slot for the next tuple */
+						ExecClearTuple(primarySlot);
+						continue;
+					}
+				}
+				
+				state->htups++;
+				FormIndexDatum(indexInfo,
+							primarySlot,
+							estate,
+							values,
+							isnull);
+							
+				/* Get heap tuple's rowid for comparison and insertion */
+				heapRowIdDatum = slot_getsysattr(primarySlot, RowIdAttributeNumber, &rowIdIsNull);
+				Assert(!rowIdIsNull);
+				
+				validationHaveHeapTuple = true;
+			}
+			else
+			{
+				validationHaveHeapTuple = false;
+			}
+		}
+		
+		if (!validationHaveIndexTuple && !validationEndedIndexScan)
+		{
+			validationHaveIndexTuple = orioledb_validate_next_index_tid(secIndex,
+																		state->tuplesort,
+																		&indexTuple,
+																		&IndexTupleOxid);
+			if (!validationHaveIndexTuple)
+			{
+				validationEndedIndexScan = true;
+			}
+		}
+		
+		if (validationHaveIndexTuple && validationHaveHeapTuple)
+		{
+			OTuple pk_key;
+			/* 
+			 * Extract PK from the full secondary index tuple for comparison.
+			 * The indexTuple now contains the FULL secondary index tuple,
+			 * so we need to extract just the PK portion for comparison.
+			 */
+			pk_key = extract_pk_from_validation_tuple(indexTuple, secIndex, GET_PRIMARY(descr));
+			
+			/* 
+			 * Compare PK from secondary index tuple with PK from heap tuple.
+			 * This ensures we're comparing in the correct primary key order.
+			 */
+			cmp = o_idx_cmp(&GET_PRIMARY(descr)->desc, &pk_key, BTreeKeyNonLeafKey, &heapTuple, BTreeKeyNonLeafKey);
+			
+			/* if PKs are equal, compare the OXIDs to ensure we have the correct version of the tuple */
+			if (cmp == 0)
+			{
+				cmp = IndexTupleOxid - XACT_INFO_GET_OXID(tupHdr->xactInfo);
+			}
+			
+			if (debug_print_index_validate)
+			{
+				elog(WARNING, "Comparison result");
+				elog(WARNING, "Heap tuple for comparison:");
+				debug_print_validate_doubletuple(indexTuple, descr, secIndex, IndexTupleOxid);
+				debug_print_validate_tuple(heapTuple, GET_PRIMARY(descr), false, XACT_INFO_GET_OXID(tupHdr->xactInfo));
+				elog(WARNING, "Comparing index tuple with heap tuple: cmp = %d", cmp);
+			}
+			
+			pfree(pk_key.data);
+		}
+		else if (validationHaveIndexTuple)
+		{
+			cmp = -1; /* index tuple is "less" than heap tuple, meaning it has no matching heap tuple, and should be deleted */
+			if (debug_print_index_validate)
+			{
+				elog(WARNING, "Heap scan ended but index scan has more tuples. Next index tuple:");
+				debug_print_validate_doubletuple(indexTuple, descr, secIndex, IndexTupleOxid);
+			}
+		}
+		else if (validationHaveHeapTuple)
+		{
+			cmp = 1; /* heap tuple is "less" than index tuple, meaning it has no matching index tuple, and should be inserted */
+			if (debug_print_index_validate)
+			{
+				elog(WARNING, "Index scan ended but heap scan has more tuples. Next heap tuple:");
+				debug_print_validate_tuple(heapTuple, GET_PRIMARY(descr), false, XACT_INFO_GET_OXID(tupHdr->xactInfo));
+			}
+		}
+		else
+		{
+			break; /* both scans ended */
+		}
+		
+		if (cmp < 0)
+		{	
+			Page		p;
+			OInMemoryBlkno blkno;
+			BTreePageItemLocator *loc;
+			OBTreeFindPageContext context;
+			OFindPageResult findResult;
+			BTreeLeafTuphdr *tupHdrSecondary;
+			OTuple leafTup __attribute__((unused));
+			
+			Assert(validationHaveIndexTuple);
+
+			/*
+			 * Secondary index has a tuple that primary index doesn't have.
+			 * This means we need to DELETE this spurious entry from the secondary index.
+			 * Delete it immediately by marking the locator as invalid
+			 */
+			
+			/* we can't fetch new page while holding the lock on the current page */
+			if (!validationEndedHeapScan)
+				unlock_page(hint.blkno);
+			else
+			{
+				unlock_page(rightMostBlock);
+				rightMostBlock = OInvalidInMemoryBlkno;
+			}
+			
+			
+			/* Initialize find context to locate the secondary index entry */
+			init_page_find_context(&context, secondaryDesc,
+									COMMITSEQNO_INPROGRESS,
+									BTREE_PAGE_FIND_MODIFY);
+			
+			/* Find the page containing this secondary index entry */
+			findResult = find_page(&context, (Pointer) &indexTuple,
+									BTreeKeyNonLeafKey,
+									0);
+			if (findResult == OFindPageResultSuccess)
+			{
+				blkno = context.items[context.index].blkno;
+				p = O_GET_IN_MEMORY_PAGE(blkno);
+				loc = &context.items[context.index].locator;
+
+				/* Verify the entry exists and matches */
+				if (BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
+				{
+					uint32 sz;
+					
+					BTREE_PAGE_READ_LEAF_ITEM(tupHdrSecondary, leafTup, p, loc);
+					/*
+					 * Entry found and matches. Delete it immediately by marking
+					 * the locator as invalid (non-transactional deletion).
+					 */
+					sz =  BTREE_PAGE_GET_ITEM_SIZE(p, loc);
+					/* Mark page as dirty before modification */
+					page_block_reads(blkno);
+					
+					tupHdrSecondary->deleted = BTreeLeafTupleDeleted;
+					tupHdrSecondary->xactInfo = OXID_GET_XACT_INFO(BootstrapTransactionId, RowLockUpdate, false);
+					/* Mark the locator as invalid to delete the entry */
+					BTREE_PAGE_LOCATOR_SET_INVALID(loc);
+					/* Update page statistics */
+					PAGE_ADD_N_VACATED(p, sz);
+					
+					/* Mark the page as modified */
+					MARK_DIRTY(secondaryDesc, blkno);
+					state->tups_deleted++;
+				}
+
+				/* Unlock the page */
+				unlock_page(blkno);
+			}
+			
+			/* Reset the heap scan, as we have unlocked the page and the state might have changed. */
+			btree_iterator_free(iterator);
+				
+			if (!O_TUPLE_IS_NULL(heapLastBoundary))
+			{
+				iterator = create_validate_iterator(&GET_PRIMARY(descr)->desc,
+													&heapLastBoundary,
+													BTreeKeyLeafTuple,
+													&oSnapshot, ForwardScanDirection);
+			}
+			else
+			{
+				/* This only may happen with the first tuple */
+				iterator = create_validate_iterator(&GET_PRIMARY(descr)->desc,
+													NULL,
+													BTreeKeyNone,
+													&oSnapshot, ForwardScanDirection);
+			}
+	
+			if (validationHaveHeapTuple)
+				ExecClearTuple(primarySlot);
+			
+			/* fetch again to reset the state */
+			validationHaveHeapTuple = false;
+			validationEndedHeapScan = false;
+
+			/* fetch next index tuple for the next iteration */
+			validationHaveIndexTuple = false;
+		}
+		else if (cmp > 0)
+		{
+			BTreeLeafTuphdr headerHeapOld; 
+			
+			Assert(validationHaveHeapTuple);
+				
+			/* 
+			 * Unlock the page so that we can insert the missing tuple to the 
+			 * index and to the tuplesort, and reset the same scan.
+			 * But first make a copy of tuple and header.
+			 */
+			headerHeapOld = *tupHdr;
+			unlock_page(hint.blkno);
+				
+			/*
+			 * Heap has a tuple that secondary index doesn't have.
+			 * Insert the missing tuple into secondary index.
+			 */
+			SET_VALIDATE_PROCESS_OXID(XACT_INFO_GET_OXID(headerHeapOld.xactInfo));
+			if (index_insert(indexRelation, values, isnull, heapRowIdDatum,
+							 heapRelation, checkUnique, false, indexInfo))
+			{
+				OTuple fullIndexTuple;
+				
+				state->tups_inserted++;
+				
+				/* 
+				 * We got new tuple in the index, as we can not put tuples into tuplesort, 
+				 * we make it look like it is fetched from the index scan.
+				 */
+				fullIndexTuple = tts_orioledb_make_secondary_tuple(primarySlot, secIndex, true);
+				indexTuple = convert_secondary_tuple_for_validation(fullIndexTuple, secIndex,
+																	headerHeapOld);
+				IndexTupleOxid = XACT_INFO_GET_OXID(headerHeapOld.xactInfo);
+				validationHaveIndexTuple = true;
+				
+				/* 
+				 * Backoff the tuplesort, as we have not processed the new tuple yet.
+				 * So that during next fetch from tuplesort, we would get the tuple again for processing.
+				 * If tuples in tuplesort have ended, we would get NULL next time and end the index scan.
+				 */
+				orioledb_validate_tuple_backoff(state->tuplesort);
+				validationEndedIndexScan = false;
+			}
+
+			/* Reset the heap scan, as we have unlocked the page and the state might have changed. */
+			btree_iterator_free(iterator);
+			if (!O_TUPLE_IS_NULL(heapLastBoundary))
+			{
+				iterator = create_validate_iterator(&GET_PRIMARY(descr)->desc,
+													&heapLastBoundary,
+													BTreeKeyLeafTuple,
+													&oSnapshot, ForwardScanDirection);
+			}
+			else
+			{
+				/* This only may happen with the first tuple */
+				iterator = create_validate_iterator(&GET_PRIMARY(descr)->desc,
+													NULL,
+													BTreeKeyNone,
+													&oSnapshot, ForwardScanDirection);
+			}
+			
+			validationHaveHeapTuple = false;
+			validationEndedHeapScan = false;
+
+			ExecClearTuple(primarySlot);
+		}
+		else
+		{
+			/*
+			 * Both have the same tuple (cmp == 0). 
+			 * Move to next items in both scans.
+			 */
+			Assert(validationHaveHeapTuple && validationHaveIndexTuple);
+			
+			/* make a copy of heap tuple for the next iteration before we unlock the page */
+			if (!O_TUPLE_IS_NULL(heapLastBoundary))
+				pfree(heapLastBoundary.data);
+			heapLastBoundary.formatFlags = heapTuple.formatFlags;
+			heapLastBoundary.data = palloc(o_btree_len(&GET_PRIMARY(descr)->desc, heapTuple, OTupleLength));
+			memcpy(heapLastBoundary.data, heapTuple.data,
+					o_btree_len(&GET_PRIMARY(descr)->desc, heapTuple, OTupleLength));
+
+			btree_set_validation_boundary(GET_PRIMARY(descr), heapLastBoundary);
+			ExecClearTuple(primarySlot);		
+			
+			validationHaveIndexTuple = false;
+			validationHaveHeapTuple = false;
+		}
+	}
+
+	/*
+	 * Clear the validation boundary - validation is now complete.
+	 * All concurrent transactions can now freely modify all secondary index entries.
+	 */
+	btree_set_validation_boundary_full_visible(GET_PRIMARY(descr));
+	Assert(rightMostBlock != OInvalidInMemoryBlkno);
+	unlock_page(rightMostBlock);
+	
+	if (!O_TUPLE_IS_NULL(heapLastBoundary))
+		pfree(heapLastBoundary.data);
+	
+	am_validate_process = false;
+	
+	ExecDropSingleTupleTableSlot(primarySlot);
+	FreeExecutorState(estate);
+	btree_iterator_free(iterator);
+	
+	
+	/* 
+	 * If index is unique, we also need to validate that there are no duplicate entries in the index itself. 
+	 * This can be done by a separate bulkdelete scan on the index, which will check for duplicates and delete them if found.
+	 */
+	if (indexInfo->ii_Unique)
+	{
+		ORelOids tableoids;
+		int indexNum;
+		IndexBuildResult result;
+		
+		elog(DEBUG2, "checking secondary index for duplicates");
+		
+		ORelOidsSetFromRel(tableoids, heapRelation);
+		OTable *table = o_tables_get(tableoids);
+		
+		for (indexNum = 0; indexNum < descr->nIndices; indexNum++)
+		{
+			ORelOids indexOids = descr->indices[indexNum]->oids;
+			if (indexNum == PrimaryIndexNumber)
+				continue;
+						
+			if (ORelOidsIsEqual(indexOids, secIndexOids))
+			{
+				break;
+			}
+		}
+		
+		indexNum = table->has_primary ? indexNum  : indexNum - 1;
+		check_secondary_index_unique(table, descr, indexNum, &result);
+	}	
 }
 
 
@@ -1871,7 +3050,7 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 	reservoir_init_selection_state(&rstate, targrows);
 
 	tuple = btree_seq_scan_getnext_raw(scan, CurrentMemoryContext,
-									   &scanEnd, NULL);
+									   &scanEnd, NULL, NULL);
 	while (!scanEnd)
 	{
 		if (!O_TUPLE_IS_NULL(tuple))
@@ -1928,7 +3107,7 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 			deadrows += 1;
 		}
 		tuple = btree_seq_scan_getnext_raw(scan, CurrentMemoryContext,
-										   &scanEnd, NULL);
+										   &scanEnd, NULL, NULL);
 	}
 	free_btree_seq_scan(scan);
 
@@ -2353,7 +3532,10 @@ static const TableAmRoutine orioledb_am_methods = {
 	.scan_analyze_next_block = orioledb_scan_analyze_next_block,
 	.scan_analyze_next_tuple = orioledb_scan_analyze_next_tuple,
 	.index_build_range_scan = orioledb_index_build_range_scan,
-	.index_validate_scan = orioledb_index_validate_scan,
+	.index_validate_scan = orioledb_fake_index_validate_scan,
+	.index_validate = orioledb_index_validate,
+	.index_concurrently_swap = orioledb_reindex_concurrent_swap,
+	.index_drop = orioledb_index_validate_cleanup_old_concurrent,
 
 	.relation_size = orioledb_calculate_relation_size,
 	.relation_needs_toast_table = orioledb_relation_needs_toast_table,

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -1587,7 +1587,7 @@ o_update_secondary_index(OIndexDescr *id,
 									id->name.data,
 									true);
 
-		if (!id->unique || o_has_nulls(new_ix_tup))
+		if (!id->unique || o_has_nulls(new_ix_tup) || btree_index_is_ready_not_valid(id->oids.reloid))
 			res.success = o_btree_modify(&id->desc, BTreeOperationInsert,
 										 new_ix_tup, BTreeKeyLeafTuple,
 										 (Pointer) &new_key, BTreeKeyBound,
@@ -1786,6 +1786,18 @@ o_tbl_index_delete(OIndexDescr *id, OIndexNumber ix_num, TupleTableSlot *slot,
 	OTuple		nullTup;
 
 	O_TUPLE_SET_NULL(nullTup);
+	
+	/*
+	 * For secondary indexes during concurrent index build validation,
+	 * we create an undo record tracking the operation. The boundary check
+	 * will happen later when the page lock is held.
+	 */
+	if (id->desc.type != oIndexPrimary && !o_get_last_pk_satisfies_boundary() && btree_index_is_ready_not_valid(id->oids.reloid))
+	{
+		memset(&result, 0, sizeof(result));
+		result.success = true;
+		return result;  /* Skip boundary check for this operation */
+	}
 
 	fill_key_bound(slot, id, &bound);
 	o_btree_load_shmem(&id->desc);
@@ -1885,6 +1897,16 @@ o_tbl_index_insert(OTableDescr *descr,
 
 	if (!primary)
 	{
+		/*
+		 * Create undo record for this secondary index operation.
+		 * The undo record will track what actually happened during the operation.
+		 * The boundary check will occur later when the page lock is held.
+		 */
+		if (!IS_VALIDATE_PROCESS() && !o_get_last_pk_satisfies_boundary() && btree_index_is_ready_not_valid(id->oids.reloid))  /* Skip primary at index 0 */
+		{
+			return OBTreeModifyResultInserted;  /* Skip boundary check for this operation */ 
+		}
+		
 		if (own_tup)
 		{
 			fill_key_bound(slot, id, &knew);
@@ -1906,7 +1928,7 @@ o_tbl_index_insert(OTableDescr *descr,
 
 	o_btree_load_shmem(bd);
 	if (primary || !id->unique ||
-		(!id->nulls_not_distinct && o_has_nulls(tup)))
+		(!id->nulls_not_distinct && o_has_nulls(tup)) || btree_index_is_ready_not_valid(id->oids.reloid))
 		result = o_btree_modify(bd, BTreeOperationInsert,
 								tup, BTreeKeyLeafTuple,
 								(Pointer) &knew, BTreeKeyBound,
@@ -2389,6 +2411,9 @@ o_lock_wait_callback(BTreeDescr *descr, OTuple tup, OTuple *newtup,
 			elog(ERROR, "Unknown wait policy: %u", o_arg->waitPolicy);
 			break;
 	}
+	
+	pg_unreachable();
+	return OBTreeCallbackActionXidWait;
 }
 
 static OBTreeModifyCallbackAction

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -44,9 +44,6 @@ static JsonbValue *o_key_to_jsonb(BTreeDescr *desc, OTuple key,
 static OTuple o_sidx_tuple_make_key(BTreeDescr *desc, OTuple tupl,
 									Pointer data, bool keep_version,
 									bool *allocated);
-static OTuple o_tuple_make_key(BTreeDescr *desc, OTuple tuple,
-							   Pointer data, bool keep_version,
-							   bool *allocated);
 static OTuple o_create_key_tuple(BTreeDescr *desc, OTuple tuple,
 								 Pointer data, OIndexType type,
 								 bool keep_version);
@@ -449,7 +446,7 @@ o_idx_unique_hash(BTreeDescr *desc, OTuple tuple)
 }
 
 /* creates index tuple from table tuple for primary index */
-static OTuple
+OTuple
 o_tuple_make_key(BTreeDescr *desc, OTuple tuple, Pointer data,
 				 bool keep_version, bool *allocated)
 {

--- a/src/tuple/sort.c
+++ b/src/tuple/sort.c
@@ -29,6 +29,7 @@ typedef struct
 	TupleDesc	tupDesc;
 	OIndexDescr *id;
 	bool		enforceUnique;
+	bool		hasOxidField;	/* True if tuples have oxid appended at end */
 } OIndexBuildSortArg;
 
 static void
@@ -66,10 +67,10 @@ comparetup_orioledb_index(const SortTuple *a, const SortTuple *b, Tuplesortstate
 	int			nkey;
 	int32		compare;
 	AttrNumber	attno;
-	Datum		datum1,
-				datum2;
-	bool		isnull1,
-				isnull2;
+	Datum		datum1 = 0,
+				datum2 = 0;
+	bool		isnull1 = false,
+				isnull2 = false;
 	OIndexBuildSortArg *arg = (OIndexBuildSortArg *) base->arg;
 	OTupleFixedFormatSpec *spec = &arg->id->leafSpec;
 
@@ -136,13 +137,51 @@ comparetup_orioledb_index(const SortTuple *a, const SortTuple *b, Tuplesortstate
 	 * sort algorithm wouldn't have checked whether one must appear before the
 	 * other.
 	 */
-	if (arg->enforceUnique && !equal_hasnull)
+	if (arg->enforceUnique && !(!arg->id->nulls_not_distinct && equal_hasnull))
 	{
+		StringInfo	str = makeStringInfo();
+		int			i;
+
+		appendStringInfo(str, "(");
+		for (i = 0; i < arg->id->nKeyFields; i++)
+		{
+			if (i != 0)
+				appendStringInfo(str, ", ");
+			appendStringInfo(str, "%s",
+							 arg->id->nonLeafTupdesc->attrs[i].attname.data);
+		}
+		appendStringInfo(str, ")=(");
+		sortKey = base->sortKeys;
+		for (i = 0; i < arg->id->nUniqueFields; i++, sortKey++)
+		{
+			bool		isnull;
+			Datum		value;
+
+			attno = sortKey->ssup_attno;
+			value = o_fastgetattr(ltup, attno, tupDesc, spec, &isnull);
+			if (i != 0)
+				appendStringInfo(str, ", ");
+			if (isnull)
+				appendStringInfo(str, "null");
+			else
+			{
+				Oid			typoutput;
+				bool		typisvarlena;
+				char	   *res;
+
+				getTypeOutputInfo(arg->id->nonLeafTupdesc->attrs[i].atttypid,
+								  &typoutput, &typisvarlena);
+				res = OidOutputFunctionCall(typoutput, value);
+				appendStringInfo(str, "'%s'", res);
+			}
+		}
+		appendStringInfo(str, ")");
+
 		ereport(ERROR,
 				(errcode(ERRCODE_UNIQUE_VIOLATION),
 				 errmsg("could not create unique index \"%s\"",
 						arg->id->name.data),
-				 errdetail("Duplicate keys exist.")));
+				 errdetail("Duplicate key \"%s\" violates unique constraint.", str->data)));
 	}
 
 	return 0;
@@ -160,8 +199,18 @@ writetup_orioledb_index(Tuplesortstate *state, LogicalTape *tape, SortTuple *stu
 	tuple = read_o_tuple(stup->tuple);
 	tuplen = o_tuple_size(tuple, spec) + sizeof(int) + 1;
 
+	/* Add oxid size for validation tuples */
+	if (arg->hasOxidField)
+		tuplen += sizeof(OXid);
+		
 	LogicalTapeWrite(tape, (void *) &tuplen, sizeof(tuplen));
 	LogicalTapeWrite(tape, (void *) tuple.data, o_tuple_size(tuple, spec));
+	/* Write oxid if present */
+	if (arg->hasOxidField)
+	{
+		Pointer oxidPtr = tuple.data + o_tuple_size(tuple, spec);
+		LogicalTapeWrite(tape, oxidPtr, sizeof(OXid));
+	}
 	LogicalTapeWrite(tape, (void *) &tuple.formatFlags, 1);
 	if (base->sortopt & TUPLESORT_RANDOMACCESS) /* need trailing length word? */
 		LogicalTapeWrite(tape, (void *) &tuplen, sizeof(tuplen));
@@ -241,6 +290,7 @@ tuplesort_begin_orioledb_index(OIndexDescr *idx,
 	arg->id = idx;
 	arg->tupDesc = idx->leafTupdesc;
 	arg->enforceUnique = idx->unique;
+	arg->hasOxidField = true;
 
 	base->sortKeys = (SortSupport) palloc0(sort_fields *
 										   sizeof(SortSupportData));
@@ -275,6 +325,139 @@ tuplesort_begin_orioledb_index(OIndexDescr *idx,
 	return state;
 }
 
+/*
+ * tuplesort_begin_orioledb_index_secondary_pk - create tuplesort for secondary index validation
+ *
+ * This function creates a tuplesort for validating secondary indexes during concurrent
+ * index builds. Unlike tuplesort_begin_orioledb_index which takes a single index descriptor,
+ * this function takes both secondary and primary index descriptors.
+ *
+ * The tuples stored have a special layout:
+ * - First: Secondary index key fields (only the actual key fields, not including PK)
+ * - Then: Primary key fields
+ *
+ * The sorting is done ONLY by the primary key fields, which enables merge-join
+ * validation with the primary index scan. The tupDesc describes all fields (secondary key + PK),
+ * but the sortKeys only reference the PK portion for sorting.
+ *
+ * This is essential for functional secondary indexes where secondary key values cannot
+ * be computed from PK tuples alone - we must store the actual secondary key values
+ * from the index being validated.
+ *
+ * Parameters:
+ *   secondary - The secondary index descriptor (provides secondary key field information)
+ *   primary - The primary index descriptor (provides PK fields and sorting rules)
+ *   workMem - Memory limit for in-memory sorting
+ *   randomAccess - Whether random access to sorted data is required
+ *   coordinate - Coordination info for parallel sort (can be NULL)
+ *
+ * Returns: Tuplesortstate configured for secondary index validation
+ */
+Tuplesortstate *
+tuplesort_begin_orioledb_index_secondary_pk(OIndexDescr *secondary,
+											 OIndexDescr *primary,
+											 int workMem,
+											 bool randomAccess,
+											 SortCoordinate coordinate)
+{
+	Tuplesortstate *state = tuplesort_begin_common(workMem, coordinate,
+												   randomAccess);
+	TuplesortPublic *base = TuplesortstateGetPublic(state);
+	MemoryContext oldcontext;
+	OIndexBuildSortArg *arg;
+	int			secondary_key_fields;
+	int			pk_fields;
+	int			total_fields;
+	int			i;
+	TupleDesc	combinedTupDesc;
+
+	/*
+	 * Calculate field counts:
+	 * - secondary_key_fields: only the key fields of secondary index (NOT including PK)
+	 * - pk_fields: number of PK key fields
+	 * - total_fields: secondary key fields + PK fields (no duplication)
+	 */
+	secondary_key_fields = secondary->nKeyFields;
+	pk_fields = primary->nKeyFields;
+	total_fields = secondary_key_fields + pk_fields;
+
+	oldcontext = MemoryContextSwitchTo(base->maincontext);
+	
+	/*
+	 * Create combined tuple descriptor with secondary key fields first, then PK fields.
+	 * We use the primary index for comparison (stored in arg->id), but the tupDesc
+	 * includes all fields.
+	 */
+	combinedTupDesc = CreateTemplateTupleDesc(total_fields);
+	
+	/* Add secondary key fields */
+	for (i = 0; i < secondary_key_fields; i++)
+	{
+		TupleDescInitEntry(combinedTupDesc,
+						   i + 1,
+						   NameStr(secondary->leafTupdesc->attrs[i].attname),
+						   secondary->leafTupdesc->attrs[i].atttypid,
+						   secondary->leafTupdesc->attrs[i].atttypmod,
+						   0);
+		combinedTupDesc->attrs[i].attcollation =
+			secondary->leafTupdesc->attrs[i].attcollation;
+	}
+	
+	/* Add PK fields after secondary key fields */
+	for (i = 0; i < pk_fields; i++)
+	{
+		TupleDescInitEntry(combinedTupDesc,
+						   secondary_key_fields + i + 1,
+						   NameStr(primary->leafTupdesc->attrs[i].attname),
+						   primary->leafTupdesc->attrs[i].atttypid,
+						   primary->leafTupdesc->attrs[i].atttypmod,
+						   0);
+		combinedTupDesc->attrs[secondary_key_fields + i].attcollation =
+			primary->leafTupdesc->attrs[i].attcollation;
+	}
+	
+	arg = (OIndexBuildSortArg *) palloc0(sizeof(OIndexBuildSortArg));
+	arg->id = primary;  /* Use primary for comparison logic */
+	arg->tupDesc = combinedTupDesc;
+	arg->enforceUnique = false;  /* Secondary index validation doesn't enforce uniqueness on PK */
+	arg->hasOxidField = true;  /* Validation tuples have oxid appended */
+	/*
+	 * Set up sort keys - we only sort by PK fields, which are at the end
+	 * of our combined tuple descriptor
+	 */
+	base->sortKeys = (SortSupport) palloc0(pk_fields * sizeof(SortSupportData));
+	base->nKeys = pk_fields;
+
+	base->removeabbrev = removeabbrev_orioledb_index;
+	base->comparetup = comparetup_orioledb_index;
+	base->writetup = writetup_orioledb_index;
+	base->readtup = readtup_orioledb_index;
+	base->arg = arg;
+
+	/*
+	 * Configure sort keys to reference PK fields in the combined tuple descriptor.
+	 * PK fields start at position (secondary_key_fields + 1) in our tuple descriptor.
+	 */
+	for (i = 0; i < pk_fields; i++)
+	{
+		SortSupport sortKey = &base->sortKeys[i];
+
+		sortKey->ssup_cxt = CurrentMemoryContext;
+		sortKey->ssup_collation = primary->fields[i].collation;
+		sortKey->ssup_nulls_first = primary->fields[i].nullfirst;
+		/* Attribute number in the combined tuple descriptor */
+		sortKey->ssup_attno = secondary_key_fields + i + 1;
+		sortKey->abbreviate = (i == 0);
+		sortKey->ssup_reverse = !primary->fields[i].ascending;
+		/* FIXME: no abbrev converter yet */
+		o_finish_sort_support_function(primary->fields[i].comparator, sortKey);
+	}
+
+	MemoryContextSwitchTo(oldcontext);
+
+	return state;
+}
+
 Tuplesortstate *
 tuplesort_begin_orioledb_toast(OIndexDescr *toast,
 							   OIndexDescr *primary,
@@ -299,6 +482,7 @@ tuplesort_begin_orioledb_toast(OIndexDescr *toast,
 	arg->id = primary;
 	arg->tupDesc = toast->leafTupdesc;
 	arg->enforceUnique = true;
+	arg->hasOxidField = false;
 
 	base->sortKeys = (SortSupport)
 		palloc0((key_fields + TOAST_NON_LEAF_FIELDS_NUM) *
@@ -402,6 +586,11 @@ tuplesort_putotuple(Tuplesortstate *state, OTuple tup)
 	 * Then call the common code.
 	 */
 	tupsize = o_tuple_size(tup, spec);
+	
+	/* Add oxid size for validation tuples */
+	if (arg->hasOxidField)
+		tupsize += sizeof(OXid);
+	
 	stup.tuple = MemoryContextAlloc(base->tuplecontext, MAXIMUM_ALIGNOF + tupsize);
 	write_o_tuple(stup.tuple, tup, tupsize);
 	written_tup = read_o_tuple(stup.tuple);

--- a/test/expected/index_concurrently.out
+++ b/test/expected/index_concurrently.out
@@ -1,0 +1,169 @@
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+CREATE TABLE t_concurrent_build (
+	id int PRIMARY KEY,
+	val int
+) USING orioledb;
+-- Insert enough data to make index build take time
+INSERT INTO t_concurrent_build SELECT i, i * 100 FROM generate_series(2, 5000000) i;
+-- Create a simple done table to signal when background job completes
+CREATE TABLE concurrent_build_done (step int);
+-- Start concurrent index build in background
+\! psql -d reindex_concurrently_test_db -c "CREATE INDEX CONCURRENTLY t_concurrent_build_idx ON t_concurrent_build (val);"  && psql -d reindex_concurrently_test_db -c "INSERT INTO concurrent_build_done VALUES (1);" &
+-- Wait for build phase to start (1 seconds)
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Case 1: INSERT new tuple (key=99999) - will be deleted later
+-- Case 2: DELETE existing tuple (key=100) - will be reinserted later
+INSERT INTO t_concurrent_build VALUES (1, 100);
+DELETE FROM t_concurrent_build WHERE id = 5;
+INSERT INTO t_concurrent_build VALUES (5000001, 500000100);
+DELETE FROM t_concurrent_build WHERE id = 50000;
+DELETE FROM t_concurrent_build WHERE id = 50001;
+SELECT pg_sleep(3);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+BEGIN;
+INSERT INTO t_concurrent_build VALUES (50000, 5000000);
+SAVEPOINT sp1;
+INSERT INTO t_concurrent_build VALUES (50001, 5000100);
+SELECT pg_sleep(30);  -- Ensure this transaction overlaps with index build
+ pg_sleep 
+----------
+ 
+(1 row)
+
+ROLLBACK TO sp1;  -- Rollback second insert, but keep first one
+COMMIT;
+-- Wait for background job completion signal
+DO $$
+DECLARE
+	done_count int := 0;
+BEGIN
+	WHILE done_count = 0 LOOP
+		SELECT COUNT(*) INTO done_count FROM concurrent_build_done WHERE step = 1;
+		IF done_count = 0 THEN
+			PERFORM pg_sleep(1);
+		END IF;
+        COMMIT;
+	END LOOP;
+END $$;
+CREATE INDEX
+INSERT 0 1
+-- Verify the index was created
+\d+ t_concurrent_build
+                            Table "public.t_concurrent_build"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ id     | integer |           | not null |         | plain   |              | 
+ val    | integer |           |          |         | plain   |              | 
+Indexes:
+    "t_concurrent_build_pkey" PRIMARY KEY, btree (id)
+    "t_concurrent_build_idx" btree (val)
+
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_concurrent_build'::regclass, true, true);
+               orioledb_tbl_indices                
+---------------------------------------------------
+ Index t_concurrent_build_pkey                    +
+     reloid: 16464                                +
+     relnode: 16467                               +
+     Index type: primary, unique                  +
+     Leaf tuple size: 2, non-leaf tuple size: 1   +
+     Non-leaf tuple fields: id                    +
+     Leaf tuple fields: id, val                   +
+ Index t_concurrent_build_idx                     +
+     reloid: 16472                                +
+     relnode: 16472                               +
+     Index type: secondary                        +
+     Leaf tuple size: 2, non-leaf tuple size: 2   +
+     Non-leaf tuple fields: val, id               +
+     Leaf tuple fields: val, id                   +
+ Index toast                                      +
+     reloid: 16462                                +
+     relnode: 16466                               +
+     Index type: secondary                        +
+     Leaf tuple size: 4, non-leaf tuple size: 3   +
+     Non-leaf tuple fields: id, attnum, chunknum  +
+     Leaf tuple fields: id, attnum, chunknum, data+
+ 
+(1 row)
+
+-- Verify index works correctly
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 100;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Index Only Scan using t_concurrent_build_idx on t_concurrent_build
+   Index Cond: (val = 100)
+(2 rows)
+
+SELECT id FROM t_concurrent_build WHERE val = 100;
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 500;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Index Only Scan using t_concurrent_build_idx on t_concurrent_build
+   Index Cond: (val = 500)
+(2 rows)
+
+SELECT id FROM t_concurrent_build WHERE val = 500;
+ id 
+----
+(0 rows)
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 5000000;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Index Only Scan using t_concurrent_build_idx on t_concurrent_build
+   Index Cond: (val = 5000000)
+(2 rows)
+
+SELECT id FROM t_concurrent_build WHERE val = 5000000;
+  id   
+-------
+ 50000
+(1 row)
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 5000100;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Index Only Scan using t_concurrent_build_idx on t_concurrent_build
+   Index Cond: (val = 5000100)
+(2 rows)
+
+SELECT id FROM t_concurrent_build WHERE val = 5000100;
+ id 
+----
+(0 rows)
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 500000100;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Index Only Scan using t_concurrent_build_idx on t_concurrent_build
+   Index Cond: (val = 500000100)
+(2 rows)
+
+SELECT id FROM t_concurrent_build WHERE val = 500000100;
+   id    
+---------
+ 5000001
+(1 row)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+\c regression
+DROP DATABASE reindex_concurrently_test_db;

--- a/test/expected/index_concurrently_unique.out
+++ b/test/expected/index_concurrently_unique.out
@@ -1,0 +1,93 @@
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+CREATE TABLE t_concurrent_build (
+	id int PRIMARY KEY,
+	val int
+) USING orioledb;
+-- Insert enough data to make index build take time
+INSERT INTO t_concurrent_build SELECT i, i * 100 FROM generate_series(2, 5000000) i;
+-- Create a simple done table to signal when background job completes
+CREATE TABLE concurrent_build_done (step int);
+INSERT INTO t_concurrent_build VALUES (1, 200); 
+CREATE UNIQUE INDEX CONCURRENTLY t_concurrent_build_idx ON t_concurrent_build (val);
+ERROR:  could not create unique index "t_concurrent_build_idx"
+DETAIL:  Duplicate key "(val)=('200')" violates unique constraint.
+\d+ t_concurrent_build
+                            Table "public.t_concurrent_build"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ id     | integer |           | not null |         | plain   |              | 
+ val    | integer |           |          |         | plain   |              | 
+Indexes:
+    "t_concurrent_build_pkey" PRIMARY KEY, btree (id)
+    "t_concurrent_build_idx" UNIQUE, btree (val) INVALID
+
+DROP INDEX t_concurrent_build_idx;
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_concurrent_build'::regclass, true, true);
+               orioledb_tbl_indices                
+---------------------------------------------------
+ Index t_concurrent_build_pkey                    +
+     reloid: 16552                                +
+     relnode: 16555                               +
+     Index type: primary, unique                  +
+     Leaf tuple size: 2, non-leaf tuple size: 1   +
+     Non-leaf tuple fields: id                    +
+     Leaf tuple fields: id, val                   +
+ Index toast                                      +
+     reloid: 16550                                +
+     relnode: 16554                               +
+     Index type: secondary                        +
+     Leaf tuple size: 4, non-leaf tuple size: 3   +
+     Non-leaf tuple fields: id, attnum, chunknum  +
+     Leaf tuple fields: id, attnum, chunknum, data+
+ 
+(1 row)
+
+DELETE FROM t_concurrent_build WHERE id = 1;
+-- Start concurrent index build in background
+\! psql -d reindex_concurrently_test_db -c "CREATE UNIQUE INDEX CONCURRENTLY t_concurrent_build_idx ON t_concurrent_build (val);"  && psql -d reindex_concurrently_test_db -c "INSERT INTO concurrent_build_done VALUES (1);" &
+-- Wait for build phase to start (1 seconds)
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+DELETE FROM t_concurrent_build WHERE id = 4000000;
+INSERT INTO t_concurrent_build VALUES (1, 400000000);
+-- Wait for background job completion signal
+DO $$
+DECLARE
+	done_count int := 0;
+BEGIN
+	WHILE done_count = 0 LOOP
+		SELECT COUNT(*) INTO done_count FROM concurrent_build_done WHERE step = 1;
+		IF done_count = 0 THEN
+			PERFORM pg_sleep(1);
+		END IF;
+        COMMIT;
+	END LOOP;
+END $$;
+CREATE INDEX
+INSERT 0 1
+-- Verify the index was created
+\d+ t_concurrent_build
+                            Table "public.t_concurrent_build"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ id     | integer |           | not null |         | plain   |              | 
+ val    | integer |           |          |         | plain   |              | 
+Indexes:
+    "t_concurrent_build_pkey" PRIMARY KEY, btree (id)
+    "t_concurrent_build_idx" UNIQUE, btree (val)
+
+DELETE FROM t_concurrent_build WHERE id = 1;
+INSERT INTO t_concurrent_build VALUES (1, 200);
+ERROR:  duplicate key value violates unique constraint "t_concurrent_build_idx"
+DETAIL:  Key (val)=('200') already exists.
+DROP INDEX t_concurrent_build_idx;
+INSERT INTO t_concurrent_build VALUES (1, 200);
+\c regression
+DROP DATABASE reindex_concurrently_test_db;

--- a/test/expected/reindex_concurrently_content.out
+++ b/test/expected/reindex_concurrently_content.out
@@ -1,0 +1,146 @@
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+create table t_reindex
+(
+    id int,
+    someint int,
+    balance int
+) using orioledb;
+CREATE TABLE test_step (
+    test_step int
+);
+CREATE TABLE done_items (
+    done_items int
+);
+INSERT INTO t_reindex SELECT t, 11 - t, 0 FROM generate_series(1,1000) as t;
+SELECT oid, relname, relfilenode FROM pg_class where relname like 't_reindex%';
+  oid  |  relname  | relfilenode 
+-------+-----------+-------------
+ 16636 | t_reindex |       16636
+(1 row)
+
+CREATE INDEX CONCURRENTLY t_reindex_idx ON t_reindex (id);
+SELECT oid, relname, relfilenode FROM pg_class where relname like 't_reindex%';
+  oid  |    relname    | relfilenode 
+-------+---------------+-------------
+ 16636 | t_reindex     |       16636
+ 16647 | t_reindex_idx |       16647
+(2 rows)
+
+SELECT pg_relation_size( 't_reindex_idx'::regclass);
+ pg_relation_size 
+------------------
+            40960
+(1 row)
+
+UPDATE t_reindex SET id = id + 1000000;
+SELECT pg_relation_size( 't_reindex_idx'::regclass);
+ pg_relation_size 
+------------------
+            81920
+(1 row)
+
+\d+ t_reindex;
+                                 Table "public.t_reindex"
+ Column  |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+---------+---------+-----------+----------+---------+---------+--------------+-------------
+ id      | integer |           |          |         | plain   |              | 
+ someint | integer |           |          |         | plain   |              | 
+ balance | integer |           |          |         | plain   |              | 
+Indexes:
+    "t_reindex_idx" btree (id)
+
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_reindex'::regclass, true, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     reloid: 16636                                  +
+     relnode: 16636                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, id, someint, balance  +
+ Index t_reindex_idx                                +
+     reloid: 16647                                  +
+     relnode: 16647                                 +
+     Index type: secondary                          +
+     Leaf tuple size: 2, non-leaf tuple size: 2     +
+     Non-leaf tuple fields: id, ctid                +
+     Leaf tuple fields: id, ctid                    +
+ Index toast                                        +
+     reloid: 16639                                  +
+     relnode: 16639                                 +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+SELECT pg_relation_size( 't_reindex_idx'::regclass);
+ pg_relation_size 
+------------------
+            40960
+(1 row)
+
+\d+ t_reindex;
+                                 Table "public.t_reindex"
+ Column  |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+---------+---------+-----------+----------+---------+---------+--------------+-------------
+ id      | integer |           |          |         | plain   |              | 
+ someint | integer |           |          |         | plain   |              | 
+ balance | integer |           |          |         | plain   |              | 
+Indexes:
+    "t_reindex_idx" btree (id)
+
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_reindex'::regclass, true, true);
+                orioledb_tbl_indices                 
+-----------------------------------------------------
+ Index ctid_primary                                 +
+     reloid: 16636                                  +
+     relnode: 16636                                 +
+     Index type: primary, unique, ctid              +
+     Leaf tuple size: 4, non-leaf tuple size: 1     +
+     Non-leaf tuple fields: ctid                    +
+     Leaf tuple fields: ctid, id, someint, balance  +
+ Index t_reindex_idx                                +
+     reloid: 16648                                  +
+     relnode: 16648                                 +
+     Index type: secondary                          +
+     Leaf tuple size: 2, non-leaf tuple size: 2     +
+     Non-leaf tuple fields: id, ctid                +
+     Leaf tuple fields: id, ctid                    +
+ Index toast                                        +
+     reloid: 16639                                  +
+     relnode: 16639                                 +
+     Index type: secondary                          +
+     Leaf tuple size: 4, non-leaf tuple size: 3     +
+     Non-leaf tuple fields: ctid, attnum, chunknum  +
+     Leaf tuple fields: ctid, attnum, chunknum, data+
+ 
+(1 row)
+
+set enable_seqscan = off;
+SELECT COUNT(*) FROM t_reindex WHERE id > 1000000;
+ count 
+-------
+  1000
+(1 row)
+
+EXPLAIN SELECT COUNT(*) FROM t_reindex WHERE id > 1000000;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Aggregate  (cost=21.85..21.86 rows=1 width=8)
+   ->  Custom Scan (o_scan) on t_reindex  (cost=10.86..21.02 rows=333 width=0)
+         Bitmap heap scan
+         Recheck Cond: (id > 1000000)
+         ->  Bitmap Index Scan on t_reindex_idx  (cost=0.00..10.77 rows=333 width=0)
+               Index Cond: (id > 1000000)
+(6 rows)
+
+RESET enable_seqscan;
+\c regression
+DROP DATABASE reindex_concurrently_test_db;

--- a/test/expected/reindex_concurrently_insert.out
+++ b/test/expected/reindex_concurrently_insert.out
@@ -1,0 +1,306 @@
+-- test with ctid
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+create table t_reindex
+(
+    id int,
+    someint int,
+    balance int
+) using orioledb;
+CREATE TABLE test_step (
+    test_step int
+);
+CREATE TABLE done_items (
+    done_items int
+);
+INSERT INTO t_reindex SELECT t, 99998 - t, 0 FROM generate_series(1,99999) as t;
+create index CONCURRENTLY t_reindex_idx on t_reindex(someint);
+SET enable_seqscan = off;
+EXPLAIN SELECT COUNT(*) FROM t_reindex;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Aggregate  (cost=4280.40..4280.41 rows=1 width=8)
+   ->  Custom Scan (o_scan) on t_reindex  (cost=2441.41..4030.40 rows=99999 width=0)
+         Bitmap heap scan
+         ->  Bitmap Index Scan on t_reindex_idx  (cost=0.00..2416.41 rows=99999 width=0)
+(4 rows)
+
+SELECT COUNT(*) FROM t_reindex;
+ count 
+-------
+ 99999
+(1 row)
+
+SET enable_seqscan = on;
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+INSERT INTO test_step VALUES (1);
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+ case 
+------
+    1
+(1 row)
+
+TRUNCATE test_step;
+TRUNCATE done_items;
+UPDATE t_reindex SET balance = 0;
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "INSERT INTO t_reindex VALUES ($i+100000000, $i, 1); INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+INSERT INTO test_step VALUES (1);
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+ case 
+------
+    1
+(1 row)
+
+\c regression
+DROP DATABASE reindex_concurrently_test_db;
+-- test with pk
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+create table t_reindex
+(
+    id int PRIMARY KEY,
+    someint int,
+    balance int
+) using orioledb;
+CREATE TABLE test_step (
+    test_step int
+);
+CREATE TABLE done_items (
+    done_items int
+);
+INSERT INTO t_reindex SELECT t, 99998 - t, 0 FROM generate_series(1,99999) as t;
+create index CONCURRENTLY t_reindex_idx on t_reindex(someint);
+SET enable_seqscan = off;
+EXPLAIN SELECT COUNT(*) FROM t_reindex;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Aggregate  (cost=3720.27..3720.28 rows=1 width=8)
+   ->  Custom Scan (o_scan) on t_reindex  (cost=1993.29..3470.28 rows=99999 width=0)
+         Bitmap heap scan
+         ->  Bitmap Index Scan on t_reindex_idx  (cost=0.00..1968.29 rows=99999 width=0)
+(4 rows)
+
+SELECT COUNT(*) FROM t_reindex;
+ count 
+-------
+ 99999
+(1 row)
+
+SET enable_seqscan = on;
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+INSERT INTO test_step VALUES (1);
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+ case 
+------
+    1
+(1 row)
+
+TRUNCATE test_step;
+TRUNCATE done_items;
+UPDATE t_reindex SET balance = 0;
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET id = id + 100000000, balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+INSERT INTO test_step VALUES (1);
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+ case 
+------
+    1
+(1 row)
+
+TRUNCATE test_step;
+TRUNCATE done_items;
+UPDATE t_reindex SET balance = 0;
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET someint = someint + 100000000, balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+SELECT pg_sleep(5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+\d+ t_reindex;
+                                 Table "public.t_reindex"
+ Column  |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+---------+---------+-----------+----------+---------+---------+--------------+-------------
+ id      | integer |           | not null |         | plain   |              | 
+ someint | integer |           |          |         | plain   |              | 
+ balance | integer |           |          |         | plain   |              | 
+Indexes:
+    "t_reindex_pkey" PRIMARY KEY, btree (id)
+    "t_reindex_idx" btree (someint)
+
+INSERT INTO test_step VALUES (1);
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+ case 
+------
+    1
+(1 row)
+
+\c regression
+DROP DATABASE reindex_concurrently_test_db;

--- a/test/expected/stats.out
+++ b/test/expected/stats.out
@@ -571,7 +571,6 @@ SELECT pg_stat_have_stats('relation', :dboid, :stats_test_idx1_oid);
 (1 row)
 
 REINDEX index CONCURRENTLY stats_test_idx1;
-WARNING:  REINDEX CONCURRENTLY is not supported for orioledb tables yet, using a plain REINDEX instead
 -- true since REINDEX INDEX CONCURRENTLY was changed to plain REINDEX
 SELECT pg_stat_have_stats('relation', :dboid, :stats_test_idx1_oid);
  pg_stat_have_stats 

--- a/test/expected/tableam.out
+++ b/test/expected/tableam.out
@@ -29,7 +29,6 @@ CREATE TABLE o_tableam1
 	key int8 NOT NULL,
 	value text
 ) USING orioledb;
--- not supported
 CREATE INDEX CONCURRENTLY o_tableam1_ix_concurrently ON o_tableam1 (key);
 ERROR:  concurrent index creation is not supported for orioledb tables yet
 CREATE INDEX o_tableam1_ix_options ON o_tableam1 (value) WITH (compression = on);

--- a/test/orioledb_regression.conf
+++ b/test/orioledb_regression.conf
@@ -8,3 +8,6 @@ checkpoint_timeout = 9000
 max_wal_size = 5GB
 wal_level = logical
 orioledb.main_buffers = 128MB
+log_statement = 'mod'
+
+orioledb.enable_rewind = false

--- a/test/sql/index_concurrently.sql
+++ b/test/sql/index_concurrently.sql
@@ -1,0 +1,84 @@
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+
+
+CREATE TABLE t_concurrent_build (
+	id int PRIMARY KEY,
+	val int
+) USING orioledb;
+
+-- Insert enough data to make index build take time
+INSERT INTO t_concurrent_build SELECT i, i * 100 FROM generate_series(2, 5000000) i;
+
+-- Create a simple done table to signal when background job completes
+CREATE TABLE concurrent_build_done (step int);
+
+-- Start concurrent index build in background
+\! psql -d reindex_concurrently_test_db -c "CREATE INDEX CONCURRENTLY t_concurrent_build_idx ON t_concurrent_build (val);"  && psql -d reindex_concurrently_test_db -c "INSERT INTO concurrent_build_done VALUES (1);" &
+
+-- Wait for build phase to start (1 seconds)
+SELECT pg_sleep(1);
+
+-- Case 1: INSERT new tuple (key=99999) - will be deleted later
+-- Case 2: DELETE existing tuple (key=100) - will be reinserted later
+INSERT INTO t_concurrent_build VALUES (1, 100);
+DELETE FROM t_concurrent_build WHERE id = 5;
+INSERT INTO t_concurrent_build VALUES (5000001, 500000100);
+DELETE FROM t_concurrent_build WHERE id = 50000;
+DELETE FROM t_concurrent_build WHERE id = 50001;
+
+SELECT pg_sleep(3);
+BEGIN;
+INSERT INTO t_concurrent_build VALUES (50000, 5000000);
+SAVEPOINT sp1;
+INSERT INTO t_concurrent_build VALUES (50001, 5000100);
+SELECT pg_sleep(30);  -- Ensure this transaction overlaps with index build
+ROLLBACK TO sp1;  -- Rollback second insert, but keep first one
+COMMIT;
+-- Wait for background job completion signal
+DO $$
+DECLARE
+	done_count int := 0;
+BEGIN
+	WHILE done_count = 0 LOOP
+		SELECT COUNT(*) INTO done_count FROM concurrent_build_done WHERE step = 1;
+		IF done_count = 0 THEN
+			PERFORM pg_sleep(1);
+		END IF;
+        COMMIT;
+	END LOOP;
+END $$;
+
+-- Verify the index was created
+\d+ t_concurrent_build
+
+
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_concurrent_build'::regclass, true, true);
+
+-- Verify index works correctly
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 100;
+SELECT id FROM t_concurrent_build WHERE val = 100;
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 500;
+SELECT id FROM t_concurrent_build WHERE val = 500;
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 5000000;
+SELECT id FROM t_concurrent_build WHERE val = 5000000;
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 5000100;
+SELECT id FROM t_concurrent_build WHERE val = 5000100;
+
+EXPLAIN (COSTS OFF) SELECT id FROM t_concurrent_build WHERE val = 500000100;
+SELECT id FROM t_concurrent_build WHERE val = 500000100;
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+
+\c regression
+DROP DATABASE reindex_concurrently_test_db;

--- a/test/sql/index_concurrently_unique.sql
+++ b/test/sql/index_concurrently_unique.sql
@@ -1,0 +1,60 @@
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+
+CREATE TABLE t_concurrent_build (
+	id int PRIMARY KEY,
+	val int
+) USING orioledb;
+
+-- Insert enough data to make index build take time
+INSERT INTO t_concurrent_build SELECT i, i * 100 FROM generate_series(2, 5000000) i;
+
+-- Create a simple done table to signal when background job completes
+CREATE TABLE concurrent_build_done (step int);
+
+
+INSERT INTO t_concurrent_build VALUES (1, 200); 
+CREATE UNIQUE INDEX CONCURRENTLY t_concurrent_build_idx ON t_concurrent_build (val);
+\d+ t_concurrent_build
+DROP INDEX t_concurrent_build_idx;
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_concurrent_build'::regclass, true, true);
+DELETE FROM t_concurrent_build WHERE id = 1;
+
+-- Start concurrent index build in background
+\! psql -d reindex_concurrently_test_db -c "CREATE UNIQUE INDEX CONCURRENTLY t_concurrent_build_idx ON t_concurrent_build (val);"  && psql -d reindex_concurrently_test_db -c "INSERT INTO concurrent_build_done VALUES (1);" &
+
+-- Wait for build phase to start (1 seconds)
+SELECT pg_sleep(1);
+
+DELETE FROM t_concurrent_build WHERE id = 4000000;
+INSERT INTO t_concurrent_build VALUES (1, 400000000);
+
+-- Wait for background job completion signal
+DO $$
+DECLARE
+	done_count int := 0;
+BEGIN
+	WHILE done_count = 0 LOOP
+		SELECT COUNT(*) INTO done_count FROM concurrent_build_done WHERE step = 1;
+		IF done_count = 0 THEN
+			PERFORM pg_sleep(1);
+		END IF;
+        COMMIT;
+	END LOOP;
+END $$;
+
+-- Verify the index was created
+\d+ t_concurrent_build
+
+DELETE FROM t_concurrent_build WHERE id = 1;
+INSERT INTO t_concurrent_build VALUES (1, 200);
+
+DROP INDEX t_concurrent_build_idx;
+
+INSERT INTO t_concurrent_build VALUES (1, 200);
+
+\c regression
+DROP DATABASE reindex_concurrently_test_db;

--- a/test/sql/reindex_concurrently_content.sql
+++ b/test/sql/reindex_concurrently_content.sql
@@ -1,0 +1,50 @@
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+create table t_reindex
+(
+    id int,
+    someint int,
+    balance int
+) using orioledb;
+
+CREATE TABLE test_step (
+    test_step int
+);
+
+CREATE TABLE done_items (
+    done_items int
+);
+
+INSERT INTO t_reindex SELECT t, 11 - t, 0 FROM generate_series(1,1000) as t;
+
+SELECT oid, relname, relfilenode FROM pg_class where relname like 't_reindex%';
+
+CREATE INDEX CONCURRENTLY t_reindex_idx ON t_reindex (id);
+SELECT oid, relname, relfilenode FROM pg_class where relname like 't_reindex%';
+SELECT pg_relation_size( 't_reindex_idx'::regclass);
+
+UPDATE t_reindex SET id = id + 1000000;
+
+SELECT pg_relation_size( 't_reindex_idx'::regclass);
+
+\d+ t_reindex;
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_reindex'::regclass, true, true);
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+
+SELECT pg_relation_size( 't_reindex_idx'::regclass);
+\d+ t_reindex;
+SELECT * FROM orioledb.orioledb_tbl_indices( 't_reindex'::regclass, true, true);
+
+set enable_seqscan = off;
+SELECT COUNT(*) FROM t_reindex WHERE id > 1000000;
+EXPLAIN SELECT COUNT(*) FROM t_reindex WHERE id > 1000000;
+RESET enable_seqscan;
+
+\c regression
+DROP DATABASE reindex_concurrently_test_db;
+
+

--- a/test/sql/reindex_concurrently_insert.sql
+++ b/test/sql/reindex_concurrently_insert.sql
@@ -1,0 +1,258 @@
+-- test with ctid
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+create table t_reindex
+(
+    id int,
+    someint int,
+    balance int
+) using orioledb;
+
+CREATE TABLE test_step (
+    test_step int
+);
+
+CREATE TABLE done_items (
+    done_items int
+);
+
+INSERT INTO t_reindex SELECT t, 99998 - t, 0 FROM generate_series(1,99999) as t;
+
+create index CONCURRENTLY t_reindex_idx on t_reindex(someint);
+
+SET enable_seqscan = off;
+EXPLAIN SELECT COUNT(*) FROM t_reindex;
+SELECT COUNT(*) FROM t_reindex;
+SET enable_seqscan = on;
+
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+
+SELECT pg_sleep(5);
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+
+INSERT INTO test_step VALUES (1);
+
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+
+SELECT pg_sleep(2);
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+
+
+TRUNCATE test_step;
+TRUNCATE done_items;
+
+UPDATE t_reindex SET balance = 0;
+
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "INSERT INTO t_reindex VALUES ($i+100000000, $i, 1); INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+
+SELECT pg_sleep(5);
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+
+INSERT INTO test_step VALUES (1);
+
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+
+SELECT pg_sleep(2);
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+
+
+\c regression
+DROP DATABASE reindex_concurrently_test_db;
+
+-- test with pk
+CREATE DATABASE reindex_concurrently_test_db;
+\c reindex_concurrently_test_db
+
+CREATE SCHEMA orioledb;
+CREATE EXTENSION orioledb SCHEMA orioledb;
+create table t_reindex
+(
+    id int PRIMARY KEY,
+    someint int,
+    balance int
+) using orioledb;
+
+CREATE TABLE test_step (
+    test_step int
+);
+
+CREATE TABLE done_items (
+    done_items int
+);
+
+INSERT INTO t_reindex SELECT t, 99998 - t, 0 FROM generate_series(1,99999) as t;
+
+create index CONCURRENTLY t_reindex_idx on t_reindex(someint);
+
+SET enable_seqscan = off;
+EXPLAIN SELECT COUNT(*) FROM t_reindex;
+SELECT COUNT(*) FROM t_reindex;
+SET enable_seqscan = on;
+
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+
+SELECT pg_sleep(5);
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+
+INSERT INTO test_step VALUES (1);
+
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+
+SELECT pg_sleep(2);
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+
+
+TRUNCATE test_step;
+TRUNCATE done_items;
+
+UPDATE t_reindex SET balance = 0;
+
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET id = id + 100000000, balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+
+SELECT pg_sleep(5);
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+
+INSERT INTO test_step VALUES (1);
+
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+
+SELECT pg_sleep(2);
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+
+
+TRUNCATE test_step;
+TRUNCATE done_items;
+
+UPDATE t_reindex SET balance = 0;
+
+\! (i=1; while [ "$(psql -t -c "SELECT COUNT(1) FROM test_step WHERE test_step = 1" reindex_concurrently_test_db | xargs )" -eq 0 ]; do psql -q -c "UPDATE t_reindex SET someint = someint + 100000000, balance = balance + 1 WHERE someint = (($i * 1753) % 99995)::int + 1; INSERT INTO done_items VALUES (1);" reindex_concurrently_test_db ; i=$((i+1)); done ;  psql -q -c "INSERT INTO test_step VALUES (2);" reindex_concurrently_test_db ;) &
+
+SELECT pg_sleep(5);
+
+REINDEX INDEX CONCURRENTLY t_reindex_idx;
+\d+ t_reindex;
+
+INSERT INTO test_step VALUES (1);
+
+-- wait until 2 appears in test_step
+DO $$
+DECLARE
+    v int;
+BEGIN
+    LOOP
+        SELECT test_step INTO v FROM test_step WHERE test_step = 2;
+        IF v IS NOT NULL THEN
+            EXIT;
+        END IF;
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;
+
+SELECT pg_sleep(2);
+
+-- check that after reindex is done, balance was incremented with loop count
+SELECT CASE 
+         WHEN a.sum_balance = b.sum_done 
+         THEN 1 
+         ELSE 0 
+       END 
+FROM 
+  (SELECT SUM(balance) AS sum_balance FROM t_reindex) a,
+  (SELECT SUM(done_items) AS sum_done FROM done_items) b;
+
+
+\c regression
+DROP DATABASE reindex_concurrently_test_db;
+
+

--- a/test/sql/stats.sql
+++ b/test/sql/stats.sql
@@ -277,7 +277,7 @@ SELECT 'stats_test_idx1'::regclass::oid AS stats_test_idx1_oid \gset
 select a from stats_test_tab1 where a = 3;
 SELECT pg_stat_have_stats('relation', :dboid, :stats_test_idx1_oid);
 REINDEX index CONCURRENTLY stats_test_idx1;
--- true since REINDEX INDEX CONCURRENTLY was changed to plain REINDEX
+
 SELECT pg_stat_have_stats('relation', :dboid, :stats_test_idx1_oid);
 -- true for new oid
 SELECT 'stats_test_idx1'::regclass::oid AS stats_test_idx1_oid \gset

--- a/test/sql/tableam.sql
+++ b/test/sql/tableam.sql
@@ -24,7 +24,6 @@ CREATE TABLE o_tableam1
 	value text
 ) USING orioledb;
 
--- not supported
 CREATE INDEX CONCURRENTLY o_tableam1_ix_concurrently ON o_tableam1 (key);
 CREATE INDEX o_tableam1_ix_options ON o_tableam1 (value) WITH (compression = on);
 ALTER TABLE o_tableam1 ADD EXCLUDE USING btree (value WITH =);

--- a/test/t/not_supported_yet_test.py
+++ b/test/t/not_supported_yet_test.py
@@ -68,7 +68,7 @@ class NotSupportedYetTest(BaseTest):
 		""")
 		self.assertEqual(
 		    err.decode("utf-8").split("\n")[0],
-		    "WARNING:  REINDEX CONCURRENTLY is not supported for orioledb tables yet, using a plain REINDEX instead"
+		    "WARNING:  REINDEX CONCURRENTLY is not supported for orioledb PK, using a plain REINDEX instead"
 		)
 
 		# Using simple reindex instead of concurrent for database containing orioledb tables
@@ -77,7 +77,7 @@ class NotSupportedYetTest(BaseTest):
 		""")
 		self.assertEqual(
 		    err.decode("utf-8").split("\n")[0],
-		    "WARNING:  REINDEX CONCURRENTLY is not supported for orioledb tables yet, using a plain REINDEX instead"
+		    "WARNING:  REINDEX CONCURRENTLY is not supported for orioledb PK, using a plain REINDEX instead"
 		)
 
 		node.stop()
@@ -297,15 +297,9 @@ class NotSupportedYetTest(BaseTest):
 			) USING orioledb;
 		""")
 
-		with self.assertRaises(QueryException) as e:
-			node.safe_psql("""
-				CREATE INDEX CONCURRENTLY ON o_test (i);
-			""")
-
-		self.assertErrorMessageEquals(
-		    e,
-		    "concurrent index creation is not supported for orioledb tables yet"
-		)
+		node.safe_psql("""
+			CREATE INDEX CONCURRENTLY ON o_test (i);
+		""")
 
 		node.safe_psql("""
 			REINDEX TABLE o_test;


### PR DESCRIPTION
The procedure follows a two-pass approach similar to PostgreSQL's concurrent index build, adapted for OrioleDB architecture:

1. Initial build using a consistent snapshot
   - Scan the table and build the index from tuples visible in the snapshot
   - Resulting index is not yet valid for queries, and write operations.

2. Validation phase
   - Collect index entries (secondary key, primary key, xid)
   - Perform a second table scan to reconcile differences between the table and the partially built index
   - Increase the validation boundary.

3. Boundary-controlled insertion
   - The index does not become fully writable all at once, but rather in a monotonically increasing fashion.
   - Ensure tuple stability while transferring missing entries
   - Handle concurrent modifications without blocking OLTP workload

More details about the algorithm and design can be found in: [src/tableam/concurrent_index_build.md](https://github.com/orioledb/orioledb/pull/730/changes#diff-a21d846b805cf55d9d04463b2f8cdf38c9fb294bc7ee0a39d0929d4c60465d83)


uplink to postgres -> https://github.com/orioledb/postgres/pull/45