### PR TITLE
Fix "index row size exceeds maximum" when building index on compressed toasted data

### DIFF
--- a/include/tuple/slot.h
+++ b/include/tuple/slot.h
@@ -90,7 +90,7 @@ extern bool tts_orioledb_modified(TupleTableSlot *oldSlot,
 								  Bitmapset *attrs);
 extern void tts_orioledb_set_ctid(TupleTableSlot *slot, ItemPointer iptr);
 extern Datum o_get_tbl_att(TupleTableSlot *slot, int attnum, bool primaryIsCtid,
-						   bool *isnull, Oid *typid);
+						   bool *isnull, Oid *typid, bool decompress);
 Datum		o_get_idx_expr_att(TupleTableSlot *slot, OIndexDescr *idx,
 							   ExprState *exp_state, bool *isnull);
 

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -538,7 +538,7 @@ exclusion_fill_bound(TupleTableSlot *slot, OIndexDescr *idx, OBTreeKeyBound *bou
 
 		if (attnum != EXPR_ATTNUM)
 			value = o_get_tbl_att(slot, attnum, idx->primaryIsCtid,
-								  &isnull, &typid);
+								  &isnull, &typid, true);
 		else
 		{
 			value = o_get_idx_expr_att(slot, idx,

--- a/src/tuple/slot.c
+++ b/src/tuple/slot.c
@@ -895,7 +895,7 @@ tts_orioledb_store_non_leaf_tuple(TupleTableSlot *slot, OTuple tuple,
 
 Datum
 o_get_tbl_att(TupleTableSlot *slot, int attnum, bool primaryIsCtid,
-			  bool *isnull, Oid *typid)
+			  bool *isnull, Oid *typid, bool decompress)
 {
 	int			i;
 	Datum		value;
@@ -942,7 +942,8 @@ o_get_tbl_att(TupleTableSlot *slot, int attnum, bool primaryIsCtid,
 	*isnull = slot->tts_isnull[i];
 	value = slot->tts_values[i];
 
-	if (!*isnull && att->attlen < 0 && VARATT_IS_EXTENDED(value))
+	if (!*isnull && att->attlen < 0 && 
+		(VARATT_IS_EXTENDED(value) && (decompress || !VARATT_IS_COMPRESSED(value))))
 	{
 		if (!oSlot->to_toast)
 			alloc_to_toast_vfree_detoasted(&oSlot->base);
@@ -997,7 +998,7 @@ tts_orioledb_get_index_values(TupleTableSlot *slot, OIndexDescr *idx,
 
 		if (attnum != EXPR_ATTNUM)
 			values[i] = o_get_tbl_att(slot, attnum, idx->primaryIsCtid,
-									  &isnull[i], NULL);
+									  &isnull[i], NULL, false);
 		else
 		{
 			values[i] = o_get_idx_expr_att(slot, idx,
@@ -1069,7 +1070,7 @@ tts_orioledb_fill_key_bound(TupleTableSlot *slot, OIndexDescr *idx,
 
 		if (attnum != EXPR_ATTNUM)
 			value = o_get_tbl_att(slot, attnum, idx->primaryIsCtid,
-								  &isnull, &typid);
+								  &isnull, &typid, true);
 		else
 		{
 			value = o_get_idx_expr_att(slot, idx,
@@ -1109,7 +1110,7 @@ appendStringInfoIndexKey(StringInfo str, TupleTableSlot *slot, OIndexDescr *id)
 
 		if (attnum != EXPR_ATTNUM)
 			value = o_get_tbl_att(slot, attnum, id->primaryIsCtid,
-								  &isnull, NULL);
+								  &isnull, NULL, true);
 		else
 		{
 			value = o_get_idx_expr_att(slot, id,

--- a/test/expected/toast_column_compress_1.out
+++ b/test/expected/toast_column_compress_1.out
@@ -198,6 +198,116 @@ ORDER BY attname;
 (1 row)
 
 DROP TABLE o_test_set_compression CASCADE;
+-- Test compression behavior with different storage options
+-- and index creation order.
+-- case 1: extended storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTENDED) using orioledb;
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+CREATE INDEX idx ON cmdata(f1);
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+  10000
+(1 row)
+
+DROP TABLE cmdata;
+-- case 1.5: extended storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTENDED) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+  10000
+(1 row)
+
+DROP TABLE cmdata;
+-- case 2: main storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE MAIN) using orioledb;
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+CREATE INDEX idx ON cmdata(f1);
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+  10000
+(1 row)
+
+DROP TABLE cmdata;
+-- case 2.5: main storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE MAIN) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+  10000
+(1 row)
+
+DROP TABLE cmdata;
+-- case 3: external storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTERNAL) using orioledb;
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+-- should error because key can only be compressed for index, but not toasted (as for heap).
+CREATE INDEX idx ON cmdata(f1);
+ERROR:  index row size 10018 exceeds orioledb maximum 2688 for index "idx"
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+  10000
+(1 row)
+
+DROP TABLE cmdata;
+-- case 3.5: external storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTERNAL) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+-- should error because key can only be compressed for index, but not toasted (as for heap).
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+ERROR:  index row size 10018 exceeds orioledb maximum 2688 for index "idx"
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+(0 rows)
+
+DROP TABLE cmdata;
+-- case 4: plain storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE PLAIN) using orioledb;
+-- should error because key is too long to be stored in plain storage.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+ERROR:  index row size 10024 exceeds orioledb maximum 2688 for table "cmdata"
+-- should error because key is too long to be stored in plain orioledb storage.
+-- note that the max tuple size for plain storage for heap is about 3 times
+-- higher than that for orioledb because of the different page layout,
+-- so we can insert a longer value for heap than for orioledb.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 267));
+ERROR:  index row size 2694 exceeds orioledb maximum 2688 for table "cmdata"
+-- should not error
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 266));
+CREATE INDEX idx ON cmdata(f1);
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+   2660
+(1 row)
+
+DROP TABLE cmdata;
+-- case 4.5: plain storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE PLAIN) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+-- should error because key is too long to be stored in plain storage.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+ERROR:  index row size 10024 exceeds orioledb maximum 2688 for table "cmdata"
+-- should error because key is too long to be stored in plain orioledb storage.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 267));
+ERROR:  index row size 2694 exceeds orioledb maximum 2688 for table "cmdata"
+-- should not error
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 266));
+SELECT length(f1) FROM cmdata WHERE a = 1;
+ length 
+--------
+   2660
+(1 row)
+
+DROP TABLE cmdata;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table o_test_2

--- a/test/sql/toast_column_compress.sql
+++ b/test/sql/toast_column_compress.sql
@@ -77,6 +77,80 @@ ORDER BY attname;
 
 DROP TABLE o_test_set_compression CASCADE;
 
+-- Test compression behavior with different storage options
+-- and index creation order.
+
+-- case 1: extended storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTENDED) using orioledb;
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+CREATE INDEX idx ON cmdata(f1);
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
+-- case 1.5: extended storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTENDED) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
+-- case 2: main storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE MAIN) using orioledb;
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+CREATE INDEX idx ON cmdata(f1);
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
+-- case 2.5: main storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE MAIN) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
+-- case 3: external storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTERNAL) using orioledb;
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+-- should error because key can only be compressed for index, but not toasted (as for heap).
+CREATE INDEX idx ON cmdata(f1);
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
+-- case 3.5: external storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE EXTERNAL) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+-- should error because key can only be compressed for index, but not toasted (as for heap).
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
+-- case 4: plain storage, insert before index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE PLAIN) using orioledb;
+-- should error because key is too long to be stored in plain storage.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+-- should error because key is too long to be stored in plain orioledb storage.
+-- note that the max tuple size for plain storage for heap is about 3 times
+-- higher than that for orioledb because of the different page layout,
+-- so we can insert a longer value for heap than for orioledb.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 267));
+-- should not error
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 266));
+CREATE INDEX idx ON cmdata(f1);
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
+-- case 4.5: plain storage, insert after index creation
+CREATE TABLE cmdata(a int, f1 text STORAGE PLAIN) using orioledb;
+CREATE INDEX idx ON cmdata(f1);
+-- should error because key is too long to be stored in plain storage.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 1000));
+-- should error because key is too long to be stored in plain orioledb storage.
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 267));
+-- should not error
+INSERT INTO cmdata VALUES(1, repeat('1234567890', 266));
+SELECT length(f1) FROM cmdata WHERE a = 1;
+DROP TABLE cmdata;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA toast_column_compress CASCADE;
 RESET search_path;


### PR DESCRIPTION
CREATE INDEX on a column containing existing PGLZ/LZ4-compressed data fails with index row size N exceeds orioledb maximum 2688, while inserting data into a pre-existing index on the same column works fine.

Root Cause
o_get_tbl_att() calls PG_DETOAST_DATUM on all VARATT_IS_EXTENDED values, which includes inline compressed varlenas. During build_secondary_index_worker_heap_scan, this decompresses stored PGLZ values back to their full size (e.g., 10000 bytes), blowing past the index tuple size limit.

fixes #756 and #721 