### PR TITLE
Include OrioleDB tables size in counting database size

### DIFF
--- a/include/tableam/handler.h
+++ b/include/tableam/handler.h
@@ -141,6 +141,8 @@ extern Size orioledb_parallelscan_initialize_inner(ParallelTableScanDesc pscan);
 extern void orioledb_parallelscan_reinitialize(Relation rel, ParallelTableScanDesc pscan);
 
 extern int64 orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 method);
+extern int64 orioledb_calculate_database_size(Oid dbOid);
+extern database_size_hook_type prev_database_size_hook;
 
 typedef enum
 {

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -158,6 +158,8 @@ static void (*prev_shmem_request_hook) (void) = NULL;
 static base_init_startup_hook_type prev_base_init_startup_hook = NULL;
 static get_relation_info_hook_type prev_get_relation_info_hook = NULL;
 static skip_tree_height_hook_type prev_skip_tree_height_hook = NULL;
+database_size_hook_type prev_database_size_hook = NULL;
+
 CheckPoint_hook_type next_CheckPoint_hook = NULL;
 static bool o_newlocale_from_collation(void);
 
@@ -1173,6 +1175,8 @@ _PG_init(void)
 	waitSnapshotHook = orioledb_wait_snapshot;
 	GetReplayXlogPtrHook = recovery_get_effective_replay_ptr;
 
+	prev_database_size_hook = database_size_hook;
+	database_size_hook = orioledb_calculate_database_size;
 	RecoveryStopsBeforeHook = orioledb_recovery_stops_before_hook;
 
 	if (enable_rewind)

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -2627,3 +2627,103 @@ rowid_set_csn(OIndexDescr *id, Datum pkDatum, CommitSeqNo csn)
 		add->csn = csn;
 	}
 }
+
+/*
+ * Return physical size of directory contents, or 0 if dir doesn't exist
+ * Private copy of Postgres db_dir_size()
+ */
+static int64
+orioledb_db_dir_size(const char *path)
+{
+	int64		dirsize = 0;
+	struct dirent *direntry;
+	DIR		   *dirdesc;
+	char		filename[MAXPGPATH * 2];
+
+	dirdesc = AllocateDir(path);
+
+	if (!dirdesc)
+		return 0;
+
+	while ((direntry = ReadDir(dirdesc, path)) != NULL)
+	{
+		struct stat fst;
+
+		CHECK_FOR_INTERRUPTS();
+
+		if (strcmp(direntry->d_name, ".") == 0 ||
+			strcmp(direntry->d_name, "..") == 0)
+			continue;
+
+		snprintf(filename, sizeof(filename), "%s/%s", path, direntry->d_name);
+
+		if (stat(filename, &fst) < 0)
+		{
+			if (errno == ENOENT)
+				continue;
+			else
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("could not stat file \"%s\": %m", filename)));
+		}
+		dirsize += fst.st_size;
+	}
+
+	FreeDir(dirdesc);
+	return dirsize;
+}
+
+/*
+ * Calculate Orioledb-related part of database size in all tablespaces.
+ * User access privileges should be checked before calling this hook
+ * (see calculate_database_size() function)
+ */
+int64
+orioledb_calculate_database_size(Oid dbOid)
+{
+	int64		totalsize;
+	DIR		   *dirdesc;
+	struct dirent *direntry;
+	char		dirpath[MAXPGPATH];
+	char		pathname[MAXPGPATH + 21 + sizeof(TABLESPACE_VERSION_DIRECTORY) + 13];
+
+	/*
+	 * No user privileges check here. They must have been checked before
+	 * calling this hook
+	 */
+
+	/* Shared storage in pg_global is not counted */
+
+	/* Include pg_default storage */
+	snprintf(pathname, sizeof(pathname), "orioledb_data/%u", dbOid);
+	totalsize = orioledb_db_dir_size(pathname);
+
+	/* Scan the non-default tablespaces */
+	snprintf(dirpath, MAXPGPATH, "pg_tblspc");
+	dirdesc = AllocateDir(dirpath);
+
+	while ((direntry = ReadDir(dirdesc, dirpath)) != NULL)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		if (strcmp(direntry->d_name, ".") == 0 ||
+			strcmp(direntry->d_name, "..") == 0)
+			continue;
+
+		snprintf(pathname, sizeof(pathname), "pg_tblspc/%s/%s/orioledb_data/%u",
+				 direntry->d_name, TABLESPACE_VERSION_DIRECTORY, dbOid);
+		totalsize += orioledb_db_dir_size(pathname);
+	}
+
+	FreeDir(dirdesc);
+
+	/* Support database_size_hook chaining */
+	if (prev_database_size_hook != NULL)
+	{
+		elog(DEBUG4, "called prev_database_size_hook");
+		totalsize += prev_database_size_hook(dbOid);
+	}
+
+	elog(DEBUG4, "orioledb_calculate_database_size totalsize added: %ld", totalsize);
+	return totalsize;
+}

--- a/test/expected/database.out
+++ b/test/expected/database.out
@@ -15,3 +15,158 @@ ERROR:  template database "orioledb_template" has OrioleDB tables
 DROP DATABASE orioledb_template;
 DROP DATABASE heapdb;
 DROP DATABASE heapdb_template;
+-- Check pg_database_size()
+CREATE EXTENSION orioledb;
+CREATE DATABASE oriole_database;
+\c oriole_database
+-- generate pseudo-random string function in deterministic way
+CREATE FUNCTION generate_string(seed integer, length integer) RETURNS text
+        AS $$
+                SELECT substr(string_agg(
+                                                substr(encode(sha256(seed::text::bytea || '_' || i::text::bytea), 'hex'), 1, 21),
+                                ''), 1, length)
+                FROM generate_series(1, (length + 20) / 21) i; $$
+LANGUAGE SQL;
+CHECKPOINT;
+select round(pg_database_size('oriole_database'), -6);
+  round  
+---------
+ 8000000
+(1 row)
+
+CREATE EXTENSION orioledb;
+CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
+INSERT INTO oriole_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('oriole_database'), -6);
+  round   
+----------
+ 11000000
+(1 row)
+
+SET allow_in_place_tablespaces = true;
+CREATE TABLESPACE dbsize_tblspace LOCATION '';
+CREATE TABLE oriole_table_tblspc (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb TABLESPACE dbsize_tblspace;
+INSERT INTO oriole_table_tblspc(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('oriole_database'), -6);
+  round   
+----------
+ 15000000
+(1 row)
+
+\d+ oriole_table
+                                               Table "public.oriole_table"
+ Column |  Type   | Collation | Nullable |                 Default                 | Storage | Stats target | Description 
+--------+---------+-----------+----------+-----------------------------------------+---------+--------------+-------------
+ i      | integer |           | not null | nextval('oriole_table_i_seq'::regclass) | plain   |              | 
+ t      | text    |           |          |                                         | plain   |              | 
+Indexes:
+    "oriole_table_pkey" PRIMARY KEY, btree (i)
+
+\d+ oriole_table_tblspc
+                                               Table "public.oriole_table_tblspc"
+ Column |  Type   | Collation | Nullable |                    Default                     | Storage | Stats target | Description 
+--------+---------+-----------+----------+------------------------------------------------+---------+--------------+-------------
+ i      | integer |           | not null | nextval('oriole_table_tblspc_i_seq'::regclass) | plain   |              | 
+ t      | text    |           |          |                                                | plain   |              | 
+Indexes:
+    "oriole_table_tblspc_pkey" PRIMARY KEY, btree (i)
+Tablespace: "dbsize_tblspace"
+
+\c postgres
+DROP DATABASE oriole_database;
+SELECT orioledb_rewind_sync();
+ orioledb_rewind_sync 
+----------------------
+ 
+(1 row)
+
+DROP TABLESPACE dbsize_tblspace;
+DROP EXTENSION orioledb CASCADE;
+CREATE EXTENSION orioledb;
+CREATE DATABASE mixed_database;
+\c mixed_database
+-- generate pseudo-random string function in deterministic way
+CREATE FUNCTION generate_string(seed integer, length integer) RETURNS text
+        AS $$
+                SELECT substr(string_agg(
+                                                substr(encode(sha256(seed::text::bytea || '_' || i::text::bytea), 'hex'), 1, 21),
+                                ''), 1, length)
+                FROM generate_series(1, (length + 20) / 21) i; $$
+LANGUAGE SQL;
+CREATE EXTENSION orioledb;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+  round  
+---------
+ 8000000
+(1 row)
+
+CREATE TABLE heap_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING heap;
+INSERT INTO heap_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+  round   
+----------
+ 11000000
+(1 row)
+
+CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
+INSERT INTO oriole_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+  round   
+----------
+ 15000000
+(1 row)
+
+SET allow_in_place_tablespaces = true;
+CREATE TABLESPACE dbsize_tblspace LOCATION '';
+CREATE TABLE oriole_table_tblspc (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb TABLESPACE dbsize_tblspace;
+INSERT INTO oriole_table_tblspc(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+  round   
+----------
+ 18000000
+(1 row)
+
+\d+ oriole_table
+                                               Table "public.oriole_table"
+ Column |  Type   | Collation | Nullable |                 Default                 | Storage | Stats target | Description 
+--------+---------+-----------+----------+-----------------------------------------+---------+--------------+-------------
+ i      | integer |           | not null | nextval('oriole_table_i_seq'::regclass) | plain   |              | 
+ t      | text    |           |          |                                         | plain   |              | 
+Indexes:
+    "oriole_table_pkey" PRIMARY KEY, btree (i)
+
+\d+ heap_table
+                                               Table "public.heap_table"
+ Column |  Type   | Collation | Nullable |                Default                | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------------------------------------+---------+--------------+-------------
+ i      | integer |           | not null | nextval('heap_table_i_seq'::regclass) | plain   |              | 
+ t      | text    |           |          |                                       | plain   |              | 
+Indexes:
+    "heap_table_pkey" PRIMARY KEY, btree (i)
+
+\d+ oriole_table_tblspc
+                                               Table "public.oriole_table_tblspc"
+ Column |  Type   | Collation | Nullable |                    Default                     | Storage | Stats target | Description 
+--------+---------+-----------+----------+------------------------------------------------+---------+--------------+-------------
+ i      | integer |           | not null | nextval('oriole_table_tblspc_i_seq'::regclass) | plain   |              | 
+ t      | text    |           |          |                                                | plain   |              | 
+Indexes:
+    "oriole_table_tblspc_pkey" PRIMARY KEY, btree (i)
+Tablespace: "dbsize_tblspace"
+
+\c postgres
+DROP DATABASE mixed_database;
+SELECT orioledb_rewind_sync();
+ orioledb_rewind_sync 
+----------------------
+ 
+(1 row)
+
+DROP TABLESPACE dbsize_tblspace;
+DROP EXTENSION orioledb CASCADE;

--- a/test/sql/database.sql
+++ b/test/sql/database.sql
@@ -23,3 +23,88 @@ CREATE DATABASE orioledb TEMPLATE orioledb_template;
 DROP DATABASE orioledb_template;
 DROP DATABASE heapdb;
 DROP DATABASE heapdb_template;
+
+-- Check pg_database_size()
+CREATE EXTENSION orioledb;
+CREATE DATABASE oriole_database;
+\c oriole_database
+
+-- generate pseudo-random string function in deterministic way
+CREATE FUNCTION generate_string(seed integer, length integer) RETURNS text
+        AS $$
+                SELECT substr(string_agg(
+                                                substr(encode(sha256(seed::text::bytea || '_' || i::text::bytea), 'hex'), 1, 21),
+                                ''), 1, length)
+                FROM generate_series(1, (length + 20) / 21) i; $$
+LANGUAGE SQL;
+
+CHECKPOINT;
+select round(pg_database_size('oriole_database'), -6);
+
+CREATE EXTENSION orioledb;
+CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
+INSERT INTO oriole_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('oriole_database'), -6);
+
+SET allow_in_place_tablespaces = true;
+CREATE TABLESPACE dbsize_tblspace LOCATION '';
+CREATE TABLE oriole_table_tblspc (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb TABLESPACE dbsize_tblspace;
+INSERT INTO oriole_table_tblspc(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('oriole_database'), -6);
+
+\d+ oriole_table
+\d+ oriole_table_tblspc
+
+\c postgres
+DROP DATABASE oriole_database;
+SELECT orioledb_rewind_sync();
+DROP TABLESPACE dbsize_tblspace;
+DROP EXTENSION orioledb CASCADE;
+
+CREATE EXTENSION orioledb;
+CREATE DATABASE mixed_database;
+\c mixed_database
+
+-- generate pseudo-random string function in deterministic way
+CREATE FUNCTION generate_string(seed integer, length integer) RETURNS text
+        AS $$
+                SELECT substr(string_agg(
+                                                substr(encode(sha256(seed::text::bytea || '_' || i::text::bytea), 'hex'), 1, 21),
+                                ''), 1, length)
+                FROM generate_series(1, (length + 20) / 21) i; $$
+LANGUAGE SQL;
+
+CREATE EXTENSION orioledb;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+
+CREATE TABLE heap_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING heap;
+INSERT INTO heap_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+
+CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
+INSERT INTO oriole_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+
+SET allow_in_place_tablespaces = true;
+CREATE TABLESPACE dbsize_tblspace LOCATION '';
+
+CREATE TABLE oriole_table_tblspc (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb TABLESPACE dbsize_tblspace;
+INSERT INTO oriole_table_tblspc(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+CHECKPOINT;
+select round(pg_database_size('mixed_database'), -6);
+
+\d+ oriole_table
+\d+ heap_table
+\d+ oriole_table_tblspc
+
+\c postgres
+
+DROP DATABASE mixed_database;
+SELECT orioledb_rewind_sync();
+DROP TABLESPACE dbsize_tblspace;
+DROP EXTENSION orioledb CASCADE;


### PR DESCRIPTION
Orioledb relations reside in a separate orioledb_data dir, for which calculate_database_size was unaware for.

This patch implements hook function to count orioledb_data files both
 for datadir and pg_tblspc/ dir.

Limitation for counting: orioledb_undo is not per-database so it's not
 counted now. This could underestimate reported database size results
for workload heavy with DML modifications.