### PR TITLE
Fix compatibility with older Python versions

### DIFF
--- a/orioledb_s3_loader.py
+++ b/orioledb_s3_loader.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError, ParamValidationError
 from concurrent.futures import ThreadPoolExecutor
 from boto3.s3.transfer import TransferConfig
 from threading import Event
-from typing import Callable
+from typing import Callable, Dict, Optional
 from urllib.parse import urlparse
 
 
@@ -366,7 +366,7 @@ class OrioledbS3ObjectLoader:
 
 	def download_unchanged_files(self, bucket_name: str,
 	                             file_checksums_name: str, chkp_num: int,
-	                             file_checksums: dict[str, str] | None):
+	                             file_checksums: Optional[Dict[str, str]]):
 		# We won't be able to download unchanged previous files if this is
 		# the first checkpoint
 		if chkp_num <= 1:
@@ -405,7 +405,8 @@ class OrioledbS3ObjectLoader:
 
 	def download_unchanged_small_files(self, bucket_name: str,
 	                                   file_checksums_name: str, chkp_num: int,
-	                                   file_checksums: dict[str, str] | None):
+	                                   file_checksums: Optional[Dict[str,
+	                                                                 str]]):
 		# We won't be able to download unchanged previous files if this is
 		# the first checkpoint
 		if chkp_num <= 1:

--- a/test/t/rewind_xid_evict_large_test.py
+++ b/test/t/rewind_xid_evict_large_test.py
@@ -86,10 +86,10 @@ class RewindXidTest(BaseTest):
 		    "    PRIMARY KEY (id)\n"
 		    ") USING orioledb;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp2.close()
 
@@ -154,10 +154,10 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.close()
 
@@ -172,7 +172,7 @@ class RewindXidTest(BaseTest):
 		xid = int(a)
 		#		print(xid, invalidoxid)
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp.close()
 		node.pgbench_with_wait(options=[
@@ -232,11 +232,11 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.close()
@@ -312,7 +312,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("BEGIN;\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.write("SAVEPOINT sp1;\n")
@@ -323,7 +323,7 @@ class RewindXidTest(BaseTest):
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.write("COMMIT;\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("BEGIN;\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.write("SAVEPOINT sp1;\n")
@@ -403,7 +403,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("BEGIN;\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
@@ -418,7 +418,7 @@ class RewindXidTest(BaseTest):
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.write("COMMIT;\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("BEGIN;\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
@@ -506,7 +506,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING orioledb;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp.close()
 
@@ -602,7 +602,7 @@ class RewindXidTest(BaseTest):
 		    "	val text\n"
 		    ") USING orioledb;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp.close()
 
@@ -698,7 +698,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp.close()
 
@@ -794,7 +794,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp.close()
 
@@ -887,7 +887,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("BEGIN;\n")
 		fp.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp.write("SAVEPOINT sp1;\n")
@@ -991,7 +991,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("BEGIN;\n")
 		fp.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp.write("SAVEPOINT sp1;\n")
@@ -1327,7 +1327,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING orioledb;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("BEGIN;\n")
 		fp.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
@@ -1450,7 +1450,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING orioledb;\n")
 
-		fp = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp.write("BEGIN;\n")
 		fp.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")

--- a/test/t/rewind_xid_test.py
+++ b/test/t/rewind_xid_test.py
@@ -108,10 +108,10 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING orioledb;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp2.close()
 
@@ -167,10 +167,10 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.close()
 
@@ -227,7 +227,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("BEGIN;\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.write("SAVEPOINT sp1;\n")
@@ -238,7 +238,7 @@ class RewindXidTest(BaseTest):
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.write("COMMIT;\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("BEGIN;\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.write("SAVEPOINT sp1;\n")
@@ -309,11 +309,11 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.close()
@@ -386,7 +386,7 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("BEGIN;\n")
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
@@ -401,7 +401,7 @@ class RewindXidTest(BaseTest):
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.write("COMMIT;\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("BEGIN;\n")
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
@@ -489,11 +489,11 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_ddl (val) VALUES ('newval!');\n")
@@ -608,13 +608,13 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_ddl (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap_ddl (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_heap (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_ddl (val) VALUES ('newval!');\n")
@@ -715,11 +715,11 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test_ddl (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap_ddl (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test_ddl (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_heap_ddl (val) VALUES ('newval!');\n")
 		fp2.close()
@@ -809,11 +809,11 @@ class RewindXidTest(BaseTest):
 		    "	PRIMARY KEY (id)\n"
 		    ") USING heap;\n")
 
-		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp1 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp1.write("INSERT INTO o_test_ddl (val) VALUES ('oldval!');\n")
 		fp1.write("INSERT INTO o_test_heap_ddl (val) VALUES ('oldval!');\n")
 		fp1.close()
-		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete_on_close=False)
+		fp2 = tempfile.NamedTemporaryFile(mode='wt', delete=False)
 		fp2.write("INSERT INTO o_test_ddl (val) VALUES ('newval!');\n")
 		fp2.write("INSERT INTO o_test_heap_ddl (val) VALUES ('newval!');\n")
 		fp2.close()


### PR DESCRIPTION
If you consider upgrading the Python requirement to 3.9+, we can use the new type annotation syntax in the second commit. In that case, this import must be added for 3.9:

```py
from __future__ import annotations
```
