### PR TITLE
fix fillfactor set for secondary index and reset

### DIFF
--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -3791,7 +3791,6 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 						OSnapshot	oSnapshot;
 						OXid		oxid;
 						ORelOids	idx_oids;
-						OBTOptions *options = (OBTOptions *) rel->rd_options;
 						Oid			reltablespace;
 
 						ORelOidsSetFromRel(idx_oids, rel);
@@ -3802,13 +3801,13 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 						for (ix_num = 0; ix_num < o_table->nindices; ix_num++)
 						{
 							OTableIndex *index = &o_table->indices[ix_num];
+							OBTOptions *options = (OBTOptions *) rel->rd_options;
 
 							if (ORelOidsIsEqual(index->oids, idx_oids))
 							{
 								namestrcpy(&index->name,
 										   rel->rd_rel->relname.data);
-								if (options)
-									index->fillfactor = options->bt_options.fillfactor;
+								index->fillfactor = options ? options->bt_options.fillfactor : BTREE_DEFAULT_FILLFACTOR;
 								break;
 							}
 						}
@@ -3817,9 +3816,11 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 							reltablespace = MyDatabaseTableSpace;
 						if (o_table->indices[ix_num].tablespace == reltablespace)
 						{
+							int			ctid_idx_off = o_table->has_primary ? 0 : 1;
+
 							fill_current_oxid_osnapshot(&oxid, &oSnapshot);
 							o_tables_rel_meta_lock(tbl);
-							o_indices_update(o_table, ix_num, oxid, oSnapshot.csn);
+							o_indices_update(o_table, ix_num + ctid_idx_off, oxid, oSnapshot.csn);
 							o_tables_update(o_table, oxid, oSnapshot.csn);
 							o_tables_rel_meta_unlock(tbl, InvalidOid);
 							o_invalidate_oids(idx_oids);

--- a/test/expected/fillfactor.out
+++ b/test/expected/fillfactor.out
@@ -236,6 +236,29 @@ SELECT level, count, ROUND(avgoccupied * 100 / 8192)
      1 |     1 |    18
 (2 rows)
 
+ALTER INDEX o_test_fillfactor_ix1 RESET (fillfactor);
+\d+ o_test_fillfactor
+                                Table "fillfactor.o_test_fillfactor"
+ Column |       Type        | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+-------------------+-----------+----------+---------+----------+--------------+-------------
+ f1     | text              |           | not null |         | extended |              | 
+ f2     | character varying |           |          |         | extended |              | 
+ f3     | integer           |           |          |         | plain    |              | 
+ f4     | integer           |           |          |         | plain    |              | 
+ f5     | integer           |           |          |         | plain    |              | 
+ f6     | integer           |           |          |         | plain    |              | 
+Indexes:
+    "o_test_fillfactor_pkey" PRIMARY KEY, btree (f1)
+    "o_test_fillfactor_ix1" btree (f1)
+Options: fillfactor=20
+
+\d+ o_test_fillfactor_ix1
+          Index "fillfactor.o_test_fillfactor_ix1"
+ Column | Type | Key? | Definition | Storage  | Stats target 
+--------+------+------+------------+----------+--------------
+ f1     | text | yes  | f1         | extended | 
+btree, for table "fillfactor.o_test_fillfactor"
+
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to table o_test_fillfactor
 DROP SCHEMA fillfactor CASCADE;

--- a/test/sql/fillfactor.sql
+++ b/test/sql/fillfactor.sql
@@ -105,6 +105,10 @@ INSERT INTO o_test_fillfactor SELECT to_char(v, '0000000'), 10-v, (v+5)%7, (v+15
 SELECT level, count, ROUND(avgoccupied * 100 / 8192)
     FROM orioledb_tree_stat('o_test_fillfactor_ix1'::regclass);
 
+ALTER INDEX o_test_fillfactor_ix1 RESET (fillfactor);
+\d+ o_test_fillfactor
+\d+ o_test_fillfactor_ix1
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA fillfactor CASCADE;
 RESET search_path;


### PR DESCRIPTION
- On reset fillfactor saved BTOption delete after saving and on get value pointer is corrupted.
-  Fillfactor was not set for secondary index for table without primary key