### PR TITLE
fix replication of reindex table with secondary indices

### DIFF
--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -3195,7 +3195,38 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 		}
 		else
 		{
+			OTableDescr tmp_descr;
+
+			o_fill_tmp_table_descr(&tmp_descr, new_o_table);
+
 			o_tables_meta_unlock_no_wal();
+			if (ix_num < nindices && old_o_table->indices[ix_num].type != oIndexPrimary &&
+				old_o_table->indices[ix_num].oids.reloid == new_o_table->indices[ix_num].oids.reloid &&
+				old_o_table->indices[ix_num].oids.relnode != new_o_table->indices[ix_num].oids.relnode)
+			{
+				Assert(is_recovery_in_progress());
+
+				/*
+				 * In main recovery worker send message to main index creation
+				 * worker in dedicated recovery workers pool and exit
+				 */
+				if (!*recovery_single_process)
+				{
+					ORelOids	invalid_oids;
+
+					/* Send recovery message to become a leader */
+					ORelOidsSetInvalid(invalid_oids);
+					recovery_send_leader_oids(oids, ix_num, new_o_table->version,
+											  invalid_oids, 0, false);
+				}
+				else
+					build_secondary_index(changed_tablespace ?
+										  old_o_table->oids.relnode :
+										  InvalidOid,
+										  new_o_table, &tmp_descr, ix_num,
+										  false, NULL);
+			}
+			o_free_tmp_table_descr(&tmp_descr);
 		}
 
 		pfree(old_o_table);

--- a/test/t/reindex_test.py
+++ b/test/t/reindex_test.py
@@ -226,3 +226,60 @@ class ReindexTest(BaseTest):
 
 		node.start()
 		node.stop()
+
+	def test_replication_reindex_secondary(self):
+		node = self.node
+		node.start()
+
+		with self.node as master:
+			with self.getReplica().start() as replica:
+				with master.connect() as con1:
+					con1.begin()
+
+					con1.execute("""
+						CREATE EXTENSION IF NOT EXISTS orioledb;
+						CREATE TABLE o_test_1(
+							val_1 int PRIMARY KEY,
+							val_2 int,
+							val_3 text
+						) USING orioledb;
+
+						CREATE UNIQUE INDEX o_test_1_val2_idx ON o_test_1(val_2);
+						CREATE INDEX o_test_1_val3_idx ON o_test_1(val_3);
+						INSERT INTO o_test_1 SELECT x, 2 * x, 'test_data' || x FROM generate_series(1, 1000) x;
+					""")
+
+					con1.commit()
+
+				master.execute("DELETE FROM o_test_1 WHERE val_1 %% 2 = 1;")
+				master.execute("REINDEX TABLE o_test_1;")
+
+				self.catchup_orioledb(replica)
+
+				set_scan = "set enable_seqscan = {}; set enable_indexscan = {}; set enable_bitmapscan = {};"
+
+				self.assertEqual(
+				    replica.execute(
+				        f"{set_scan.format('on', 'off', 'off')} SELECT * FROM o_test_1 WHERE val_2 = 202;"
+				    ), [])
+				self.assertEqual(
+				    replica.execute(
+				        f"{set_scan.format('off', 'on', 'on')}  SELECT * FROM o_test_1 WHERE val_2 = 202;"
+				    ), [])
+				self.assertEqual(
+				    replica.execute(
+				        f"{set_scan.format('off', 'on', 'on')}  SELECT * FROM o_test_1 WHERE val_3 = 'test_data101';"
+				    ), [])
+
+				self.assertEqual(
+				    replica.execute(
+				        f"{set_scan.format('on', 'off', 'off')} SELECT * FROM o_test_1 WHERE val_2 = 500;"
+				    ), [(250, 500, 'test_data250')])
+				self.assertEqual(
+				    replica.execute(
+				        f"{set_scan.format('off', 'on', 'on')}  SELECT * FROM o_test_1 WHERE val_2 = 500;"
+				    ), [(250, 500, 'test_data250')])
+				self.assertEqual(
+				    replica.execute(
+				        f"{set_scan.format('off', 'on', 'on')}  SELECT * FROM o_test_1 WHERE val_3 = 'test_data250';"
+				    ), [(250, 500, 'test_data250')])


### PR DESCRIPTION
On reindex table with primary key firstly table rebuild as citd-primary table and then this on rebuild as table with primary key. On master side  when table has some secondary indices data writes on rebuild as citd-primary table, but recreate this one as table with primary-key data for secondary indices writes as separate building new secondary indices. Replica was missed step building secondary index for primary key because old and new tables has the same index count and just change refillenode in oriole system catalogs. So after replication secondary indices become an empty on replica. 