### PR TITLE
Fix UPDATE operation for a replicated table that use a bridge index.

### DIFF
--- a/include/tableam/operations.h
+++ b/include/tableam/operations.h
@@ -153,7 +153,7 @@ extern bool o_is_index_predicate_satisfied(OIndexDescr *idx,
 										   TupleTableSlot *slot,
 										   ExprContext *econtext);
 extern void o_truncate_table(ORelOids oids, bool missingOK);
-extern void o_apply_new_bridge_index_ctid(OTableDescr *descr, Relation relation, TupleTableSlot *slot, CommitSeqNo csn);
+extern void o_apply_new_bridge_index_ctid(OTableDescr *descr, Relation relation, TupleTableSlot *slot, CommitSeqNo csn, bool increment_bridge_ctid);
 extern int	o_exclusion_cmp(OIndexDescr *id, OBTreeKeyBound *key1, OTuple *tuple2);
 
 #endif

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -507,7 +507,7 @@ orioledb_tuple_insert_with_arbiter(ResultRelInfo *rinfo,
 		OXid		oxid;
 
 		fill_current_oxid_osnapshot(&oxid, &oSnapshot);
-		o_apply_new_bridge_index_ctid(descr, rel, slot, oSnapshot.csn);
+		o_apply_new_bridge_index_ctid(descr, rel, slot, oSnapshot.csn, true);
 	}
 
 	tts_orioledb_toast(slot, descr);

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -163,7 +163,7 @@ update_arg_get_slot(OModifyCallbackArg *arg)
 
 void
 o_apply_new_bridge_index_ctid(OTableDescr *descr, Relation relation,
-							  TupleTableSlot *slot, CommitSeqNo csn)
+							  TupleTableSlot *slot, CommitSeqNo csn, bool increment_bridge_ctid)
 {
 	OIndexDescr *primary = GET_PRIMARY(descr);
 	OTableSlot *oslot = (OTableSlot *) slot;
@@ -205,8 +205,11 @@ o_apply_new_bridge_index_ctid(OTableDescr *descr, Relation relation,
 
 	do
 	{
-		oslot->bridge_ctid = btree_bridge_ctid_get_and_inc(&primary->desc, &overflow);
-		oslot->bridgeChanged = true;
+		if (increment_bridge_ctid)
+		{
+			oslot->bridge_ctid = btree_bridge_ctid_get_and_inc(&primary->desc, &overflow);
+			oslot->bridgeChanged = true;
+		}
 
 		values[0] = PointerGetDatum(&oslot->bridge_ctid);
 		isnull[0] = false;
@@ -277,81 +280,6 @@ delete_old_bridge_index_ctid(OTableDescr *descr, Relation relation,
 							   tss_orioledb_print_idx_key(bridge_slot, descr->bridge))));
 }
 
-/*  TODO: Merge with o_apply_new_bridge_index_ctid */
-static void
-reinsert_bridge_ctid_on_pkey_changed(OTableDescr *descr, Relation relation,
-									 TupleTableSlot *slot, CommitSeqNo csn)
-{
-	OIndexDescr *primary = GET_PRIMARY(descr);
-	OTableSlot *oslot = (OTableSlot *) slot;
-	bool		success;
-	BTreeModifyCallbackInfo callbackInfo =
-	{
-		.waitCallback = NULL,
-		.modifyDeletedCallback = o_insert_callback,
-		.modifyCallback = NULL,
-		.needsUndoForSelfCreated = true
-	};
-	OSnapshot	o_snapshot;
-	OXid		oxid;
-	TupleTableSlot *bridge_slot;
-	uint32		version = 0;
-	OTuple		tuple;
-	Datum		values[INDEX_MAX_KEYS + 1];
-	bool		isnull[INDEX_MAX_KEYS + 1];
-	bool		overflow = false;
-
-	slot_getallattrs(slot);
-
-	o_btree_load_shmem(&primary->desc);
-	if (descr->bridge->primaryIsCtid)
-	{
-		values[1] = PointerGetDatum(&slot->tts_tid);
-		isnull[1] = false;
-	}
-	else
-	{
-		int			i;
-
-		for (i = 0; i < GET_PRIMARY(descr)->nKeyFields; i++)
-		{
-			AttrNumber	attnum = GET_PRIMARY(descr)->tableAttnums[i] - 1;
-
-			values[i + 1] = slot->tts_values[attnum];
-			isnull[i + 1] = slot->tts_isnull[attnum];
-		}
-	}
-
-	do
-	{
-		values[0] = PointerGetDatum(&oslot->bridge_ctid);
-		isnull[0] = false;
-
-		tuple = o_form_tuple(descr->bridge->leafTupdesc, &descr->bridge->leafSpec, version,
-							 values, isnull, NULL);
-		bridge_slot = descr->bridge->new_leaf_slot;
-		tts_orioledb_store_tuple(bridge_slot, tuple, descr, csn, BridgeIndexNumber, false, NULL);
-		callbackInfo.arg = bridge_slot;
-
-		fill_current_oxid_osnapshot(&oxid, &o_snapshot);
-
-		success = (o_tbl_index_insert(descr, descr->bridge, &tuple, bridge_slot,
-									  oxid, o_snapshot.csn, &callbackInfo, UNIQUE_CHECK_YES) == OBTreeModifyResultInserted);
-
-		if (!success && !overflow)
-			o_report_duplicate(relation, descr->bridge, bridge_slot);
-	} while (!success);
-
-	if (primary->desc.storageType == BTreeStoragePersistence)
-	{
-		o_wal_insert(&descr->bridge->desc, tuple, REPLICA_IDENTITY_DEFAULT, descr->version);
-		flush_local_wal(false, false);
-	}
-
-	if (tuple.data)
-		pfree(tuple.data);
-}
-
 TupleTableSlot *
 o_tbl_insert(OTableDescr *descr, Relation relation,
 			 TupleTableSlot *slot, OXid oxid, CommitSeqNo csn)
@@ -389,7 +317,7 @@ o_tbl_insert(OTableDescr *descr, Relation relation,
 	}
 
 	if (descr->bridge)
-		o_apply_new_bridge_index_ctid(descr, relation, slot, csn);
+		o_apply_new_bridge_index_ctid(descr, relation, slot, csn, true);
 
 	tts_orioledb_toast(slot, descr);
 
@@ -1294,7 +1222,7 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 	tts_orioledb_toast(slot, descr);
 	tts_orioledb_fill_key_bound(slot, GET_PRIMARY(descr), &newPkey);
 	if (touched_indices)
-		o_apply_new_bridge_index_ctid(descr, rel, slot, csn);
+		o_apply_new_bridge_index_ctid(descr, rel, slot, csn, true);
 
 	newTup = tts_orioledb_form_tuple(slot, descr);
 	o_btree_check_size_of_tuple(o_tuple_size(newTup, &primary->leafSpec),
@@ -1361,7 +1289,8 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 			if (descr->bridge)
 			{
 				delete_old_bridge_index_ctid(descr, rel, &((OTableSlot *) oldSlot)->bridge_ctid, csn);
-				reinsert_bridge_ctid_on_pkey_changed(descr, rel, slot, csn);
+				if (!touched_indices)
+					o_apply_new_bridge_index_ctid(descr, rel, slot, csn, false);
 			}
 
 			/* reinsert TOAST value */

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -2602,3 +2602,35 @@ COMMIT\n""")
 				self.assertListEqual(
 				    subscriber.execute('SELECT a, b FROM tab1 ORDER BY a'),
 				    [(2, 'yyyyyy')])
+
+	def test_logical_subscription_pkey_update_with_brin(self):
+		with self.node as publisher:
+			publisher.start()
+
+			subscriber = self.getSubsriber()
+			with subscriber.start() as subscriber:
+				publisher.safe_psql("""
+					CREATE EXTENSION IF NOT EXISTS orioledb;
+					CREATE TABLE tab1 (a int PRIMARY KEY) USING orioledb;
+				""")
+
+				subscriber.safe_psql("""
+					CREATE EXTENSION IF NOT EXISTS orioledb;
+					CREATE TABLE tab1 (a int PRIMARY KEY) USING orioledb;
+					CREATE INDEX tab1_a_brin_idx ON tab1 USING brin (a);
+				""")
+
+				pub = publisher.publish('test_pub', tables=['tab1'])
+				sub = subscriber.subscribe(pub, 'test_sub')
+				wait_ready(subscriber)
+
+				publisher.safe_psql("""
+					INSERT INTO tab1 VALUES (1);
+					UPDATE tab1 SET a = 2 WHERE a = 1;
+				""")
+
+				sub.catchup()
+
+				self.assertListEqual(
+				    subscriber.execute('SELECT a FROM tab1 ORDER BY a'),
+				    [(2, )])


### PR DESCRIPTION
Related to #742.