### PR TITLE
Revert "Restart PostgreSQL instance when rewind is done"

### DIFF
--- a/include/rewind/rewind.h
+++ b/include/rewind/rewind.h
@@ -42,10 +42,6 @@ extern void log_print_rewind_queue(void);
 
 #define SUBXIDS_PER_ITEM	(25)
 
-
-#define PG_CTL_CMD_LEN (8)		/* Actually we only need 4 extra chars */
-#define PG_CTL_MAX_CMD_LEN (MAXPGPATH + PG_CTL_CMD_LEN)
-
 /* RewindItem and SubxidsItem should have same size to be castable to each other */
 /* Empty RewindItem and SubxidsItem have invalid oxid and tag */
 typedef struct RewindItem

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -377,32 +377,6 @@ static RmgrData rmgr =
 	.rm_decode = orioledb_decode
 };
 
-/*
- * We currently do not support restarting PG instance from within the extension
- * on certain systems. Refuse to enable rewind on those systems.
- */
-static bool
-orioledb_enable_rewind_check_hook(bool *newval, void **extra, GucSource source)
-{
-#if defined(WIN32)
-	if (*newval)
-	{
-		GUC_check_errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
-		GUC_check_errdetail("Rewind is not supported on Windows.");
-		return false;
-	}
-#elif !defined(HAVE_SETSID)
-	if (*newval)
-	{
-		GUC_check_errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
-		GUC_check_errdetail("Rewind is not supported on systems without setsid(2).");
-		return false;
-	}
-#endif
-	/* Supported system or newval == false */
-	return true;
-}
-
 void
 _PG_init(void)
 {
@@ -960,7 +934,7 @@ _PG_init(void)
 							 false,
 							 PGC_POSTMASTER,
 							 0,
-							 orioledb_enable_rewind_check_hook,
+							 NULL,
 							 NULL,
 							 NULL);
 

--- a/src/rewind/rewind.c
+++ b/src/rewind/rewind.c
@@ -30,11 +30,9 @@
 #include "postmaster/bgwriter.h"
 #include "postmaster/autovacuum.h"
 #include "storage/bufmgr.h"
-#include "storage/ipc.h"
 #include "storage/latch.h"
 #include "storage/proc.h"
 #include "storage/sinvaladt.h"
-#include "utils/elog.h"
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
@@ -81,9 +79,6 @@ PG_FUNCTION_INFO_V1(orioledb_rewind_set_complete);
 #define	REWIND_MODE_XID	(3)
 
 static void orioledb_rewind_internal(int rewind_mode, int rewind_time, OXid rewind_oxid, TransactionId rewind_xid, TimestampTz rewind_timestamp);
-static void try_restart_pg(void);
-static void cleanup_fds(void);
-static void bootstrap_signals(void);
 
 /* Interface functions */
 
@@ -790,8 +785,9 @@ orioledb_rewind_internal(int rewind_mode, int rewind_time, OXid rewind_oxid, Tra
 
 	LWLockRelease(&rewindMeta->rewindEvictLock);
 	elog(LOG, "Rewind complete");
-
-	try_restart_pg();
+	/* Restart Postgres */
+	(void) kill(PostmasterPid, SIGTERM);
+	return;
 }
 
 TransactionId
@@ -1692,145 +1688,4 @@ OXid
 get_rewind_run_xmin(void)
 {
 	return pg_atomic_read_u64(&rewindMeta->runXmin);
-}
-
-
-/*
- * try_restart_pg
- *
- * Attempt to restart the PostgreSQL instance.
- *
- * This function spawns a persistent, detached process that executes
- * "pg_ctl restart". Detachment ensures the child process survives
- * once the postmaster exits.
- *
- * dependency: This implementation relies on fork(2) and setsid(2). Systems
- * lacking these primitives (e.g. Windows), are not supported, so we can't end
- * up here. See orioledb_enable_rewind_check_hook for details.
- */
-static void
-try_restart_pg(void)
-{
-	pid_t		pid;
-	sigset_t	blocked_sigset,
-				old_sigset;
-
-	/* Block all signals until we're done */
-	sigfillset(&blocked_sigset);
-	sigprocmask(SIG_BLOCK, &blocked_sigset, &old_sigset);
-
-	/* Flush stdio channels just before fork, to avoid double-output problems */
-	fflush(NULL);
-
-	pid = fork();
-
-	if (pid < 0)
-	{
-		/* fork failed, restore signals and bail */
-		sigprocmask(SIG_SETMASK, &old_sigset, NULL);
-
-		elog(DEBUG3, "fork failed while attempting to restart,"
-			 " stopping instead");
-
-		ereport(WARNING,
-				(errmsg("could not restart instance"),
-				 errdetail("Sending shutdown request to postmaster.")));
-		(void) kill(PostmasterPid, SIGTERM);
-		return;
-	}
-
-	if (pid > 0)
-	{
-		/* fork successful, in parent. Restore signals and return to client */
-		sigprocmask(SIG_SETMASK, &old_sigset, NULL);
-		ereport(NOTICE,
-				(errmsg("attempting to restart database system")));
-		return;
-	}
-
-	/* fork succeeded, in child */
-	if (setsid() < 0)
-	{
-		/* setsid failed: */
-		goto emergency_shutdown;
-	}
-
-	{
-		/* We're in a session that will survive when the parent goes away */
-		sigset_t	empty_mask;
-		char		bindir[MAXPGPATH];
-		char		cmd[PG_CTL_MAX_CMD_LEN];
-		char	   *lastslash;
-
-		strlcpy(bindir, my_exec_path, MAXPGPATH);
-
-		lastslash = strrchr(bindir, '/');
-
-		/* if for some reason we got a bogus bindir */
-		if (lastslash == NULL)
-			goto emergency_shutdown;
-
-		*lastslash = '\0';
-		snprintf(cmd, sizeof(cmd), "%s/pg_ctl", bindir);
-
-		/* Do a little dance with fds to make logger shutdown cleanly */
-		cleanup_fds();
-		/* Sleep 0.5s to let the parent return */
-		pg_usleep(500000);
-		/* Be paranoid: restore default signal handlers and mask before execl */
-		bootstrap_signals();
-		sigemptyset(&empty_mask);
-		sigprocmask(SIG_SETMASK, &empty_mask, NULL);
-
-		execl(cmd, cmd, "restart", "-D", DataDir, (char *) NULL);
-		/* execl failed: */
-		goto emergency_shutdown;
-	}
-
-emergency_shutdown:
-
-	/*
-	 * If we got here, either execl or setsid failed. We can't just bail
-	 * because logging isn't safe since we can't guarantee allocating memory
-	 * won't result in a deadlock. Additionally we might've already cleaned up
-	 * the FDs so elog won't reach the logger anyway. We also can't really
-	 * proc_exit() or even exit(): Both will result in a crash while executing
-	 * on-exit callbacks. So we request a shutdown and _exit(). 71 exit code
-	 * is "system error". We don't want to put too much effort into
-	 * investigating here.
-	 */
-	(void) kill(PostmasterPid, SIGTERM);
-	_exit(71);
-}
-
-static void
-cleanup_fds(void)
-{
-	int			devnull = open("/dev/null", O_RDWR);
-
-	if (devnull >= 0)
-	{
-		/*
-		 * We can't just close stderr/stdout fds, so redirect them to
-		 * /dev/null instead
-		 */
-		dup2(devnull, fileno(stdin));
-		dup2(devnull, fileno(stderr));
-		dup2(devnull, fileno(stdout));
-
-		/* Be paranoid: we don't want to ever close stdin/stderr/stdout */
-		if (devnull > fileno(stdin) && devnull > fileno(stdout)
-			&& devnull > fileno(stderr))
-			close(devnull);
-	}
-}
-
-static void
-bootstrap_signals(void)
-{
-	pqsignal(SIGHUP, SIG_DFL);
-	pqsignal(SIGPIPE, SIG_DFL);
-	pqsignal(SIGINT, SIG_DFL);
-	pqsignal(SIGTERM, SIG_DFL);
-	pqsignal(SIGQUIT, SIG_DFL);
 }

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -362,19 +362,6 @@ class BaseTest(unittest.TestCase):
 		node.is_started = False
 		node.start()
 
-	def get_pg_start_time(self, node):
-		result = node.execute("select pg_postmaster_start_time()")
-		start_time = result[0][0]
-		return start_time
-
-	def wait_restart(self, node, previous_start_time, timeout_s=900):
-		node.poll_query_until(
-		    f"select pg_postmaster_start_time() != '{previous_start_time}'",
-		    expected=True,
-		    sleep_time=1,
-		    max_attempts=timeout_s,
-		    suppress=[Exception])
-
 
 # execute SQL query Thread for PostgreSql node's connection
 class ThreadQueryExecutor(Thread):

--- a/test/t/rewind_time_test.py
+++ b/test/t/rewind_time_test.py
@@ -20,12 +20,6 @@ class RewindTest(BaseTest):
 	def wait_shutdown_and_start(self, node):
 		super().wait_shutdown_and_start(node)
 
-	def wait_restart(self, node, previous_start_time):
-		super().wait_restart(node, previous_start_time)
-
-	def get_pg_start_time(self, node):
-		return super().get_pg_start_time(node)
-
 	def test_rewind_oriole(self):
 		node = self.node
 		node.append_conf(
@@ -48,14 +42,6 @@ class RewindTest(BaseTest):
 			    'postgres', "INSERT INTO o_test\n"
 			    "	VALUES (%d, %d || 'val');\n" % (i, i))
 
-		# Store the current timestamp in a temp table to reuse it later
-		node.safe_psql(
-		    'postgres', "DROP TABLE IF EXISTS o_rewind;\n"
-		    "CREATE TABLE o_rewind(ts, note) AS\n"
-		    "	SELECT\n"
-		    "		clock_timestamp() as ts,\n"
-		    "		'before sleep' as note;")
-
 		time.sleep(10)
 
 		for i in range(6, 20):
@@ -63,17 +49,9 @@ class RewindTest(BaseTest):
 			    'postgres', "INSERT INTO o_test\n"
 			    "	VALUES (%d, %d || 'val');\n" % (i, i))
 
-		previous_start_time = self.get_pg_start_time(node)
+		node.safe_psql('postgres', "select orioledb_rewind_by_time(9);\n")
 
-		# Rewind to the time we stored above + 5 seconds for safety
-		node.safe_psql(
-		    'postgres', "SELECT orioledb_rewind_by_time(i-5) "
-		    "	FROM "
-		    "		o_rewind as r, "
-		    "		lateral (select floor(date_part('epoch', clock_timestamp()-r.ts))::int4) f(i) "
-		    "	WHERE note = 'before sleep';")
-
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test;')),
@@ -103,14 +81,6 @@ class RewindTest(BaseTest):
 			    'postgres', "INSERT INTO o_test_heap\n"
 			    "	VALUES (%d, %d || 'val');\n" % (i, i))
 
-		# Store the current timestamp in a temp table to reuse it later
-		node.safe_psql(
-		    'postgres', "DROP TABLE IF EXISTS o_rewind;\n"
-		    "CREATE TABLE o_rewind(ts, note) AS\n"
-		    "	SELECT\n"
-		    "		clock_timestamp() as ts,\n"
-		    "		'before sleep' as note;")
-
 		time.sleep(10)
 
 		for i in range(6, 20):
@@ -118,17 +88,9 @@ class RewindTest(BaseTest):
 			    'postgres', "INSERT INTO o_test_heap\n"
 			    "	VALUES (%d, %d || 'val');\n" % (i, i))
 
-		previous_start_time = self.get_pg_start_time(node)
+		node.safe_psql('postgres', "select orioledb_rewind_by_time(9);\n")
 
-		# Rewind to the time we stored above + 5 seconds for safety
-		node.safe_psql(
-		    'postgres', "SELECT orioledb_rewind_by_time(i-5) "
-		    "	FROM "
-		    "		o_rewind as r, "
-		    "		lateral (select floor(date_part('epoch', clock_timestamp()-r.ts))::int4) f(i) "
-		    "	WHERE note = 'before sleep';")
-
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test_heap;')),
@@ -305,11 +267,6 @@ class RewindTest(BaseTest):
 		    "INSERT INTO o_test VALUES (%d, %d || 'val'); SAVEPOINT sp1;\n"
 		    "INSERT INTO o_test_heap VALUES (%d, %d || 'val');\n"
 		    "INSERT INTO o_test VALUES (%d, %d || 'val'); SAVEPOINT sp2;\n"
-		    "DROP TABLE IF EXISTS o_rewind;"
-		    "CREATE TABLE o_rewind(ts, note) AS\n"
-		    "	SELECT\n"
-		    "		clock_timestamp() as ts,\n"
-		    "		'before sleep' as note;"
 		    "SELECT pg_sleep(10);\n"
 		    "INSERT INTO o_test_heap VALUES (%d, %d || 'val');\n"
 		    "INSERT INTO o_test VALUES (%d, %d || 'val'); SAVEPOINT sp3;\n"
@@ -332,15 +289,9 @@ class RewindTest(BaseTest):
 			    (i, i, i, i, i + 1, i + 1, i + 1, i + 1, i + 2, i + 2, i + 2,
 			     i + 2, i + 3, i + 3, i + 3, i + 3))
 
-		previous_start_time = self.get_pg_start_time(node)
-		node.safe_psql(
-		    'postgres', "SELECT orioledb_rewind_by_time(i-5) "
-		    "	FROM "
-		    "		o_rewind as r, "
-		    "		lateral (select floor(date_part('epoch', clock_timestamp()-r.ts))::int4) f(i) "
-		    "	WHERE note = 'before sleep';")
+		node.safe_psql('postgres', "select orioledb_rewind_by_time(9);\n")
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(

--- a/test/t/rewind_xid_evict_large_test.py
+++ b/test/t/rewind_xid_evict_large_test.py
@@ -23,12 +23,6 @@ class RewindXidTest(BaseTest):
 	def wait_shutdown_and_start(self, node):
 		super().wait_shutdown_and_start(node)
 
-	def wait_restart(self, node, previous_start_time):
-		super().wait_restart(node, previous_start_time)
-
-	def get_pg_start_time(self, node):
-		return super().get_pg_start_time(node)
-
 	# Evict tests:
 	# test_rewind_xid_oriole_evict
 	# test_rewind_xid_heap_evict
@@ -122,12 +116,11 @@ class RewindXidTest(BaseTest):
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test;')),
 		    "[(10005,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
 		node.safe_psql(
 		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
 		    (invalidxid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test ORDER BY 1;')),
@@ -190,14 +183,11 @@ class RewindXidTest(BaseTest):
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test_heap;')),
 		    "[(10005,)]")
-
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
 		    (xid, invalidoxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(
@@ -271,14 +261,11 @@ class RewindXidTest(BaseTest):
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test_heap;')),
 		    "[(5005,)]")
-
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test ORDER BY 1;')),
@@ -359,14 +346,11 @@ class RewindXidTest(BaseTest):
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test_heap;')),
 		    "[(20024,)]")
-
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
 		    (xid, invalidoxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(
@@ -462,14 +446,11 @@ class RewindXidTest(BaseTest):
 		#		    'postgres', 'select orioledb_get_rewind_evicted_length();\n'))[0]
 		#		ev = int(c)
 		#		print(len, ev, len - ev)
-
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(
@@ -566,13 +547,11 @@ class RewindXidTest(BaseTest):
 				break
 			time.sleep(0.1)
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(
@@ -755,13 +734,11 @@ class RewindXidTest(BaseTest):
 				break
 			time.sleep(0.1)
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(
@@ -951,13 +928,11 @@ class RewindXidTest(BaseTest):
 				break
 			time.sleep(0.1)
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(
@@ -1401,13 +1376,11 @@ class RewindXidTest(BaseTest):
 				break
 			time.sleep(0.1)
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(

--- a/test/t/rewind_xid_test.py
+++ b/test/t/rewind_xid_test.py
@@ -23,12 +23,6 @@ class RewindXidTest(BaseTest):
 	def wait_shutdown_and_start(self, node):
 		super().wait_shutdown_and_start(node)
 
-	def wait_restart(self, node, previous_start_time):
-		super().wait_restart(node, previous_start_time)
-
-	def get_pg_start_time(self, node):
-		return super().get_pg_start_time(node)
-
 	# Small tests:
 	# test_rewind_xid_oriole
 	# test_rewind_xid_heap
@@ -88,13 +82,11 @@ class RewindXidTest(BaseTest):
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test;')),
 		    "[(20,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
 		    (invalidxid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test ORDER BY id;')),
@@ -145,13 +137,11 @@ class RewindXidTest(BaseTest):
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test_heap;')),
 		    "[(20,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
 		    (xid, invalidoxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(
@@ -220,13 +210,11 @@ class RewindXidTest(BaseTest):
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test_heap;')),
 		    "[(96,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
 		    (xid, invalidoxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(
@@ -293,13 +281,11 @@ class RewindXidTest(BaseTest):
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test_heap;')),
 		    "[(20,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test ORDER BY id;')),
@@ -391,13 +377,11 @@ class RewindXidTest(BaseTest):
 		    str(node.execute('postgres', 'SELECT count(*) FROM o_test_heap;')),
 		    "[(96,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.maxDiff = None
 		self.assertEqual(
@@ -493,13 +477,11 @@ class RewindXidTest(BaseTest):
 		                     'SELECT count(*) FROM o_test_heap_ddl;')),
 		    "[(15,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test ORDER BY id;')),
@@ -604,13 +586,11 @@ class RewindXidTest(BaseTest):
 		node.safe_psql('postgres', "DROP TABLE o_test_heap_ddl;\n")
 		node.safe_psql('postgres', "DROP TABLE o_test_ddl;\n")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(node.execute('postgres', 'SELECT * FROM o_test ORDER BY id;')),
@@ -709,13 +689,11 @@ class RewindXidTest(BaseTest):
 		                     'SELECT count(*) FROM o_test_heap_ddl;')),
 		    "[(15,)]")
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(
@@ -807,13 +785,11 @@ class RewindXidTest(BaseTest):
 		],
 		                       stderr=sys.stderr)
 
-		previous_start_time = self.get_pg_start_time(node)
-
 		node.safe_psql(
 		    'postgres',
 		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
 
-		self.wait_restart(node, previous_start_time)
+		self.wait_shutdown_and_start(node)
 
 		self.assertEqual(
 		    str(


### PR DESCRIPTION
Revert restart of postgres instance during executing `rewind()` function. This might conflict with systemd service and restart should rely on systemd configuration.

This reverts commit bae6393ad848d8b0b2525ae15e2f3b9daf40b406.