### PR TITLE
Wake startup when worker is caught up but finishedPtr lags

### DIFF
--- a/include/recovery/recovery.h
+++ b/include/recovery/recovery.h
@@ -56,6 +56,7 @@ extern int	recovery_pool_size_guc;
 extern int	recovery_idx_pool_size_guc;
 extern OXid recovery_oxid;
 extern TransactionId recoveryHeapTransactionId;
+extern pg_atomic_uint64 *recovery_finished_list_ptr;
 
 typedef struct BTreeDescr BTreeDescr;
 

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -735,8 +735,15 @@ recovery_queue_read(shm_mq_handle *queue, Size *data_size, int id)
 		 * If any of the committed transactions required the feedback, wake up
 		 * the main recovery process: it would have a chance to provide it.
 		 */
-		if (recovery_needs_feedback)
-			WakeupRecovery();
+		{
+			XLogRecPtr	commit_ptr = pg_atomic_read_u64(&worker_ptrs[id].commitPtr);
+			XLogRecPtr	rec_ptr = pg_atomic_read_u64(recovery_ptr);
+
+			if (recovery_needs_feedback ||
+			    (commit_ptr == rec_ptr &&
+			     commit_ptr != pg_atomic_read_u64(recovery_finished_list_ptr)))
+				WakeupRecovery();
+		}
 
 		pg_usleep(usleep_time);
 


### PR DESCRIPTION
When a worker's queue is empty and its commitPtr has reached recovery_ptr but recovery_finished_list_ptr has not yet been updated, wake the startup process to immediately run update_proc_retain_undo_location(), assigning CSNs to committed transactions and updating finishedPtr. This eliminates up to 10-second replay lag visible in pg_stat_replication without spurious wakeups in idle state.