### PR TITLE
Add an argument to rewind functions to make restart optional 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,6 +60,7 @@ ci/antithesis
 
 # Ignore generated scripts
 sql/orioledb--1.0.sql
+sql/orioledb--1.6--1.7.sql
 
 
 #######################################################

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ make.flags
 sql/orioledb--1.0.sql
 sql/orioledb--1.4--1.5.sql
 sql/orioledb--1.5--1.6.sql
+sql/orioledb--1.6--1.7.sql
 # Exclude the PostGIS Docker build directory
 /docker-postgis

--- a/doc/usage/rewind.mdx
+++ b/doc/usage/rewind.mdx
@@ -47,17 +47,38 @@ While the Rewind Worker manages its "to-do list" in a fixed-size circular buffer
 
 ## Rewind Functions
 
-### `orioledb_rewind_by_time(seconds integer)`
+### `orioledb_rewind_by_time(seconds int4[, attempt_restart bool])`
 Rewinds the cluster state by the specified number of seconds from the current time.
-*   **Example:** `SELECT orioledb_rewind_by_time(600);`
 
-### `orioledb_rewind_to_timestamp(target_time timestamptz)`
+* **Parameters:**
+  * `seconds`: The number of seconds to rewind the cluster state.
+  * `attempt_restart`: If `true`, the database system will automatically restart after the rewind. If `false`, the database will only be shut down. Default is `false`.
+* **Examples:**
+  * `SELECT orioledb_rewind_by_time(600);` — Rewinds by 10 minutes and shuts down the database without restarting.
+  * `SELECT orioledb_rewind_by_time(600, true);` — Rewinds by 10 minutes and restarts the database.
+
+### `orioledb_rewind_to_timestamp(target_time timestamptz[, attempt_restart bool])`
 Rewinds the cluster to a specific point in time.
-*   **Example:** `SELECT orioledb_rewind_to_timestamp('2025-01-01 12:00:00 UTC');`
 
-### `orioledb_rewind_to_transaction(xid xid8, oxid int8)`
-Rewinds the cluster to a state **before** specific transaction pair identified by the PostgreSQL Transaction ID (`xid`) and the OrioleDB Transaction ID (`oxid`). `oxid` can be acquired by calling `orioledb_get_current_oxid()`.
-*   **Example:** `SELECT orioledb_rewind_to_transaction(1750, 555);`
+* **Parameters:**
+  * `target_time`: The exact timestamp to which the cluster state will be rewound.
+  * `attempt_restart`: If `true`, the database system will automatically restart after the rewind. If `false`, the database will only be shut down.  Default is `false`.
+* **Examples:**
+  * `SELECT orioledb_rewind_to_timestamp('2025-01-01 12:00:00 UTC', true);` — Rewinds to January 1, 2025, at 12:00:00 UTC, and restarts the database.
+  * `SELECT orioledb_rewind_to_timestamp('2025-01-01 12:00:00 UTC');` — Rewinds to the specified timestamp and shuts down the database without restarting.
+
+---
+
+### `orioledb_rewind_to_transaction(xid int4, oxid int8[, attempt_restart bool])`
+Rewinds the cluster to a state **before** a specific transaction pair identified by the PostgreSQL Transaction ID (`xid`) and the OrioleDB Transaction ID (`oxid`).
+
+* **Parameters:**
+  * `xid`: The PostgreSQL Transaction ID.
+  * `oxid`: The OrioleDB Transaction ID.
+  * `attempt_restart`: If `true`, the database system will automatically restart after the rewind. If `false`, the database will only be shut down.  Default is `false`.
+* **Examples:**
+  * `SELECT orioledb_rewind_to_transaction(1750, 555, true);` — Rewinds the cluster state to just before transaction pair `1750`/`555` and restarts the database.
+  * `SELECT orioledb_rewind_to_transaction(1750, 555);` — Rewinds the cluster state to just before the specified transaction pair and shuts down the database without restarting.
 
 ### Examining the Rewind Horizon
 To check the available rewind range, use:
@@ -73,7 +94,7 @@ When a rewind function is invoked, the system executes the following steps:
 2. Signals the Rewind Worker to stop adding new transactions to the buffer.
 3. Signals all other active backends to terminate. The process waits up to 100 seconds for backends to exit.
 4. Reverts the data pages to the requested state.
-5. Once the rewind is complete, the function attempts to restart the PostgreSQL instance to finalize the state change.
+5. Once the rewind is complete, depending on the value of `attempt_restart` argument, the function either shuts down the database or attempts to restart the PostgreSQL instance to finalize the state change.
 
 :::warning[Restart Reliability]
 The automatic restart is a single, best-effort attempt. If the restart fails (e.g., due to configuration errors), manual intervention is required to bring the server back online. Ensure you have system-level access to the server to manually start the service, as the SQL connection will be terminated immediately upon completion of the rewind.
@@ -88,7 +109,7 @@ To rewind the database to a specific transaction state, you must first record th
 -- Record these values
 SELECT pg_current_xact_id(), orioledb_get_current_oxid();
 
- pg_current_xact_id | orioledb_get_current_oxid 
+ pg_current_xact_id | orioledb_get_current_oxid
 --------------------+---------------------------
                1750 |                       555
 ```
@@ -104,7 +125,7 @@ DROP TABLE important_data;
 -- Revert to the IDs recorded in step 1
 SELECT orioledb_rewind_to_transaction(1750, 555);
 ```
-*The server will log "Rewind complete" and attempt to restart.*
+*The server will log "Rewind complete" and shut down.*
 
 :::note[Data consistency]
 For applications requiring strong consistency guarantees, it is recommended to explicitly acquire locks on relevant tables within the transaction intended as the rewind target. (Step 1 in the example above)

--- a/orioledb.control
+++ b/orioledb.control
@@ -1,5 +1,5 @@
 # orioledb extension
 comment = 'OrioleDB -- the next generation transactional engine'
-default_version = '1.6'
+default_version = '1.7'
 module_pathname = '$libdir/orioledb'
 relocatable = true

--- a/sql/orioledb--1.6--1.7_dev.sql
+++ b/sql/orioledb--1.6--1.7_dev.sql
@@ -1,0 +1,5 @@
+/* contrib/orioledb/sql/orioledb--1.6--1.7_dev.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.7'" to load this file. \quit
+

--- a/sql/orioledb--1.6--1.7_prod.sql
+++ b/sql/orioledb--1.6--1.7_prod.sql
@@ -1,0 +1,20 @@
+/* contrib/orioledb/sql/orioledb--1.6--1.7_prod.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.7'" to load this file. \quit
+
+CREATE FUNCTION orioledb_rewind_by_time(rewind_time int, attempt_restart bool)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_rewind_to_transaction(xid int, oxid bigint, attempt_restart bool)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_rewind_to_timestamp(rewind_timestamp TimestampTz, attempt_restart bool)
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+

--- a/src/rewind/rewind.c
+++ b/src/rewind/rewind.c
@@ -80,7 +80,7 @@ PG_FUNCTION_INFO_V1(orioledb_rewind_set_complete);
 #define REWIND_MODE_TIMESTAMP (2)
 #define	REWIND_MODE_XID	(3)
 
-static void orioledb_rewind_internal(int rewind_mode, int rewind_time, OXid rewind_oxid, TransactionId rewind_xid, TimestampTz rewind_timestamp);
+static void orioledb_rewind_internal(int rewind_mode, int rewind_time, OXid rewind_oxid, TransactionId rewind_xid, TimestampTz rewind_timestamp, bool attempt_restart);
 static void try_restart_pg(void);
 static void cleanup_fds(void);
 static void bootstrap_signals(void);
@@ -98,8 +98,12 @@ Datum
 orioledb_rewind_by_time(PG_FUNCTION_ARGS)
 {
 	int			rewind_time = PG_GETARG_INT32(0);
+	bool		attempt_restart = false;
 
-	orioledb_rewind_internal(REWIND_MODE_TIME, rewind_time, InvalidOXid, InvalidTransactionId, (TimestampTz) 0);
+	if (PG_NARGS() == 2)
+		attempt_restart = PG_GETARG_BOOL(1);
+
+	orioledb_rewind_internal(REWIND_MODE_TIME, rewind_time, InvalidOXid, InvalidTransactionId, (TimestampTz) 0, attempt_restart);
 	PG_RETURN_VOID();
 }
 
@@ -108,8 +112,12 @@ orioledb_rewind_to_transaction(PG_FUNCTION_ARGS)
 {
 	TransactionId xid = PG_GETARG_INT32(0);
 	OXid		oxid = PG_GETARG_INT64(1);
+	bool		attempt_restart = false;
 
-	orioledb_rewind_internal(REWIND_MODE_XID, 0, oxid, xid, (TimestampTz) 0);
+	if (PG_NARGS() == 3)
+		attempt_restart = PG_GETARG_BOOL(2);
+
+	orioledb_rewind_internal(REWIND_MODE_XID, 0, oxid, xid, (TimestampTz) 0, attempt_restart);
 	PG_RETURN_VOID();
 }
 
@@ -117,8 +125,12 @@ Datum
 orioledb_rewind_to_timestamp(PG_FUNCTION_ARGS)
 {
 	TimestampTz rewind_timestamp = PG_GETARG_TIMESTAMPTZ(0);
+	bool		attempt_restart = false;
 
-	orioledb_rewind_internal(REWIND_MODE_TIMESTAMP, 0, InvalidOXid, InvalidTransactionId, rewind_timestamp);
+	if (PG_NARGS() == 2)
+		attempt_restart = PG_GETARG_BOOL(1);
+
+	orioledb_rewind_internal(REWIND_MODE_TIMESTAMP, 0, InvalidOXid, InvalidTransactionId, rewind_timestamp, attempt_restart);
 	PG_RETURN_VOID();
 }
 
@@ -581,11 +593,12 @@ rewind_complete:
 
 /*
  *  Check rewind conditions for sanity, disable adding new transactions to a rewind buffer,
- *  terminate all other backends, do actual rewind, then shutdown postgres.
- *  NB: starting up Postgres after rewind is not possible from backend, it needs to be done externally.
+ *  terminate all other backends, do actual rewind, then shutdown or restart postgres.
+ *  NB: after rewind, this function either shuts down Postgres or, when attempt_restart is true,
+ *  tries a best-effort restart via try_restart_pg().
  */
 static void
-orioledb_rewind_internal(int rewind_mode, int rewind_time, OXid rewind_oxid, TransactionId rewind_xid, TimestampTz rewind_timestamp)
+orioledb_rewind_internal(int rewind_mode, int rewind_time, OXid rewind_oxid, TransactionId rewind_xid, TimestampTz rewind_timestamp, bool attempt_restart)
 {
 	TimestampTz rewindStartTimeStamp;
 	int			retry;
@@ -791,7 +804,10 @@ orioledb_rewind_internal(int rewind_mode, int rewind_time, OXid rewind_oxid, Tra
 	LWLockRelease(&rewindMeta->rewindEvictLock);
 	elog(LOG, "Rewind complete");
 
-	try_restart_pg();
+	if (attempt_restart)
+		try_restart_pg();
+	else
+		(void) kill(PostmasterPid, SIGTERM);
 }
 
 TransactionId

--- a/test/t/rewind_time_test.py
+++ b/test/t/rewind_time_test.py
@@ -26,7 +26,48 @@ class RewindTest(BaseTest):
 	def get_pg_start_time(self, node):
 		return super().get_pg_start_time(node)
 
-	def test_rewind_oriole(self):
+	def test_rewind_oriole_shutdown(self):
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "orioledb.rewind_max_time = 100\n"
+		    "orioledb.enable_rewind = true\n")
+		node.start()
+
+		node.safe_psql('postgres',
+		               "CREATE EXTENSION IF NOT EXISTS orioledb;\n")
+
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_test (\n"
+		    "	id integer NOT NULL,\n"
+		    "	val text,\n"
+		    "	PRIMARY KEY (id)\n"
+		    ") USING orioledb;\n")
+
+		for i in range(1, 6):
+			node.safe_psql(
+			    'postgres', "INSERT INTO o_test\n"
+			    "	VALUES (%d, %d || 'val');\n" % (i, i))
+
+		time.sleep(10)
+
+		for i in range(6, 20):
+			node.safe_psql(
+			    'postgres', "INSERT INTO o_test\n"
+			    "	VALUES (%d, %d || 'val');\n" % (i, i))
+
+		node.safe_psql('postgres', "select orioledb_rewind_by_time(9);\n")
+		time.sleep(1)
+
+		node.is_started = False
+		node.start()
+
+		self.assertEqual(
+		    str(node.execute('postgres', 'SELECT * FROM o_test;')),
+		    "[(1, '1val'), (2, '2val'), (3, '3val'), (4, '4val'), (5, '5val')]"
+		)
+		node.stop()
+
+	def test_rewind_oriole_restart(self):
 		node = self.node
 		node.append_conf(
 		    'postgresql.conf', "orioledb.rewind_max_time = 100\n"
@@ -67,7 +108,7 @@ class RewindTest(BaseTest):
 
 		# Rewind to the time we stored above + 5 seconds for safety
 		node.safe_psql(
-		    'postgres', "SELECT orioledb_rewind_by_time(i-5) "
+		    'postgres', "SELECT orioledb_rewind_by_time(i-5, true) "
 		    "	FROM "
 		    "		o_rewind as r, "
 		    "		lateral (select floor(date_part('epoch', clock_timestamp()-r.ts))::int4) f(i) "
@@ -122,7 +163,7 @@ class RewindTest(BaseTest):
 
 		# Rewind to the time we stored above + 5 seconds for safety
 		node.safe_psql(
-		    'postgres', "SELECT orioledb_rewind_by_time(i-5) "
+		    'postgres', "SELECT orioledb_rewind_by_time(i-5, true) "
 		    "	FROM "
 		    "		o_rewind as r, "
 		    "		lateral (select floor(date_part('epoch', clock_timestamp()-r.ts))::int4) f(i) "
@@ -334,7 +375,7 @@ class RewindTest(BaseTest):
 
 		previous_start_time = self.get_pg_start_time(node)
 		node.safe_psql(
-		    'postgres', "SELECT orioledb_rewind_by_time(i-5) "
+		    'postgres', "SELECT orioledb_rewind_by_time(i-5, true) "
 		    "	FROM "
 		    "		o_rewind as r, "
 		    "		lateral (select floor(date_part('epoch', clock_timestamp()-r.ts))::int4) f(i) "

--- a/test/t/rewind_xid_evict_large_test.py
+++ b/test/t/rewind_xid_evict_large_test.py
@@ -124,7 +124,8 @@ class RewindXidTest(BaseTest):
 
 		previous_start_time = self.get_pg_start_time(node)
 		node.safe_psql(
-		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+		    'postgres',
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 		    (invalidxid, oxid))
 
 		self.wait_restart(node, previous_start_time)
@@ -194,7 +195,8 @@ class RewindXidTest(BaseTest):
 		previous_start_time = self.get_pg_start_time(node)
 
 		node.safe_psql(
-		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+		    'postgres',
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 		    (xid, invalidoxid))
 
 		self.wait_restart(node, previous_start_time)
@@ -276,7 +278,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -363,7 +366,8 @@ class RewindXidTest(BaseTest):
 		previous_start_time = self.get_pg_start_time(node)
 
 		node.safe_psql(
-		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+		    'postgres',
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 		    (xid, invalidoxid))
 
 		self.wait_restart(node, previous_start_time)
@@ -467,7 +471,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -570,7 +575,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid2, oxid2))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -666,7 +672,7 @@ class RewindXidTest(BaseTest):
 		with self.assertRaises(QueryException) as e:
 			node.safe_psql(
 			    'postgres',
-			    "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+			    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 			    (xid1, oxid1))
 		self.assertIn(
 		    'ERROR:  Requested rewind to XID %d which is in the past from the earliest retained'
@@ -759,7 +765,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid2, oxid2))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -955,7 +962,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid2, oxid2))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -1057,7 +1065,7 @@ class RewindXidTest(BaseTest):
 		with self.assertRaises(QueryException) as e:
 			node.safe_psql(
 			    'postgres',
-			    "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+			    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 			    (xid1, oxid1))
 		self.assertIn(
 		    'ERROR:  Requested rewind to XID %d which is in the past from the earliest retained'
@@ -1163,7 +1171,7 @@ class RewindXidTest(BaseTest):
 #		self.assertEqual(oxidc-oxid1, 0)
 #
 #		node.safe_psql('postgres',
-#		               "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2,oxid2))
+#		               "select orioledb_rewind_to_transaction(%d,%ld,true);\n" % (xid2,oxid2))
 #
 #		self.wait_shutdown_and_start(node)
 #
@@ -1277,7 +1285,7 @@ class RewindXidTest(BaseTest):
 #		self.assertEqual(oxidc-oxid1, 7)
 #
 #		node.safe_psql('postgres',
-#		               "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid1,oxid1))
+#		               "select orioledb_rewind_to_transaction(%d,%ld,true);\n" % (xid1,oxid1))
 #
 #		self.wait_shutdown_and_start(node)
 #
@@ -1405,7 +1413,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid2, oxid2))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid2, oxid2))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -1526,7 +1535,7 @@ class RewindXidTest(BaseTest):
 		with self.assertRaises(QueryException) as e:
 			node.safe_psql(
 			    'postgres',
-			    "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+			    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 			    (xid1, oxid1))
 		self.assertIn(
 		    'ERROR:  Requested rewind to XID %d which is in the past from the earliest retained'

--- a/test/t/rewind_xid_test.py
+++ b/test/t/rewind_xid_test.py
@@ -44,7 +44,55 @@ class RewindXidTest(BaseTest):
 
 	# Small scale tests
 
-	def test_rewind_xid_oriole(self):
+	def test_rewind_xid_oriole_shutdown(self):
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "orioledb.rewind_max_time = 500\n"
+		    "orioledb.enable_rewind = true\n"
+		    "orioledb.rewind_buffers = 6\n")
+		node.start()
+
+		node.safe_psql('postgres',
+		               "CREATE EXTENSION IF NOT EXISTS orioledb;\n")
+
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_test (\n"
+		    "	id integer NOT NULL,\n"
+		    "	val text,\n"
+		    "	PRIMARY KEY (id)\n"
+		    ") USING orioledb;\n")
+
+		for i in range(1, 6):
+			node.safe_psql(
+			    'postgres', "INSERT INTO o_test\n"
+			    "	VALUES (%d, %d || 'val');\n" % (i, i))
+
+		a, *b = (node.execute('postgres',
+		                      'select orioledb_get_current_oxid();\n'))[0]
+		oxid = int(a)
+		#		print(oxid)
+		invalidxid = 0
+
+		for i in range(6, 20):
+			node.safe_psql(
+			    'postgres', "INSERT INTO o_test\n"
+			    "	VALUES (%d, %d || 'val');\n" % (i, i))
+
+		node.safe_psql(
+		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+		    (invalidxid, oxid))
+		time.sleep(1)
+
+		node.is_started = False
+		node.start()
+
+		self.assertEqual(
+		    str(node.execute('postgres', 'SELECT * FROM o_test;')),
+		    "[(1, '1val'), (2, '2val'), (3, '3val'), (4, '4val'), (5, '5val')]"
+		)
+		node.stop()
+
+	def test_rewind_xid_oriole_restart(self):
 		node = self.node
 		node.append_conf(
 		    'postgresql.conf', "orioledb.rewind_max_time = 500\n"
@@ -91,7 +139,8 @@ class RewindXidTest(BaseTest):
 		previous_start_time = self.get_pg_start_time(node)
 
 		node.safe_psql(
-		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+		    'postgres',
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 		    (invalidxid, oxid))
 
 		self.wait_restart(node, previous_start_time)
@@ -148,7 +197,8 @@ class RewindXidTest(BaseTest):
 		previous_start_time = self.get_pg_start_time(node)
 
 		node.safe_psql(
-		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+		    'postgres',
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 		    (xid, invalidoxid))
 
 		self.wait_restart(node, previous_start_time)
@@ -223,7 +273,8 @@ class RewindXidTest(BaseTest):
 		previous_start_time = self.get_pg_start_time(node)
 
 		node.safe_psql(
-		    'postgres', "select orioledb_rewind_to_transaction(%d,%ld);\n" %
+		    'postgres',
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
 		    (xid, invalidoxid))
 
 		self.wait_restart(node, previous_start_time)
@@ -297,7 +348,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -395,7 +447,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -497,7 +550,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -608,7 +662,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -713,7 +768,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 
@@ -811,7 +867,8 @@ class RewindXidTest(BaseTest):
 
 		node.safe_psql(
 		    'postgres',
-		    "select orioledb_rewind_to_transaction(%d,%ld);\n" % (xid, oxid))
+		    "select orioledb_rewind_to_transaction(%d,%ld,true);\n" %
+		    (xid, oxid))
 
 		self.wait_restart(node, previous_start_time)
 


### PR DESCRIPTION
- Added a new argument attempt_restart (false by default) to all user facing rewind functions
- Bumped extension version to 1.7
- Updated the documentation