### PR TITLE
fix custom tablespace oid for logical replication

### DIFF
--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -250,6 +250,8 @@ struct OTableDescr
 	int			nIndices;
 	/* number of unique trees */
 	int			nUniqueIndices;
+	/* OID of the tablespace for table */
+	Oid			tablespace;
 };
 
 typedef struct

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -1250,7 +1250,7 @@ decode_wal_record(void *vctx, WalRecord *rec)
 						Assert(ctx->descr != NULL);
 						Assert(!O_TUPLE_IS_NULL(tuple1.tuple));
 						change = ReorderBufferGetChange(ctx->dctx->reorder);
-						change->data.tp.rlocator.spcOid = DEFAULTTABLESPACE_OID;
+						change->data.tp.rlocator.spcOid = ctx->descr->tablespace;
 						change->data.tp.rlocator.dbOid = rec->oids.datoid;
 						change->data.tp.rlocator.relNumber = rec->oids.relnode;
 						elog(DEBUG4, "reloid: %u", rec->oids.reloid);

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -644,6 +644,7 @@ fill_table_descr_common_fields(OTableDescr *descr, OTable *o_table)
 	descr->refcnt = 0;
 	descr->oids = o_table->oids;
 	descr->version = o_table->version;
+	descr->tablespace = o_table->tablespace;
 	descr->tupdesc = o_table_tupdesc(o_table);
 	descr->oldTuple = MakeSingleTupleTableSlot(descr->tupdesc,
 											   &TTSOpsOrioleDB);


### PR DESCRIPTION
Logical replication fails when using partitioned tables with a custom tablespace. This occurs due to incorrect tablespace handling in the logical decoder, leading to invalid relation lookups during decoding of changes.