### PR TITLE
Fix root page eviction for CTID PK, smgr init loop, reserved pages race, and add shared pool inspection function

### DIFF
--- a/doc/architecture/checkpoints.mdx
+++ b/doc/architecture/checkpoints.mdx
@@ -82,3 +82,56 @@ This message indicates that the child page has been processed, and the parent ne
 ### WalkContinue
 
 This message has no parameters. It just indicates that checkpointer must continue processing the same page with the same `next downlink`. That happens when the checkpointer has to wait for the concurrent operation. Such as meeting IO in-process downlink and having to release the log and wait till the IO is finished.
+
+## Sequential buffers
+
+### What are sequential buffers?
+
+Sequential buffers (*seq bufs*) are lightweight, file-backed streaming I/O abstractions used by the checkpointer and by ordinary backends that write B-tree pages.  Instead of holding all checkpoint metadata in shared memory, seq bufs stream data to and from on-disk files using two in-memory OrioleDB pages as a double-buffer.  While one page is being filled (or drained) by the caller, the other can be flushed to disk or pre-fetched in the background, giving sequential throughput without occupying large amounts of shared memory.
+
+Each seq buf is identified by a `SeqBufTag` – a `(datoid, relnode, checkpointNumber, type)` tuple.  The `type` field distinguishes the two kinds of files:
+
+- **`'m'` (map file)** – the checkpoint map that records on-disk page locations.
+- **`'t'` (temporary file)** – the temporary tracking file used during the checkpoint walk.
+
+The in-memory state that must be shared between the checkpointer and writer backends lives in `SeqBufDescShared`, which is embedded directly in the B-tree meta page (`BTreeMetaPage`).  Per-backend state such as the open file descriptor lives in `SeqBufDescPrivate`, which is stored in the tree descriptor (`BTreeDescr`) and is private to each backend.
+
+### Why are sequential buffers used?
+
+Each checkpointable B-tree keeps three groups of seq bufs:
+
+1. **`freeBuf`** – On entry to a new checkpoint the checkpointer opens this buffer to *read* the list of free disk extents recorded by the *previous* checkpoint.  As the current checkpoint writes pages it can reuse those extents, avoiding unnecessary file growth.  There is exactly one `freeBuf` per tree (no dual array) because it is replaced atomically at the start of each checkpoint: the new file is put in place before the old one is removed.
+
+2. **`nextChkp[2]`** – The checkpointer opens one of these two slots to *write* the checkpoint map file for the current checkpoint.  Every time a B-tree page is flushed to disk, its location is appended to the map.  The next checkpoint will read this map via a `freeBuf` so that it knows where each page lives without having to walk the whole tree again.
+
+3. **`tmpBuf[2]`** – The checkpointer opens one of these two slots to *write* a temporary file that tracks every page written during the checkpoint walk.  After the walk finishes, this file is sorted, duplicates are removed, and it drives the hole-punching pass that reclaims unused space inside the data file.  The file is deleted once the checkpoint is complete.
+
+### Why are there two slots (the `[2]` arrays)?
+
+OrioleDB checkpoints run concurrently with normal DML.  To avoid serialising checkpoint N against the initialisation of checkpoint N+1, each of the arrays (`nextChkp`, `tmpBuf`, `datafileLength`, `partsInfo`) is indexed by `checkpointNumber % 2`.
+
+At any moment exactly one slot is "active" – the slot currently being written by the in-progress checkpoint – while the other slot either still holds data from the previous checkpoint (needed for recovery until the new checkpoint is verified) or is idle.
+
+```
+Checkpoint N   → uses slot  N % 2
+Checkpoint N+1 → uses slot (N+1) % 2   (the other slot)
+```
+
+This ping-pong scheme means checkpoint N+1 can begin allocating pages and initialising its seq buf files while checkpoint N is still finalising, without any shared state collision.
+
+The two dirty flags on the meta page (`dirtyFlag1`, `dirtyFlag2`) support the same scheme.  `dirtyFlag1` is cleared at the start of the checkpoint.  `dirtyFlag2` provides an extra generation so that a modification racing the clear of `dirtyFlag1` is never silently lost.  If both flags are false when the checkpointer is about to start processing a tree, the tree has not changed since the last checkpoint; the freshly initialised seq buf files are closed and removed immediately without writing any data.
+
+### When are sequential buffers removed?
+
+Seq buf **in-memory pages** are returned to the page pool as soon as the buffer is finalised.  This happens in one of the following situations:
+
+- **Checkpoint completes successfully** – `tmpBuf` pages are freed after post-processing; `nextChkp` pages are freed after the map file header is written and the file is renamed.
+- **Tree descriptor is evicted** – when a tree descriptor is reclaimed from the descriptor cache, `btree_finalize_private_seq_bufs()` flushes and frees all in-memory pages belonging to that descriptor's active seq bufs.
+- **Tree is dropped** – `checkpointable_tree_free()` closes all seq buf file descriptors, freeing the OS resources.
+
+Seq buf **on-disk files** have a longer lifetime than the in-memory pages:
+
+- The **tmp file** (`'t'`) is deleted once the checkpoint that created it has finished post-processing.
+- The **map file** (`'m'`) from checkpoint N is kept until checkpoint N+1 has been completed and its own map file is in place.  This ensures that point-in-time recovery can always find the latest clean checkpoint.
+- The **free-extent file** is replaced atomically: the new file is written and renamed into place before the old one is unlinked.
+- If a tree was **not modified** between two checkpoints (both dirty flags are false), the seq buf files initialised for that checkpoint are closed immediately and removed without writing any data.

--- a/include/btree/btree.h
+++ b/include/btree/btree.h
@@ -181,6 +181,26 @@ struct BTreeDescr
 	uint8		fillfactor;
 	UndoLogType undoType;
 	BTreeStorageType storageType;
+
+	/*
+	 * Per-backend private seq buf descriptors.  The corresponding shared
+	 * state lives in the BTreeMetaPage (freeBuf, nextChkp[], tmpBuf[]).
+	 *
+	 * freeBuf       – reads the free-extent file produced by the previous
+	 * checkpoint so that the current checkpoint can reuse those disk
+	 * locations.
+	 *
+	 * nextChkp[2]   – writes the checkpoint map file for the current
+	 * checkpoint.  Indexed by (checkpointNumber % 2) so that two consecutive
+	 * checkpoints use different slots and can coexist without interference.
+	 * Only one slot is active at any time; the other is uninitialised or
+	 * belongs to the previous (already completed) checkpoint.
+	 *
+	 * tmpBuf[2]     – writes the temporary file used during the current
+	 * checkpoint walk to track dirty and newly placed pages. Also indexed by
+	 * (checkpointNumber % 2).  The file is consumed during post-processing
+	 * (sort + hole-punch) and removed once the checkpoint is complete.
+	 */
 	SeqBufDescPrivate freeBuf;
 	SeqBufDescPrivate nextChkp[2];
 	SeqBufDescPrivate tmpBuf[2];

--- a/sql/orioledb--1.6--1.7_prod.sql
+++ b/sql/orioledb--1.6--1.7_prod.sql
@@ -22,3 +22,8 @@ CREATE FUNCTION orioledb_undo_size(OUT undo_type text, OUT undo_size int8)
 RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_print_pool_pages(ppool_arg integer DEFAULT NULL, OUT block_num int8, OUT name TEXT, OUT datoid int8, OUT reloid int8, OUT relnode int8, OUT type TEXT, OUT state int8)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -304,8 +304,15 @@ btree_open_smgr_file(BTreeDescr *desc, uint32 num, uint32 chkpNum,
 		{
 			int			i = desc->smgr.array.filesAllocated;
 
+			/*
+			 * btree_open_smgr should have been called before, so
+			 * filesAllocated should be greater than 0
+			 */
+			Assert(desc->smgr.array.filesAllocated > 0);
+
 			while (num >= desc->smgr.array.filesAllocated)
 				desc->smgr.array.filesAllocated *= 2;
+
 			desc->smgr.array.files = (File *) repalloc(desc->smgr.array.files,
 													   sizeof(File) * desc->smgr.array.filesAllocated);
 			for (; i < desc->smgr.array.filesAllocated; i++)
@@ -2327,7 +2334,7 @@ btree_finalize_private_seq_bufs(BTreeDescr *desc, EvictedTreeData *evicted_data,
 
 		evicted_data->tmpBuf.tag = desc->tmpBuf[chkp_index].shared->tag;
 		if (notModified)
-			seq_buf_close_file(&desc->nextChkp[chkp_index]);
+			seq_buf_close_file(&desc->tmpBuf[chkp_index]);
 		else
 			evicted_data->tmpBuf.offset = seq_buf_finalize(&desc->tmpBuf[chkp_index]);
 		FREE_PAGE_IF_VALID(desc->ppool, desc->tmpBuf[chkp_index].shared->pages[0]);
@@ -2548,6 +2555,13 @@ get_evict_btree_locks(OInMemoryBlkno blkno, ORelOids oids, OIndexType type,
 	id = (OIndexDescr *) desc->arg;
 	state->tableOids = id->tableOids;
 
+	/*
+	 * if primary index is ctid, then we don't need to lock the table, because
+	 * ctid is the table itself
+	 */
+	if (id->primaryIsCtid)
+		return desc;
+
 	if (!recovery && !(state->tableRegularLock = o_tables_rel_try_lock_extended(&state->tableOids, AccessExclusiveLock, &nested, false)))
 		return NULL;
 
@@ -2584,6 +2598,9 @@ release_evict_btree_locks(ORelOids oids, EvictBtreeLocksState *state)
 
 /*
  * Examine single page and evict it if possible.
+ *
+ * Note that here we skip seq buf pages, as we will evict them together with the
+ * tree in evict_btree() when we evict the root page.
  */
 OWalkPageResult
 walk_page(OInMemoryBlkno blkno, bool evict)

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -1540,7 +1540,7 @@ checkpoint_init_new_seq_bufs(BTreeDescr *descr, int chkpNum)
 				 errmsg("could not init a new sequence buffer file %s: %m",
 						get_seq_buf_filename(&next_tmp_tag))));
 
-	if (descr->storageType != BTreeStoragePersistence)
+	if (descr->storageType == BTreeStorageTemporary)
 		return;
 
 	init_seq_buf_pages(descr, &meta_page->nextChkp[next_chkp_index]);
@@ -5040,8 +5040,8 @@ init_seq_buf_pages(BTreeDescr *desc, SeqBufDescShared *shared)
 	Assert(!OInMemoryBlknoIsValid(shared->pages[0]));
 	Assert(!OInMemoryBlknoIsValid(shared->pages[1]));
 
-	shared->pages[0] = ppool_get_page(desc->ppool, PPOOL_RESERVE_META);;
-	shared->pages[1] = ppool_get_page(desc->ppool, PPOOL_RESERVE_META);;
+	shared->pages[0] = ppool_get_page(desc->ppool, PPOOL_RESERVE_META);
+	shared->pages[1] = ppool_get_page(desc->ppool, PPOOL_RESERVE_META);
 
 	Assert(OInMemoryBlknoIsValid(shared->pages[0]));
 	Assert(OInMemoryBlknoIsValid(shared->pages[1]));

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -231,6 +231,7 @@ static bool check_debug_max_bridge_ctid(char **newval, void **extra, GucSource s
 static void assign_debug_max_bridge_ctid(const char *newval, void *extra);
 
 PG_FUNCTION_INFO_V1(orioledb_page_stats);
+PG_FUNCTION_INFO_V1(orioledb_print_pool_pages);
 PG_FUNCTION_INFO_V1(orioledb_version);
 PG_FUNCTION_INFO_V1(orioledb_commit_hash);
 PG_FUNCTION_INFO_V1(orioledb_ucm_check);
@@ -1647,6 +1648,149 @@ orioledb_page_stats(PG_FUNCTION_ARGS)
 		values[2] = Int64GetDatum(num_free_pages);
 		values[3] = Int64GetDatum((int64) ppool_dirty_pages_count(&page_pools[i]));
 		values[4] = Int64GetDatum(total_num_pages);
+		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);
+	}
+
+	return (Datum) 0;
+}
+
+Datum
+orioledb_print_pool_pages(PG_FUNCTION_ARGS)
+{
+	OInMemoryBlkno blkno,
+				start_blkno,
+				end_blkno;
+	Datum		values[7];
+	bool		nulls[7];
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	TupleDesc	tupdesc;
+	Tuplestorestate *tupstore;
+	MemoryContext per_query_ctx;
+	MemoryContext oldcontext;
+	int32		ppool_arg = OPagePoolMain;
+	OPagePoolType ppool_type;
+
+	/* optional first argument: page pool type (int) */
+	if (PG_NARGS() > 0 && !PG_ARGISNULL(0))
+		ppool_arg = PG_GETARG_INT32(0);
+
+	if (ppool_arg < 0 || ppool_arg >= OPagePoolTypesCount)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid page pool type: %d", ppool_arg)));
+
+	ppool_type = (OPagePoolType) ppool_arg;
+
+	orioledb_check_shmem();
+
+	per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+	oldcontext = MemoryContextSwitchTo(per_query_ctx);
+
+	/* Build a tuple descriptor for our result type */
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		elog(ERROR, "return type must be a row type");
+
+	tupstore = tuplestore_begin_heap(true, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = tupstore;
+	rsinfo->setDesc = tupdesc;
+
+	MemoryContextSwitchTo(oldcontext);
+
+	/* compute start and end blkno for requested pool */
+	switch (ppool_type)
+	{
+		case OPagePoolFreeTree:
+			start_blkno = 0;
+			end_blkno = page_pools[OPagePoolFreeTree].size;
+			break;
+		case OPagePoolCatalog:
+			start_blkno = (OInMemoryBlkno) free_tree_buffers_count;
+			end_blkno = start_blkno + page_pools[OPagePoolCatalog].size;
+			break;
+		case OPagePoolMain:
+			start_blkno = (OInMemoryBlkno) main_buffers_offset;
+			end_blkno = start_blkno + page_pools[OPagePoolMain].size;
+			break;
+		default:
+			/* defensive fallback */
+			start_blkno = 0;
+			end_blkno = 0;
+			break;
+	}
+
+	for (blkno = start_blkno; blkno < end_blkno; blkno++)
+	{
+		OrioleDBPageDesc *page_desc = O_GET_IN_MEMORY_PAGEDESC(blkno);
+		OrioleDBPageHeader *header = (OrioleDBPageHeader *) O_GET_IN_MEMORY_PAGE(blkno);
+		uint64		state;
+
+		MemSet(nulls, 0, sizeof(nulls));
+
+		values[0] = Int64GetDatum(blkno);
+		if (IS_SYS_TREE_OIDS(page_desc->oids))
+		{
+			values[1] = PointerGetDatum(cstring_to_text("sys tree"));
+		}
+		else if (ORelOidsIsValid(page_desc->oids))
+		{
+			Relation	rel = try_relation_open(page_desc->oids.reloid, AccessShareLock);
+
+			if (rel)
+			{
+				char	   *relname = RelationGetRelationName(rel);
+
+				values[1] = PointerGetDatum(cstring_to_text(relname));
+				relation_close(rel, AccessShareLock);
+			}
+			else
+			{
+				values[1] = PointerGetDatum(cstring_to_text("unknown"));
+			}
+		}
+		else if (page_desc->type == oIndexInvalid)
+		{
+			values[1] = PointerGetDatum(cstring_to_text("seq buffer"));
+		}
+		else
+		{
+			values[1] = PointerGetDatum(cstring_to_text("unknown"));
+		}
+		values[2] = Int64GetDatum(page_desc->oids.datoid);
+		values[3] = Int64GetDatum(page_desc->oids.reloid);
+		values[4] = Int64GetDatum(page_desc->oids.relnode);
+
+		switch (page_desc->type)
+		{
+			case oIndexInvalid:
+				values[5] = PointerGetDatum(cstring_to_text("invalid"));
+				break;
+			case oIndexToast:
+				values[5] = PointerGetDatum(cstring_to_text("toast"));
+				break;
+			case oIndexPrimary:
+				values[5] = PointerGetDatum(cstring_to_text("primary"));
+				break;
+			case oIndexUnique:
+				values[5] = PointerGetDatum(cstring_to_text("unique"));
+				break;
+			case oIndexRegular:
+				values[5] = PointerGetDatum(cstring_to_text("regular"));
+				break;
+			case oIndexBridge:
+				values[5] = PointerGetDatum(cstring_to_text("bridge"));
+				break;
+			case oIndexExclusion:
+				values[5] = PointerGetDatum(cstring_to_text("exclusion"));
+				break;
+			default:
+				values[5] = PointerGetDatum(cstring_to_text("unknown"));
+				break;
+		}
+
+		state = pg_atomic_read_u64(&header->state);
+		values[6] = Int64GetDatum(O_PAGE_STATE_GET_USAGE_COUNT(state));
+
 		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);
 	}
 

--- a/src/utils/page_pool.c
+++ b/src/utils/page_pool.c
@@ -92,19 +92,16 @@ ppool_shmem_init(OPagePool *pool, Pointer ptr, bool found)
 void
 ppool_reserve_pages(OPagePool *pool, int kind, int count)
 {
-	uint64		val;
-
 	Assert(!have_locked_pages());
 
 	count -= pool->numPagesReserved[kind];
 	if (count <= 0)
 		return;
 
-	val = pg_atomic_sub_fetch_u64(pool->availablePagesCount, count);
-	while (val & (UINT64CONST(1) << 63))
+	while (pg_atomic_sub_fetch_u64(pool->availablePagesCount, count) & (UINT64CONST(1) << 63))
 	{
+		pg_atomic_add_fetch_u64(pool->availablePagesCount, count);
 		ppool_run_clock(pool, true, NULL);
-		val = pg_atomic_read_u64(pool->availablePagesCount);
 	}
 
 	pool->numPagesReserved[kind] += count;

--- a/src/utils/seq_buf.c
+++ b/src/utils/seq_buf.c
@@ -106,7 +106,7 @@ init_seq_buf(SeqBufDescPrivate *seqBufPrivate, SeqBufDescShared *shared,
 			OrioleDBPageDesc *page_desc = O_GET_IN_MEMORY_PAGEDESC(shared->pages[i]);
 
 			ORelOidsSetInvalid(page_desc->oids);
-			page_desc->type = 0;
+			page_desc->type = oIndexInvalid;
 		}
 
 		if (!write && (tag->type == 'm' || seq_buf_file_exist(tag)))


### PR DESCRIPTION
Fix multiple issues related to page management, eviction, and initialization.

1. Fix eviction of root pages for CTID-based primary keys.
   Previously, such root pages were not evicted, which led to accumulation
   of these pages together with seq buffer pages that are evicted alongside
   their corresponding root pages. This could result in an infinite search
   for free slots in the page pool.

2. Adjust pool reservation logic to return pages before eviction.
   When a backend takes multiple pages and then needs to perform eviction,
   it now puts back already taken pages before proceeding. This prevents
   other backends from observing an artificially depleted pool and
   unnecessarily entering eviction.

3. Fix checkpoint logic for unlogged pages.
   Previously, checkpoint did not recreate seq buffers for unlogged pages,
   leading to inconsistent state. The logic is now corrected to properly
   handle these cases.

4. Add auxiliary SQL function to inspect pool contents.
   The function takes a pool type identifier and returns the list of pages
   currently present in the corresponding pool, allowing inspection of
   catalog, main, and free pools.

fix for #785 