### PR TITLE
fix set rel options via ALTER TABLE

### DIFF
--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -3813,7 +3813,7 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 							}
 						}
 						Assert(ix_num < o_table->nindices);
-						if (reltablespace == 0)
+						if (!OidIsValid(reltablespace))
 							reltablespace = MyDatabaseTableSpace;
 						if (o_table->indices[ix_num].tablespace == reltablespace)
 						{
@@ -3877,6 +3877,8 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 					ORelOids	old_oids;
 					Oid			old_reltablespace = rel->rd_rel->reltablespace;
 
+					if (!OidIsValid(old_reltablespace))
+						old_reltablespace = MyDatabaseTableSpace;
 					ORelOidsSetFromRel(old_oids, rel);
 					CommandCounterIncrement();
 					if (old_reltablespace != rel->rd_rel->reltablespace)
@@ -3970,10 +3972,14 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 					ORelOptions *options = (ORelOptions *) tbl->rd_options;
 					uint8		new_fillfactor;
 					bool		new_index_bridging;
+					Oid			reltablespace = rel->rd_rel->reltablespace;
 
+					if (reltablespace == 0)
+						reltablespace = MyDatabaseTableSpace;
 					CommandCounterIncrement();
 					ORelOidsSetFromRel(oids, tbl);
-					if (ORelOidsIsValid(saved_oids) && o_saved_reltablespace != rel->rd_rel->reltablespace)
+					if (OidIsValid(o_saved_reltablespace) &&
+						o_saved_reltablespace != reltablespace)
 					{
 						/*
 						 * We come here during "ALTER TABLE ... SET

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -892,6 +892,7 @@ orioledb_utility_command(PlannedStmt *pstmt,
 		in_rewrite = false;
 		o_saved_relrewrite = InvalidOid;
 		o_saved_reltablespace = InvalidOid;
+		ORelOidsSetInvalid(saved_oids);
 		savedDataQuery = NULL;
 		in_nontransactional_truncate = false;
 	}
@@ -3972,7 +3973,7 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 
 					CommandCounterIncrement();
 					ORelOidsSetFromRel(oids, tbl);
-					if (o_saved_reltablespace != rel->rd_rel->reltablespace)
+					if (ORelOidsIsValid(saved_oids) && o_saved_reltablespace != rel->rd_rel->reltablespace)
 					{
 						/*
 						 * We come here during "ALTER TABLE ... SET
@@ -4029,6 +4030,7 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 						o_table_free(new_o_table);
 
 						o_saved_reltablespace = InvalidOid;
+						ORelOidsSetInvalid(saved_oids);
 					}
 					else
 					{

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -740,6 +740,17 @@ SELECT orioledb_tbl_indices('atable'::regclass);
  
 (1 row)
 
+ALTER TABLE atable SET (fillfactor=80);
+\d+ atable
+                                 Table "tablespace.atable"
+ Column  |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+---------+---------+-----------+----------+---------+---------+--------------+-------------
+ column1 | integer |           | not null |         | plain   |              | 
+Indexes:
+    "anindex" UNIQUE, btree (column1 DESC)
+Tablespace: "regress_tblspace"
+Options: fillfactor=80
+
 DROP TABLE atable;
 DROP DATABASE tblspace_test_db;
 ALTER TABLE ALL IN TABLESPACE regress_tblspace SET TABLESPACE pg_default;

--- a/test/sql/tablespace.sql
+++ b/test/sql/tablespace.sql
@@ -179,6 +179,9 @@ SELECT orioledb_tbl_indices('atable'::regclass);
 DROP INDEX atable_ix2;
 SELECT orioledb_tbl_indices('atable'::regclass);
 
+ALTER TABLE atable SET (fillfactor=80);
+\d+ atable
+
 DROP TABLE atable;
 
 DROP DATABASE tblspace_test_db;


### PR DESCRIPTION
ALTER TABLE ... SET failed when table is not in default tablespace. Because it has the same execution path as SET TABLESPACE, but table space oid doesn't change and there is no old table, that was catch with assert