### PR TITLE
Fix typos in PR #831

### DIFF
--- a/include/recovery/wal_reader.h
+++ b/include/recovery/wal_reader.h
@@ -204,8 +204,6 @@ typedef struct WalReaderState
  *   - leave r->ptr positioned at the next record tag.
  *
  * It must not read beyond r->end; use WR_REQUIRE_SIZE / WR_PARSE / WR_SKIP.
- *
- * For payload-less records, descriptor->parse is NULL (record is tag-only).
  */
 typedef WalParseResult (*WalParseFn) (WalReaderState *r, WalRecord *rec);
 

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -411,7 +411,7 @@ get_undo_type_name(UndoLogType undoType)
 		case UndoLogSystem:
 			return "system";
 		default:
-			elog(ERROR, "Unkown undo log type: %d", undoType);
+			elog(ERROR, "Unknown undo log type: %d", undoType);
 	}
 }
 
@@ -3369,7 +3369,7 @@ orioledb_get_proc_retain_undo_locations(PG_FUNCTION_ARGS)
 
 			values[0] = Int32GetDatum(proc->pid);
 			values[1] = Int32GetDatum(i);
-			values[2] = PointerGetDatum(cstring_to_text(get_undo_type_name(i)));
+			values[2] = PointerGetDatum(cstring_to_text(get_undo_type_name(j)));
 			values[3] = Int64GetDatum(reserved);
 			values[4] = Int64GetDatum(transaction);
 			values[5] = Int64GetDatum(snapshot);


### PR DESCRIPTION
- `get_undo_type_name()` should use `j` in `orioledb_get_proc_retain_undo_locations()`
- "Unkown" -> "Unknown"
- Delete not up-to-date comment in `include/recovery/wal_reader.h`

Fix to #831 