### PR TITLE
Add TPC-C performance benchmarking CI workflow

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,0 +1,211 @@
+name: perf-test
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      pg_version:
+        description: "PostgreSQL version"
+        required: false
+        default: "17"
+      compiler:
+        description: "Compiler"
+        required: false
+        default: "gcc"
+      bench_duration:
+        description: "Duration per benchmark run"
+        required: false
+        default: "5m"
+      bench_runs:
+        description: "Number of benchmark runs"
+        required: false
+        default: "1"
+      warehouses:
+        description: "Number of warehouses / TPC-C scale factor (comma-separated for multiple, e.g. 1,10,100)"
+        required: false
+        default: "1"
+      vus_scale:
+        description: "VU scale multiplier (1 = 99 VUs, 0.5 ≈ 50, 0.1 ≈ 11)"
+        required: false
+        default: "1"
+      pool_size:
+        description: "Connection pool size (max and min connections)"
+        required: false
+        default: "100"
+      base_ref:
+        description: "Base branch/commit to compare against (default: main)"
+        required: false
+        default: "main"
+
+jobs:
+  setup:
+    name: Generate run matrix
+    runs-on: ubuntu-latest
+    outputs:
+      run-matrix: ${{ steps.gen.outputs.run-matrix }}
+    steps:
+      - id: gen
+        env:
+          RUNS: ${{ inputs.bench_runs || '1' }}
+          WAREHOUSES: ${{ inputs.warehouses || '1' }}
+        run: |
+          echo "run-matrix=$(python3 -c "
+          import json, os
+          runs = int(os.environ['RUNS'])
+          whs = [s.strip() for s in os.environ['WAREHOUSES'].split(',')]
+          print(json.dumps({'run': list(range(1, runs+1)), 'warehouses': whs}))
+          ")" >> $GITHUB_OUTPUT
+
+  bench-base:
+    name: "Bench base ${{ matrix.warehouses }}W #${{ matrix.run }}"
+    needs: setup
+    runs-on: perf-runner
+    strategy:
+      matrix: ${{ fromJson(needs.setup.outputs.run-matrix) }}
+      max-parallel: 1
+    env:
+      LLVM_VER: 18
+      CHECK_TYPE: normal
+      COMPILER: ${{ inputs.compiler || 'gcc' }}
+      PG_VERSION: ${{ inputs.pg_version || '17' }}
+      DURATION: ${{ inputs.bench_duration || '5m' }}
+      WAREHOUSES: ${{ matrix.warehouses }}
+      VUS_SCALE: ${{ inputs.vus_scale || '1' }}
+      POOL_SIZE: ${{ inputs.pool_size || '100' }}
+    steps:
+      - name: Checkout extension code (base branch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || inputs.base_ref || 'main' }}
+          path: orioledb
+      - name: Get the required tag name
+        shell: bash
+        run: |
+          echo "PGTAG=$(grep '^${{ env.PG_VERSION }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+      - name: Checkout PostgreSQL
+        uses: actions/checkout@v4
+        with:
+          repository: orioledb/postgres
+          ref: ${{ env.PGTAG }}
+          path: postgresql
+      - name: Setup prerequisites
+        run: bash ./orioledb/ci/prerequisites.sh
+      - name: Build (with local cache)
+        run: bash ./orioledb/ci/perf_build.sh
+      - name: Start PostgreSQL
+        run: bash ./orioledb/ci/perf_pg_start.sh
+      - name: Resolve current user
+        run: echo "PGUSER=$(whoami)" >> $GITHUB_ENV
+      - name: Run TPC-C benchmark
+        uses: stroppy-io/stroppy-action@main
+        with:
+          preset: tpcc
+          driver-url: postgres://${{ env.PGUSER }}@localhost:5432/postgres
+          artifact-name: perf-results-base-${{ matrix.warehouses }}W-${{ matrix.run }}
+      - name: Stop PostgreSQL
+        if: always()
+        run: bash ./orioledb/ci/perf_pg_stop.sh
+
+  bench-head:
+    name: "Bench head ${{ matrix.warehouses }}W #${{ matrix.run }}"
+    needs:
+      - setup
+      - bench-base
+    runs-on: perf-runner
+    strategy:
+      matrix: ${{ fromJson(needs.setup.outputs.run-matrix) }}
+      max-parallel: 1
+    env:
+      LLVM_VER: 18
+      CHECK_TYPE: normal
+      COMPILER: ${{ inputs.compiler || 'gcc' }}
+      PG_VERSION: ${{ inputs.pg_version || '17' }}
+      DURATION: ${{ inputs.bench_duration || '5m' }}
+      WAREHOUSES: ${{ matrix.warehouses }}
+      VUS_SCALE: ${{ inputs.vus_scale || '1' }}
+      POOL_SIZE: ${{ inputs.pool_size || '100' }}
+    steps:
+      - name: Checkout extension code (head branch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: orioledb
+      - name: Get the required tag name
+        shell: bash
+        run: |
+          echo "PGTAG=$(grep '^${{ env.PG_VERSION }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+      - name: Checkout PostgreSQL
+        uses: actions/checkout@v4
+        with:
+          repository: orioledb/postgres
+          ref: ${{ env.PGTAG }}
+          path: postgresql
+      - name: Setup prerequisites
+        run: bash ./orioledb/ci/prerequisites.sh
+      - name: Build (with local cache)
+        run: bash ./orioledb/ci/perf_build.sh
+      - name: Start PostgreSQL
+        run: bash ./orioledb/ci/perf_pg_start.sh
+      - name: Resolve current user
+        run: echo "PGUSER=$(whoami)" >> $GITHUB_ENV
+      - name: Run TPC-C benchmark
+        uses: stroppy-io/stroppy-action@main
+        with:
+          preset: tpcc
+          driver-url: postgres://${{ env.PGUSER }}@localhost:5432/postgres
+          artifact-name: perf-results-head-${{ matrix.warehouses }}W-${{ matrix.run }}
+      - name: Stop PostgreSQL
+        if: always()
+        run: bash ./orioledb/ci/perf_pg_stop.sh
+
+  compare:
+    name: Compare results
+    needs:
+      - bench-base
+      - bench-head
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout extension code
+        uses: actions/checkout@v4
+        with:
+          path: orioledb
+      - name: Download base results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: perf-results-base-*
+          path: results-base/
+      - name: Download head results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: perf-results-head-*
+          path: results-head/
+      - name: Compare results
+        run: |
+          python3 ./orioledb/ci/perf_compare.py \
+            --base-dir results-base/ \
+            --head-dir results-head/ \
+            --runs "${{ inputs.bench_runs || '1' }}" \
+            --duration "${{ inputs.bench_duration || '5m' }}" \
+            --warehouses "${{ inputs.warehouses || '1' }}" \
+            --output comment.md
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          MARKER="<!-- perf-test-results -->"
+          BODY=$(cat comment.md)
+          COMMENT="${MARKER}"$'\n'"${BODY}"
+
+          # Check if a comment with the marker already exists
+          EXISTING=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/${EXISTING} \
+              -X PATCH -f body="$COMMENT"
+          else
+            gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
+              -f body="$COMMENT"
+          fi

--- a/ci/perf_build.sh
+++ b/ci/perf_build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -eux
+
+# Local build cache for self-hosted runners.
+# Avoids rebuilding PG+OrioleDB in each matrix job.
+ORIOLEDB_SHA=$(cd orioledb && git rev-parse HEAD)
+CACHE_KEY="${COMPILER}-${PGTAG}-${ORIOLEDB_SHA}"
+CACHE_DIR="/tmp/perf-build-cache/${CACHE_KEY}"
+
+if [ -d "$CACHE_DIR/pgsql" ]; then
+	echo "=== Restoring build from local cache ==="
+	cp -a "$CACHE_DIR/pgsql" "$GITHUB_WORKSPACE/pgsql"
+	exit 0
+fi
+
+echo "=== Building from scratch ==="
+
+if [ $COMPILER = "clang" ]; then
+	export CC=clang-$LLVM_VER
+else
+	export CC=gcc
+fi
+
+# configure & build PostgreSQL (debug symbols, no asserts)
+CONFIG_ARGS="--enable-debug --disable-cassert --with-icu --prefix=$GITHUB_WORKSPACE/pgsql"
+
+cd postgresql
+./configure $CONFIG_ARGS
+if printf "%s\n" "$PGTAG" | grep -v -Fqe "patches$(sed -n "/PACKAGE_VERSION='\(.*\)'/ s//\1/ p" configure | cut -d'.' -f1 )_"; then \
+	echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global; \
+fi ;
+make -sj `nproc`
+make -sj `nproc` install
+make -C contrib -sj `nproc`
+make -C contrib -sj `nproc` install
+cd ..
+
+export PATH="$GITHUB_WORKSPACE/pgsql/bin:$PATH"
+
+# build OrioleDB (no coverage, no sanitizer, no -Werror)
+cd orioledb
+make -j `nproc` USE_PGXS=1
+make -j `nproc` USE_PGXS=1 install
+cd ..
+
+# Save to local cache, clean up old entries (keep last 4)
+mkdir -p "$CACHE_DIR"
+cp -a "$GITHUB_WORKSPACE/pgsql" "$CACHE_DIR/pgsql"
+find /tmp/perf-build-cache/ -maxdepth 1 -mindepth 1 -type d \
+	| sort | head -n -4 | xargs -r rm -rf

--- a/ci/perf_compare.py
+++ b/ci/perf_compare.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Compare k6/stroppy TPC-C benchmark results between base and head branches.
+
+Parses k6 summary JSON files (produced by stroppy-action with --summary-export).
+Each file is a single JSON object: {"metrics": {"metric_name": {"avg":..., "med":..., ...}}}
+"""
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+
+
+def parse_k6_summary(filepath):
+    """Parse k6 summary JSON results file.
+
+    Returns a flat dict of normalized metric values suitable for comparison.
+    """
+    with open(filepath) as f:
+        data = json.load(f)
+
+    raw_metrics = data.get("metrics", {})
+    if not raw_metrics:
+        return {}
+
+    metrics = {}
+
+    # iteration_duration — latency metrics (ms)
+    it = raw_metrics.get("iteration_duration", {})
+    if it:
+        metrics["avg_duration_ms"] = it.get("avg", 0)
+        metrics["med_duration_ms"] = it.get("med", 0)
+        metrics["p90_duration_ms"] = it.get("p(90)", 0)
+        metrics["p95_duration_ms"] = it.get("p(95)", 0)
+
+    # iterations — throughput counter
+    iters = raw_metrics.get("iterations", {})
+    if iters:
+        metrics["total_iterations"] = iters.get("count", 0)
+        metrics["total_iterations_rate"] = iters.get("rate", 0)
+
+    # run_query_duration — query latency
+    qd = raw_metrics.get("run_query_duration", {})
+    if qd:
+        metrics["query_avg_ms"] = qd.get("avg", 0)
+        metrics["query_p90_ms"] = qd.get("p(90)", 0)
+        metrics["query_p95_ms"] = qd.get("p(95)", 0)
+
+    # run_query_count — query throughput
+    qc = raw_metrics.get("run_query_count", {})
+    if qc:
+        metrics["query_rate"] = qc.get("rate", 0)
+
+    return metrics
+
+
+def find_result_files(results_dir, num_runs, scale_factor=None):
+    """Find stroppy JSON result files in the download directory.
+
+    stroppy-action artifacts are downloaded as:
+      results-dir/perf-results-{branch}-sf{SF}-{N}/stroppy-results.json
+    If scale_factor is given, only match directories containing that sf.
+    """
+    pattern = os.path.join(results_dir, "**", "stroppy-results.json")
+    files = sorted(glob.glob(pattern, recursive=True))
+    if not files:
+        files = sorted(glob.glob(os.path.join(results_dir, "*.json")))
+    if scale_factor is not None:
+        sf_tag = f"-sf{scale_factor}-"
+        files = [f for f in files if sf_tag in f]
+    return files[:num_runs]
+
+
+def load_run_results(results_dir, num_runs, scale_factor=None):
+    """Load and parse all result files from a results directory."""
+    files = find_result_files(results_dir, num_runs, scale_factor)
+    all_metrics = []
+    for filepath in files:
+        print(f"Parsing: {filepath}", file=sys.stderr)
+        metrics = parse_k6_summary(filepath)
+        if metrics:
+            all_metrics.append(metrics)
+        else:
+            print(f"Warning: no metrics found in {filepath}", file=sys.stderr)
+    return all_metrics
+
+
+def compute_medians(all_metrics):
+    """Compute median values across all runs for each metric."""
+    if not all_metrics:
+        return {}
+    keys = set()
+    for m in all_metrics:
+        keys.update(m.keys())
+    medians = {}
+    for key in sorted(keys):
+        values = [m[key] for m in all_metrics if key in m]
+        if values:
+            medians[key] = statistics.median(values)
+    return medians
+
+
+def format_change(base_val, head_val, lower_is_better=False):
+    """Format percentage change with direction indicator."""
+    if base_val == 0:
+        return "N/A"
+    change = (head_val - base_val) / base_val * 100
+    sign = "+" if change > 0 else ""
+    if lower_is_better:
+        indicator = " :white_check_mark:" if change < -2 else (" :warning:" if change > 2 else "")
+    else:
+        indicator = " :white_check_mark:" if change > 2 else (" :warning:" if change < -2 else "")
+    return f"{sign}{change:.1f}%{indicator}"
+
+
+def format_value(value, is_rate=False):
+    """Format a metric value for display."""
+    if is_rate:
+        return f"{value:.1f}/s"
+    return f"{value:.1f}ms"
+
+
+def generate_markdown(base_medians, head_medians, config):
+    """Generate markdown comparison table."""
+    lines = []
+    lines.append("## Performance Test Results (TPC-C)")
+    lines.append("")
+    lines.append("| Metric | Base | Head | Change |")
+    lines.append("|--------|------|------|--------|")
+
+    # Throughput metrics (higher is better)
+    rate_metrics = [
+        ("total_iterations_rate", "Iterations/s"),
+        ("query_rate", "Queries/s"),
+    ]
+
+    for key, label in rate_metrics:
+        base_val = base_medians.get(key)
+        head_val = head_medians.get(key)
+        if base_val is not None and head_val is not None:
+            lines.append(
+                f"| {label} | {format_value(base_val, is_rate=True)} "
+                f"| {format_value(head_val, is_rate=True)} "
+                f"| {format_change(base_val, head_val)} |"
+            )
+
+    # Count metric
+    base_iters = base_medians.get("total_iterations")
+    head_iters = head_medians.get("total_iterations")
+    if base_iters is not None and head_iters is not None:
+        lines.append(
+            f"| Total iterations | {int(base_iters)} "
+            f"| {int(head_iters)} "
+            f"| {format_change(base_iters, head_iters)} |"
+        )
+
+    # Duration metrics (lower is better)
+    duration_metrics = [
+        ("avg_duration_ms", "Avg iteration duration"),
+        ("med_duration_ms", "Median iteration duration"),
+        ("p90_duration_ms", "P90 iteration duration"),
+        ("p95_duration_ms", "P95 iteration duration"),
+        ("query_avg_ms", "Avg query duration"),
+        ("query_p90_ms", "P90 query duration"),
+        ("query_p95_ms", "P95 query duration"),
+    ]
+
+    for key, label in duration_metrics:
+        base_val = base_medians.get(key)
+        head_val = head_medians.get(key)
+        if base_val is not None and head_val is not None and (base_val > 0 or head_val > 0):
+            lines.append(
+                f"| {label} | {format_value(base_val)} "
+                f"| {format_value(head_val)} "
+                f"| {format_change(base_val, head_val, lower_is_better=True)} |"
+            )
+
+    lines.append("")
+    lines.append(
+        f"**Config**: {config['runs']} runs, {config['duration']} each, "
+        f"scale_factor={config['scale_factor']}"
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare TPC-C benchmark results")
+    parser.add_argument("--base-dir", required=True, help="Directory with base branch results")
+    parser.add_argument("--head-dir", required=True, help="Directory with head branch results")
+    parser.add_argument("--runs", type=int, default=5, help="Number of benchmark runs")
+    parser.add_argument("--duration", default="10m", help="Duration per run")
+    parser.add_argument("--scale-factor", default="1",
+                        help="TPC-C scale factor (comma-separated for multiple)")
+    parser.add_argument("--output", default="comment.md", help="Output markdown file")
+    args = parser.parse_args()
+
+    scale_factors = [s.strip() for s in args.scale_factor.split(",")]
+    sections = []
+
+    for sf in scale_factors:
+        base_metrics = load_run_results(args.base_dir, args.runs, scale_factor=sf)
+        head_metrics = load_run_results(args.head_dir, args.runs, scale_factor=sf)
+
+        if not base_metrics:
+            print(f"Error: no base branch results found for scale_factor={sf}", file=sys.stderr)
+            sys.exit(1)
+        if not head_metrics:
+            print(f"Error: no head branch results found for scale_factor={sf}", file=sys.stderr)
+            sys.exit(1)
+
+        base_medians = compute_medians(base_metrics)
+        head_medians = compute_medians(head_metrics)
+
+        config = {
+            "runs": args.runs,
+            "duration": args.duration,
+            "scale_factor": sf,
+        }
+
+        sections.append(generate_markdown(base_medians, head_medians, config))
+
+    markdown = "\n---\n\n".join(sections)
+    with open(args.output, "w") as f:
+        f.write(markdown)
+
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/perf_pg_start.sh
+++ b/ci/perf_pg_start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eux
+
+export PATH="$GITHUB_WORKSPACE/pgsql/bin:$PATH"
+
+PGDATA="$GITHUB_WORKSPACE/pgdata"
+
+# Initialize PostgreSQL
+rm -rf "$PGDATA"
+initdb -N --encoding=UTF-8 --locale=C -D "$PGDATA"
+
+# Configure for benchmarks
+TOTAL_MEM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+SHARED_BUFFERS_MB=$(( TOTAL_MEM_KB / 4 / 1024 ))
+
+cat >> "$PGDATA/postgresql.conf" <<EOF
+listen_addresses = 'localhost'
+shared_preload_libraries = 'orioledb'
+default_table_access_method = 'orioledb'
+shared_buffers = '${SHARED_BUFFERS_MB}MB'
+max_connections = 200
+max_wal_size = '4GB'
+checkpoint_completion_target = 0.9
+EOF
+
+# Start PostgreSQL
+pg_ctl -D "$PGDATA" -l "$PGDATA/postgresql.log" start
+
+# Wait for PostgreSQL to be ready
+pg_isready -t 30
+

--- a/ci/perf_pg_stop.sh
+++ b/ci/perf_pg_stop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eux
+
+export PATH="$GITHUB_WORKSPACE/pgsql/bin:$PATH"
+
+PGDATA="$GITHUB_WORKSPACE/pgdata"
+
+pg_ctl -D "$PGDATA" stop || true
+rm -rf "$PGDATA"


### PR DESCRIPTION
## Summary

Add TPC-C performance benchmarking CI workflow that automatically runs on every pull request, comparing performance of the head branch against the base branch.

## How it works

The workflow has 3 sequential stages:

1. **bench-base** — builds PostgreSQL + OrioleDB from the base (target) branch and runs TPC-C benchmark via [stroppy-action](https://github.com/stroppy-io/stroppy-action)
2. **bench-head** — same for the head (PR) branch, runs after base to avoid resource contention
3. **compare** — downloads artifacts from both runs, computes metric deltas (`ci/perf_compare.py`), and posts a markdown table as a PR comment (updates existing comment on re-runs)

Benchmark jobs run sequentially (`max-parallel: 1`) on the same runner to ensure consistent comparison.

## Prerequisites

### Self-hosted runner with label `perf-runner`

Benchmark jobs (`bench-base`, `bench-head`) use `runs-on: perf-runner`. You need a self-hosted GitHub Actions runner registered with this label. Requirements:

- **Dedicated machine** — no other workloads during benchmarks, to avoid noisy-neighbor effects
- **Build tools** — gcc (or clang-18), make, and PostgreSQL build dependencies (installed by `ci/prerequisites.sh`)
- **Sufficient RAM** — the scripts auto-configure `shared_buffers` to 25% of total memory

### Build cache

`ci/perf_build.sh` maintains a local build cache at `/tmp/perf-build-cache/` on the self-hosted runner. Builds are cached by `{compiler}-{pgtag}-{orioledb_sha}`, keeping the last 4 entries. This avoids full rebuilds when only the extension changes.

## Workflow dispatch parameters

Can be triggered manually via `workflow_dispatch` with these inputs:

| Parameter        | Default | Description                                          |
|------------------|---------|------------------------------------------------------|
| `pg_version`     | `17`    | PostgreSQL major version (resolved via `.pgtags` file) |
| `compiler`       | `gcc`   | `gcc` or `clang`                                     |
| `bench_duration` | `5m`    | Duration per benchmark run (k6 format)               |
| `bench_runs`     | `1`     | Number of runs (median is used for comparison)       |
| `scale_factor`   | `1`     | TPC-C scale factor (warehouses)                      |

For pull requests, defaults are used (1 run, 5 minutes, scale factor 1).

## Files added

- **`.github/workflows/perf-test.yml`** — main workflow definition. Defines 3 jobs: `bench-base` (benchmark the target branch), `bench-head` (benchmark the PR branch), `compare` (compare results). Benchmark jobs run sequentially on `perf-runner`, comparison runs on `ubuntu-latest`. Parameters (PG version, compiler, duration, number of runs, scale factor) are configurable via `workflow_dispatch`.

- **`ci/perf_build.sh`** — builds PostgreSQL and OrioleDB. Uses a local build cache on the self-hosted runner (`/tmp/perf-build-cache/`), keyed by `{compiler}-{pgtag}-{orioledb_sha}`. On cache hit, copies the ready build; on miss, builds from scratch (configure, make, make install). Keeps the last 4 builds, removes older ones.

- **`ci/perf_pg_start.sh`** — initializes and starts PostgreSQL for benchmarking. Runs `initdb`, configures `shared_buffers` (25% of RAM), `max_connections=200`, `max_wal_size=4GB`, loads `orioledb` as a shared preload library, and sets `orioledb` as the default table access method.

- **`ci/perf_pg_stop.sh`** — stops PostgreSQL (`pg_ctl stop`) and cleans up `$PGDATA`.

- **`ci/perf_compare.py`** — parses stroppy-action JSON results (k6 summary format), extracts metrics (throughput: iterations/s, queries/s; latency: avg, median, p90, p95), computes medians across all runs, and generates a markdown comparison table (base vs head) with percentage changes. When triggered from a PR, posts the result as a comment (or updates the existing one).
