### PR TITLE
Allow pre-initialized catalog cache in single-user mode; fix missing …

### DIFF
--- a/src/catalog/o_sys_cache.c
+++ b/src/catalog/o_sys_cache.c
@@ -2362,7 +2362,7 @@ void
 o_set_syscache_hooks(void)
 {
 	o_sys_cache_hooks_depth++;
-	if (!IsTransactionState())
+	if (!IsTransactionState() && SearchCatCacheInternal_hook == NULL)
 	{
 		if (!CurrentResourceOwner)
 		{

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -740,13 +740,13 @@ apply_tbl_modify_record(OTableDescr *descr, RecoveryMsgType type,
 	{
 		case RecoveryMsgTypeInsert:
 			apply_tbl_insert(descr, p, oxid, csn);
-			return;
+			break;
 		case RecoveryMsgTypeDelete:
 			apply_tbl_delete(descr, p, oxid, csn);
-			return;
+			break;
 		case RecoveryMsgTypeUpdate:
 			apply_tbl_update(descr, p, oxid, csn);
-			return;
+			break;
 		default:
 			Assert(false);
 			elog(ERROR, "Wrong primary index modify record type %d", type);


### PR DESCRIPTION
…o_unset_syscache_hooks call

Single-user mode may run recovery and then start a session in the same process. When OrioleDB is loaded, recovery initializes the catalog cache, which caused session startup to fail because it expected a non-initialized state.

Allow the catalog cache to be already initialized when starting a session in single-user mode after recovery.

Additionally, fix a missing o_unset_syscache_hooks call, which left OrioleDB syscache hooks installed across the recovery/session boundary and contributed to crashes and inconsistent backend state.

This ensures that backend-global state is properly handled when recovery and normal session execution happen within the same process.

#734 

uplink -> https://github.com/orioledb/postgres/pull/46