### PR TITLE
Fix orioledb_tbl_bin_structure() to properly display tuple data

### DIFF
--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -21,6 +21,7 @@
 #include "btree/io.h"
 #include "btree/iterator.h"
 #include "btree/page_chunks.h"
+#include "btree/page_contents.h"
 #include "catalog/indices.h"
 #include "tableam/descr.h"
 #include "tableam/handler.h"
@@ -33,6 +34,7 @@
 #include "access/relation.h"
 #include "access/table.h"
 #include "access/tupmacs.h"
+#include "catalog/pg_attribute.h"
 #include "catalog/pg_type_d.h"
 #include "commands/defrem.h"
 #include "funcapi.h"
@@ -427,16 +429,13 @@ append_bits(StringInfo str, Page p, OffsetNumber *offset,
 			(*bit_offset)++;
 			if (*bit_offset % 8 == 0)
 			{
+				appendStringInfo(str, " ");
 				(*offset)++;
 				byte_start = 0;
 				if (len - j - 1 > BITS_PER_BYTE)
 					byte_end = BITS_PER_BYTE;
 				else
 					byte_end = len - j - 1;
-			}
-			if ((j + 1) % 8 == 0)
-			{
-				appendStringInfo(str, " ");
 			}
 		}
 		appendStringInfo(str, "\n");
@@ -509,15 +508,16 @@ print_page_bin_structure(BTreeDescr *desc, OInMemoryBlkno blkno,
 
 	level--;					/* o_header END */
 
+	APPEND_FIELD("undoLocation", UndoLocation);
+	APPEND_FIELD("csn", CommitSeqNo);
+	APPEND_FIELD("rightLink", uint64);
+
 	bit_offset = 0;
 	APPEND_BIT_FIELD("flags", 6);
 	APPEND_BIT_FIELD("field1", 11);
 	APPEND_BIT_FIELD("field2", 15);
 	Assert(bit_offset == sizeof(uint32) * BITS_PER_BYTE);
 
-	APPEND_FIELD("undoLocation", UndoLocation);
-	APPEND_FIELD("csn", CommitSeqNo);
-	APPEND_FIELD("rightLink", uint64);
 	APPEND_FIELD("maxKeyLen", LocationIndex);
 	APPEND_FIELD("prevInsertOffset", OffsetNumber);
 	APPEND_FIELD("chunksCount", OffsetNumber);
@@ -541,7 +541,8 @@ print_page_bin_structure(BTreeDescr *desc, OInMemoryBlkno blkno,
 		bit_offset = 0;
 		APPEND_BIT_FIELD("shortLocation", 12);
 		APPEND_BIT_FIELD("offset", 10);
-		APPEND_BIT_FIELD("hikeyShortLocation", 8);
+		APPEND_BIT_FIELD("hikeyShortLocation", 7);
+		APPEND_BIT_FIELD("chunkKeysFixed", 1);
 		APPEND_BIT_FIELD("hikeyFlags", 2);
 		Assert(bit_offset == sizeof(uint32) * BITS_PER_BYTE);
 		level--;				/* chunkDesc[i] END */
@@ -550,18 +551,23 @@ print_page_bin_structure(BTreeDescr *desc, OInMemoryBlkno blkno,
 
 	appendStringInfoSpaces(outbuf, level * 4);
 	appendStringInfo(outbuf, "BTreePageHeader REST (%lu)\n",
-					 sizeof(BTreePageHeader) - offset);
-	append_bytes(outbuf, p, &offset, sizeof(BTreePageHeader) - offset, level,
+					 MAXALIGN(offset) - offset);
+	append_bytes(outbuf, p, &offset, MAXALIGN(offset) - offset, level,
 				 print_bytes);
+
+	Assert(MAXALIGN(offsetof(BTreePageHeader, chunkDesc) +
+					header->chunksCount * sizeof(BTreePageChunkDesc)) == offset);
 
 	level--;					/* BTreePageHeader END */
 
-	appendStringInfo(outbuf, "HIKEY DATA (%lu) \n",
-					 SHORT_GET_LOCATION(header->chunkDesc[0].shortLocation) -
-					 sizeof(BTreePageHeader));
+	appendStringInfo(outbuf, "HIKEY DATA (%u) \n", header->hikeysEnd - offset);
+	append_bytes(outbuf, p, &offset, header->hikeysEnd - offset,
+				 level, print_bytes);
+
+	appendStringInfo(outbuf, "HIKEY AREA REST (%u)\n",
+					 SHORT_GET_LOCATION(header->chunkDesc[0].shortLocation) - offset);
 	append_bytes(outbuf, p, &offset,
-				 SHORT_GET_LOCATION(header->chunkDesc[0].shortLocation) -
-				 sizeof(BTreePageHeader),
+				 SHORT_GET_LOCATION(header->chunkDesc[0].shortLocation) - offset,
 				 level, print_bytes);
 
 	appendStringInfo(outbuf, "CHUNKS: ARRAY:\n");
@@ -628,12 +634,27 @@ print_page_bin_structure(BTreeDescr *desc, OInMemoryBlkno blkno,
 				OTuple		tup;
 				OTupleReaderState reader;
 				TuplePrintOpaque *opaque = (TuplePrintOpaque *) printArg;
-				TupleDesc	tupdesc = opaque->keyDesc;
+				TupleDesc	tupdesc = opaque->desc;
+				LocationIndex len;
+
+				if (j + 1 < chunkItemsCount)
+				{
+					len = ITEM_GET_OFFSET(chunk->items[j + 1]) -
+						ITEM_GET_OFFSET(chunk->items[j]);
+				}
+				else
+				{
+					len = chunkSize - ITEM_GET_OFFSET(chunk->items[j]);
+				}
 
 				appendStringInfoSpaces(outbuf, level * 4);
-				appendStringInfo(outbuf, "[%d]: BTreeLeafTuphdr(%zu)\n", j,
-								 sizeof(BTreeLeafTuphdr));
+				appendStringInfo(outbuf, "[%d]: %d\n", j, len);
 				level++;		/* ITEM DATA[j] BEGIN */
+
+				appendStringInfoSpaces(outbuf, level * 4);
+				appendStringInfo(outbuf, "BTreeLeafTuphdr(%zu)\n",
+								 sizeof(BTreeLeafTuphdr));
+				level++;		/* Leaf tuple header BEGIN */
 
 				bit_offset = 0;
 				APPEND_BIT_FIELD("xactInfo", 61);
@@ -646,27 +667,18 @@ print_page_bin_structure(BTreeDescr *desc, OInMemoryBlkno blkno,
 				APPEND_BIT_FIELD("formatFlags", 2);
 				Assert(bit_offset == sizeof(UndoLocation) * BITS_PER_BYTE);
 
+				level--;		/* Leaf tuple header END */
+				len -= sizeof(BTreeLeafTuphdr);
+
 				tup.data = &p[offset];
 				tup.formatFlags = ITEM_GET_FLAGS(chunk->items[j]);
-				o_tuple_init_reader(&reader, tup, tupdesc, opaque->keySpec);
+				o_tuple_init_reader(&reader, tup, tupdesc, opaque->spec);
 
 				if (!(tup.formatFlags & O_TUPLE_FLAGS_FIXED_FORMAT))
 				{
-					uint16		len = 0;
-					uint32		off;
-					uint32		next_off;
-
-					off = o_tuple_next_field_offset(&reader,
-													TupleDescAttr(tupdesc, 0));
-					next_off =
-						o_tuple_next_field_offset(&reader,
-												  TupleDescAttr(tupdesc, 1));
-
 					appendStringInfoSpaces(outbuf, level * 4);
-					appendStringInfo(outbuf,
-									 "Tuple header: OTupleHeader(%lu)\n",
+					appendStringInfo(outbuf, "OTupleHeader(%zu)\n",
 									 sizeof(OTupleHeader));
-					len += sizeof(OTupleHeader);
 					level++;	/* Tuple header BEGIN */
 
 					bit_offset = 0;
@@ -678,14 +690,52 @@ print_page_bin_structure(BTreeDescr *desc, OInMemoryBlkno blkno,
 					APPEND_FIELD("version", uint32);
 
 					level--;	/* Tuple header END */
+					len -= sizeof(OTupleHeader);
+
+					if (reader.hasnulls)
+					{
+						uint32		bitmapSize = MAXALIGN(BITMAPLEN(reader.natts));
+
+						bit_offset = 0;
+						APPEND_BIT_FIELD("Null bitmap", bitmapSize * BITS_PER_BYTE);
+						len -= bitmapSize;
+					}
+				}
+
+				Assert(&p[offset] == reader.tp);
+
+				{
+					uint32		off;
+					uint32		next_off = 0;
 
 					appendStringInfoSpaces(outbuf, level * 4);
 					appendStringInfo(outbuf, "Tuple data: %d\n", len);
 					level++;	/* Tuple data BEGIN */
-					for (k = 0; k < opaque->keyDesc->natts; k++)
+					for (k = 0; k < opaque->desc->natts; k++)
 					{
 						Form_pg_attribute atti =
-							TupleDescAttr(opaque->keyDesc, k);
+							TupleDescAttr(opaque->desc, k);
+
+						if (reader.hasnulls && att_isnull(k, reader.bp))
+						{
+							reader.slow = true;
+							reader.attnum++;
+							continue;
+						}
+
+						off = o_tuple_next_field_offset(&reader, atti);
+
+						if (next_off < off)
+						{
+							align = off - next_off;
+							appendStringInfoSpaces(outbuf, level * 4);
+							appendStringInfo(outbuf, "ATTR ALIGN: %u - %u\n",
+											 off, next_off);
+							append_bytes(outbuf, p, &offset, align, level,
+										 print_bytes);
+						}
+
+						next_off = reader.off;
 
 						appendStringInfoSpaces(outbuf, level * 4);
 						appendStringInfo(outbuf, "%s: %u - %u: %c\n",
@@ -704,20 +754,17 @@ print_page_bin_structure(BTreeDescr *desc, OInMemoryBlkno blkno,
 							append_bytes(outbuf, p, &offset, next_off - off,
 										 level, print_bytes);
 						}
-						len += next_off - off;
-						off = next_off;
-						next_off = o_tuple_next_field_offset(&reader, atti);
 					}
-					level--;	/* Tuple data END */
-					align = MAXALIGN(len) - len;
+					align = MAXALIGN(offset) - offset;
 					if (align > 0)
 					{
 						appendStringInfoSpaces(outbuf, level * 4);
-						appendStringInfo(outbuf, "TUPLE DATA ALIGN (%d)\n",
-										 align);
+						appendStringInfo(outbuf, "TUPLE DATA ALIGN: %u - %u\n",
+										 next_off + align, next_off);
 						append_bytes(outbuf, p, &offset, align, level,
 									 print_bytes);
 					}
+					level--;	/* Tuple data END */
 				}
 
 				level--;		/* ITEM DATA[j] END */

--- a/test/expected/tableam.out
+++ b/test/expected/tableam.out
@@ -4484,239 +4484,256 @@ INSERT INTO o_test_split_rightmost
   SELECT a, repeat('x', a) FROM generate_series(978, 985) as a;
 -- For the Page 1, dataSize VALUE should not be greater than ORIOLEDB_BLCKSZ
 SELECT orioledb_tbl_bin_structure('o_test_split_rightmost'::regclass);
-          orioledb_tbl_bin_structure           
------------------------------------------------
- Index o_test_split_rightmost_pkey contents   +
- Page 0:                                      +
- BTreePageHeader(64)                          +
-     o_header: OrioleDBPageHeader(16)         +
-         state: pg_atomic_uint64(8)           +
-         usageCount: pg_atomic_uint32(4)      +
-         checkpointNum: uint32(4)             +
-     flags: 6 bit                             +
-     field1: 11 bit                           +
-     field2: 15 bit                           +
-     undoLocation: UndoLocation(8)            +
-     csn: CommitSeqNo(8)                      +
-     rightLink: uint64(8)                     +
-     maxKeyLen: LocationIndex(2)              +
-     prevInsertOffset: OffsetNumber(2)        +
-     chunksCount: OffsetNumber(2)             +
-     itemsCount: OffsetNumber(2)              +
-     hikeysEnd: OffsetNumber(2)               +
-     dataSize: LocationIndex(2)               +
-     dataSize VALUE: 1536                     +
-     chunkDesc: ARRAY:                        +
-         [0]: BTreePageChunkDesc(4)           +
-             shortLocation: 12 bit            +
-             offset: 10 bit                   +
-             hikeyShortLocation: 8 bit        +
-             hikeyFlags: 2 bit                +
-     BTreePageHeader REST (4)                 +
- HIKEY DATA (448)                             +
- CHUNKS: ARRAY:                               +
-     [0]: 1024                                +
-         ITEMS: ARRAY:                        +
-             [0]: LocationIndex(2)            +
-             [1]: LocationIndex(2)            +
-         ITEMS ARRAY ALIGN (4)                +
-         ITEM DATA: ARRAY                     +
- Page 1:                                      +
- BTreePageHeader(64)                          +
-     o_header: OrioleDBPageHeader(16)         +
-         state: pg_atomic_uint64(8)           +
-         usageCount: pg_atomic_uint32(4)      +
-         checkpointNum: uint32(4)             +
-     flags: 6 bit                             +
-     field1: 11 bit                           +
-     field2: 15 bit                           +
-     undoLocation: UndoLocation(8)            +
-     csn: CommitSeqNo(8)                      +
-     rightLink: uint64(8)                     +
-     maxKeyLen: LocationIndex(2)              +
-     prevInsertOffset: OffsetNumber(2)        +
-     chunksCount: OffsetNumber(2)             +
-     itemsCount: OffsetNumber(2)              +
-     hikeysEnd: OffsetNumber(2)               +
-     dataSize: LocationIndex(2)               +
-     dataSize VALUE: 7176                     +
-     chunkDesc: ARRAY:                        +
-         [0]: BTreePageChunkDesc(4)           +
-             shortLocation: 12 bit            +
-             offset: 10 bit                   +
-             hikeyShortLocation: 8 bit        +
-             hikeyFlags: 2 bit                +
-     BTreePageHeader REST (4)                 +
- HIKEY DATA (1000)                            +
- CHUNKS: ARRAY:                               +
-     [0]: 6112                                +
-         ITEMS: ARRAY:                        +
-             [0]: LocationIndex(2)            +
-             [1]: LocationIndex(2)            +
-             [2]: LocationIndex(2)            +
-             [3]: LocationIndex(2)            +
-             [4]: LocationIndex(2)            +
-             [5]: LocationIndex(2)            +
-         ITEMS ARRAY ALIGN (4)                +
-         ITEM DATA: ARRAY                     +
-             [0]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 988 - 4: i        +
-                         LONG DATA            +
-                 TUPLE DATA ALIGN (4)         +
-             [1]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 988 - 4: i        +
-                         LONG DATA            +
-                 TUPLE DATA ALIGN (4)         +
-             [2]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 988 - 4: i        +
-                         LONG DATA            +
-                 TUPLE DATA ALIGN (4)         +
-             [3]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 992 - 4: i        +
-                         LONG DATA            +
-             [4]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 992 - 4: i        +
-                         LONG DATA            +
-             [5]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 992 - 4: i        +
-                         LONG DATA            +
- Page 2:                                      +
- BTreePageHeader(64)                          +
-     o_header: OrioleDBPageHeader(16)         +
-         state: pg_atomic_uint64(8)           +
-         usageCount: pg_atomic_uint32(4)      +
-         checkpointNum: uint32(4)             +
-     flags: 6 bit                             +
-     field1: 11 bit                           +
-     field2: 15 bit                           +
-     undoLocation: UndoLocation(8)            +
-     csn: CommitSeqNo(8)                      +
-     rightLink: uint64(8)                     +
-     maxKeyLen: LocationIndex(2)              +
-     prevInsertOffset: OffsetNumber(2)        +
-     chunksCount: OffsetNumber(2)             +
-     itemsCount: OffsetNumber(2)              +
-     hikeysEnd: OffsetNumber(2)               +
-     dataSize: LocationIndex(2)               +
-     dataSize VALUE: 2304                     +
-     chunkDesc: ARRAY:                        +
-         [0]: BTreePageChunkDesc(4)           +
-             shortLocation: 12 bit            +
-             offset: 10 bit                   +
-             hikeyShortLocation: 8 bit        +
-             hikeyFlags: 2 bit                +
-     BTreePageHeader REST (4)                 +
- HIKEY DATA (192)                             +
- CHUNKS: ARRAY:                               +
-     [0]: 2048                                +
-         ITEMS: ARRAY:                        +
-             [0]: LocationIndex(2)            +
-             [1]: LocationIndex(2)            +
-         ITEMS ARRAY ALIGN (4)                +
-         ITEM DATA: ARRAY                     +
-             [0]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 992 - 4: i        +
-                         LONG DATA            +
-             [1]: BTreeLeafTuphdr(16)         +
-                 xactInfo: 61 bit             +
-                 deleted: 2 bit               +
-                 chainHasLocks: 1 bit         +
-                 undoLocation: 62 bit         +
-                 formatFlags: 2 bit           +
-                 Tuple header: OTupleHeader(8)+
-                     hasnulls: 1 bit          +
-                     len: 15 bit              +
-                     natts: uint16(2)         +
-                     version: uint32(4)       +
-                 Tuple data: 8                +
-                     val_1: 4 - 0: i          +
-                     val_2: 996 - 4: i        +
-                         LONG DATA            +
-                 TUPLE DATA ALIGN (4)         +
+            orioledb_tbl_bin_structure            
+--------------------------------------------------
+ Index o_test_split_rightmost_pkey contents      +
+ Page 0:                                         +
+ BTreePageHeader(64)                             +
+     o_header: OrioleDBPageHeader(16)            +
+         state: pg_atomic_uint64(8)              +
+         usageCount: pg_atomic_uint32(4)         +
+         checkpointNum: uint32(4)                +
+     undoLocation: UndoLocation(8)               +
+     csn: CommitSeqNo(8)                         +
+     rightLink: uint64(8)                        +
+     flags: 6 bit                                +
+     field1: 11 bit                              +
+     field2: 15 bit                              +
+     maxKeyLen: LocationIndex(2)                 +
+     prevInsertOffset: OffsetNumber(2)           +
+     chunksCount: OffsetNumber(2)                +
+     itemsCount: OffsetNumber(2)                 +
+     hikeysEnd: OffsetNumber(2)                  +
+     dataSize: LocationIndex(2)                  +
+     dataSize VALUE: 1536                        +
+     chunkDesc: ARRAY:                           +
+         [0]: BTreePageChunkDesc(4)              +
+             shortLocation: 12 bit               +
+             offset: 10 bit                      +
+             hikeyShortLocation: 7 bit           +
+             chunkKeysFixed: 1 bit               +
+             hikeyFlags: 2 bit                   +
+     BTreePageHeader REST (4)                    +
+ HIKEY DATA (0)                                  +
+ HIKEY AREA REST (448)                           +
+ CHUNKS: ARRAY:                                  +
+     [0]: 1024                                   +
+         ITEMS: ARRAY:                           +
+             [0]: LocationIndex(2)               +
+             [1]: LocationIndex(2)               +
+         ITEMS ARRAY ALIGN (4)                   +
+         ITEM DATA: ARRAY                        +
+ Page 1:                                         +
+ BTreePageHeader(64)                             +
+     o_header: OrioleDBPageHeader(16)            +
+         state: pg_atomic_uint64(8)              +
+         usageCount: pg_atomic_uint32(4)         +
+         checkpointNum: uint32(4)                +
+     undoLocation: UndoLocation(8)               +
+     csn: CommitSeqNo(8)                         +
+     rightLink: uint64(8)                        +
+     flags: 6 bit                                +
+     field1: 11 bit                              +
+     field2: 15 bit                              +
+     maxKeyLen: LocationIndex(2)                 +
+     prevInsertOffset: OffsetNumber(2)           +
+     chunksCount: OffsetNumber(2)                +
+     itemsCount: OffsetNumber(2)                 +
+     hikeysEnd: OffsetNumber(2)                  +
+     dataSize: LocationIndex(2)                  +
+     dataSize VALUE: 7176                        +
+     chunkDesc: ARRAY:                           +
+         [0]: BTreePageChunkDesc(4)              +
+             shortLocation: 12 bit               +
+             offset: 10 bit                      +
+             hikeyShortLocation: 7 bit           +
+             chunkKeysFixed: 1 bit               +
+             hikeyFlags: 2 bit                   +
+     BTreePageHeader REST (4)                    +
+ HIKEY DATA (1000)                               +
+ HIKEY AREA REST (0)                             +
+ CHUNKS: ARRAY:                                  +
+     [0]: 6112                                   +
+         ITEMS: ARRAY:                           +
+             [0]: LocationIndex(2)               +
+             [1]: LocationIndex(2)               +
+             [2]: LocationIndex(2)               +
+             [3]: LocationIndex(2)               +
+             [4]: LocationIndex(2)               +
+             [5]: LocationIndex(2)               +
+         ITEMS ARRAY ALIGN (4)                   +
+         ITEM DATA: ARRAY                        +
+             [0]: 1016                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 992                 +
+                     val_1: 4 - 0: i             +
+                     val_2: 986 - 4: i           +
+                         LONG DATA               +
+                     TUPLE DATA ALIGN: 992 - 986 +
+             [1]: 1016                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 992                 +
+                     val_1: 4 - 0: i             +
+                     val_2: 987 - 4: i           +
+                         LONG DATA               +
+                     TUPLE DATA ALIGN: 992 - 987 +
+             [2]: 1016                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 992                 +
+                     val_1: 4 - 0: i             +
+                     val_2: 988 - 4: i           +
+                         LONG DATA               +
+                     TUPLE DATA ALIGN: 992 - 988 +
+             [3]: 1016                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 992                 +
+                     val_1: 4 - 0: i             +
+                     val_2: 989 - 4: i           +
+                         LONG DATA               +
+                     TUPLE DATA ALIGN: 992 - 989 +
+             [4]: 1016                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 992                 +
+                     val_1: 4 - 0: i             +
+                     val_2: 990 - 4: i           +
+                         LONG DATA               +
+                     TUPLE DATA ALIGN: 992 - 990 +
+             [5]: 1016                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 992                 +
+                     val_1: 4 - 0: i             +
+                     val_2: 991 - 4: i           +
+                         LONG DATA               +
+                     TUPLE DATA ALIGN: 992 - 991 +
+ Page 2:                                         +
+ BTreePageHeader(64)                             +
+     o_header: OrioleDBPageHeader(16)            +
+         state: pg_atomic_uint64(8)              +
+         usageCount: pg_atomic_uint32(4)         +
+         checkpointNum: uint32(4)                +
+     undoLocation: UndoLocation(8)               +
+     csn: CommitSeqNo(8)                         +
+     rightLink: uint64(8)                        +
+     flags: 6 bit                                +
+     field1: 11 bit                              +
+     field2: 15 bit                              +
+     maxKeyLen: LocationIndex(2)                 +
+     prevInsertOffset: OffsetNumber(2)           +
+     chunksCount: OffsetNumber(2)                +
+     itemsCount: OffsetNumber(2)                 +
+     hikeysEnd: OffsetNumber(2)                  +
+     dataSize: LocationIndex(2)                  +
+     dataSize VALUE: 2304                        +
+     chunkDesc: ARRAY:                           +
+         [0]: BTreePageChunkDesc(4)              +
+             shortLocation: 12 bit               +
+             offset: 10 bit                      +
+             hikeyShortLocation: 7 bit           +
+             chunkKeysFixed: 1 bit               +
+             hikeyFlags: 2 bit                   +
+     BTreePageHeader REST (4)                    +
+ HIKEY DATA (0)                                  +
+ HIKEY AREA REST (192)                           +
+ CHUNKS: ARRAY:                                  +
+     [0]: 2048                                   +
+         ITEMS: ARRAY:                           +
+             [0]: LocationIndex(2)               +
+             [1]: LocationIndex(2)               +
+         ITEMS ARRAY ALIGN (4)                   +
+         ITEM DATA: ARRAY                        +
+             [0]: 1016                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 992                 +
+                     val_1: 4 - 0: i             +
+                     val_2: 992 - 4: i           +
+                         LONG DATA               +
+             [1]: 1024                           +
+                 BTreeLeafTuphdr(16)             +
+                     xactInfo: 61 bit            +
+                     deleted: 2 bit              +
+                     chainHasLocks: 1 bit        +
+                     undoLocation: 62 bit        +
+                     formatFlags: 2 bit          +
+                 OTupleHeader(8)                 +
+                     hasnulls: 1 bit             +
+                     len: 15 bit                 +
+                     natts: uint16(2)            +
+                     version: uint32(4)          +
+                 Tuple data: 1000                +
+                     val_1: 4 - 0: i             +
+                     val_2: 993 - 4: i           +
+                         LONG DATA               +
+                     TUPLE DATA ALIGN: 1000 - 993+
  
 (1 row)
 


### PR DESCRIPTION
The function had multiple bugs causing incorrect or missing tuple data display.

- Use correct descriptor (desc) and spec (spec) for leaf pages
- Update BTreePageHeader and BTreePageChunkDesc fields to comply with recent changes
- Calculate padding size correctly at the end of BTreePageHeader struct
- Display null bitmap when available
- Display data for fixed-format tuples too
- Skip null fields
- Display alignment padding between fields (ATTR ALIGN)
- Display tuple data length correctly
- Put space on the correct position to indicate byte boundary for the bitfields
- Indent item headers correctly to avoid giving the impression of nested structs

Assisted-by: GLM-4.7 via Crush <crush@charm.land>