### PR TITLE
Issue #722: Fix memory leak by releasing BTreeIterator

### DIFF
--- a/src/catalog/o_enum_cache.c
+++ b/src/catalog/o_enum_cache.c
@@ -273,7 +273,10 @@ o_enum_cache_delete_all(Oid datoid, Oid enum_oid)
 			break;
 
 		if (o_enum->key.common.lsn > key.common.lsn)
+		{
+			pfree(tup.data);
 			break;
+		}
 
 		o_enum_data =
 			(OEnumData *) (((Pointer) o_enum) + offsetof(OEnum, data) +
@@ -281,7 +284,11 @@ o_enum_cache_delete_all(Oid datoid, Oid enum_oid)
 		o_enum_cache_delete(datoid, o_enum->key.keys[0],
 							NameGetDatum(O_KEY_GET_NAME(&o_enum->key, 1)));
 		o_enumoid_cache_delete(datoid, o_enum_data->oid);
+
+		pfree(tup.data);
 	} while (true);
+
+	btree_iterator_free(it);
 }
 
 HeapTuple
@@ -418,7 +425,10 @@ o_load_enum_cache_data_hook(TypeCacheEntry *tcache)
 			break;
 
 		if (o_enum->key.common.lsn > key.common.lsn)
+		{
+			pfree(tup.data);
 			break;
+		}
 
 		if (numitems >= maxitems)
 		{
@@ -431,7 +441,11 @@ o_load_enum_cache_data_hook(TypeCacheEntry *tcache)
 		items[numitems].enum_oid = o_enum_data->oid;
 		items[numitems].sort_order = o_enum_data->enumsortorder;
 		numitems++;
+
+		pfree(tup.data);
 	} while (true);
+
+	btree_iterator_free(it);
 
 	/* Sort the items into OID order */
 	qsort(items, numitems, sizeof(EnumItem), enum_oid_cmp);

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -1667,6 +1667,7 @@ o_indices_foreach_oids(OIndexOidsCallback callback, void *arg)
 		tuple = o_btree_iterator_fetch(it, NULL, NULL,
 									   BTreeKeyNone, false, NULL);
 	}
+	btree_iterator_free(it);
 }
 
 static const char *

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -313,6 +313,7 @@ o_tables_foreach_oids(OTablesOidsCallback callback,
 		tuple = o_btree_iterator_fetch(it, NULL, NULL,
 									   BTreeKeyNone, false, NULL);
 	}
+	btree_iterator_free(it);
 }
 
 /*

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -657,9 +657,14 @@ o_check_exclusion_constraint(OTableDescr *descr, OIndexDescr *index, TupleTableS
 							(Pointer) &bound, BTreeKeyBound,
 							(Pointer) &tuple, BTreeKeyLeafTuple);
 			if (res != 0)
+			{
+				pfree(tuple.data);
+				btree_iterator_free(iter);
 				return false;
+			}
 		}
 
+		pfree(tuple.data);
 		tuple = o_btree_iterator_fetch(iter, NULL, NULL,
 									   BTreeKeyNone, true, NULL);
 

--- a/src/tuple/toast.c
+++ b/src/tuple/toast.c
@@ -728,6 +728,8 @@ generic_toast_delete_optional_wal(ToastAPI *api, void *key, OXid oxid,
 		pfree(tuple.data);
 	} while (true);
 
+	btree_iterator_free(it);
+
 	return deleted;
 }
 


### PR DESCRIPTION
BTreeIterator is allocated within `generic_toast_delete_optional_wal` on every call for every key. But it wasn't freed before, therefore it can lead to noticeable memory leak when the function is called many times within same memory context.

Issue #722 