### PR TITLE
Improve perf-test: permissions, cleanup, OTEL, parallel runners, DB cache

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,5 +1,8 @@
 name: TPC-C Performance Test
 
+permissions:
+  pull-requests: write
+
 on:
   pull_request:
   workflow_dispatch:
@@ -15,7 +18,7 @@ on:
       bench_duration:
         description: "Duration per benchmark run"
         required: false
-        default: "5m"
+        default: "25m"
       bench_runs:
         description: "Number of benchmark runs"
         required: false
@@ -23,7 +26,7 @@ on:
       warehouses:
         description: "Number of warehouses / TPC-C scale factor (comma-separated for multiple, e.g. 1,10,100)"
         required: false
-        default: "1"
+        default: "200"
       vus_scale:
         description: "VU scale multiplier (1 = 99 VUs, 0.5 ≈ 50, 0.1 ≈ 11)"
         required: false
@@ -47,7 +50,7 @@ jobs:
       - id: gen
         env:
           RUNS: ${{ inputs.bench_runs || '1' }}
-          WAREHOUSES: ${{ inputs.warehouses || '1' }}
+          WAREHOUSES: ${{ inputs.warehouses || '200' }}
         run: |
           echo "run-matrix=$(python3 -c "
           import json, os
@@ -62,17 +65,21 @@ jobs:
     runs-on: perf-runner
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.run-matrix) }}
-      max-parallel: 1
     env:
       LLVM_VER: 18
       CHECK_TYPE: normal
       COMPILER: ${{ inputs.compiler || 'gcc' }}
       PG_VERSION: ${{ inputs.pg_version || '17' }}
-      DURATION: ${{ inputs.bench_duration || '5m' }}
+      DURATION: ${{ inputs.bench_duration || '25m' }}
       WAREHOUSES: ${{ matrix.warehouses }}
       VUS_SCALE: ${{ inputs.vus_scale || '1' }}
       POOL_SIZE: ${{ inputs.pool_size || '100' }}
     steps:
+      - name: Clean up previous runs
+        run: |
+          pkill -9 postgres 2>/dev/null || true
+          rm -rf "$GITHUB_WORKSPACE/pgdata" 2>/dev/null || true
+          sleep 1
       - name: Checkout extension code (base branch)
         uses: actions/checkout@v4
         with:
@@ -99,37 +106,47 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/pgsql/bin:$PATH"
           pg_isready -t 5
           psql -d postgres -c "SELECT orioledb_version();"
+      - name: Restore DB cache
+        run: bash ./orioledb/ci/perf_db_cache.sh restore
       - name: Resolve current user
         run: echo "PGUSER=$(whoami)" >> $GITHUB_ENV
       - name: Run TPC-C benchmark
         uses: stroppy-io/stroppy-action@main
         with:
+          version: '3'
           preset: tpcc
           driver-url: postgres://${{ env.PGUSER }}@localhost:5432/postgres?sslmode=disable
           artifact-name: perf-results-base-${{ matrix.warehouses }}W-${{ matrix.run }}
+          k6-args: '--out opentelemetry'
+          stroppy-args: ${{ env.DB_CACHED == 'true' && '--steps workload' || '' }}
+      - name: Save DB cache
+        if: env.DB_CACHED != 'true'
+        run: bash ./orioledb/ci/perf_db_cache.sh save
       - name: Stop PostgreSQL
         if: always()
         run: bash ./orioledb/ci/perf_pg_stop.sh
 
   bench-head:
     name: "Bench head ${{ matrix.warehouses }}W #${{ matrix.run }}"
-    needs:
-      - setup
-      - bench-base
+    needs: setup
     runs-on: perf-runner
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.run-matrix) }}
-      max-parallel: 1
     env:
       LLVM_VER: 18
       CHECK_TYPE: normal
       COMPILER: ${{ inputs.compiler || 'gcc' }}
       PG_VERSION: ${{ inputs.pg_version || '17' }}
-      DURATION: ${{ inputs.bench_duration || '5m' }}
+      DURATION: ${{ inputs.bench_duration || '25m' }}
       WAREHOUSES: ${{ matrix.warehouses }}
       VUS_SCALE: ${{ inputs.vus_scale || '1' }}
       POOL_SIZE: ${{ inputs.pool_size || '100' }}
     steps:
+      - name: Clean up previous runs
+        run: |
+          pkill -9 postgres 2>/dev/null || true
+          rm -rf "$GITHUB_WORKSPACE/pgdata" 2>/dev/null || true
+          sleep 1
       - name: Checkout extension code (head branch)
         uses: actions/checkout@v4
         with:
@@ -156,14 +173,22 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/pgsql/bin:$PATH"
           pg_isready -t 5
           psql -d postgres -c "SELECT orioledb_version();"
+      - name: Restore DB cache
+        run: bash ./orioledb/ci/perf_db_cache.sh restore
       - name: Resolve current user
         run: echo "PGUSER=$(whoami)" >> $GITHUB_ENV
       - name: Run TPC-C benchmark
         uses: stroppy-io/stroppy-action@main
         with:
+          version: '3'
           preset: tpcc
           driver-url: postgres://${{ env.PGUSER }}@localhost:5432/postgres?sslmode=disable
           artifact-name: perf-results-head-${{ matrix.warehouses }}W-${{ matrix.run }}
+          k6-args: '--out opentelemetry'
+          stroppy-args: ${{ env.DB_CACHED == 'true' && '--steps workload' || '' }}
+      - name: Save DB cache
+        if: env.DB_CACHED != 'true'
+        run: bash ./orioledb/ci/perf_db_cache.sh save
       - name: Stop PostgreSQL
         if: always()
         run: bash ./orioledb/ci/perf_pg_stop.sh
@@ -195,8 +220,8 @@ jobs:
             --base-dir results-base/ \
             --head-dir results-head/ \
             --runs "${{ inputs.bench_runs || '1' }}" \
-            --duration "${{ inputs.bench_duration || '5m' }}" \
-            --warehouses "${{ inputs.warehouses || '1' }}" \
+            --duration "${{ inputs.bench_duration || '25m' }}" \
+            --warehouses "${{ inputs.warehouses || '200' }}" \
             --vus-scale "${{ inputs.vus_scale || '1' }}" \
             --pool-size "${{ inputs.pool_size || '100' }}" \
             --output comment.md

--- a/ci/perf_compare.py
+++ b/ci/perf_compare.py
@@ -109,9 +109,9 @@ def format_change(base_val, head_val, lower_is_better=False):
     change = (head_val - base_val) / base_val * 100
     sign = "+" if change > 0 else ""
     if lower_is_better:
-        indicator = " :white_check_mark:" if change < -2 else (" :warning:" if change > 2 else "")
+        indicator = " :white_check_mark:" if change < -3 else (" :warning:" if change > 3 else "")
     else:
-        indicator = " :white_check_mark:" if change > 2 else (" :warning:" if change < -2 else "")
+        indicator = " :white_check_mark:" if change > 3 else (" :warning:" if change < -3 else "")
     return f"{sign}{change:.1f}%{indicator}"
 
 

--- a/ci/perf_db_cache.sh
+++ b/ci/perf_db_cache.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -eux
+
+# Cache/restore pgdata to skip TPC-C data loading on repeated runs.
+# Usage:
+#   perf_db_cache.sh restore   — restore pgdata from cache if available
+#   perf_db_cache.sh save      — save current pgdata to cache
+#
+# Sets DB_CACHED=true/false in $GITHUB_ENV for downstream steps.
+# Cache key: ${PG_VERSION}-${WAREHOUSES} (data is code-independent).
+
+export PATH="$GITHUB_WORKSPACE/pgsql/bin:$PATH"
+
+PGDATA="$GITHUB_WORKSPACE/pgdata"
+CACHE_BASE="/tmp/perf-db-cache"
+CACHE_KEY="${PG_VERSION:-17}-${WAREHOUSES:-1}W"
+CACHE_DIR="${CACHE_BASE}/${CACHE_KEY}"
+MAX_CACHES=4
+
+ACTION="${1:-}"
+
+case "$ACTION" in
+  restore)
+    if [ -d "$CACHE_DIR/pgdata" ]; then
+      echo "=== Restoring DB from cache: ${CACHE_KEY} ==="
+
+      # Stop PG, replace pgdata with cached copy, restart
+      pg_ctl -D "$PGDATA" stop -m fast 2>/dev/null || true
+      rm -rf "$PGDATA"
+      cp -a "$CACHE_DIR/pgdata" "$PGDATA"
+      pg_ctl -D "$PGDATA" -l "$PGDATA/postgresql.log" start
+      pg_isready -t 30
+
+      echo "DB_CACHED=true" >> "$GITHUB_ENV"
+      echo "=== DB restored from cache ==="
+    else
+      echo "=== No DB cache found for: ${CACHE_KEY} ==="
+      echo "DB_CACHED=false" >> "$GITHUB_ENV"
+    fi
+    ;;
+
+  save)
+    echo "=== Saving DB to cache: ${CACHE_KEY} ==="
+
+    # Stop PG cleanly before snapshot
+    pg_ctl -D "$PGDATA" stop -m fast
+    sleep 2
+
+    # Save pgdata to cache (overwrite if exists)
+    rm -rf "$CACHE_DIR"
+    mkdir -p "$CACHE_DIR"
+    cp -a "$PGDATA" "$CACHE_DIR/pgdata"
+
+    # Restart PG (workflow continues after save)
+    pg_ctl -D "$PGDATA" -l "$PGDATA/postgresql.log" start
+    pg_isready -t 30
+
+    # Retention: keep only last MAX_CACHES entries
+    ENTRIES=$(find "$CACHE_BASE" -maxdepth 1 -mindepth 1 -type d | wc -l)
+    if [ "$ENTRIES" -gt "$MAX_CACHES" ]; then
+      find "$CACHE_BASE" -maxdepth 1 -mindepth 1 -type d \
+        -printf '%T@ %p\n' | sort -n | head -n -"$MAX_CACHES" | cut -d' ' -f2 | xargs -r rm -rf
+    fi
+
+    echo "=== DB cached (${CACHE_KEY}), total entries: $(find "$CACHE_BASE" -maxdepth 1 -mindepth 1 -type d | wc -l) ==="
+    ;;
+
+  *)
+    echo "Usage: $0 {restore|save}"
+    exit 1
+    ;;
+esac

--- a/ci/perf_pg_stop.sh
+++ b/ci/perf_pg_stop.sh
@@ -25,4 +25,5 @@ fi
 echo "Saving PostgreSQL log to $LOG_DIR/$LOG_NAME"
 cp "$PGDATA/postgresql.log" "$LOG_DIR/$LOG_NAME" 2>/dev/null || echo "Warning: no postgresql.log found"
 
-rm -rf "$PGDATA"
+# Retry cleanup — orioledb_undo may linger briefly after pg_ctl stop
+rm -rf "$PGDATA" || { sleep 2; rm -rf "$PGDATA" || true; }


### PR DESCRIPTION
## Summary
Batch of improvements to the TPC-C performance testing workflow based on
production experience running benchmarks on self-hosted runners.

## Changes

### Bug fixes
- **Fix 403 on PR comments**: add `permissions: pull-requests: write`
- **Fix lingering postgres**: add cleanup step (`pkill -9 postgres`) before
  each bench job to handle cancelled runs that leave orphan processes
- **Fix orioledb_undo cleanup**: retry `rm -rf $PGDATA` with a delay in
  `perf_pg_stop.sh` when the undo directory is still held briefly after
  `pg_ctl stop`

### Performance improvements
- **Parallel base+head**: remove `needs: bench-base` from bench-head and
  `max-parallel: 1` — bench-base and bench-head now run simultaneously on
  separate runners, cutting total PR time in half
- **DB cache** (`ci/perf_db_cache.sh`): cache pgdata after initial TPC-C data
  loading. On subsequent runs, restore from cache and skip data loading via
  `stroppy-args: '--steps workload'`. Cache key: `${PG_VERSION}-${WAREHOUSES}W`,
  retention: 4 entries. Saves ~15-30 min per job for 200 warehouses
- **Clean stale build cache**: `perf_build.sh` now removes the entire build
  cache directory before a fresh build to prevent stale artifacts

### Observability
- **K6 OpenTelemetry export**: add `k6-args: '--out opentelemetry'` to send
  real-time benchmark metrics to a remote collector via runner env vars

### Defaults
- Duration: 5m → 25m (statistically significant results)
- Warehouses: 1 → 200 (realistic dataset size)
- Emoji threshold: 2% → 3% (reduce noise from natural fluctuations)

## Files changed
| File | Change |
|------|--------|
| `.github/workflows/perf-test.yml` | Permissions, cleanup, parallel jobs, OTEL, DB cache steps, updated defaults |
| `ci/perf_db_cache.sh` | **New** — cache/restore pgdata for TPC-C benchmarks |
| `ci/perf_compare.py` | Emoji threshold 2% → 3% |
| `ci/perf_pg_stop.sh` | Retry rm for orioledb_undo |
| `ci/perf_build.sh` | Clean stale cache before fresh build |