### PR TITLE
Refactoring of sys cache code

### DIFF
--- a/include/catalog/o_sys_cache.h
+++ b/include/catalog/o_sys_cache.h
@@ -260,9 +260,22 @@ extern void o_sys_cache_update_if_needed(OSysCache *sys_cache,
 										 OSysCacheKey *key, Pointer arg);
 extern bool o_sys_cache_delete(OSysCache *sys_cache, OSysCacheKey *key);
 
-extern void custom_types_add_all(OTable *o_table, OTableIndex *o_table_index);
-extern void custom_type_add_if_needed(Oid datoid, Oid typoid,
-									  XLogRecPtr insert_lsn);
+extern void o_cache_table_types(OTable *o_table);
+extern void o_cache_index_types(OTable *o_table, OTableIndex *o_table_index);
+extern void o_cache_type(Oid datoid, Oid typoid, Oid opclass,
+						 XLogRecPtr insert_lsn);
+
+/*
+ * safe version that collect processed types to prevent recursion
+ * when collecting any functions for type
+ */
+extern void o_cache_type_safe(Oid datoid, Oid typoid, Oid opclass,
+							  XLogRecPtr insert_lsn, List **processed);
+extern bool custom_type_try_add_hash_fn_if_needed(Oid typoid,
+												  Oid opclass,
+												  List **processed);
+extern void o_validate_composite_type(Oid typoid, Oid opclass);
+extern Oid	o_get_hash_proc_by_btree_opclass(Oid btreeOpclass);
 
 extern void o_sys_caches_delete_by_lsn(XLogRecPtr checkPointRedo);
 
@@ -394,8 +407,6 @@ o_sys_cache_set_datoid_lsn(XLogRecPtr *cur_lsn, Oid *datoid)
 	}
 }
 
-extern void o_composite_type_element_save(Oid datoid, Oid oid,
-										  XLogRecPtr insert_lsn);
 extern void o_set_syscache_hooks(void);
 extern void o_unset_syscache_hooks(void);
 extern void o_reset_syscache_hooks(void);
@@ -448,8 +459,6 @@ typedef struct
 
 O_SYS_CACHE_DECLS(range_cache, ORange, 1);
 extern HeapTuple o_range_cache_search_htup(TupleDesc tupdesc, Oid rngtypid);
-extern void o_range_cache_add_rngsubopc(Oid datoid, Oid rngtypid,
-										XLogRecPtr insert_lsn);
 extern void o_range_cache_tup_print(BTreeDescr *desc, StringInfo buf,
 									OTuple tup, Pointer arg);
 
@@ -471,8 +480,8 @@ typedef struct OClass OClass;
 typedef struct OClassArg
 {
 	bool		column_drop;
-	bool		sys_table;
 	int			dropped;
+	bool		found;
 } OClassArg;
 
 O_SYS_CACHE_DECLS(class_cache, OClass, 1);
@@ -494,7 +503,6 @@ typedef struct OOpclass
 } OOpclass;
 
 O_SYS_CACHE_DECLS(opclass_cache, OOpclass, 1);
-extern void o_opclass_cache_add_table(OTable *o_table);
 extern OOpclass *o_opclass_get(Oid opclassoid, Oid datoid);
 extern HeapTuple o_opclass_cache_search_htup(TupleDesc tupdesc,
 											 Oid opclassoid);
@@ -504,10 +512,17 @@ extern void o_opclass_cache_tup_print(BTreeDescr *desc, StringInfo buf,
 /* o_proc_cache.c */
 typedef struct OProc OProc;
 
+typedef struct OProcArg
+{
+	Oid			collation;
+	List	  **processed;
+} OProcArg;
+
 O_SYS_CACHE_DECLS(proc_cache, OProc, 1);
 extern Datum o_fmgr_sql(PG_FUNCTION_ARGS);
 extern void o_proc_cache_validate_add(Oid datoid, Oid procoid, Oid fncollation,
-									  char *func_type, char *used_for);
+									  char *func_type, char *used_for,
+									  List **processed);
 extern void o_proc_cache_fill_finfo(FmgrInfo *finfo, Oid procoid, Oid datoid);
 extern HeapTuple o_proc_cache_search_htup(TupleDesc tupdesc, Oid procoid);
 

--- a/include/utils/planner.h
+++ b/include/utils/planner.h
@@ -18,9 +18,10 @@ extern void o_validate_funcexpr(Node *node, char *hint_msg);
 extern void o_validate_function_by_oid(Oid procoid, char *hint_msg);
 
 extern void o_collect_funcexpr(Node *node);
-extern void o_collect_function_by_oid(Oid procoid, Oid inputcollid);
 extern void o_collect_op_by_oid(Oid opoid);
 
-extern void o_collect_functions_pstmt(PlannedStmt *pstmt);
+extern void o_collect_function_by_oid(Oid procoid, Oid inputcollid,
+									  List **processed);
+extern void o_collect_functions_pstmt(PlannedStmt *pstmt, List **processed);
 
 #endif

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -2082,7 +2082,7 @@ create_o_table_for_rel(Relation rel)
 									 RelationGetFillFactor(rel, BTREE_DEFAULT_FILLFACTOR),
 									 rel->rd_rel->reltablespace,
 									 false);
-	o_opclass_cache_add_table(o_table);
+	o_cache_table_types(o_table);
 
 	o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
 	o_database_cache_add_if_needed(datoid, datoid, cur_lsn, NULL);
@@ -3279,12 +3279,10 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 
 		if (rel != NULL)
 		{
-			if (rel->rd_rel->relkind == RELKIND_COMPOSITE_TYPE)
+			if (rel->rd_rel->relkind == RELKIND_COMPOSITE_TYPE &&
+				(subId != 0))
 			{
 				o_find_composite_type_dependencies(rel->rd_rel->reltype, rel);
-				CommandCounterIncrement();
-				o_class_cache_update_if_needed(MyDatabaseId, rel->rd_rel->oid,
-											   NULL);
 			}
 			else if ((rel->rd_rel->relkind == RELKIND_RELATION ||
 					  rel->rd_rel->relkind == RELKIND_MATVIEW) &&
@@ -3606,10 +3604,20 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 		{
 			if (rel->rd_rel->relkind == RELKIND_COMPOSITE_TYPE)
 			{
+				OClassArg	arg = {0};
+
 				o_find_composite_type_dependencies(rel->rd_rel->reltype, rel);
 				CommandCounterIncrement();
 				o_class_cache_update_if_needed(MyDatabaseId, rel->rd_rel->oid,
-											   NULL);
+											   (Pointer) &arg);
+				if (arg.found)
+				{
+					XLogRecPtr	cur_lsn;
+
+					o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
+					o_cache_type(MyDatabaseId, rel->rd_rel->reltype, InvalidOid,
+								 cur_lsn);
+				}
 			}
 			else if ((rel->rd_rel->relkind == RELKIND_RELATION ||
 					  rel->rd_rel->relkind == RELKIND_MATVIEW) &&
@@ -4113,12 +4121,24 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 				break;
 
 			case TYPTYPE_COMPOSITE:
-				rel = relation_open(typeidTypeRelid(objectId), AccessShareLock);
-				o_find_composite_type_dependencies(objectId, rel);
-				relation_close(rel, AccessShareLock);
-				CommandCounterIncrement();
-				o_class_cache_update_if_needed(MyDatabaseId, rel->rd_rel->oid,
-											   NULL);
+				{
+					OClassArg	arg = {0};
+
+					rel = relation_open(typeidTypeRelid(objectId), AccessShareLock);
+					o_find_composite_type_dependencies(objectId, rel);
+					relation_close(rel, AccessShareLock);
+					CommandCounterIncrement();
+					o_class_cache_update_if_needed(MyDatabaseId, rel->rd_rel->oid,
+												   (Pointer) &arg);
+					if (arg.found)
+					{
+						XLogRecPtr	cur_lsn;
+
+						o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
+						o_cache_type(MyDatabaseId, rel->rd_rel->reltype, InvalidOid,
+									 cur_lsn);
+					}
+				}
 				break;
 
 			default:

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -392,7 +392,6 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 			   IndexBuildResult *result)
 {
 	OTable	   *old_o_table = NULL;
-	OTable	   *new_o_table;
 	OTable	   *o_table;
 	OIndexNumber ix_num;
 	OTableIndex *table_index;
@@ -505,6 +504,8 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 			/* Rebuild, assign new oids */
 			if (ix_type == oIndexPrimary)
 			{
+				OTable	   *new_o_table;
+
 				new_o_table = o_tables_get(oids);
 				o_table = new_o_table;
 				assign_new_oids(new_o_table, heap, false);
@@ -581,8 +582,7 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 	else
 		o_tables_table_meta_lock(o_table);
 
-	o_opclass_cache_add_table(o_table);
-	custom_types_add_all(o_table, table_index);
+	o_cache_index_types(o_table, table_index);
 	if (!reuse_relnode && table_index->type == oIndexPrimary)
 	{
 		Assert(old_o_table);

--- a/src/catalog/o_aggregate_cache.c
+++ b/src/catalog/o_aggregate_cache.c
@@ -131,11 +131,6 @@ o_aggregate_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key,
 	o_agg->aggmtranstype = aggform->aggmtranstype;
 	o_agg->aggtranstype = aggform->aggtranstype;
 
-	o_type_cache_add_if_needed(key->common.datoid, o_agg->aggtranstype,
-							   key->common.lsn, NULL);
-	o_type_cache_add_if_needed(key->common.datoid, o_agg->aggmtranstype,
-							   key->common.lsn, NULL);
-
 	textInitVal = SysCacheGetAttr(AGGFNOID, aggtup,
 								  Anum_pg_aggregate_agginitval,
 								  &initValueIsNull);

--- a/src/catalog/o_class_cache.c
+++ b/src/catalog/o_class_cache.c
@@ -86,10 +86,7 @@ o_class_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	Size		len;
 	OClass	   *o_class = (OClass *) *entry_ptr;
 	OClassArg  *carg = (OClassArg *) arg;
-	bool		sys_cache;
 	Oid			classoid = DatumGetObjectId(key->keys[0]);
-
-	sys_cache = carg && !carg->column_drop && carg->sys_table;
 
 	rel = relation_open(classoid, AccessShareLock);
 
@@ -100,6 +97,7 @@ o_class_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 		o_class->attrs = (FormData_pg_attribute *) repalloc(o_class->attrs,
 															len);
 		memset(o_class->attrs, 0, len);
+		carg->found = true;
 	}
 	else
 	{
@@ -112,7 +110,6 @@ o_class_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	o_class->natts = rel->rd_att->natts;
 	for (i = 0; i < o_class->natts; i++)
 	{
-		bool		process;
 		FormData_pg_attribute *class_attr,
 				   *typcache_attr;
 
@@ -145,12 +142,6 @@ o_class_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 		class_attr->attisdropped = typcache_attr->attisdropped ||
 			(carg && carg->column_drop &&
 			 carg->dropped - 1 == i);
-
-		process = !class_attr->attisdropped && !sys_cache;
-		if (process)
-			o_composite_type_element_save(key->common.datoid,
-										  class_attr->atttypid,
-										  key->common.lsn);
 	}
 	MemoryContextSwitchTo(prev_context);
 	relation_close(rel, AccessShareLock);

--- a/src/catalog/o_collation_cache.c
+++ b/src/catalog/o_collation_cache.c
@@ -286,11 +286,9 @@ orioledb_save_collation(Oid colloid)
 	{
 		XLogRecPtr	cur_lsn;
 		Oid			datoid;
-		OClassArg	arg = {.sys_table = true};
 
 		o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
-		o_class_cache_add_if_needed(datoid, CollationRelationId, cur_lsn,
-									(Pointer) &arg);
+		o_class_cache_add_if_needed(datoid, CollationRelationId, cur_lsn, NULL);
 		o_collation_cache_add_if_needed(datoid, colloid, cur_lsn, NULL);
 	}
 }

--- a/src/catalog/o_opclass_cache.c
+++ b/src/catalog/o_opclass_cache.c
@@ -32,13 +32,11 @@
 #include "catalog/pg_am.h"
 #include "catalog/pg_amop.h"
 #include "catalog/pg_amproc.h"
-#include "catalog/pg_database.h"
 #include "catalog/pg_opclass.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
-#include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/syscache.h"
@@ -70,116 +68,6 @@ O_SYS_CACHE_INIT_FUNC(opclass_cache)
 									   &opclass_cache_funcs);
 }
 
-static void
-add_btree_opclass(Oid datoid, Oid opclassoid, XLogRecPtr insert_lsn)
-{
-	XLogRecPtr	sys_lsn;
-	Oid			sys_datoid;
-	OClassArg	class_arg = {.sys_table = true};
-	Oid			btree_opf;
-	Oid			btree_opintype;
-
-	btree_opf = get_opclass_family(opclassoid);
-	btree_opintype = get_opclass_input_type(opclassoid);
-
-	o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
-	o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId, sys_lsn,
-								(Pointer) &class_arg);
-	o_opclass_cache_add_if_needed(datoid, opclassoid, insert_lsn,
-								  NULL);
-	o_class_cache_add_if_needed(sys_datoid, AccessMethodProcedureRelationId,
-								sys_lsn, (Pointer) &class_arg);
-	o_amproc_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-								 btree_opintype, BTORDER_PROC, insert_lsn,
-								 NULL);
-	o_class_cache_add_if_needed(sys_datoid, AccessMethodOperatorRelationId,
-								sys_lsn, (Pointer) &class_arg);
-
-	if (get_opfamily_member(btree_opf, btree_opintype, btree_opintype,
-							BTLessStrategyNumber))
-		o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-										 btree_opintype, BTLessStrategyNumber,
-										 insert_lsn, NULL);
-	if (get_opfamily_member(btree_opf, btree_opintype, btree_opintype,
-							BTLessEqualStrategyNumber))
-		o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-										 btree_opintype,
-										 BTLessEqualStrategyNumber, insert_lsn,
-										 NULL);
-	if (get_opfamily_member(btree_opf, btree_opintype, btree_opintype,
-							BTEqualStrategyNumber))
-		o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-										 btree_opintype, BTEqualStrategyNumber,
-										 insert_lsn, NULL);
-}
-
-/*
- * Inserts opclasses for all fields of the o_table to the opclass B-tree.
- */
-void
-o_opclass_cache_add_table(OTable *o_table)
-{
-	int			cur_ix;
-	XLogRecPtr	cur_lsn;
-	Oid			datoid;
-	XLogRecPtr	sys_lsn;
-	Oid			sys_datoid;
-	OClassArg	class_arg = {.sys_table = true};
-
-	o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
-	o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId, sys_lsn,
-								(Pointer) &class_arg);
-
-	o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
-	datoid = o_table->oids.datoid;
-
-	o_database_cache_add_if_needed(Template1DbOid, Template1DbOid, cur_lsn, NULL);
-
-	/*
-	 * Inserts opclasses for TOAST index.
-	 */
-	o_opclass_cache_add_if_needed(datoid,
-								  GetDefaultOpClass(INT2OID, BTREE_AM_OID),
-								  cur_lsn, NULL);
-	add_btree_opclass(datoid, GetDefaultOpClass(INT2OID, BTREE_AM_OID),
-					  cur_lsn);
-	o_collect_function_by_oid(F_HASHINT2, InvalidOid);
-	o_opclass_cache_add_if_needed(datoid,
-								  GetDefaultOpClass(INT4OID, BTREE_AM_OID),
-								  cur_lsn, NULL);
-	add_btree_opclass(datoid, GetDefaultOpClass(INT4OID, BTREE_AM_OID),
-					  cur_lsn);
-	o_collect_function_by_oid(F_HASHINT4, InvalidOid);
-
-	/*
-	 * Inserts opclass for default index if there is no unique index.
-	 */
-	if (o_table->nindices == 0 || o_table->indices[0].type == oIndexRegular)
-	{
-		o_opclass_cache_add_if_needed(datoid,
-									  GetDefaultOpClass(TIDOID, BTREE_AM_OID),
-									  cur_lsn, NULL);
-		add_btree_opclass(datoid, GetDefaultOpClass(TIDOID, BTREE_AM_OID),
-						  cur_lsn);
-		o_collect_function_by_oid(F_HASHTID, InvalidOid);
-
-	}
-
-	for (cur_ix = 0; cur_ix < o_table->nindices; cur_ix++)
-	{
-		OTableIndex *index = &o_table->indices[cur_ix];
-		int			cur_field;
-
-		for (cur_field = 0; cur_field < index->nkeyfields; cur_field++)
-		{
-			o_opclass_cache_add_if_needed(datoid,
-										  index->fields[cur_field].opclass,
-										  cur_lsn, NULL);
-			add_btree_opclass(datoid, index->fields[cur_field].opclass,
-							  cur_lsn);
-		}
-	}
-}
 
 /*
  * o_opclass_get
@@ -268,15 +156,8 @@ o_opclass_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	inputtype = o_opclass->inputtype;
 	o_opclass->ssupOid = get_opfamily_proc(o_opclass->opfamily, inputtype,
 										   inputtype, BTSORTSUPPORT_PROC);
-	if (OidIsValid(o_opclass->ssupOid))
-		o_proc_cache_validate_add(key->common.datoid,
-								  o_opclass->ssupOid, InvalidOid,
-								  "sort", "field");
-
 	o_opclass->cmpOid = get_opfamily_proc(o_opclass->opfamily, inputtype,
 										  inputtype, BTORDER_PROC);
-	o_proc_cache_validate_add(key->common.datoid, o_opclass->cmpOid,
-							  InvalidOid, "comparsion", "field");
 	ReleaseSysCache(opclasstuple);
 }
 

--- a/src/catalog/o_proc_cache.c
+++ b/src/catalog/o_proc_cache.c
@@ -151,7 +151,7 @@ typedef SQLFunctionCache *SQLFunctionCachePtr;
 
 static void init_sql_fcache(FunctionCallInfo fcinfo, Oid collation,
 							bool lazyEvalOK, sql_func_data *out_sql_func,
-							MemoryContext out_sql_func_cxt);
+							MemoryContext out_sql_func_cxt, List **processed);
 static void sql_exec_error_callback(void *arg);
 
 static Pointer o_proc_cache_serialize_entry(Pointer entry, int *len);
@@ -189,12 +189,14 @@ o_proc_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	HeapTuple	proctup;
 	Form_pg_proc procform;
 	OProc	   *o_proc = (OProc *) *entry_ptr;
-	Oid		   *fncollation = (Oid *) arg;
+	OProcArg   *parg = (OProcArg *) arg;
 	bool		lazyEvalOK = false;
 	SQLFunctionCachePtr fcache;
 	MemoryContext oldcontext;
 	int			i;
 	Oid			procoid = DatumGetObjectId(key->keys[0]);
+	Oid			fncollation = parg->collation;
+	List	  **processed = parg->processed;
 
 	proctup = SearchSysCache1(PROCOID, key->keys[0]);
 	if (!HeapTupleIsValid(proctup))
@@ -228,11 +230,6 @@ o_proc_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	o_proc->argtypes = palloc0(o_proc->nargs * sizeof(Oid));
 	memcpy(o_proc->argtypes, procform->proargtypes.values,
 		   o_proc->nargs * sizeof(Oid));
-	for (i = 0; i < o_proc->nargs; i++)
-	{
-		o_type_cache_add_if_needed(key->common.datoid, o_proc->argtypes[i],
-								   key->common.lsn, NULL);
-	}
 
 	fmgr_symbol(procoid, &o_proc->probin, &o_proc->prosrc);
 
@@ -240,15 +237,12 @@ o_proc_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	{
 		FmgrInfo   *finfo;
 		FunctionCallInfo fcinfo;
-		OClassArg	arg = {.sys_table = true};
-		XLogRecPtr	cur_lsn;
-		Oid			datoid;
 
 		finfo = palloc0(sizeof(FmgrInfo));
 		fcinfo = palloc0(SizeForFunctionCallInfo(2));
 		fmgr_info(procoid, finfo);
 		InitFunctionCallInfoData(*fcinfo, finfo, 2,
-								 *fncollation, NULL, NULL);
+								 fncollation, NULL, NULL);
 
 		/* Check call context */
 		if (fcinfo->flinfo->fn_retset)
@@ -278,11 +272,8 @@ o_proc_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 
 		o_proc->sql_func = palloc0(sizeof(sql_func_data));
 		init_sql_fcache(fcinfo, fcinfo->fncollation, lazyEvalOK,
-						o_proc->sql_func, o_proc->cxt);
+						o_proc->sql_func, o_proc->cxt, processed);
 
-		o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
-		o_class_cache_add_if_needed(datoid, TypeRelationId, cur_lsn,
-									(Pointer) &arg);
 		for (i = 0; i < o_proc->sql_func->nnqtlists; i++)
 		{
 			int			j;
@@ -293,7 +284,7 @@ o_proc_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 
 				pstmt = castNode(PlannedStmt, o_proc->sql_func->qtlists[i][j]);
 
-				o_collect_functions_pstmt(pstmt);
+				o_collect_functions_pstmt(pstmt, processed);
 			}
 		}
 		fcache = (SQLFunctionCachePtr) fcinfo->flinfo->fn_extra;
@@ -752,7 +743,8 @@ o_prepare_sql_fn_parse_info(OProc *o_proc, Node *call_expr, Oid inputCollation)
  */
 static void
 init_sql_fcache(FunctionCallInfo fcinfo, Oid collation, bool lazyEvalOK,
-				sql_func_data *out_sql_func, MemoryContext out_sql_func_cxt)
+				sql_func_data *out_sql_func, MemoryContext out_sql_func_cxt,
+				List **processed)
 {
 	FmgrInfo   *finfo = fcinfo->flinfo;
 	Oid			foid = finfo->fn_oid;
@@ -1213,8 +1205,7 @@ init_sql_fcache(FunctionCallInfo fcinfo, Oid collation, bool lazyEvalOK,
 
 				att = &jf->jf_cleanTupType->attrs[cur_resno - 1];
 				out_sql_func->jf_atts[cur_resno - 1] = att->atttypid;
-				o_type_cache_add_if_needed(datoid, att->atttypid, cur_lsn,
-										   NULL);
+				o_cache_type_safe(datoid, att->atttypid, InvalidOid, cur_lsn, processed);
 				cur_resno++;
 			}
 		}
@@ -1568,7 +1559,7 @@ o_fmgr_sql(PG_FUNCTION_ARGS)
 
 	if (fcache == NULL)
 	{
-		init_sql_fcache(fcinfo, fcinfo->fncollation, lazyEvalOK, NULL, NULL);
+		init_sql_fcache(fcinfo, fcinfo->fncollation, lazyEvalOK, NULL, NULL, NULL);
 		fcache = (SQLFunctionCachePtr) fcinfo->flinfo->fn_extra;
 	}
 
@@ -1954,7 +1945,7 @@ sql_exec_error_callback(void *arg)
 
 void
 o_proc_cache_validate_add(Oid datoid, Oid procoid, Oid fncollation,
-						  char *func_type, char *used_for)
+						  char *func_type, char *used_for, List **processed)
 {
 	StringInfoData str;
 
@@ -1964,7 +1955,7 @@ o_proc_cache_validate_add(Oid datoid, Oid procoid, Oid fncollation,
 					 "of orioledb index", func_type, used_for);
 	o_validate_function_by_oid(procoid, str.data);
 
-	o_collect_function_by_oid(procoid, fncollation);
+	o_collect_function_by_oid(procoid, fncollation, processed);
 	pfree(str.data);
 }
 

--- a/src/catalog/o_range_cache.c
+++ b/src/catalog/o_range_cache.c
@@ -88,16 +88,6 @@ o_range_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	o_range->rngsubtype = rangeform->rngsubtype;
 	o_range->rngsubopc = rangeform->rngsubopc;
 	o_range->rngcollation = rangeform->rngcollation;
-	custom_type_add_if_needed(key->common.datoid, o_range->rngsubtype,
-							  key->common.lsn);
-	o_type_cache_add_if_needed(key->common.datoid, o_range->rngsubtype,
-							   key->common.lsn, NULL);
-	o_opclass_cache_add_if_needed(key->common.datoid, o_range->rngsubopc,
-								  key->common.lsn, NULL);
-	if (OidIsValid(o_range->rngcollation))
-		o_collation_cache_add_if_needed(key->common.datoid,
-										o_range->rngcollation, key->common.lsn,
-										NULL);
 
 	MemoryContextSwitchTo(prev_context);
 	ReleaseSysCache(rangetup);
@@ -155,31 +145,6 @@ o_range_cache_search_htup(TupleDesc tupdesc, Oid rngtypid)
 	return result;
 }
 
-void
-o_range_cache_add_rngsubopc(Oid datoid, Oid rngtypid, XLogRecPtr insert_lsn)
-{
-	ORange	   *o_range;
-	XLogRecPtr	sys_lsn;
-	Oid			sys_datoid;
-	OClassArg	class_arg = {.sys_table = true};
-	Oid			btree_opf;
-	Oid			btree_opintype;
-
-	o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
-	o_range =
-		o_range_cache_search(datoid, rngtypid, insert_lsn, range_cache->nkeys);
-	Assert(o_range);
-	o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId, sys_lsn,
-								(Pointer) &class_arg);
-	o_class_cache_add_if_needed(sys_datoid, AccessMethodProcedureRelationId,
-								sys_lsn, (Pointer) &class_arg);
-	btree_opf = get_opclass_family(o_range->rngsubopc);
-	btree_opintype = get_opclass_input_type(o_range->rngsubopc);
-	o_amproc_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-								 btree_opintype, BTORDER_PROC, insert_lsn,
-								 NULL);
-}
-
 static OSysCache *multirange_cache = NULL;
 
 static void o_multirange_cache_free_entry(Pointer entry);
@@ -230,8 +195,6 @@ o_multirange_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key,
 	}
 
 	o_multirange->rngtypid = rangeform->rngtypid;
-	custom_type_add_if_needed(key->common.datoid, o_multirange->rngtypid,
-							  key->common.lsn);
 
 	MemoryContextSwitchTo(prev_context);
 	ReleaseSysCache(rangetup);

--- a/src/catalog/o_sys_cache.c
+++ b/src/catalog/o_sys_cache.c
@@ -16,7 +16,6 @@
 
 #include "orioledb.h"
 
-#include "access/hash.h"
 #include "btree/btree.h"
 #include "btree/modify.h"
 #include "catalog/o_sys_cache.h"
@@ -27,13 +26,16 @@
 #include "tuple/toast.h"
 #include "utils/planner.h"
 
+#include "access/hash.h"
 #include "access/heaptoast.h"
+#include "access/relation.h"
 #include "commands/defrem.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_amop.h"
 #include "catalog/pg_amproc.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
+#include "catalog/pg_database.h"
 #include "catalog/pg_enum.h"
 #include "catalog/pg_opclass.h"
 #include "catalog/pg_operator.h"
@@ -45,6 +47,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/fmgrtab.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
@@ -888,14 +891,12 @@ o_sys_cache_add_if_needed(OSysCache *sys_cache, OSysCacheKey *key, Pointer arg)
 {
 	Pointer		entry = NULL;
 	bool		inserted PG_USED_FOR_ASSERTS_ONLY;
-	bool		found = false;
 
 	o_sys_cache_lock(sys_cache, key, AccessExclusiveLock);
 
 	entry = o_sys_cache_search(sys_cache, sys_cache->nkeys, key);
-	found = entry != NULL;
 
-	if (found)
+	if (entry != NULL)
 	{
 		o_sys_cache_unlock(sys_cache, key, AccessExclusiveLock);
 		return;
@@ -1308,83 +1309,230 @@ oSysCacheToastGetTupleDataSize(OTuple tuple, void *arg)
 	return common->dataLength;
 }
 
+static void
+o_cache_type_opclasses(Oid datoid, Oid typoid,
+					   Oid btree_opclass, Oid hash_opclass,
+					   XLogRecPtr insert_lsn,
+					   List **processed)
+{
+	if (!OidIsValid(btree_opclass))
+		btree_opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+	if (OidIsValid(btree_opclass))
+	{
+		XLogRecPtr	sys_lsn;
+		Oid			sys_datoid;
+		Oid			btree_opf;
+		Oid			btree_opintype;
+		Oid			ssupOid;
+		Oid			cmpOid;
+
+		btree_opf = get_opclass_family(btree_opclass);
+		btree_opintype = get_opclass_input_type(btree_opclass);
+
+		o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
+		o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId, sys_lsn,
+									NULL);
+		ssupOid = get_opfamily_proc(btree_opf, btree_opintype, btree_opintype,
+									BTSORTSUPPORT_PROC);
+		if (OidIsValid(ssupOid))
+			o_proc_cache_validate_add(datoid, ssupOid, InvalidOid, "sort", "field",
+									  processed);
+		cmpOid = get_opfamily_proc(btree_opf, btree_opintype, btree_opintype,
+								   BTORDER_PROC);
+		o_proc_cache_validate_add(datoid, cmpOid, InvalidOid, "comparsion",
+								  "field", processed);
+		o_opclass_cache_add_if_needed(datoid, btree_opclass, insert_lsn, NULL);
+		o_class_cache_add_if_needed(sys_datoid, AccessMethodProcedureRelationId,
+									sys_lsn, NULL);
+		o_amproc_cache_add_if_needed(datoid, btree_opf, btree_opintype,
+									 btree_opintype, BTORDER_PROC, insert_lsn,
+									 NULL);
+		o_class_cache_add_if_needed(sys_datoid, AccessMethodOperatorRelationId,
+									sys_lsn, NULL);
+
+		if (get_opfamily_member(btree_opf, btree_opintype, btree_opintype,
+								BTLessStrategyNumber))
+			o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
+											 btree_opintype, BTLessStrategyNumber,
+											 insert_lsn, NULL);
+		if (get_opfamily_member(btree_opf, btree_opintype, btree_opintype,
+								BTLessEqualStrategyNumber))
+			o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
+											 btree_opintype,
+											 BTLessEqualStrategyNumber, insert_lsn,
+											 NULL);
+		if (get_opfamily_member(btree_opf, btree_opintype, btree_opintype,
+								BTEqualStrategyNumber))
+			o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
+											 btree_opintype, BTEqualStrategyNumber,
+											 insert_lsn, NULL);
+	}
+	if (!OidIsValid(hash_opclass))
+		hash_opclass = GetDefaultOpClass(typoid, HASH_AM_OID);
+	if (OidIsValid(hash_opclass))
+	{
+		XLogRecPtr	sys_lsn;
+		Oid			sys_datoid;
+		Oid			hash_opf;
+		Oid			hash_opintype;
+
+		hash_opf = get_opclass_family(hash_opclass);
+		hash_opintype = get_opclass_input_type(hash_opclass);
+
+		o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
+		o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId, sys_lsn,
+									NULL);
+		o_opclass_cache_add_if_needed(datoid, hash_opclass, insert_lsn, NULL);
+		o_class_cache_add_if_needed(sys_datoid,
+									AccessMethodProcedureRelationId, sys_lsn,
+									NULL);
+		o_amproc_cache_add_if_needed(datoid, hash_opf, hash_opintype,
+									 hash_opintype, HASHSTANDARD_PROC,
+									 insert_lsn, NULL);
+		o_amproc_cache_add_if_needed(datoid, hash_opf, hash_opintype,
+									 hash_opintype, HASHEXTENDED_PROC,
+									 insert_lsn, NULL);
+
+		o_class_cache_add_if_needed(sys_datoid, AccessMethodOperatorRelationId,
+									sys_lsn, NULL);
+		o_amop_strat_cache_add_if_needed(datoid, hash_opf, hash_opintype,
+										 hash_opintype, HTEqualStrategyNumber,
+										 insert_lsn, NULL);
+	}
+}
+
 void
-custom_type_add_if_needed(Oid datoid, Oid typoid, XLogRecPtr insert_lsn)
+o_cache_type(Oid datoid, Oid typoid, Oid opclass, XLogRecPtr insert_lsn)
+{
+	List	   *processed = NIL;
+
+	o_cache_type_safe(datoid, typoid, opclass, insert_lsn, &processed);
+	list_free_deep(processed);
+}
+
+void
+o_cache_type_safe(Oid datoid, Oid typoid, Oid opclass, XLogRecPtr insert_lsn,
+				  List **processed)
 {
 	Form_pg_type typeform;
 	HeapTuple	tuple = NULL;
+	List	   *oids;
+	MemoryContext oldcxt;
+
+	if (!OidIsValid(opclass))
+		opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+
+	oldcxt = MemoryContextSwitchTo(CurTransactionContext);
+	/* cppcheck-suppress unknownEvaluationOrder */
+	oids = list_make2_oid(typoid, opclass);
+	Assert(processed);
+	if (*processed && list_member(*processed, oids))
+		return;
+	else
+	{
+		(*processed) = lappend(*processed, oids);
+	}
+	MemoryContextSwitchTo(oldcxt);
 
 	tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typoid));
 	Assert(tuple);
 	typeform = (Form_pg_type) GETSTRUCT(tuple);
 
+	o_type_cache_add_if_needed(datoid, typoid, insert_lsn, NULL);
+	o_cache_type_opclasses(datoid, typoid, opclass, InvalidOid, insert_lsn,
+						   processed);
 	switch (typeform->typtype)
 	{
 		case TYPTYPE_COMPOSITE:
 			if (typeform->typtypmod == -1)
 			{
-				OClassArg	arg = {.sys_table = false};
+				int			i;
+				Relation	rel;
 
-				o_class_cache_add_if_needed(datoid, typeform->typrelid,
-											insert_lsn, (Pointer) &arg);
-				o_type_cache_add_if_needed(datoid, typeform->oid, insert_lsn,
-										   NULL);
+				o_class_cache_add_if_needed(datoid, typeform->typrelid, insert_lsn,
+											NULL);
+				rel = relation_open(typeform->typrelid, AccessShareLock);
+				for (i = 0; i < rel->rd_att->natts; i++)
+				{
+					FormData_pg_attribute *typcache_attr;
+
+					typcache_attr = &rel->rd_att->attrs[i];
+					if (!typcache_attr->attisdropped)
+						o_cache_type_safe(datoid, typcache_attr->atttypid,
+										  InvalidOid, insert_lsn,
+										  processed);
+				}
+				relation_close(rel, AccessShareLock);
 			}
 			break;
 		case TYPTYPE_RANGE:
 			{
+				HeapTuple	rangetup;
+				Form_pg_range rangeform;
 				XLogRecPtr	sys_lsn;
 				Oid			sys_datoid;
-				OClassArg	class_arg = {.sys_table = true};
 
 				o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
 				o_class_cache_add_if_needed(sys_datoid, RangeRelationId,
-											sys_lsn, (Pointer) &class_arg);
-				o_range_cache_add_if_needed(datoid, typeform->oid, insert_lsn,
+											sys_lsn, NULL);
+				o_range_cache_add_if_needed(datoid, typoid, insert_lsn,
 											NULL);
-				o_type_cache_add_if_needed(datoid, typeform->oid, insert_lsn,
-										   NULL);
-				o_range_cache_add_rngsubopc(datoid, typeform->oid, insert_lsn);
+				rangetup = SearchSysCache1(RANGETYPE, ObjectIdGetDatum(typoid));
+				if (!HeapTupleIsValid(rangetup))
+					elog(ERROR, "cache lookup failed for range (%u)", typoid);
+				rangeform = (Form_pg_range) GETSTRUCT(rangetup);
+				o_cache_type_safe(datoid, rangeform->rngsubtype,
+								  rangeform->rngsubopc, insert_lsn, processed);
+				if (OidIsValid(rangeform->rngcollation))
+					o_collation_cache_add_if_needed(datoid,
+													rangeform->rngcollation,
+													insert_lsn,
+													NULL);
+				ReleaseSysCache(rangetup);
 			}
 			break;
 		case TYPTYPE_MULTIRANGE:
 			{
 				XLogRecPtr	sys_lsn;
 				Oid			sys_datoid;
-				OClassArg	class_arg = {.sys_table = true};
+				HeapTuple	multirangetup;
+				Form_pg_range multirangeform;
 
+				multirangetup = SearchSysCache1(RANGEMULTIRANGE,
+												ObjectIdGetDatum(typoid));
+				if (!HeapTupleIsValid(multirangetup))
+					elog(ERROR, "cache lookup failed for multirange (%u)", typoid);
+				multirangeform = (Form_pg_range) GETSTRUCT(multirangetup);
 				o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
-				o_class_cache_add_if_needed(sys_datoid, RangeRelationId,
-											sys_lsn, (Pointer) &class_arg);
-				o_multirange_cache_add_if_needed(datoid, typeform->oid,
-												 insert_lsn, NULL);
-				o_type_cache_add_if_needed(datoid, typeform->oid, insert_lsn,
-										   NULL);
+				o_class_cache_add_if_needed(sys_datoid, RangeRelationId, sys_lsn,
+											NULL);
+				o_multirange_cache_add_if_needed(datoid, typoid, insert_lsn, NULL);
+				o_cache_type_safe(datoid, multirangeform->rngtypid,
+								  multirangeform->rngsubopc, insert_lsn,
+								  processed);
+				ReleaseSysCache(multirangetup);
 			}
 			break;
 		case TYPTYPE_ENUM:
 			{
 				XLogRecPtr	sys_lsn;
 				Oid			sys_datoid;
-				OClassArg	class_arg = {.sys_table = true};
 
 				o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
 				o_class_cache_add_if_needed(sys_datoid, EnumRelationId, sys_lsn,
-											(Pointer) &class_arg);
-				o_type_cache_add_if_needed(datoid, typeform->oid, insert_lsn,
-										   NULL);
-				o_enum_cache_add_all(datoid, typeform->oid, insert_lsn);
+											NULL);
+				o_enum_cache_add_all(datoid, typoid, insert_lsn);
 			}
 			break;
 		case TYPTYPE_DOMAIN:
-			custom_type_add_if_needed(datoid, typeform->typbasetype,
-									  insert_lsn);
+			o_cache_type_safe(datoid, typeform->typbasetype, InvalidOid,
+							  insert_lsn, processed);
 			break;
 		default:
 			if (typeform->typcategory == TYPCATEGORY_ARRAY)
 			{
-				o_composite_type_element_save(datoid, typeform->typelem,
-											  insert_lsn);
+				o_cache_type_safe(datoid, typeform->typelem, InvalidOid,
+								  insert_lsn, processed);
 			}
 			break;
 	}
@@ -1393,11 +1541,242 @@ custom_type_add_if_needed(Oid datoid, Oid typoid, XLogRecPtr insert_lsn)
 }
 
 /*
+ * Find a hash function for the type given its btree opclass.  Looks up the
+ * equality operator of the btree opclass, then searches for a hash opclass
+ * that uses the same equality operator, and returns the hash procedure from
+ * that hash opclass.  Returns InvalidOid if no matching hash procedure exists.
+ */
+Oid
+o_get_hash_proc_by_btree_opclass(Oid btreeOpclass)
+{
+	Oid			btreeOpfamily;
+	Oid			inputType;
+	Oid			equalOp;
+	RegProcedure result;
+
+	btreeOpfamily = get_opclass_family(btreeOpclass);
+	inputType = get_opclass_input_type(btreeOpclass);
+	Assert(OidIsValid(btreeOpfamily));
+	equalOp = get_opfamily_member(btreeOpfamily, inputType, inputType, BTEqualStrategyNumber);
+	if (!OidIsValid(equalOp))
+		return InvalidOid;
+
+	if (get_op_hash_functions(equalOp, &result, NULL))
+		return result;
+	else
+		return InvalidOid;
+}
+
+bool
+custom_type_try_add_hash_fn_if_needed(Oid typoid, Oid opclass, List **processed)
+{
+	bool		hashable = true;
+	Form_pg_type typeform;
+	HeapTuple	tuple = NULL;
+	Oid			hash_fn_oid;
+
+	tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typoid));
+	Assert(tuple);
+	typeform = (Form_pg_type) GETSTRUCT(tuple);
+
+	hash_fn_oid = o_get_hash_proc_by_btree_opclass(opclass);
+	hashable = OidIsValid(hash_fn_oid);
+
+	if (hashable)
+	{
+		o_validate_function_by_oid(hash_fn_oid,
+								   " should be used as hash function "
+								   "for type of column used in orioledb index");
+		o_collect_function_by_oid(hash_fn_oid, InvalidOid, processed);
+		switch (typeform->typtype)
+		{
+			case TYPTYPE_COMPOSITE:
+				if (typeform->typtypmod == -1)
+				{
+					int			i;
+					Relation	rel;
+
+					rel = relation_open(typeform->typrelid, AccessShareLock);
+					for (i = 0; i < rel->rd_att->natts; i++)
+					{
+						FormData_pg_attribute *typcache_attr;
+
+						typcache_attr = &rel->rd_att->attrs[i];
+						if (!typcache_attr->attisdropped)
+						{
+							typoid = typcache_attr->atttypid;
+							opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+							hashable = custom_type_try_add_hash_fn_if_needed(typoid, opclass, processed);
+						}
+
+						if (!hashable)
+							break;
+					}
+					relation_close(rel, AccessShareLock);
+				}
+				break;
+			case TYPTYPE_RANGE:
+				{
+					HeapTuple	rangetup;
+					Form_pg_range rangeform;
+
+					rangetup = SearchSysCache1(RANGETYPE, ObjectIdGetDatum(typoid));
+					if (!HeapTupleIsValid(rangetup))
+						elog(ERROR, "cache lookup failed for range (%u)", typoid);
+					rangeform = (Form_pg_range) GETSTRUCT(rangetup);
+
+					typoid = rangeform->rngsubtype;
+					opclass = rangeform->rngsubopc;
+					hashable = custom_type_try_add_hash_fn_if_needed(typoid, opclass, processed);
+					ReleaseSysCache(rangetup);
+				}
+				break;
+			case TYPTYPE_MULTIRANGE:
+				{
+					HeapTuple	rangetup;
+					Form_pg_range rangeform;
+
+					rangetup = SearchSysCache1(RANGEMULTIRANGE,
+											   ObjectIdGetDatum(typoid));
+					if (!HeapTupleIsValid(rangetup))
+						elog(ERROR, "cache lookup failed for range (%u)", typoid);
+					rangeform = (Form_pg_range) GETSTRUCT(rangetup);
+
+					typoid = rangeform->rngsubtype;
+					opclass = rangeform->rngsubopc;
+					hashable = custom_type_try_add_hash_fn_if_needed(typoid, opclass, processed);
+					ReleaseSysCache(rangetup);
+				}
+				break;
+			case TYPTYPE_ENUM:
+				break;
+			case TYPTYPE_DOMAIN:
+				{
+					typoid = typeform->typbasetype;
+					opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+					hashable = custom_type_try_add_hash_fn_if_needed(typoid, opclass, processed);
+				}
+				break;
+			default:
+				if (typeform->typcategory == TYPCATEGORY_ARRAY)
+				{
+					typoid = typeform->typelem;
+					opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+					hashable = custom_type_try_add_hash_fn_if_needed(typoid, opclass, processed);
+				}
+				break;
+		}
+	}
+	if (tuple != NULL)
+		ReleaseSysCache(tuple);
+	return hashable;
+}
+
+void
+o_validate_composite_type(Oid typoid, Oid opclass)
+{
+	Form_pg_type typeform;
+	HeapTuple	tuple = NULL;
+
+	tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typoid));
+	Assert(tuple);
+	typeform = (Form_pg_type) GETSTRUCT(tuple);
+
+	if (OidIsValid(opclass))
+	{
+		switch (typeform->typtype)
+		{
+			case TYPTYPE_COMPOSITE:
+				if (typeform->typtypmod == -1)
+				{
+					int			i;
+					Relation	rel;
+
+					rel = relation_open(typeform->typrelid, AccessShareLock);
+					for (i = 0; i < rel->rd_att->natts; i++)
+					{
+						FormData_pg_attribute *typcache_attr;
+
+						typcache_attr = &rel->rd_att->attrs[i];
+						if (!typcache_attr->attisdropped)
+						{
+							typoid = typcache_attr->atttypid;
+							opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+							o_validate_composite_type(typoid, opclass);
+						}
+					}
+					relation_close(rel, AccessShareLock);
+				}
+				break;
+			case TYPTYPE_RANGE:
+				{
+					HeapTuple	rangetup;
+					Form_pg_range rangeform;
+
+					rangetup = SearchSysCache1(RANGETYPE, ObjectIdGetDatum(typoid));
+					if (!HeapTupleIsValid(rangetup))
+						elog(ERROR, "cache lookup failed for range (%u)", typoid);
+					rangeform = (Form_pg_range) GETSTRUCT(rangetup);
+
+					typoid = rangeform->rngsubtype;
+					opclass = rangeform->rngsubopc;
+					o_validate_composite_type(typoid, opclass);
+					ReleaseSysCache(rangetup);
+				}
+				break;
+			case TYPTYPE_MULTIRANGE:
+				{
+					HeapTuple	rangetup;
+					Form_pg_range rangeform;
+
+					rangetup = SearchSysCache1(RANGEMULTIRANGE,
+											   ObjectIdGetDatum(typoid));
+					if (!HeapTupleIsValid(rangetup))
+						elog(ERROR, "cache lookup failed for range (%u)", typoid);
+					rangeform = (Form_pg_range) GETSTRUCT(rangetup);
+
+					typoid = rangeform->rngsubtype;
+					opclass = rangeform->rngsubopc;
+					o_validate_composite_type(typoid, opclass);
+					ReleaseSysCache(rangetup);
+				}
+				break;
+			case TYPTYPE_ENUM:
+				break;
+			case TYPTYPE_DOMAIN:
+				{
+					typoid = typeform->typbasetype;
+					opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+					o_validate_composite_type(typoid, opclass);
+				}
+				break;
+			default:
+				if (typeform->typcategory == TYPCATEGORY_ARRAY)
+				{
+					typoid = typeform->typelem;
+					opclass = GetDefaultOpClass(typoid, BTREE_AM_OID);
+					o_validate_composite_type(typoid, opclass);
+				}
+				break;
+		}
+	}
+	if (tuple != NULL)
+		ReleaseSysCache(tuple);
+
+	if (!OidIsValid(opclass))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FUNCTION),
+				 errmsg("could not identify a comparison function for type \"%s\" used in btree index field",
+						format_type_be(typoid)),
+				 errdetail("not allowing it here, because any inserts in such index will break recovery for orioledb tables")));
+}
+
+/*
  * Inserts type elements for all fields of the o_table to the orioledb sys
  * cache.
  */
 void
-custom_types_add_all(OTable *o_table, OTableIndex *o_table_index)
+o_cache_index_types(OTable *o_table, OTableIndex *o_table_index)
 {
 	int			cur_field;
 	XLogRecPtr	cur_lsn;
@@ -1407,93 +1786,58 @@ custom_types_add_all(OTable *o_table, OTableIndex *o_table_index)
 	for (cur_field = 0; cur_field < o_table_index->nfields; cur_field++)
 	{
 		int			attnum = o_table_index->fields[cur_field].attnum;
+		Oid			opclass = o_table_index->fields[cur_field].opclass;
 		Oid			typid;
+		List	   *processed = NIL;
 
 		if (attnum != EXPR_ATTNUM)
 			typid = o_table->fields[attnum].typid;
 		else
 			typid = o_table_index->exprfields[expr_field++].typid;
-		custom_type_add_if_needed(o_table->oids.datoid, typid, cur_lsn);
+		o_cache_type_safe(o_table->oids.datoid, typid, opclass, cur_lsn,
+						  &processed);
+		list_free_deep(processed);
 	}
+
 }
 
+/*
+ * Inserts opclasses for all fields of the o_table to the opclass B-tree.
+ */
 void
-o_composite_type_element_save(Oid datoid, Oid typoid, XLogRecPtr insert_lsn)
+o_cache_table_types(OTable *o_table)
 {
-	Oid			default_btree_opclass;
-	Oid			default_hash_opclass;
+	XLogRecPtr	cur_lsn;
+	Oid			datoid;
+	XLogRecPtr	sys_lsn;
+	Oid			sys_datoid;
+	List	   *processed = NIL;
 
-	custom_type_add_if_needed(datoid, typoid, insert_lsn);
-	o_type_cache_add_if_needed(datoid, typoid, insert_lsn, NULL);
-	default_btree_opclass = o_type_cache_default_opclass(typoid, BTREE_AM_OID);
-	if (OidIsValid(default_btree_opclass))
-	{
-		XLogRecPtr	sys_lsn;
-		Oid			sys_datoid;
-		OClassArg	class_arg = {.sys_table = true};
-		Oid			btree_opf;
-		Oid			btree_opintype;
+	o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
+	o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId, sys_lsn,
+								NULL);
 
-		btree_opf = get_opclass_family(default_btree_opclass);
-		btree_opintype = get_opclass_input_type(default_btree_opclass);
+	o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
+	datoid = o_table->oids.datoid;
 
-		o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
-		o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId,
-									sys_lsn, (Pointer) &class_arg);
-		o_opclass_cache_add_if_needed(datoid, default_btree_opclass,
-									  insert_lsn, NULL);
-		o_class_cache_add_if_needed(sys_datoid,
-									AccessMethodProcedureRelationId, sys_lsn,
-									(Pointer) &class_arg);
-		o_amproc_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-									 btree_opintype, BTORDER_PROC, insert_lsn,
-									 NULL);
-		o_class_cache_add_if_needed(sys_datoid, AccessMethodOperatorRelationId,
-									sys_lsn, (Pointer) &class_arg);
-		o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-										 btree_opintype, BTLessStrategyNumber,
-										 insert_lsn, NULL);
-		o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-										 btree_opintype,
-										 BTLessEqualStrategyNumber, insert_lsn,
-										 NULL);
-		o_amop_strat_cache_add_if_needed(datoid, btree_opf, btree_opintype,
-										 btree_opintype, BTEqualStrategyNumber,
-										 insert_lsn, NULL);
-	}
-	default_hash_opclass = o_type_cache_default_opclass(typoid, HASH_AM_OID);
-	if (OidIsValid(default_hash_opclass))
-	{
-		XLogRecPtr	sys_lsn;
-		Oid			sys_datoid;
-		OClassArg	class_arg = {.sys_table = true};
-		Oid			hash_opf;
-		Oid			hash_opintype;
+	o_database_cache_add_if_needed(Template1DbOid, Template1DbOid, cur_lsn, NULL);
 
-		hash_opf = get_opclass_family(default_hash_opclass);
-		hash_opintype = get_opclass_input_type(default_hash_opclass);
+	/*
+	 * Inserts opclasses for TOAST index.
+	 */
+	o_cache_type(datoid, INT2OID, InvalidOid, cur_lsn);
+	o_collect_function_by_oid(F_HASHINT2, InvalidOid, &processed);
 
-		o_sys_cache_set_datoid_lsn(&sys_lsn, &sys_datoid);
-		o_class_cache_add_if_needed(sys_datoid, OperatorClassRelationId,
-									sys_lsn, (Pointer) &class_arg);
-		o_opclass_cache_add_if_needed(datoid, default_hash_opclass, insert_lsn,
-									  NULL);
-		o_class_cache_add_if_needed(sys_datoid,
-									AccessMethodProcedureRelationId, sys_lsn,
-									(Pointer) &class_arg);
-		o_amproc_cache_add_if_needed(datoid, hash_opf, hash_opintype,
-									 hash_opintype, HASHSTANDARD_PROC,
-									 insert_lsn, NULL);
-		o_amproc_cache_add_if_needed(datoid, hash_opf, hash_opintype,
-									 hash_opintype, HASHEXTENDED_PROC,
-									 insert_lsn, NULL);
+	o_cache_type(datoid, INT4OID, InvalidOid, cur_lsn);
+	o_collect_function_by_oid(F_HASHINT4, InvalidOid, &processed);
 
-		o_class_cache_add_if_needed(sys_datoid, AccessMethodOperatorRelationId,
-									sys_lsn, (Pointer) &class_arg);
-		o_amop_strat_cache_add_if_needed(datoid, hash_opf, hash_opintype,
-										 hash_opintype, HTEqualStrategyNumber,
-										 insert_lsn, NULL);
-	}
+	/*
+	 * Inserts opclass for default index.
+	 */
+	Assert(o_table->nindices == 0);
+	o_cache_type(datoid, TIDOID, InvalidOid, cur_lsn);
+	o_collect_function_by_oid(F_HASHTID, InvalidOid, &processed);
+	list_free_deep(processed);
 }
 
 static CatCTup *

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -362,33 +362,6 @@ o_deparse_expression(char *expr_str, Oid relid)
 	return TextDatumGetCString(expr);
 }
 
-/*
- * Find a hash function for the type given its btree opclass.  Looks up the
- * equality operator of the btree opclass, then searches for a hash opclass
- * that uses the same equality operator, and returns the hash procedure from
- * that hash opclass.  Returns InvalidOid if no matching hash procedure exists.
- */
-static Oid
-get_hash_proc_by_btree_opclass(Oid btreeOpclass)
-{
-	Oid			btreeOpfamily;
-	Oid			inputType;
-	Oid			equalOp;
-	RegProcedure result;
-
-	btreeOpfamily = get_opclass_family(btreeOpclass);
-	inputType = get_opclass_input_type(btreeOpclass);
-	Assert(OidIsValid(btreeOpfamily));
-	equalOp = get_opfamily_member(btreeOpfamily, inputType, inputType, BTEqualStrategyNumber);
-	if (!OidIsValid(equalOp))
-		return InvalidOid;
-
-	if (get_op_hash_functions(equalOp, &result, NULL))
-		return result;
-	else
-		return InvalidOid;
-}
-
 void
 o_table_fill_index(OTable *o_table, OIndexNumber ix_num, Relation index_rel)
 {
@@ -580,9 +553,13 @@ o_table_fill_index(OTable *o_table, OIndexNumber ix_num, Relation index_rel)
 		{
 			int16		opt = index_rel->rd_indoption[keyno];
 			Oid			typid;
+			bool		hashable = true;
+			List	   *processed = NIL;
 
 			if (AttributeNumberIsValid(attnum))
+			{
 				typid = o_table->fields[ix_field->attnum].typid;
+			}
 			else
 			{
 				Assert(exprField != NULL);
@@ -591,6 +568,8 @@ o_table_fill_index(OTable *o_table, OIndexNumber ix_num, Relation index_rel)
 			}
 			ix_field->collation = index_rel->rd_indcollation[keyno];
 			ix_field->opclass = indclass->values[keyno];
+
+			o_validate_composite_type(typid, ix_field->opclass);
 
 			ix_field->ordering = SORTBY_DEFAULT;
 			ix_field->nullsOrdering = SORTBY_NULLS_DEFAULT;
@@ -605,59 +584,20 @@ o_table_fill_index(OTable *o_table, OIndexNumber ix_num, Relation index_rel)
 				ix_field->nullsOrdering = SORTBY_NULLS_FIRST;
 			}
 
-			ix_field->hash_fn_oid = get_hash_proc_by_btree_opclass(ix_field->opclass);
+			hashable = custom_type_try_add_hash_fn_if_needed(typid,
+															 ix_field->opclass,
+															 &processed);
+			list_free_deep(processed);
 
-			if (OidIsValid(ix_field->hash_fn_oid))
+			if (hashable)
 			{
-				o_validate_function_by_oid(ix_field->hash_fn_oid,
-										   " should be used as hash function "
-										   "for type of column used in orioledb index");
-				o_collect_function_by_oid(ix_field->hash_fn_oid, InvalidOid);
-				/* TODO: Move this to something like custom_type_add_if_needed */
-				{
-					Form_pg_type typeform;
-					HeapTuple	tuple = NULL;
-
-					tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typid));
-					Assert(tuple);
-					typeform = (Form_pg_type) GETSTRUCT(tuple);
-					if (typeform->typtype == TYPTYPE_RANGE)
-					{
-						HeapTuple	rangetup;
-						Form_pg_range rangeform;
-						XLogRecPtr	insert_lsn;
-						Oid			rnghashsubopc;
-						Oid			rnghashsubopf;
-						Oid			rnghashsubinput;
-
-						rangetup = SearchSysCache1(RANGETYPE, typid);
-						if (!HeapTupleIsValid(rangetup))
-							elog(ERROR, "cache lookup failed for range (%u)", typid);
-						rangeform = (Form_pg_range) GETSTRUCT(rangetup);
-
-						rnghashsubopc = GetDefaultOpClass(rangeform->rngsubtype, HASH_AM_OID);
-						rnghashsubinput = get_opclass_input_type(rnghashsubopc);
-						rnghashsubopf = get_opclass_family(rnghashsubopc);
-
-						o_sys_cache_set_datoid_lsn(&insert_lsn, NULL);
-						o_opclass_cache_add_if_needed(o_table->oids.datoid,
-													  rnghashsubopc,
-													  insert_lsn, NULL);
-						o_amproc_cache_add_if_needed(o_table->oids.datoid,
-													 rnghashsubopf, rnghashsubinput,
-													 rnghashsubinput, HASHSTANDARD_PROC, insert_lsn,
-													 NULL);
-						ReleaseSysCache(rangetup);
-
-					}
-					ReleaseSysCache(tuple);
-				}
+				ix_field->hash_fn_oid = o_get_hash_proc_by_btree_opclass(ix_field->opclass);
 			}
 			else
 			{
 				ix_field->hash_fn_oid = O_DEFAULT_HASH_FN_OID;
 				ereport(WARNING,
-						(errmsg("failed to fetch the hash function for btree opclass%s", generate_opclass_name(ix_field->opclass)),
+						(errmsg("failed to fetch the hash function for btree opclass %s", generate_opclass_name(ix_field->opclass)),
 						 errdetail("Recovery might be slow due to inability to distribute values among the workers.")));
 			}
 		}
@@ -1485,8 +1425,6 @@ o_tables_update(OTable *table, OXid oxid, CommitSeqNo csn)
 void
 o_tables_after_update(OTable *o_table, OXid oxid, CommitSeqNo csn)
 {
-	o_opclass_cache_add_table(o_table);
-
 	/*
 	 * @NOTE o_indices_update(o_table, PrimaryIndexNumber, oxid, csn); moved
 	 * out from here
@@ -2248,7 +2186,6 @@ o_tables_drop_columns_with_type_callback(OTable *o_table, void *arg)
 		o_tables_table_meta_unlock(o_table, InvalidOid);
 	}
 }
-
 
 /*
  * Drops all columns of a specific type

--- a/src/catalog/o_type_cache.c
+++ b/src/catalog/o_type_cache.c
@@ -104,17 +104,7 @@ o_type_cache_fill_entry(Pointer *entry_ptr, OSysCacheKey *key, Pointer arg)
 	o_type->typsubscript = typeform->typsubscript;
 
 	o_type->default_btree_opclass = GetDefaultOpClass(typeoid, BTREE_AM_OID);
-	if (!OidIsValid(o_type->default_btree_opclass) &&
-		typeform->typtype != TYPTYPE_PSEUDO)
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_FUNCTION),
-				 errmsg("could not identify a comparison function for type %s",
-						format_type_be(typeoid))));
 	o_type->default_hash_opclass = GetDefaultOpClass(typeoid, HASH_AM_OID);
-
-	if (OidIsValid(o_type->typelem))
-		o_type_cache_add_if_needed(key->common.datoid, o_type->typelem,
-								   key->common.lsn, NULL);
 
 	ReleaseSysCache(typetup);
 }

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -877,7 +877,7 @@ orioledb_relation_set_new_filenode(Relation rel,
 											 old_o_table->fillfactor,
 											 rel->rd_rel->reltablespace,
 											 old_o_table->index_bridging);
-		o_opclass_cache_add_table(new_o_table);
+		o_cache_table_types(new_o_table);
 
 		/* Copy compression settings from old table */
 		new_o_table->default_compress = old_o_table->default_compress;

--- a/src/utils/planner.c
+++ b/src/utils/planner.c
@@ -583,14 +583,13 @@ o_collect_function(Node *node, void *context)
 {
 	XLogRecPtr	cur_lsn;
 	Oid			datoid;
-	OClassArg	arg = {.sys_table = true};
+	List	  **processed = (List **) context;
 
 	if (node == NULL)
 		return false;
 
 	o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
-	o_class_cache_add_if_needed(datoid, TypeRelationId, cur_lsn,
-								(Pointer) &arg);
+	o_class_cache_add_if_needed(datoid, TypeRelationId, cur_lsn, NULL);
 	switch (nodeTag(node))
 	{
 		case T_Aggref:
@@ -604,7 +603,7 @@ o_collect_function(Node *node, void *context)
 		case T_RowCompareExpr:
 		case T_FunctionScan:
 			o_class_cache_add_if_needed(datoid, ProcedureRelationId,
-										cur_lsn, (Pointer) &arg);
+										cur_lsn, NULL);
 			break;
 		default:
 			break;
@@ -621,31 +620,46 @@ o_collect_function(Node *node, void *context)
 				OpExpr	   *opexpr = (OpExpr *) node;
 
 				o_class_cache_add_if_needed(datoid, OperatorRelationId, cur_lsn,
-											(Pointer) &arg);
+											NULL);
 				o_operator_cache_add_if_needed(datoid, opexpr->opno,
 											   cur_lsn, NULL);
-				o_type_cache_add_if_needed(datoid, opexpr->opresulttype,
-										   cur_lsn, NULL);
+				o_cache_type_safe(datoid, opexpr->opresulttype, InvalidOid,
+								  cur_lsn, processed);
 			}
 			break;
 		case T_Aggref:
 			{
 				Aggref	   *aggref = (Aggref *) node;
 				ListCell   *lc;
+				HeapTuple	aggtup;
+				Form_pg_aggregate aggform;
 
 				o_class_cache_add_if_needed(datoid, AggregateRelationId, cur_lsn,
-											(Pointer) &arg);
+											NULL);
 				o_class_cache_add_if_needed(datoid, OperatorRelationId, cur_lsn,
-											(Pointer) &arg);
+											NULL);
+
+				aggtup = SearchSysCache1(AGGFNOID,
+										 ObjectIdGetDatum(aggref->aggfnoid));
+				if (!HeapTupleIsValid(aggtup))
+					elog(ERROR, "cache lookup failed for aggregate function %u",
+						 aggref->aggfnoid);
+				aggform = (Form_pg_aggregate) GETSTRUCT(aggtup);
+				o_cache_type_safe(datoid, aggform->aggtranstype, InvalidOid,
+								  cur_lsn, processed);
+				o_cache_type_safe(datoid, aggform->aggmtranstype, InvalidOid,
+								  cur_lsn, processed);
+				ReleaseSysCache(aggtup);
+
 				o_aggregate_cache_add_if_needed(datoid, aggref->aggfnoid,
 												cur_lsn, NULL);
-				o_type_cache_add_if_needed(datoid, aggref->aggtype,
-										   cur_lsn, NULL);
+				o_cache_type_safe(datoid, aggref->aggtype, InvalidOid, cur_lsn,
+								  processed);
 
 				foreach(lc, aggref->aggargtypes)
 				{
-					o_type_cache_add_if_needed(datoid, lfirst_oid(lc),
-											   cur_lsn, NULL);
+					o_cache_type_safe(datoid, lfirst_oid(lc), InvalidOid, cur_lsn,
+									  processed);
 				}
 			}
 			break;
@@ -661,7 +675,7 @@ o_collect_function(Node *node, void *context)
 					int			j;
 
 					o_class_cache_add_if_needed(datoid, OperatorRelationId,
-												cur_lsn, (Pointer) &arg);
+												cur_lsn, NULL);
 					o_operator_cache_add_if_needed(datoid, eq_opr, cur_lsn, NULL);
 
 					/*
@@ -680,7 +694,7 @@ o_collect_function(Node *node, void *context)
 
 						o_class_cache_add_if_needed(datoid,
 													AccessMethodOperatorRelationId,
-													cur_lsn, (Pointer) &arg);
+													cur_lsn, NULL);
 						o_amop_cache_add_if_needed(datoid, aform->amopopr,
 												   aform->amoppurpose,
 												   aform->amopfamily, cur_lsn,
@@ -705,7 +719,7 @@ o_collect_function(Node *node, void *context)
 
 							o_class_cache_add_if_needed(datoid,
 														AccessMethodProcedureRelationId,
-														cur_lsn, (Pointer) &arg);
+														cur_lsn, NULL);
 							o_amproc_cache_add_if_needed(datoid, aform->amopfamily,
 														 aform->amoplefttype,
 														 aform->amoplefttype,
@@ -742,48 +756,63 @@ o_collect_function(Node *node, void *context)
 				WindowFunc *window_func = (WindowFunc *) node;
 
 				o_class_cache_add_if_needed(datoid, AggregateRelationId, cur_lsn,
-											(Pointer) &arg);
+											NULL);
 				o_class_cache_add_if_needed(datoid, OperatorRelationId, cur_lsn,
-											(Pointer) &arg);
+											NULL);
 				o_aggregate_cache_add_if_needed(datoid, window_func->winfnoid,
 												cur_lsn, NULL);
-				o_type_cache_add_if_needed(datoid, window_func->wintype,
-										   cur_lsn, NULL);
+				o_cache_type_safe(datoid, window_func->wintype, InvalidOid,
+								  cur_lsn, processed);
 			}
 			break;
 		case T_FuncExpr:
 			{
 				FuncExpr   *func_expr = (FuncExpr *) node;
 
-				o_type_cache_add_if_needed(datoid, func_expr->funcresulttype,
-										   cur_lsn, NULL);
+				o_cache_type_safe(datoid, func_expr->funcresulttype,
+								  InvalidOid, cur_lsn, processed);
 			}
 			break;
 		case T_MinMaxExpr:
 			{
 				MinMaxExpr *minmaxexpr = (MinMaxExpr *) node;
 
-				o_type_cache_add_if_needed(datoid, minmaxexpr->minmaxtype,
-										   cur_lsn, NULL);
+				o_cache_type_safe(datoid, minmaxexpr->minmaxtype,
+								  InvalidOid, cur_lsn, processed);
 			}
 			break;
 		case T_CoerceViaIO:
 			{
 				CoerceViaIO *iocoerce = (CoerceViaIO *) node;
 
-				o_type_cache_add_if_needed(datoid,
-										   exprType((Node *) iocoerce->arg),
-										   cur_lsn, NULL);
-				o_type_cache_add_if_needed(datoid, iocoerce->resulttype,
-										   cur_lsn, NULL);
+				o_cache_type_safe(datoid, exprType((Node *) iocoerce->arg),
+								  InvalidOid, cur_lsn, processed);
+				o_cache_type_safe(datoid, iocoerce->resulttype, InvalidOid,
+								  cur_lsn, processed);
 			}
 			break;
 		case T_RowExpr:
 			{
 				RowExpr    *row_expr = (RowExpr *) node;
 
-				o_type_cache_add_if_needed(datoid, row_expr->row_typeid,
-										   cur_lsn, NULL);
+				o_cache_type_safe(datoid, row_expr->row_typeid, InvalidOid,
+								  cur_lsn, processed);
+			}
+			break;
+		case T_FieldSelect:
+			{
+				FieldSelect *field_select = (FieldSelect *) node;
+
+				o_cache_type_safe(datoid, field_select->resulttype, InvalidOid,
+								  cur_lsn, processed);
+			}
+			break;
+		case T_Var:
+			{
+				Var		   *var = (Var *) node;
+
+				o_cache_type_safe(datoid, var->vartype, InvalidOid, cur_lsn,
+								  processed);
 			}
 			break;
 		default:
@@ -804,11 +833,14 @@ o_collect_function(Node *node, void *context)
 void
 o_collect_funcexpr(Node *node)
 {
+	List	   *processed = NIL;
+
 	if (!node)
 		return;
 
 	expression_tree_walker(o_wrap_top_funcexpr(node), o_collect_function,
-						   NULL);
+						   &processed);
+	list_free_deep(processed);
 }
 
 void
@@ -817,17 +849,23 @@ o_collect_function_walker(Oid functionId, Oid inputcollid, List *args,
 {
 	XLogRecPtr	cur_lsn;
 	Oid			datoid;
-	OClassArg	arg = {.sys_table = true};
 	HeapTuple	procedureTuple;
 	Form_pg_proc procedureStruct;
+	int			i;
+	List	  **processed = (List **) context;
+	OProcArg	arg = {.collation = inputcollid,.processed = processed};
 
 	procedureTuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(functionId));
 	procedureStruct = (Form_pg_proc) GETSTRUCT(procedureTuple);
 	o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
-	o_proc_cache_add_if_needed(datoid, functionId, cur_lsn,
-							   (Pointer) &inputcollid);
-	o_class_cache_add_if_needed(datoid, AuthIdRelationId, cur_lsn,
-								(Pointer) &arg);
+	o_class_cache_add_if_needed(datoid, TypeRelationId, cur_lsn, NULL);
+	o_proc_cache_add_if_needed(datoid, functionId, cur_lsn, (Pointer) &arg);
+	o_class_cache_add_if_needed(datoid, AuthIdRelationId, cur_lsn, NULL);
+	for (i = 0; i < procedureStruct->pronargs; i++)
+	{
+		o_cache_type_safe(datoid, procedureStruct->proargtypes.values[i],
+						  InvalidOid, cur_lsn, processed);
+	}
 
 	if (procedureStruct->prolang == SQLlanguageId &&
 		procedureStruct->prokind == PROKIND_FUNCTION)
@@ -839,7 +877,7 @@ o_collect_function_walker(Oid functionId, Oid inputcollid, List *args,
 }
 
 void
-o_collect_function_by_oid(Oid procoid, Oid inputcollid)
+o_collect_function_by_oid(Oid procoid, Oid inputcollid, List **processed)
 {
 	FuncExpr   *fexpr;
 	HeapTuple	procedureTuple;
@@ -862,7 +900,7 @@ o_collect_function_by_oid(Oid procoid, Oid inputcollid)
 	fexpr->location = -1;
 
 	expression_tree_walker(o_wrap_top_funcexpr((Node *) fexpr),
-						   o_collect_function, NULL);
+						   o_collect_function, processed);
 
 	ReleaseSysCache(procedureTuple);
 }
@@ -873,6 +911,7 @@ o_collect_op_by_oid(Oid opoid)
 	OpExpr	   *op_expr;
 	HeapTuple	opTuple;
 	Form_pg_operator opStruct;
+	List	   *processed = NIL;
 
 	opTuple = SearchSysCache1(OPEROID, ObjectIdGetDatum(opoid));
 	if (!HeapTupleIsValid(opTuple))
@@ -889,9 +928,10 @@ o_collect_op_by_oid(Oid opoid)
 	op_expr->args = NIL;		/* TODO: Add normal arg processing when needed */
 	op_expr->location = -1;
 	expression_tree_walker(o_wrap_top_funcexpr((Node *) op_expr),
-						   o_collect_function, NULL);
+						   o_collect_function, &processed);
 
 	ReleaseSysCache(opTuple);
+	list_free_deep(processed);
 }
 
 static bool
@@ -1338,7 +1378,7 @@ plannedstatement_tree_walker(PlannedStmt *pstmt,
 }
 
 void
-o_collect_functions_pstmt(PlannedStmt *pstmt)
+o_collect_functions_pstmt(PlannedStmt *pstmt, List **processed)
 {
-	plannedstatement_tree_walker(pstmt, o_collect_function, NULL);
+	plannedstatement_tree_walker(pstmt, o_collect_function, processed);
 }

--- a/test/expected/btree_sys_check.out
+++ b/test/expected/btree_sys_check.out
@@ -157,28 +157,35 @@ SELECT regexp_replace(
 		'\d+, \(\d+\), [A-F0-9]+/[A-F0-9]+, ',
 		'NNN, (NNN), X/X, ',
 		'g');
-                                                     regexp_replace                                                      
--------------------------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                                                   +
- state = free, datoid equal, relnode equal, ix_type = primary, clean                                                    +
-     Leftmost, Rightmost                                                                                                +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                                                             +
-     Item 0: offset = 288, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 23, cmpOid: 351, ssupOid: 3130)    +
-     Item 1: offset = 352, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 21, cmpOid: 350, ssupOid: 3129)    +
-     Item 2: offset = 416, tuple = ((NNN, (NNN), X/X, N), opfamily: 1970, inputtype: 701, cmpOid: 355, ssupOid: 3133)   +
-     Item 3: offset = 480, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 20, cmpOid: 842, ssupOid: 3131)    +
-     Item 4: offset = 544, tuple = ((NNN, (NNN), X/X, N), opfamily: 1994, inputtype: 25, cmpOid: 360, ssupOid: 3255)    +
-     Item 5: offset = 608, tuple = ((NNN, (NNN), X/X, N), opfamily: 434, inputtype: 1114, cmpOid: 2045, ssupOid: 3137)  +
-     Item 6: offset = 672, tuple = ((NNN, (NNN), X/X, N), opfamily: 397, inputtype: 2277, cmpOid: 382, ssupOid: 0)      +
-     Item 7: offset = 736, tuple = ((NNN, (NNN), X/X, N), opfamily: 1971, inputtype: 701, cmpOid: 452, ssupOid: 444)    +
-     Item 8: offset = 800, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 23, cmpOid: 450, ssupOid: 425)     +
-     Item 9: offset = 864, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 20, cmpOid: 949, ssupOid: 442)     +
-     Item 10: offset = 928, tuple = ((NNN, (NNN), X/X, N), opfamily: 2994, inputtype: 2249, cmpOid: 2987, ssupOid: 0)   +
-     Item 11: offset = 992, tuple = ((NNN, (NNN), X/X, N), opfamily: 2040, inputtype: 1114, cmpOid: 2039, ssupOid: 3411)+
-     Item 12: offset = 1056, tuple = ((NNN, (NNN), X/X, N), opfamily: 2789, inputtype: 27, cmpOid: 2794, ssupOid: 0)    +
-     Item 13: offset = 1120, tuple = ((NNN, (NNN), X/X, N), opfamily: 3522, inputtype: 3500, cmpOid: 3514, ssupOid: 0)  +
-     Item 14: offset = 1184, tuple = ((NNN, (NNN), X/X, N), opfamily: 3901, inputtype: 3831, cmpOid: 3870, ssupOid: 0)  +
-                                                                                                                        +
+                                                      regexp_replace                                                      
+--------------------------------------------------------------------------------------------------------------------------
+ Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                                                    +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                                                     +
+     Leftmost, Rightmost                                                                                                 +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                                                              +
+     Item 0: offset = 304, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 23, cmpOid: 351, ssupOid: 3130)     +
+     Item 1: offset = 368, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 21, cmpOid: 350, ssupOid: 3129)     +
+     Item 2: offset = 432, tuple = ((NNN, (NNN), X/X, N), opfamily: 1970, inputtype: 701, cmpOid: 355, ssupOid: 3133)    +
+     Item 3: offset = 496, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 20, cmpOid: 842, ssupOid: 3131)     +
+     Item 4: offset = 560, tuple = ((NNN, (NNN), X/X, N), opfamily: 1994, inputtype: 25, cmpOid: 360, ssupOid: 3255)     +
+     Item 5: offset = 624, tuple = ((NNN, (NNN), X/X, N), opfamily: 434, inputtype: 1114, cmpOid: 2045, ssupOid: 3137)   +
+     Item 6: offset = 688, tuple = ((NNN, (NNN), X/X, N), opfamily: 397, inputtype: 2277, cmpOid: 382, ssupOid: 0)       +
+     Item 7: offset = 752, tuple = ((NNN, (NNN), X/X, N), opfamily: 627, inputtype: 2277, cmpOid: 626, ssupOid: 782)     +
+     Item 8: offset = 816, tuple = ((NNN, (NNN), X/X, N), opfamily: 1971, inputtype: 701, cmpOid: 452, ssupOid: 444)     +
+     Item 9: offset = 880, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 21, cmpOid: 449, ssupOid: 441)      +
+     Item 10: offset = 944, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 23, cmpOid: 450, ssupOid: 425)     +
+     Item 11: offset = 1008, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 20, cmpOid: 949, ssupOid: 442)    +
+     Item 12: offset = 1072, tuple = ((NNN, (NNN), X/X, N), opfamily: 2994, inputtype: 2249, cmpOid: 2987, ssupOid: 0)   +
+     Item 13: offset = 1136, tuple = ((NNN, (NNN), X/X, N), opfamily: 6194, inputtype: 2249, cmpOid: 6192, ssupOid: 6193)+
+     Item 14: offset = 1200, tuple = ((NNN, (NNN), X/X, N), opfamily: 1995, inputtype: 25, cmpOid: 400, ssupOid: 448)    +
+     Item 15: offset = 1264, tuple = ((NNN, (NNN), X/X, N), opfamily: 2040, inputtype: 1114, cmpOid: 2039, ssupOid: 3411)+
+     Item 16: offset = 1328, tuple = ((NNN, (NNN), X/X, N), opfamily: 2789, inputtype: 27, cmpOid: 2794, ssupOid: 0)     +
+     Item 17: offset = 1392, tuple = ((NNN, (NNN), X/X, N), opfamily: 2227, inputtype: 27, cmpOid: 2233, ssupOid: 2234)  +
+     Item 18: offset = 1456, tuple = ((NNN, (NNN), X/X, N), opfamily: 3522, inputtype: 3500, cmpOid: 3514, ssupOid: 0)   +
+     Item 19: offset = 1520, tuple = ((NNN, (NNN), X/X, N), opfamily: 3523, inputtype: 3500, cmpOid: 3515, ssupOid: 3414)+
+     Item 20: offset = 1584, tuple = ((NNN, (NNN), X/X, N), opfamily: 3901, inputtype: 3831, cmpOid: 3870, ssupOid: 0)   +
+     Item 21: offset = 1648, tuple = ((NNN, (NNN), X/X, N), opfamily: 3903, inputtype: 3831, cmpOid: 3902, ssupOid: 3417)+
+                                                                                                                         +
  
 (1 row)
 
@@ -346,33 +353,29 @@ SELECT regexp_replace(regexp_replace(
      Item 3: offset = 808, tuple = (((NNN, (NNN), X/X, N), 0), 108)                           +
      Item 4: offset = 976, tuple = (((NNN, (NNN), X/X, N), 0), 110)                           +
      Item 5: offset = 1152, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
-     Item 6: offset = 1320, tuple = (((NNN, (NNN), X/X, N), 0), 122)                          +
-     Item 7: offset = 1504, tuple = (((NNN, (NNN), X/X, N), 0), 122)                          +
-     Item 8: offset = 1688, tuple = (((NNN, (NNN), X/X, N), 0), 126)                          +
-     Item 9: offset = 1880, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
-     Item 10: offset = 2048, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
-     Item 11: offset = 2216, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 12: offset = 2384, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 13: offset = 2552, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
-     Item 14: offset = 2720, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
-     Item 15: offset = 2888, tuple = (((NNN, (NNN), X/X, N), 0), 114)                         +
-     Item 16: offset = 3064, tuple = (((NNN, (NNN), X/X, N), 0), 116)                         +
-     Item 17: offset = 3240, tuple = (((NNN, (NNN), X/X, N), 0), 100)                         +
-   Chunk 1: offset = 18, location = 3400, hikey location = 104                                +
-     Item 18: offset = 3432, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 19: offset = 3600, tuple = (((NNN, (NNN), X/X, N), 0), 112)                         +
-     Item 20: offset = 3776, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 21: offset = 3960, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 22: offset = 4144, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 23: offset = 4328, tuple = (((NNN, (NNN), X/X, N), 0), 124)                         +
-     Item 24: offset = 4512, tuple = (((NNN, (NNN), X/X, N), 0), 128)                         +
-     Item 25: offset = 4704, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 26: offset = 4888, tuple = (((NNN, (NNN), X/X, N), 0), 136)                         +
-     Item 27: offset = 5088, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 28: offset = 5256, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
-     Item 29: offset = 5424, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
-     Item 30: offset = 5592, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 31: offset = 5760, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
+     Item 6: offset = 1320, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
+     Item 7: offset = 1488, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
+     Item 8: offset = 1656, tuple = (((NNN, (NNN), X/X, N), 0), 106)                          +
+     Item 9: offset = 1824, tuple = (((NNN, (NNN), X/X, N), 0), 106)                          +
+     Item 10: offset = 1992, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
+     Item 11: offset = 2160, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
+     Item 12: offset = 2328, tuple = (((NNN, (NNN), X/X, N), 0), 114)                         +
+     Item 13: offset = 2504, tuple = (((NNN, (NNN), X/X, N), 0), 116)                         +
+     Item 14: offset = 2680, tuple = (((NNN, (NNN), X/X, N), 0), 100)                         +
+     Item 15: offset = 2840, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
+     Item 16: offset = 3008, tuple = (((NNN, (NNN), X/X, N), 0), 112)                         +
+   Chunk 1: offset = 17, location = 3184, hikey location = 104                                +
+     Item 17: offset = 3208, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 18: offset = 3392, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 19: offset = 3576, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 20: offset = 3760, tuple = (((NNN, (NNN), X/X, N), 0), 124)                         +
+     Item 21: offset = 3944, tuple = (((NNN, (NNN), X/X, N), 0), 128)                         +
+     Item 22: offset = 4136, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 23: offset = 4320, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
+     Item 24: offset = 4488, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
+     Item 25: offset = 4656, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
+     Item 26: offset = 4824, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
+     Item 27: offset = 4992, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
                                                                                               +
  
 (1 row)
@@ -398,17 +401,18 @@ SELECT regexp_replace(regexp_replace(
      Item 3: offset = 800, tuple = ((NNN, (NNN), X/X, N), typname: text, typlen: -1, typbyval: N, typalign: 'i', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'S', typispreferred: Y, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                   +
      Item 4: offset = 976, tuple = ((NNN, (NNN), X/X, N), typname: tid, typlen: NNN, typbyval: N, typalign: 's', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'U', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                   +
      Item 5: offset = 1152, tuple = ((NNN, (NNN), X/X, N), typname: float8, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'N', typispreferred: Y, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)               +
-     Item 6: offset = 1328, tuple = ((NNN, (NNN), X/X, N), typname: timestamp, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'D', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
-   Chunk 1: offset = 7, location = 1504, hikey location = 96                                                                                                                                                                                                                                                                                                                                                                                                    +
-     Item 7: offset = 1528, tuple = ((NNN, (NNN), X/X, N), typname: record, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                +
-     Item 8: offset = 1704, tuple = ((NNN, (NNN), X/X, N), typname: anyarray, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)              +
-     Item 9: offset = 1880, tuple = ((NNN, (NNN), X/X, N), typname: void, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                 +
-     Item 10: offset = 2056, tuple = ((NNN, (NNN), X/X, N), typname: internal, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
-     Item 11: offset = 2232, tuple = ((NNN, (NNN), X/X, N), typname: anyenum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
-     Item 12: offset = 2408, tuple = ((NNN, (NNN), X/X, N), typname: anyrange, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
-     Item 13: deleted, offset = 2584, tuple = ((NNN, (NNN), X/X, Y), typname: o_enum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'e', typcategory: 'E', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)     +
-     Item 14: deleted, offset = 2760, tuple = ((NNN, (NNN), X/X, Y), typname: custom_range, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'r', typcategory: 'R', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)+
-     Item 15: deleted, offset = 2936, tuple = ((NNN, (NNN), X/X, Y), typname: custom_type, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'c', typcategory: 'C', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN) +
+     Item 6: offset = 1328, tuple = ((NNN, (NNN), X/X, N), typname: _int4, typlen: -1, typbyval: N, typalign: 'i', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'A', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                 +
+     Item 7: offset = 1504, tuple = ((NNN, (NNN), X/X, N), typname: timestamp, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'D', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
+   Chunk 1: offset = 8, location = 1680, hikey location = 96                                                                                                                                                                                                                                                                                                                                                                                                    +
+     Item 8: offset = 1704, tuple = ((NNN, (NNN), X/X, N), typname: record, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                +
+     Item 9: offset = 1880, tuple = ((NNN, (NNN), X/X, N), typname: anyarray, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)              +
+     Item 10: offset = 2056, tuple = ((NNN, (NNN), X/X, N), typname: void, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                +
+     Item 11: offset = 2232, tuple = ((NNN, (NNN), X/X, N), typname: internal, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
+     Item 12: offset = 2408, tuple = ((NNN, (NNN), X/X, N), typname: anyenum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
+     Item 13: offset = 2584, tuple = ((NNN, (NNN), X/X, N), typname: anyrange, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
+     Item 14: deleted, offset = 2760, tuple = ((NNN, (NNN), X/X, Y), typname: o_enum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'e', typcategory: 'E', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)     +
+     Item 15: deleted, offset = 2936, tuple = ((NNN, (NNN), X/X, Y), typname: custom_range, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'r', typcategory: 'R', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)+
+     Item 16: deleted, offset = 3112, tuple = ((NNN, (NNN), X/X, Y), typname: custom_type, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'c', typcategory: 'C', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN) +
                                                                                                                                                                                                                                                                                                                                                                                                                                                                 +
  
 (1 row)
@@ -485,24 +489,39 @@ SELECT regexp_replace(regexp_replace(
  state = free, datoid equal, relnode equal, ix_type = primary, clean    +
      Leftmost, Rightmost                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 64             +
-     Item 0: offset = 296, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 1: offset = 376, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 2: offset = 456, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 3: offset = 536, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 4: offset = 616, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 5: offset = 696, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 6: offset = 776, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 7: offset = 856, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 8: offset = 936, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 9: offset = 1016, tuple = ((NNN, (NNN), X/X, N), amproc: NNN) +
-     Item 10: offset = 1096, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 11: offset = 1176, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 12: offset = 1256, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 13: offset = 1336, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 14: offset = 1416, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 15: offset = 1496, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 16: offset = 1576, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 17: offset = 1656, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 0: offset = 328, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 1: offset = 408, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 2: offset = 488, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 3: offset = 568, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 4: offset = 648, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 5: offset = 728, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 6: offset = 808, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 7: offset = 888, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 8: offset = 968, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 9: offset = 1048, tuple = ((NNN, (NNN), X/X, N), amproc: NNN) +
+     Item 10: offset = 1128, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 11: offset = 1208, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 12: offset = 1288, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 13: offset = 1368, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 14: offset = 1448, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 15: offset = 1528, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 16: offset = 1608, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 17: offset = 1688, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 18: offset = 1768, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 19: offset = 1848, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 20: offset = 1928, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 21: offset = 2008, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 22: offset = 2088, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 23: offset = 2168, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 24: offset = 2248, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 25: offset = 2328, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 26: offset = 2408, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 27: offset = 2488, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 28: offset = 2568, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 29: offset = 2648, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 30: offset = 2728, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 31: offset = 2808, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 32: offset = 2888, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
                                                                         +
  
 (1 row)
@@ -563,39 +582,50 @@ SELECT regexp_replace(regexp_replace(
  state = free, datoid equal, relnode equal, ix_type = primary, clean     +
      Leftmost, Rightmost                                                 +
    Chunk 0: offset = 0, location = 256, hikey location = 64              +
-     Item 0: offset = 328, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 1: offset = 408, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 2: offset = 488, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 3: offset = 568, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 4: offset = 648, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 5: offset = 728, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 6: offset = 808, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 7: offset = 888, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 8: offset = 968, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 9: offset = 1048, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN) +
-     Item 10: offset = 1128, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 11: offset = 1208, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 12: offset = 1288, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 13: offset = 1368, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 14: offset = 1448, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 15: offset = 1528, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 16: offset = 1608, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 17: offset = 1688, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 18: offset = 1768, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 19: offset = 1848, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 20: offset = 1928, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 21: offset = 2008, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 22: offset = 2088, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 23: offset = 2168, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 24: offset = 2248, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 25: offset = 2328, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 26: offset = 2408, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 27: offset = 2488, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 28: offset = 2568, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 29: offset = 2648, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 30: offset = 2728, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 31: offset = 2808, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 32: offset = 2888, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 0: offset = 344, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 1: offset = 424, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 2: offset = 504, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 3: offset = 584, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 4: offset = 664, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 5: offset = 744, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 6: offset = 824, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 7: offset = 904, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 8: offset = 984, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 9: offset = 1064, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN) +
+     Item 10: offset = 1144, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 11: offset = 1224, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 12: offset = 1304, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 13: offset = 1384, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 14: offset = 1464, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 15: offset = 1544, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 16: offset = 1624, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 17: offset = 1704, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 18: offset = 1784, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 19: offset = 1864, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 20: offset = 1944, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 21: offset = 2024, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 22: offset = 2104, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 23: offset = 2184, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 24: offset = 2264, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 25: offset = 2344, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 26: offset = 2424, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 27: offset = 2504, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 28: offset = 2584, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 29: offset = 2664, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 30: offset = 2744, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 31: offset = 2824, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 32: offset = 2904, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 33: offset = 2984, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 34: offset = 3064, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 35: offset = 3144, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 36: offset = 3224, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 37: offset = 3304, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 38: offset = 3384, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 39: offset = 3464, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 40: offset = 3544, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 41: offset = 3624, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 42: offset = 3704, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 43: offset = 3784, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
                                                                          +
  
 (1 row)
@@ -700,16 +730,16 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
      Item 0: offset = 296, tuple = (730, 0)                         +
      Item 1: offset = 328, tuple = (734, 96)                        +
-     Item 2: offset = 360, tuple = (735, 25248)                     +
-     Item 3: offset = 392, tuple = (736, 27648)                     +
-     Item 4: offset = 424, tuple = (737, 28104)                     +
-     Item 5: offset = 456, tuple = (739, 28672)                     +
-     Item 6: offset = 488, tuple = (740, 29664)                     +
-     Item 7: offset = 520, tuple = (743, 29824)                     +
-     Item 8: offset = 552, tuple = (744, 49008)                     +
-     Item 9: offset = 584, tuple = (745, 51912)                     +
-     Item 10: offset = 616, tuple = (746, 52360)                    +
-     Item 11: offset = 648, tuple = (747, 55096)                    +
+     Item 2: offset = 360, tuple = (735, 26944)                     +
+     Item 3: offset = 392, tuple = (736, 29344)                     +
+     Item 4: offset = 424, tuple = (737, 29800)                     +
+     Item 5: offset = 456, tuple = (739, 30368)                     +
+     Item 6: offset = 488, tuple = (740, 31360)                     +
+     Item 7: offset = 520, tuple = (743, 31520)                     +
+     Item 8: offset = 552, tuple = (744, 52240)                     +
+     Item 9: offset = 584, tuple = (745, 55144)                     +
+     Item 10: offset = 616, tuple = (746, 55592)                    +
+     Item 11: offset = 648, tuple = (747, 58328)                    +
      Item 12: offset = 680, tuple = (1000, 2000)                    +
      Item 13: offset = 712, tuple = (1001, 2001)                    +
      Item 14: offset = 744, tuple = (1002, 2002)                    +

--- a/test/expected/btree_sys_check_1.out
+++ b/test/expected/btree_sys_check_1.out
@@ -157,28 +157,35 @@ SELECT regexp_replace(
 		'\d+, \(\d+\), [A-F0-9]+/[A-F0-9]+, ',
 		'NNN, (NNN), X/X, ',
 		'g');
-                                                     regexp_replace                                                      
--------------------------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                                                   +
- state = free, datoid equal, relnode equal, ix_type = primary, clean                                                    +
-     Leftmost, Rightmost                                                                                                +
-   Chunk 0: offset = 0, location = 256, hikey location = 64                                                             +
-     Item 0: offset = 288, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 23, cmpOid: 351, ssupOid: 3130)    +
-     Item 1: offset = 352, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 21, cmpOid: 350, ssupOid: 3129)    +
-     Item 2: offset = 416, tuple = ((NNN, (NNN), X/X, N), opfamily: 1970, inputtype: 701, cmpOid: 355, ssupOid: 3133)   +
-     Item 3: offset = 480, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 20, cmpOid: 842, ssupOid: 3131)    +
-     Item 4: offset = 544, tuple = ((NNN, (NNN), X/X, N), opfamily: 1994, inputtype: 25, cmpOid: 360, ssupOid: 3255)    +
-     Item 5: offset = 608, tuple = ((NNN, (NNN), X/X, N), opfamily: 434, inputtype: 1114, cmpOid: 2045, ssupOid: 3137)  +
-     Item 6: offset = 672, tuple = ((NNN, (NNN), X/X, N), opfamily: 397, inputtype: 2277, cmpOid: 382, ssupOid: 0)      +
-     Item 7: offset = 736, tuple = ((NNN, (NNN), X/X, N), opfamily: 1971, inputtype: 701, cmpOid: 452, ssupOid: 444)    +
-     Item 8: offset = 800, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 23, cmpOid: 450, ssupOid: 425)     +
-     Item 9: offset = 864, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 20, cmpOid: 949, ssupOid: 442)     +
-     Item 10: offset = 928, tuple = ((NNN, (NNN), X/X, N), opfamily: 2994, inputtype: 2249, cmpOid: 2987, ssupOid: 0)   +
-     Item 11: offset = 992, tuple = ((NNN, (NNN), X/X, N), opfamily: 2040, inputtype: 1114, cmpOid: 2039, ssupOid: 3411)+
-     Item 12: offset = 1056, tuple = ((NNN, (NNN), X/X, N), opfamily: 2789, inputtype: 27, cmpOid: 2794, ssupOid: 0)    +
-     Item 13: offset = 1120, tuple = ((NNN, (NNN), X/X, N), opfamily: 3522, inputtype: 3500, cmpOid: 3514, ssupOid: 0)  +
-     Item 14: offset = 1184, tuple = ((NNN, (NNN), X/X, N), opfamily: 3901, inputtype: 3831, cmpOid: 3870, ssupOid: 0)  +
-                                                                                                                        +
+                                                      regexp_replace                                                      
+--------------------------------------------------------------------------------------------------------------------------
+ Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                                                    +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                                                     +
+     Leftmost, Rightmost                                                                                                 +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                                                              +
+     Item 0: offset = 304, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 23, cmpOid: 351, ssupOid: 3130)     +
+     Item 1: offset = 368, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 21, cmpOid: 350, ssupOid: 3129)     +
+     Item 2: offset = 432, tuple = ((NNN, (NNN), X/X, N), opfamily: 1970, inputtype: 701, cmpOid: 355, ssupOid: 3133)    +
+     Item 3: offset = 496, tuple = ((NNN, (NNN), X/X, N), opfamily: 1976, inputtype: 20, cmpOid: 842, ssupOid: 3131)     +
+     Item 4: offset = 560, tuple = ((NNN, (NNN), X/X, N), opfamily: 1994, inputtype: 25, cmpOid: 360, ssupOid: 3255)     +
+     Item 5: offset = 624, tuple = ((NNN, (NNN), X/X, N), opfamily: 434, inputtype: 1114, cmpOid: 2045, ssupOid: 3137)   +
+     Item 6: offset = 688, tuple = ((NNN, (NNN), X/X, N), opfamily: 397, inputtype: 2277, cmpOid: 382, ssupOid: 0)       +
+     Item 7: offset = 752, tuple = ((NNN, (NNN), X/X, N), opfamily: 627, inputtype: 2277, cmpOid: 626, ssupOid: 782)     +
+     Item 8: offset = 816, tuple = ((NNN, (NNN), X/X, N), opfamily: 1971, inputtype: 701, cmpOid: 452, ssupOid: 444)     +
+     Item 9: offset = 880, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 21, cmpOid: 449, ssupOid: 441)      +
+     Item 10: offset = 944, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 23, cmpOid: 450, ssupOid: 425)     +
+     Item 11: offset = 1008, tuple = ((NNN, (NNN), X/X, N), opfamily: 1977, inputtype: 20, cmpOid: 949, ssupOid: 442)    +
+     Item 12: offset = 1072, tuple = ((NNN, (NNN), X/X, N), opfamily: 2994, inputtype: 2249, cmpOid: 2987, ssupOid: 0)   +
+     Item 13: offset = 1136, tuple = ((NNN, (NNN), X/X, N), opfamily: 6194, inputtype: 2249, cmpOid: 6192, ssupOid: 6193)+
+     Item 14: offset = 1200, tuple = ((NNN, (NNN), X/X, N), opfamily: 1995, inputtype: 25, cmpOid: 400, ssupOid: 448)    +
+     Item 15: offset = 1264, tuple = ((NNN, (NNN), X/X, N), opfamily: 2040, inputtype: 1114, cmpOid: 2039, ssupOid: 3411)+
+     Item 16: offset = 1328, tuple = ((NNN, (NNN), X/X, N), opfamily: 2789, inputtype: 27, cmpOid: 2794, ssupOid: 0)     +
+     Item 17: offset = 1392, tuple = ((NNN, (NNN), X/X, N), opfamily: 2227, inputtype: 27, cmpOid: 2233, ssupOid: 2234)  +
+     Item 18: offset = 1456, tuple = ((NNN, (NNN), X/X, N), opfamily: 3522, inputtype: 3500, cmpOid: 3514, ssupOid: 0)   +
+     Item 19: offset = 1520, tuple = ((NNN, (NNN), X/X, N), opfamily: 3523, inputtype: 3500, cmpOid: 3515, ssupOid: 3414)+
+     Item 20: offset = 1584, tuple = ((NNN, (NNN), X/X, N), opfamily: 3901, inputtype: 3831, cmpOid: 3870, ssupOid: 0)   +
+     Item 21: offset = 1648, tuple = ((NNN, (NNN), X/X, N), opfamily: 3903, inputtype: 3831, cmpOid: 3902, ssupOid: 3417)+
+                                                                                                                         +
  
 (1 row)
 
@@ -345,33 +352,29 @@ SELECT regexp_replace(regexp_replace(
      Item 3: offset = 808, tuple = (((NNN, (NNN), X/X, N), 0), 108)                           +
      Item 4: offset = 976, tuple = (((NNN, (NNN), X/X, N), 0), 110)                           +
      Item 5: offset = 1152, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
-     Item 6: offset = 1320, tuple = (((NNN, (NNN), X/X, N), 0), 122)                          +
-     Item 7: offset = 1504, tuple = (((NNN, (NNN), X/X, N), 0), 122)                          +
-     Item 8: offset = 1688, tuple = (((NNN, (NNN), X/X, N), 0), 126)                          +
-     Item 9: offset = 1880, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
-     Item 10: offset = 2048, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
-     Item 11: offset = 2216, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 12: offset = 2384, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 13: offset = 2552, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
-     Item 14: offset = 2720, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
-     Item 15: offset = 2888, tuple = (((NNN, (NNN), X/X, N), 0), 114)                         +
-     Item 16: offset = 3064, tuple = (((NNN, (NNN), X/X, N), 0), 116)                         +
-     Item 17: offset = 3240, tuple = (((NNN, (NNN), X/X, N), 0), 100)                         +
-   Chunk 1: offset = 18, location = 3400, hikey location = 104                                +
-     Item 18: offset = 3432, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 19: offset = 3600, tuple = (((NNN, (NNN), X/X, N), 0), 112)                         +
-     Item 20: offset = 3776, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 21: offset = 3960, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 22: offset = 4144, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 23: offset = 4328, tuple = (((NNN, (NNN), X/X, N), 0), 124)                         +
-     Item 24: offset = 4512, tuple = (((NNN, (NNN), X/X, N), 0), 128)                         +
-     Item 25: offset = 4704, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
-     Item 26: offset = 4888, tuple = (((NNN, (NNN), X/X, N), 0), 136)                         +
-     Item 27: offset = 5088, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 28: offset = 5256, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
-     Item 29: offset = 5424, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
-     Item 30: offset = 5592, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
-     Item 31: offset = 5760, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
+     Item 6: offset = 1320, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
+     Item 7: offset = 1488, tuple = (((NNN, (NNN), X/X, N), 0), 102)                          +
+     Item 8: offset = 1656, tuple = (((NNN, (NNN), X/X, N), 0), 106)                          +
+     Item 9: offset = 1824, tuple = (((NNN, (NNN), X/X, N), 0), 106)                          +
+     Item 10: offset = 1992, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
+     Item 11: offset = 2160, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
+     Item 12: offset = 2328, tuple = (((NNN, (NNN), X/X, N), 0), 114)                         +
+     Item 13: offset = 2504, tuple = (((NNN, (NNN), X/X, N), 0), 116)                         +
+     Item 14: offset = 2680, tuple = (((NNN, (NNN), X/X, N), 0), 100)                         +
+     Item 15: offset = 2840, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
+     Item 16: offset = 3008, tuple = (((NNN, (NNN), X/X, N), 0), 112)                         +
+   Chunk 1: offset = 17, location = 3184, hikey location = 104                                +
+     Item 17: offset = 3208, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 18: offset = 3392, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 19: offset = 3576, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 20: offset = 3760, tuple = (((NNN, (NNN), X/X, N), 0), 124)                         +
+     Item 21: offset = 3944, tuple = (((NNN, (NNN), X/X, N), 0), 128)                         +
+     Item 22: offset = 4136, tuple = (((NNN, (NNN), X/X, N), 0), 120)                         +
+     Item 23: offset = 4320, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
+     Item 24: offset = 4488, tuple = (((NNN, (NNN), X/X, N), 0), 102)                         +
+     Item 25: offset = 4656, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
+     Item 26: offset = 4824, tuple = (((NNN, (NNN), X/X, N), 0), 106)                         +
+     Item 27: offset = 4992, tuple = (((NNN, (NNN), X/X, N), 0), 108)                         +
                                                                                               +
  
 (1 row)
@@ -397,17 +400,18 @@ SELECT regexp_replace(regexp_replace(
      Item 3: offset = 800, tuple = ((NNN, (NNN), X/X, N), typname: text, typlen: -1, typbyval: N, typalign: 'i', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'S', typispreferred: Y, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                   +
      Item 4: offset = 976, tuple = ((NNN, (NNN), X/X, N), typname: tid, typlen: NNN, typbyval: N, typalign: 's', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'U', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                   +
      Item 5: offset = 1152, tuple = ((NNN, (NNN), X/X, N), typname: float8, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'N', typispreferred: Y, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)               +
-     Item 6: offset = 1328, tuple = ((NNN, (NNN), X/X, N), typname: timestamp, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'D', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
-   Chunk 1: offset = 7, location = 1504, hikey location = 96                                                                                                                                                                                                                                                                                                                                                                                                    +
-     Item 7: offset = 1528, tuple = ((NNN, (NNN), X/X, N), typname: record, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                +
-     Item 8: offset = 1704, tuple = ((NNN, (NNN), X/X, N), typname: anyarray, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)              +
-     Item 9: offset = 1880, tuple = ((NNN, (NNN), X/X, N), typname: void, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                 +
-     Item 10: offset = 2056, tuple = ((NNN, (NNN), X/X, N), typname: internal, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
-     Item 11: offset = 2232, tuple = ((NNN, (NNN), X/X, N), typname: anyenum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
-     Item 12: offset = 2408, tuple = ((NNN, (NNN), X/X, N), typname: anyrange, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
-     Item 13: deleted, offset = 2584, tuple = ((NNN, (NNN), X/X, Y), typname: o_enum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'e', typcategory: 'E', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)     +
-     Item 14: deleted, offset = 2760, tuple = ((NNN, (NNN), X/X, Y), typname: custom_range, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'r', typcategory: 'R', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)+
-     Item 15: deleted, offset = 2936, tuple = ((NNN, (NNN), X/X, Y), typname: custom_type, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'c', typcategory: 'C', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN) +
+     Item 6: offset = 1328, tuple = ((NNN, (NNN), X/X, N), typname: _int4, typlen: -1, typbyval: N, typalign: 'i', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'A', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                 +
+     Item 7: offset = 1504, tuple = ((NNN, (NNN), X/X, N), typname: timestamp, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'b', typcategory: 'D', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
+   Chunk 1: offset = 8, location = 1680, hikey location = 96                                                                                                                                                                                                                                                                                                                                                                                                    +
+     Item 8: offset = 1704, tuple = ((NNN, (NNN), X/X, N), typname: record, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                +
+     Item 9: offset = 1880, tuple = ((NNN, (NNN), X/X, N), typname: anyarray, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)              +
+     Item 10: offset = 2056, tuple = ((NNN, (NNN), X/X, N), typname: void, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)                +
+     Item 11: offset = 2232, tuple = ((NNN, (NNN), X/X, N), typname: internal, typlen: NNN, typbyval: Y, typalign: 'd', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)            +
+     Item 12: offset = 2408, tuple = ((NNN, (NNN), X/X, N), typname: anyenum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
+     Item 13: offset = 2584, tuple = ((NNN, (NNN), X/X, N), typname: anyrange, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'p', typcategory: 'P', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)             +
+     Item 14: deleted, offset = 2760, tuple = ((NNN, (NNN), X/X, Y), typname: o_enum, typlen: NNN, typbyval: Y, typalign: 'i', typstorage: 'p', typcollation: NNN, typrelid: NNN, typtype: 'e', typcategory: 'E', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)     +
+     Item 15: deleted, offset = 2936, tuple = ((NNN, (NNN), X/X, Y), typname: custom_range, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'r', typcategory: 'R', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN)+
+     Item 16: deleted, offset = 3112, tuple = ((NNN, (NNN), X/X, Y), typname: custom_type, typlen: -1, typbyval: N, typalign: 'd', typstorage: 'x', typcollation: NNN, typrelid: NNN, typtype: 'c', typcategory: 'C', typispreferred: N, typisdefined: Y, typinput: NNN, typoutput: NNN, typreceive: NNN, typsend: NNN, typelem: NNN, typdelim: ',', typbasetype: NNN, typtypmod: -1, typsubscript: NNN, default_btree_opclass: NNN, default_hash_opclass: NNN) +
                                                                                                                                                                                                                                                                                                                                                                                                                                                                 +
  
 (1 row)
@@ -484,24 +488,39 @@ SELECT regexp_replace(regexp_replace(
  state = free, datoid equal, relnode equal, ix_type = primary, clean    +
      Leftmost, Rightmost                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 64             +
-     Item 0: offset = 296, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 1: offset = 376, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 2: offset = 456, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 3: offset = 536, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 4: offset = 616, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 5: offset = 696, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 6: offset = 776, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 7: offset = 856, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 8: offset = 936, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
-     Item 9: offset = 1016, tuple = ((NNN, (NNN), X/X, N), amproc: NNN) +
-     Item 10: offset = 1096, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 11: offset = 1176, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 12: offset = 1256, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 13: offset = 1336, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 14: offset = 1416, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 15: offset = 1496, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 16: offset = 1576, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
-     Item 17: offset = 1656, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 0: offset = 328, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 1: offset = 408, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 2: offset = 488, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 3: offset = 568, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 4: offset = 648, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 5: offset = 728, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 6: offset = 808, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 7: offset = 888, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 8: offset = 968, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)  +
+     Item 9: offset = 1048, tuple = ((NNN, (NNN), X/X, N), amproc: NNN) +
+     Item 10: offset = 1128, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 11: offset = 1208, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 12: offset = 1288, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 13: offset = 1368, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 14: offset = 1448, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 15: offset = 1528, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 16: offset = 1608, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 17: offset = 1688, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 18: offset = 1768, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 19: offset = 1848, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 20: offset = 1928, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 21: offset = 2008, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 22: offset = 2088, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 23: offset = 2168, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 24: offset = 2248, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 25: offset = 2328, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 26: offset = 2408, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 27: offset = 2488, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 28: offset = 2568, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 29: offset = 2648, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 30: offset = 2728, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 31: offset = 2808, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
+     Item 32: offset = 2888, tuple = ((NNN, (NNN), X/X, N), amproc: NNN)+
                                                                         +
  
 (1 row)
@@ -562,39 +581,50 @@ SELECT regexp_replace(regexp_replace(
  state = free, datoid equal, relnode equal, ix_type = primary, clean     +
      Leftmost, Rightmost                                                 +
    Chunk 0: offset = 0, location = 256, hikey location = 64              +
-     Item 0: offset = 328, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 1: offset = 408, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 2: offset = 488, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 3: offset = 568, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 4: offset = 648, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 5: offset = 728, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 6: offset = 808, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 7: offset = 888, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 8: offset = 968, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
-     Item 9: offset = 1048, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN) +
-     Item 10: offset = 1128, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 11: offset = 1208, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 12: offset = 1288, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 13: offset = 1368, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 14: offset = 1448, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 15: offset = 1528, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 16: offset = 1608, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 17: offset = 1688, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 18: offset = 1768, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 19: offset = 1848, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 20: offset = 1928, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 21: offset = 2008, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 22: offset = 2088, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 23: offset = 2168, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 24: offset = 2248, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 25: offset = 2328, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 26: offset = 2408, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 27: offset = 2488, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 28: offset = 2568, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 29: offset = 2648, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 30: offset = 2728, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 31: offset = 2808, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
-     Item 32: offset = 2888, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 0: offset = 344, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 1: offset = 424, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 2: offset = 504, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 3: offset = 584, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 4: offset = 664, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 5: offset = 744, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 6: offset = 824, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 7: offset = 904, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 8: offset = 984, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)  +
+     Item 9: offset = 1064, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN) +
+     Item 10: offset = 1144, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 11: offset = 1224, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 12: offset = 1304, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 13: offset = 1384, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 14: offset = 1464, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 15: offset = 1544, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 16: offset = 1624, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 17: offset = 1704, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 18: offset = 1784, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 19: offset = 1864, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 20: offset = 1944, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 21: offset = 2024, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 22: offset = 2104, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 23: offset = 2184, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 24: offset = 2264, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 25: offset = 2344, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 26: offset = 2424, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 27: offset = 2504, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 28: offset = 2584, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 29: offset = 2664, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 30: offset = 2744, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 31: offset = 2824, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 32: offset = 2904, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 33: offset = 2984, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 34: offset = 3064, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 35: offset = 3144, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 36: offset = 3224, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 37: offset = 3304, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 38: offset = 3384, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 39: offset = 3464, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 40: offset = 3544, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 41: offset = 3624, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 42: offset = 3704, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
+     Item 43: offset = 3784, tuple = ((NNN, (NNN), X/X, N), amopopr: NNN)+
                                                                          +
  
 (1 row)
@@ -699,16 +729,16 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
      Item 0: offset = 296, tuple = (738, 0)                         +
      Item 1: offset = 328, tuple = (742, 96)                        +
-     Item 2: offset = 360, tuple = (743, 25248)                     +
-     Item 3: offset = 392, tuple = (744, 27648)                     +
-     Item 4: offset = 424, tuple = (745, 28104)                     +
-     Item 5: offset = 456, tuple = (747, 28672)                     +
-     Item 6: offset = 488, tuple = (748, 29664)                     +
-     Item 7: offset = 520, tuple = (751, 29824)                     +
-     Item 8: offset = 552, tuple = (752, 49008)                     +
-     Item 9: offset = 584, tuple = (753, 51912)                     +
-     Item 10: offset = 616, tuple = (754, 52360)                    +
-     Item 11: offset = 648, tuple = (755, 55096)                    +
+     Item 2: offset = 360, tuple = (743, 26944)                     +
+     Item 3: offset = 392, tuple = (744, 29344)                     +
+     Item 4: offset = 424, tuple = (745, 29800)                     +
+     Item 5: offset = 456, tuple = (747, 30368)                     +
+     Item 6: offset = 488, tuple = (748, 31360)                     +
+     Item 7: offset = 520, tuple = (751, 31520)                     +
+     Item 8: offset = 552, tuple = (752, 52240)                     +
+     Item 9: offset = 584, tuple = (753, 55144)                     +
+     Item 10: offset = 616, tuple = (754, 55592)                    +
+     Item 11: offset = 648, tuple = (755, 58328)                    +
      Item 12: offset = 680, tuple = (1000, 2000)                    +
      Item 13: offset = 712, tuple = (1001, 2001)                    +
      Item 14: offset = 744, tuple = (1002, 2002)                    +

--- a/test/expected/opclass.out
+++ b/test/expected/opclass.out
@@ -125,7 +125,7 @@ CREATE OPERATOR CLASS my_op_class_p_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_p_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_p_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_p_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_p_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_p_i" cannot be used here
 HINT:  only C and SQL functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -141,7 +141,7 @@ CREATE OPERATOR CLASS my_op_class_s_p_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_p_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_p_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_s_p_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_s_p_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_p_i" cannot be used here
 HINT:  only C and SQL functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -158,7 +158,7 @@ CREATE OPERATOR CLASS my_op_class_s_s_s_p_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_s_s_p_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_s_s_p_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_s_s_s_p_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_s_s_s_p_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_p_i" cannot be used here
 HINT:  only C and SQL functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -177,7 +177,7 @@ CREATE OPERATOR CLASS my_op_class_v_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_v_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_v_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_v_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_v_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_v_i" cannot be used here
 HINT:  only immutable functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -193,7 +193,7 @@ CREATE OPERATOR CLASS my_op_class_s_v_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_v_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_v_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_s_v_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_s_v_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_v_i" cannot be used here
 HINT:  only immutable functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -210,7 +210,7 @@ CREATE OPERATOR CLASS my_op_class_s_s_s_v_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_s_s_v_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_s_s_v_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_s_s_s_v_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_s_s_s_v_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_v_i" cannot be used here
 HINT:  only immutable functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -234,7 +234,7 @@ CREATE OPERATOR CLASS my_op_class_call FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_call(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_call);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_call
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_call
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  CALL is not allowed in a non-volatile function
 DROP OPERATOR CLASS my_op_class_call USING btree CASCADE;
@@ -253,7 +253,7 @@ CREATE OPERATOR CLASS my_op_class_delete FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_delete(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_delete);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_delete
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_delete
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_delete" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -274,7 +274,7 @@ CREATE OPERATOR CLASS my_op_class_update FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_update(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_update);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_update
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_update
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_update" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -295,7 +295,7 @@ CREATE OPERATOR CLASS my_op_class_insert FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_insert(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_insert);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_insert
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_insert
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_insert" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -315,7 +315,7 @@ CREATE OPERATOR CLASS my_op_class_select_from_table FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_select_from_table(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_select_from_table);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_select_from_table
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_select_from_table
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_select_from_table" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -345,7 +345,7 @@ CREATE OPERATOR CLASS my_op_class_s_i FOR TYPE int
 	   FUNCTION 1 opclass.my_int_cmp_s_i(int, int);
 CREATE INDEX int_val_ix_s_i ON
 	o_test_custom_opclass(int_val my_op_class_s_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_s_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_s_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -386,7 +386,7 @@ CREATE OPERATOR CLASS my_op_class_s_s_s_s_i FOR TYPE int
 	   FUNCTION 1 opclass.my_int_cmp_s_s_s_s_i(int, int);
 CREATE INDEX int_val_ix_s_s_s_s_i ON
 	o_test_custom_opclass(int_val my_op_class_s_s_s_s_i);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_s_s_s_s_i
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_s_s_s_s_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -431,7 +431,7 @@ CREATE OPERATOR CLASS my_op_class_simple_expression FOR TYPE int
 	   FUNCTION 1 my_int_cmp_simple_expression(int, int);
 CREATE INDEX int_val_ix_simple_expression ON
 	o_test_custom_opclass(int_val my_op_class_simple_expression);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_simple_expression
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_simple_expression
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -476,7 +476,7 @@ CREATE OPERATOR CLASS my_op_class_values FOR TYPE int
 	   FUNCTION 1 my_int_cmp_values(int, int);
 CREATE INDEX int_val_ix_values ON
 	o_test_custom_opclass(int_val my_op_class_values);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_values
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_values
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -521,7 +521,7 @@ CREATE OPERATOR CLASS my_op_class_generate_series FOR TYPE int
 	   FUNCTION 1 my_int_cmp_generate_series(int, int);
 CREATE INDEX int_val_ix_generate_series ON
 	o_test_custom_opclass(int_val my_op_class_generate_series);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_generate_series
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_generate_series
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -567,7 +567,7 @@ CREATE OPERATOR CLASS my_op_class_subselect FOR TYPE int
 	   FUNCTION 1 my_int_cmp_subselect(int, int);
 CREATE INDEX int_val_ix_subselect ON
 	o_test_custom_opclass(int_val my_op_class_subselect);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_subselect
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_subselect
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -615,7 +615,7 @@ CREATE OPERATOR CLASS my_op_class_cte FOR TYPE int
 	   FUNCTION 1 my_int_cmp_cte(int, int);
 CREATE INDEX int_val_ix_cte ON
 	o_test_custom_opclass(int_val my_op_class_cte);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_cte
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_cte
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -663,7 +663,7 @@ CREATE OPERATOR CLASS my_op_class_rows_func FOR TYPE int
 	   FUNCTION 1 my_int_cmp_rows_func(int, int);
 CREATE INDEX int_val_ix_rows_func ON
 	o_test_custom_opclass(int_val my_op_class_rows_func);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_rows_func
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_rows_func
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -709,7 +709,7 @@ CREATE OPERATOR CLASS my_op_class_join FOR TYPE int
 	   FUNCTION 1 my_int_cmp_join(int, int);
 CREATE INDEX int_val_ix_join ON
 	o_test_custom_opclass(int_val my_op_class_join);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_join
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_join
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -761,7 +761,7 @@ CREATE OPERATOR CLASS my_op_class_complex FOR TYPE int
 	   FUNCTION 1 my_int_cmp_complex(int, int);
 CREATE INDEX int_val_ix_complex ON
 	o_test_custom_opclass(int_val my_op_class_complex);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_complex
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_complex
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -808,7 +808,7 @@ CREATE OPERATOR CLASS my_op_class_sqlbody FOR TYPE int
 	   FUNCTION 1 my_int_cmp_sqlbody(int, int);
 CREATE INDEX int_val_ix_sqlbody ON
 	o_test_custom_opclass(int_val my_op_class_sqlbody);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_sqlbody
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_sqlbody
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -854,7 +854,7 @@ CREATE OPERATOR CLASS my_op_class_init_plan FOR TYPE int
 	   FUNCTION 1 my_int_cmp_init_plan(int, int);
 CREATE INDEX int_val_ix_init_plan ON
 	o_test_custom_opclass(int_val my_op_class_init_plan);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_init_plan
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_init_plan
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -900,7 +900,7 @@ CREATE OPERATOR CLASS my_op_class_cast FOR TYPE int
 	   FUNCTION 1 my_int_cmp_cast(int, int);
 CREATE INDEX int_val_ix_cast ON
 	o_test_custom_opclass(int_val my_op_class_cast);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_cast
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_cast
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -949,7 +949,7 @@ CREATE OPERATOR CLASS my_op_class_windowagg FOR TYPE int
 	   FUNCTION 1 my_int_cmp_windowagg(int, int);
 CREATE INDEX int_val_ix_windowagg ON
 	o_test_custom_opclass(int_val my_op_class_windowagg);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_windowagg
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_windowagg
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -991,7 +991,7 @@ CREATE OPERATOR CLASS my_op_class_build_ix FOR TYPE int
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,300);
 CREATE INDEX int_val_ix_build_ix ON
 	o_test_custom_opclass(int_val my_op_class_build_ix);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_build_ix
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_build_ix
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
 						ORDER BY int_val USING OPERATOR(<^) LIMIT 10;
@@ -1149,7 +1149,7 @@ CREATE OPERATOR CLASS my_op_class_rec
 	AS OPERATOR 1 #<#, OPERATOR 3 #=#,
 	   FUNCTION 1 my_rec_cmp(my_record, my_record);
 CREATE INDEX rec_val_ix2 ON o_test_custom_opclass(rec_val);
-WARNING:  failed to fetch the hash function for btree opclassopclass.my_op_class_rec
+WARNING:  failed to fetch the hash function for btree opclass opclass.my_op_class_rec
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass ORDER BY rec_val
 	USING OPERATOR(#<#);
@@ -1292,7 +1292,7 @@ CREATE OPERATOR CLASS o_tccfia_opclass FOR TYPE int
 BEGIN;
 CREATE INDEX int_val_ix_s_i ON
 	o_test_call_cmp_func_in_abort(val_1 o_tccfia_opclass);
-WARNING:  failed to fetch the hash function for btree opclassopclass.o_tccfia_opclass
+WARNING:  failed to fetch the hash function for btree opclass opclass.o_tccfia_opclass
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_call_cmp_func_in_abort SELECT generate_series(1,10);
 ROLLBACK;
@@ -1306,7 +1306,7 @@ CREATE TABLE not_remove_cached_comparator_in_trx (
 BEGIN;
 CREATE INDEX not_remove_cached_comparator_in_trx_ix1 ON
 	not_remove_cached_comparator_in_trx(int_val nrccit_opclass);
-WARNING:  failed to fetch the hash function for btree opclassopclass.nrccit_opclass
+WARNING:  failed to fetch the hash function for btree opclass opclass.nrccit_opclass
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO not_remove_cached_comparator_in_trx VALUES (1, 'MABB');
 DROP INDEX not_remove_cached_comparator_in_trx_ix1;

--- a/test/expected/opclass_1.out
+++ b/test/expected/opclass_1.out
@@ -125,7 +125,7 @@ CREATE OPERATOR CLASS my_op_class_p_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_p_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_p_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_p_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_p_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_p_i" cannot be used here
 HINT:  only C and SQL functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -141,7 +141,7 @@ CREATE OPERATOR CLASS my_op_class_s_p_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_p_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_p_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_s_p_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_s_p_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_p_i" cannot be used here
 HINT:  only C and SQL functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -158,7 +158,7 @@ CREATE OPERATOR CLASS my_op_class_s_s_s_p_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_s_s_p_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_s_s_p_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_s_s_s_p_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_s_s_s_p_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_p_i" cannot be used here
 HINT:  only C and SQL functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -177,7 +177,7 @@ CREATE OPERATOR CLASS my_op_class_v_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_v_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_v_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_v_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_v_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_v_i" cannot be used here
 HINT:  only immutable functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -193,7 +193,7 @@ CREATE OPERATOR CLASS my_op_class_s_v_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_v_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_v_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_s_v_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_s_v_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_v_i" cannot be used here
 HINT:  only immutable functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -210,7 +210,7 @@ CREATE OPERATOR CLASS my_op_class_s_s_s_v_i FOR TYPE int
 	AS FUNCTION 1 opclass.my_int_cmp_s_s_s_v_i(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_s_s_s_v_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_s_s_s_v_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_s_s_s_v_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_v_i" cannot be used here
 HINT:  only immutable functions should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -234,7 +234,7 @@ CREATE OPERATOR CLASS my_op_class_call FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_call(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_call);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_call
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_call
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  CALL is not allowed in a non-volatile function
 DROP OPERATOR CLASS my_op_class_call USING btree CASCADE;
@@ -253,7 +253,7 @@ CREATE OPERATOR CLASS my_op_class_delete FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_delete(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_delete);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_delete
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_delete
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_delete" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -274,7 +274,7 @@ CREATE OPERATOR CLASS my_op_class_update FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_update(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_update);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_update
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_update
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_update" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -295,7 +295,7 @@ CREATE OPERATOR CLASS my_op_class_insert FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_insert(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_insert);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_insert
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_insert
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_insert" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -315,7 +315,7 @@ CREATE OPERATOR CLASS my_op_class_select_from_table FOR TYPE int
 	AS FUNCTION 1 my_int_cmp_select_from_table(int, int);
 CREATE INDEX int_val_ix ON
 	o_test_custom_opclass(int_val my_op_class_select_from_table);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_select_from_table
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_select_from_table
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 ERROR:  function "my_int_cmp_select_from_table" cannot be used here
 HINT:  only queries without relation references should be used as B-tree comparsion support function in operator class used for field of orioledb index
@@ -345,7 +345,7 @@ CREATE OPERATOR CLASS my_op_class_s_i FOR TYPE int
 	   FUNCTION 1 opclass.my_int_cmp_s_i(int, int);
 CREATE INDEX int_val_ix_s_i ON
 	o_test_custom_opclass(int_val my_op_class_s_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_s_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_s_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -386,7 +386,7 @@ CREATE OPERATOR CLASS my_op_class_s_s_s_s_i FOR TYPE int
 	   FUNCTION 1 opclass.my_int_cmp_s_s_s_s_i(int, int);
 CREATE INDEX int_val_ix_s_s_s_s_i ON
 	o_test_custom_opclass(int_val my_op_class_s_s_s_s_i);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_s_s_s_s_i
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_s_s_s_s_i
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -431,7 +431,7 @@ CREATE OPERATOR CLASS my_op_class_simple_expression FOR TYPE int
 	   FUNCTION 1 my_int_cmp_simple_expression(int, int);
 CREATE INDEX int_val_ix_simple_expression ON
 	o_test_custom_opclass(int_val my_op_class_simple_expression);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_simple_expression
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_simple_expression
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -476,7 +476,7 @@ CREATE OPERATOR CLASS my_op_class_values FOR TYPE int
 	   FUNCTION 1 my_int_cmp_values(int, int);
 CREATE INDEX int_val_ix_values ON
 	o_test_custom_opclass(int_val my_op_class_values);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_values
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_values
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -521,7 +521,7 @@ CREATE OPERATOR CLASS my_op_class_generate_series FOR TYPE int
 	   FUNCTION 1 my_int_cmp_generate_series(int, int);
 CREATE INDEX int_val_ix_generate_series ON
 	o_test_custom_opclass(int_val my_op_class_generate_series);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_generate_series
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_generate_series
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -567,7 +567,7 @@ CREATE OPERATOR CLASS my_op_class_subselect FOR TYPE int
 	   FUNCTION 1 my_int_cmp_subselect(int, int);
 CREATE INDEX int_val_ix_subselect ON
 	o_test_custom_opclass(int_val my_op_class_subselect);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_subselect
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_subselect
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -615,7 +615,7 @@ CREATE OPERATOR CLASS my_op_class_cte FOR TYPE int
 	   FUNCTION 1 my_int_cmp_cte(int, int);
 CREATE INDEX int_val_ix_cte ON
 	o_test_custom_opclass(int_val my_op_class_cte);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_cte
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_cte
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -663,7 +663,7 @@ CREATE OPERATOR CLASS my_op_class_rows_func FOR TYPE int
 	   FUNCTION 1 my_int_cmp_rows_func(int, int);
 CREATE INDEX int_val_ix_rows_func ON
 	o_test_custom_opclass(int_val my_op_class_rows_func);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_rows_func
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_rows_func
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -709,7 +709,7 @@ CREATE OPERATOR CLASS my_op_class_join FOR TYPE int
 	   FUNCTION 1 my_int_cmp_join(int, int);
 CREATE INDEX int_val_ix_join ON
 	o_test_custom_opclass(int_val my_op_class_join);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_join
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_join
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -761,7 +761,7 @@ CREATE OPERATOR CLASS my_op_class_complex FOR TYPE int
 	   FUNCTION 1 my_int_cmp_complex(int, int);
 CREATE INDEX int_val_ix_complex ON
 	o_test_custom_opclass(int_val my_op_class_complex);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_complex
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_complex
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -808,7 +808,7 @@ CREATE OPERATOR CLASS my_op_class_sqlbody FOR TYPE int
 	   FUNCTION 1 my_int_cmp_sqlbody(int, int);
 CREATE INDEX int_val_ix_sqlbody ON
 	o_test_custom_opclass(int_val my_op_class_sqlbody);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_sqlbody
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_sqlbody
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -854,7 +854,7 @@ CREATE OPERATOR CLASS my_op_class_init_plan FOR TYPE int
 	   FUNCTION 1 my_int_cmp_init_plan(int, int);
 CREATE INDEX int_val_ix_init_plan ON
 	o_test_custom_opclass(int_val my_op_class_init_plan);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_init_plan
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_init_plan
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -900,7 +900,7 @@ CREATE OPERATOR CLASS my_op_class_cast FOR TYPE int
 	   FUNCTION 1 my_int_cmp_cast(int, int);
 CREATE INDEX int_val_ix_cast ON
 	o_test_custom_opclass(int_val my_op_class_cast);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_cast
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_cast
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -949,7 +949,7 @@ CREATE OPERATOR CLASS my_op_class_windowagg FOR TYPE int
 	   FUNCTION 1 my_int_cmp_windowagg(int, int);
 CREATE INDEX int_val_ix_windowagg ON
 	o_test_custom_opclass(int_val my_op_class_windowagg);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_windowagg
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_windowagg
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,10);
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
@@ -991,7 +991,7 @@ CREATE OPERATOR CLASS my_op_class_build_ix FOR TYPE int
 INSERT INTO o_test_custom_opclass SELECT generate_series(1,300);
 CREATE INDEX int_val_ix_build_ix ON
 	o_test_custom_opclass(int_val my_op_class_build_ix);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_build_ix
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_build_ix
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass
 						ORDER BY int_val USING OPERATOR(<^) LIMIT 10;
@@ -1149,7 +1149,7 @@ CREATE OPERATOR CLASS my_op_class_rec
 	AS OPERATOR 1 #<#, OPERATOR 3 #=#,
 	   FUNCTION 1 my_rec_cmp(my_record, my_record);
 CREATE INDEX rec_val_ix2 ON o_test_custom_opclass(rec_val);
-WARNING:  failed to fetch the hash function for btree opclassmy_op_class_rec
+WARNING:  failed to fetch the hash function for btree opclass my_op_class_rec
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_custom_opclass ORDER BY rec_val
 	USING OPERATOR(#<#);
@@ -1292,7 +1292,7 @@ CREATE OPERATOR CLASS o_tccfia_opclass FOR TYPE int
 BEGIN;
 CREATE INDEX int_val_ix_s_i ON
 	o_test_call_cmp_func_in_abort(val_1 o_tccfia_opclass);
-WARNING:  failed to fetch the hash function for btree opclasso_tccfia_opclass
+WARNING:  failed to fetch the hash function for btree opclass o_tccfia_opclass
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO o_test_call_cmp_func_in_abort SELECT generate_series(1,10);
 ROLLBACK;
@@ -1306,7 +1306,7 @@ CREATE TABLE not_remove_cached_comparator_in_trx (
 BEGIN;
 CREATE INDEX not_remove_cached_comparator_in_trx_ix1 ON
 	not_remove_cached_comparator_in_trx(int_val nrccit_opclass);
-WARNING:  failed to fetch the hash function for btree opclassnrccit_opclass
+WARNING:  failed to fetch the hash function for btree opclass nrccit_opclass
 DETAIL:  Recovery might be slow due to inability to distribute values among the workers.
 INSERT INTO not_remove_cached_comparator_in_trx VALUES (1, 'MABB');
 DROP INDEX not_remove_cached_comparator_in_trx_ix1;

--- a/test/expected/types.out
+++ b/test/expected/types.out
@@ -148,7 +148,8 @@ CREATE TABLE o_test_cid_array
 	arr cid[] NOT NULL,
 	PRIMARY KEY(arr)
 ) USING orioledb;
-ERROR:  could not identify a comparison function for type cid
+ERROR:  could not identify a comparison function for type "cid" used in btree index field
+DETAIL:  not allowing it here, because any inserts in such index will break recovery for orioledb tables
 BEGIN;
 INSERT INTO o_test_cid_array VALUES (ARRAY['1'::cid, '2'::cid]);
 ERROR:  relation "o_test_cid_array" does not exist
@@ -173,7 +174,8 @@ CREATE TABLE o_test_cid_record
 	a o_rec,
 	PRIMARY KEY(a)
 ) USING orioledb;
-ERROR:  could not identify a comparison function for type cid
+ERROR:  could not identify a comparison function for type "cid" used in btree index field
+DETAIL:  not allowing it here, because any inserts in such index will break recovery for orioledb tables
 BEGIN;
 INSERT INTO o_test_cid_record VALUES (ROW('1'::cid));
 ERROR:  relation "o_test_cid_record" does not exist
@@ -204,7 +206,8 @@ CREATE TABLE o_test_xid_array
 	arr xid[] NOT NULL,
 	PRIMARY KEY (arr)
 ) USING orioledb;
-ERROR:  could not identify a comparison function for type xid
+ERROR:  could not identify a comparison function for type "xid" used in btree index field
+DETAIL:  not allowing it here, because any inserts in such index will break recovery for orioledb tables
 BEGIN;
 INSERT INTO o_test_xid_array VALUES (ARRAY['1'::xid, '2'::xid]);
 ERROR:  relation "o_test_xid_array" does not exist

--- a/test/t/functions_test.py
+++ b/test/t/functions_test.py
@@ -71,7 +71,7 @@ class FunctionTest(BaseTest):
 		""")
 
 		self.assertEqual(
-		    "[(Decimal('123000'),)]",
+		    "[(Decimal('131000'),)]",
 		    str(
 		        node.execute(
 		            "SELECT round(undo_size, -3) FROM orioledb_undo_size() WHERE undo_type = 'system';"

--- a/test/t/types_test.py
+++ b/test/t/types_test.py
@@ -249,10 +249,11 @@ class TypesTest(BaseTest):
 			) USING orioledb;
 		""")
 		type_amount += 3  # int2, int4, tid - types needed for all our tables
-		type_amount += 1  # int8 - hash_array_extended return type
+		type_amount += 1  # int8 - hashint4extended return type
 		type_amount += 1  # anyarray
 		type_amount += 1  # internal - argument of sort support function
 		type_amount += 1  # void - return type of sort support function
+
 		self.check_total_deleted(node, 'TYPE_CACHE', type_amount, 0)
 
 		node.execute("INSERT INTO o_test VALUES ('{1, 2}');")
@@ -389,7 +390,6 @@ class TypesTest(BaseTest):
 		class_amount += 2  # pg_proc
 		class_amount += 4  # pg_amproc, pg_opclass, pg_amop, pg_authid
 		type_amount += 3  # int2, int4, tid - types needed for all our tables
-		type_amount += 1  # int8 - hash_array_extended return type
 		type_amount += 1  # record
 		type_amount += 1  # internal - argument of sort support function
 		type_amount += 1  # void - return type of sort support function
@@ -524,11 +524,11 @@ class TypesTest(BaseTest):
 		class_amount += 2  # pg_proc
 		class_amount += 4  # pg_amproc, pg_opclass, pg_amop, pg_authid
 		type_amount += 3  # int2, int4, tid - types needed for all our tables
-		type_amount += 1  # int8
 		type_amount += 2  # record, anyarray
 		type_amount += 1  # internal - argument of sort support function
 		type_amount += 1  # void - return type of sort support function
 		type_amount += 2  # coordinates, coordinates_removed
+		type_amount += 2  # _coordinates, _coordinates_removed
 		self.check_total_deleted(node, 'CLASS_CACHE', class_amount, 0)
 		self.check_total_deleted(node, 'TYPE_CACHE', type_amount, 0)
 		node.stop(['-m', 'immediate'])
@@ -761,4 +761,143 @@ class TypesTest(BaseTest):
 		self.assertEqual([(3, ), (8, ), (15, ), (94, )],
 		                 con3.execute("SELECT * FROM foo ORDER BY i;"))
 		con3.close()
+		node.stop()
+
+	def test_json_index_recovery(self):
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "shared_preload_libraries = orioledb\n")
+
+		node.start()
+		node.safe_psql("""
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+
+			CREATE TYPE named_json AS (
+				name varchar(20),
+				val json
+			);
+			CREATE TYPE named_named_json AS (
+				name varchar(20),
+				val named_json
+			);
+			CREATE TABLE test_json_array
+			(
+				arr json[] NOT NULL,
+				arr2 json[] NOT NULL,
+				rec named_json NOT NULL,
+				rec2 named_named_json NOT NULL,
+				val json NOT NULL
+			) USING orioledb;
+		""")
+		with self.assertRaises(QueryException) as e:
+			node.safe_psql("""
+				ALTER TABLE test_json_array ADD PRIMARY KEY (arr);
+			""")
+		self.assertErrorMessageEquals(
+		    e,
+		    "could not identify a comparison function for type \"json\" used in btree index field",
+		    "not allowing it here, because any inserts in such index will break recovery for orioledb tables",
+		    "DETAIL")
+		with self.assertRaises(QueryException) as e:
+			node.safe_psql("""
+				CREATE UNIQUE INDEX test_json_array_ix1 ON test_json_array (arr2);
+			""")
+		self.assertErrorMessageEquals(
+		    e,
+		    "could not identify a comparison function for type \"json\" used in btree index field",
+		    "not allowing it here, because any inserts in such index will break recovery for orioledb tables",
+		    "DETAIL")
+		node.safe_psql("""
+			SET log_error_verbosity = 'terse';
+			CREATE UNIQUE INDEX test_json_array_ix2 ON test_json_array (((rec).val->>'x'), ((rec2).val.val->>'y'));
+		""")
+		node.safe_psql("""
+			SET log_error_verbosity = 'terse';
+			CREATE UNIQUE INDEX test_json_array_ix3 ON test_json_array ((val->>'bupf'));
+		""")
+		node.safe_psql("""
+			INSERT INTO test_json_array VALUES (
+				ARRAY['1'::json, '2'::json],
+				ARRAY['10'::json, '20'::json],
+				('firstname', '{"x": 7}'),
+				('secondname', ('subname', '{"x":  2, "y": 20}')),
+				'{"bupf":     9}'
+			);
+		""")
+		node.safe_psql("""
+			INSERT INTO test_json_array VALUES (
+				ARRAY['1'::json, '3'::json],
+				ARRAY['10'::json, '30'::json],
+				('firstname', '{"x":  3}'),
+				('secondname', ('subname', '{"x":   3, "y": 30}')),
+				'{"bupf":     7}'
+
+			);
+		""")
+		with self.assertRaises(QueryException) as e:
+			node.safe_psql("""
+				INSERT INTO test_json_array VALUES (
+					ARRAY['1'::json, '4'::json],
+					ARRAY['10'::json, '40'::json],
+					('firstname', '{"x":  3}'),
+					('secondname', ('subname', '{"x":   4, "y": 30}')),
+					'{"bupf":     13}'
+				);
+			""")
+		self.assertErrorMessageEquals(
+		    e,
+		    "duplicate key value violates unique constraint \"test_json_array_ix2\"",
+		    "Key (((rec).val ->> 'x'::text), ((rec2).val.val ->> 'y'::text))=(3, 30) already exists.",
+		    "DETAIL")
+		with self.assertRaises(QueryException) as e:
+			node.safe_psql("""
+				INSERT INTO test_json_array VALUES (
+					ARRAY['1'::json, '5'::json],
+					ARRAY['10'::json, '50'::json],
+					('firstname', '{"x":  5}'),
+					('secondname', ('subname', '{"x":   5, "y": 50}')),
+					'{"bupf":     7}'
+				);
+			""")
+		self.assertErrorMessageEquals(
+		    e,
+		    "duplicate key value violates unique constraint \"test_json_array_ix3\"",
+		    "Key ((val ->> 'bupf'::text))=(7) already exists.", "DETAIL")
+		with node.connect() as con1:
+			con1.execute("SET enable_seqscan = off;")
+			self.assertEqual(
+			    [([1, 3], [10, 30], '(firstname,"{""x"":  3}")',
+			      '(secondname,"(subname,""{""""x"""":   3, """"y"""": 30}"")")',
+			      {
+			          'bupf': 7
+			      }),
+			     ([1, 2], [10, 20], '(firstname,"{""x"": 7}")',
+			      '(secondname,"(subname,""{""""x"""":  2, """"y"""": 20}"")")',
+			      {
+			          'bupf': 9
+			      })],
+			    con1.execute(
+			        "SELECT * FROM test_json_array ORDER BY ((rec).val->>'x'), ((rec2).val.val->>'y');"
+			    ))
+
+		self.crash_with_os_buffer_loss()
+
+		node.start()
+		with node.connect() as con1:
+			con1.execute("SET enable_seqscan = off;")
+			self.assertEqual(
+			    [([1, 3], [10, 30], '(firstname,"{""x"":  3}")',
+			      '(secondname,"(subname,""{""""x"""":   3, """"y"""": 30}"")")',
+			      {
+			          'bupf': 7
+			      }),
+			     ([1, 2], [10, 20], '(firstname,"{""x"": 7}")',
+			      '(secondname,"(subname,""{""""x"""":  2, """"y"""": 20}"")")',
+			      {
+			          'bupf': 9
+			      })],
+			    con1.execute(
+			        "SELECT * FROM test_json_array ORDER BY ((rec).val->>'x'), ((rec2).val.val->>'y');"
+			    ))
+
 		node.stop()


### PR DESCRIPTION
- Fix creating expression index by json field by making it check only availability of default btree opclass only for field type not for all types used in expression
- Did a slight refactoring of sys cache code by moving most of possible recursive code out of each individual sys cache to a single function (there is still possible recursion for o_cache_type -> collect_function -> o_cache_type -> collect_function, but I've added list of processed already types to break it)
- Added tests for that
- could separate fixing versions of moto and boto if needed
fixes #836