### PR TITLE
Fix index-only scan crash on secondary indexes

### DIFF
--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -1831,6 +1831,24 @@ fill_itup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
 			temp_rowid_isnull[i] = slot->tts_isnull[attnum];
 		}
 
+		/*
+		 * primaryFieldsAttnums covers PK key columns only (see
+		 * add_index_fields(fillPrimary=true), nFields = nkeyfields), but
+		 * o_new_rowid() formats the rowid against primary->nonLeafTupdesc
+		 * whose natts is nkeyfields + nIncludedFields when the PK has INCLUDE
+		 * columns.  Those INCLUDE columns aren't part of the secondary's leaf
+		 * either, so we have no value to plug in -- and refind only matches
+		 * against the key columns anyway.  Fill the tail of
+		 * temp_rowid_isnull[] with `true`s so that o_new_tuple_size doesn't
+		 * read uninitialised memory while computing the rowid tuple's null
+		 * bitmap.
+		 */
+		for (; i < GET_PRIMARY(descr)->nonLeafTupdesc->natts; i++)
+		{
+			temp_rowid_values[i] = (Datum) 0;
+			temp_rowid_isnull[i] = true;
+		}
+
 		if (o_scan->ixNum == PrimaryIndexNumber)
 		{
 			rowid_values = slot->tts_values;
@@ -1861,8 +1879,33 @@ fill_itup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
 		pfree(scan->xs_itup);
 		scan->xs_itup = NULL;
 	}
+
+	/*--
+	 * OrioleDB's internal itupdesc already matches the planner-side
+	 * indextlist layout in both column count and column order:
+	 *
+	 *   itupdesc = [non-duplicate secondary key cols
+	 *               | non-duplicate INCLUDE cols
+	 *               | duplicate cols (refilled from their source columns)
+	 *               | extra PK key cols not already in the secondary],
+	 *
+	 *   planner indextlist = rd_att (all declared cols, including dups)
+	 *                       + (when has_primary, PK key cols not in
+	 *                          rd_att.indexkeys, added by
+	 *                          set_plain_rel_pathlist_hook()).
+	 *
+	 * Their natts agree because the duplicate slots in itupdesc account
+	 * for exactly the same columns as the duplicates inside rd_att, and
+	 * because scan.c's hook only adds PK *key* cols (matching the
+	 * !primaryIsCtid path that populates the PK tail of itupdesc).  The
+	 * duplicate-slot rearrangement done by the block right above this
+	 * comment leaves slot->tts_values in itupdesc order, so we hand the
+	 * pair directly to index_form_tuple.
+	 */
 	scan->xs_itupdesc = index_descr->itupdesc;
-	scan->xs_itup = index_form_tuple(index_descr->itupdesc, slot->tts_values, slot->tts_isnull);
+	scan->xs_itup = index_form_tuple(index_descr->itupdesc,
+									 slot->tts_values,
+									 slot->tts_isnull);
 
 	ItemPointerCopy(&slot->tts_tid, &scan->xs_itup->t_tid);
 

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -212,7 +212,7 @@ orioledb_set_plain_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 		{
 			ListCell   *lc;
 			int			i;
-			int			nfields;
+			int			nkeyfields;
 			ORelOids	oids;
 			OTable	   *o_table;
 
@@ -227,9 +227,9 @@ orioledb_set_plain_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 				 * Additional pkey fields are added to index target list so
 				 * that the index only scan is selected
 				 */
-				nfields = o_table->indices[PrimaryIndexNumber].nfields;
+				nkeyfields = o_table->indices[PrimaryIndexNumber].nkeyfields;
 
-				for (i = 0; i < nfields; i++)
+				for (i = 0; i < nkeyfields; i++)
 				{
 					OTableIndexField *pk_field;
 

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -8899,6 +8899,159 @@ SELECT count(*) FROM o_test_null_mixed
 (1 row)
 
 RESET enable_seqscan;
+-- Index-only scan coverage for secondary indexes.  These all force
+-- enable_seqscan = off + enable_bitmapscan = off so the planner picks
+-- IOS, then verify the plan uses the secondary AND the rows are
+-- returned correctly.  Together they exercise the column-count /
+-- column-order alignment between OrioleDB's itupdesc layout and the
+-- planner-side indextlist that set_plain_rel_pathlist_hook() builds.
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+SET enable_indexscan = off;
+-- 1. Duplicate columns inside the secondary index (key + key, key + INCLUDE)
+CREATE TABLE o_ios_sk_dup (val_2 int, val_1 int) USING orioledb;
+CREATE INDEX o_ios_sk_dup_ix ON o_ios_sk_dup (val_1, val_2, val_1) INCLUDE (val_1);
+INSERT INTO o_ios_sk_dup SELECT v, v * 10 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF)
+	SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
+(1 row)
+
+SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+ val_1 
+-------
+    10
+    20
+    30
+    40
+    50
+(5 rows)
+
+EXPLAIN (COSTS OFF)
+	SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
+(1 row)
+
+SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+ val_1 | val_2 
+-------+-------
+    10 |     1
+    20 |     2
+    30 |     3
+    40 |     4
+    50 |     5
+(5 rows)
+
+DROP TABLE o_ios_sk_dup;
+-- 2. Duplicate columns inside the *unique* secondary index that
+-- becomes the table's primary in OrioleDB (no explicit PRIMARY KEY).
+CREATE TABLE o_ios_pk_dup (a int NOT NULL, b text NOT NULL) USING orioledb;
+CREATE UNIQUE INDEX o_ios_pk_dup_ix ON o_ios_pk_dup (a, b, a);
+INSERT INTO o_ios_pk_dup
+	SELECT v, repeat('x', v) FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_pk_dup_ix on o_ios_pk_dup
+(1 row)
+
+SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+ a |   b   
+---+-------
+ 1 | x
+ 2 | xx
+ 3 | xxx
+ 4 | xxxx
+ 5 | xxxxx
+(5 rows)
+
+DROP TABLE o_ios_pk_dup;
+-- 3. Overlap between secondary index columns and PK columns.  The PK
+-- column `a` appears in the SK; `c` does not.  fill_itup must produce
+-- (a, b, c) on the SK side -- not (a, b) (would miss c) and not (a, b,
+-- a, c) (would mis-shape).
+CREATE TABLE o_ios_pk_sk_dup
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a, c)) USING orioledb;
+CREATE INDEX o_ios_pk_sk_dup_ix ON o_ios_pk_sk_dup (a, b);
+INSERT INTO o_ios_pk_sk_dup
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Index Only Scan using o_ios_pk_sk_dup_ix on o_ios_pk_sk_dup
+(1 row)
+
+SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+ a | b  |  c  
+---+----+-----
+ 1 | 10 | 100
+ 2 | 20 | 200
+ 3 | 30 | 300
+ 4 | 40 | 400
+ 5 | 50 | 500
+(5 rows)
+
+DROP TABLE o_ios_pk_sk_dup;
+-- 4. INCLUDE columns on the PK.  set_plain_rel_pathlist_hook() must
+-- iterate only PK key columns (not its INCLUDE list) when extending
+-- the secondary's indextlist, otherwise the INCLUDE'd column of PK
+-- would be appended on the planner side but not present on the
+-- orioledb-itupdesc side -- a natts mismatch on every IOS.
+CREATE TABLE o_ios_pk_include
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a) INCLUDE (c)) USING orioledb;
+CREATE INDEX o_ios_pk_include_ix ON o_ios_pk_include (b);
+INSERT INTO o_ios_pk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_include ORDER BY b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Index Only Scan using o_ios_pk_include_ix on o_ios_pk_include
+(1 row)
+
+SELECT a, b FROM o_ios_pk_include ORDER BY b;
+ a | b  
+---+----
+ 1 | 10
+ 2 | 20
+ 3 | 30
+ 4 | 40
+ 5 | 50
+(5 rows)
+
+DROP TABLE o_ios_pk_include;
+-- 5. INCLUDE columns on the secondary index itself.
+CREATE TABLE o_ios_sk_include
+	(a int NOT NULL PRIMARY KEY, b int NOT NULL, c int NOT NULL)
+	USING orioledb;
+CREATE INDEX o_ios_sk_include_ix ON o_ios_sk_include (b) INCLUDE (c);
+INSERT INTO o_ios_sk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Index Only Scan using o_ios_sk_include_ix on o_ios_sk_include
+(1 row)
+
+SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+ a | b  |  c  
+---+----+-----
+ 1 | 10 | 100
+ 2 | 20 | 200
+ 3 | 30 | 300
+ 4 | 40 | 400
+ 5 | 50 | 500
+(5 rows)
+
+DROP TABLE o_ios_sk_include;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET enable_indexscan;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -8885,6 +8885,159 @@ SELECT count(*) FROM o_test_null_mixed
 (1 row)
 
 RESET enable_seqscan;
+-- Index-only scan coverage for secondary indexes.  These all force
+-- enable_seqscan = off + enable_bitmapscan = off so the planner picks
+-- IOS, then verify the plan uses the secondary AND the rows are
+-- returned correctly.  Together they exercise the column-count /
+-- column-order alignment between OrioleDB's itupdesc layout and the
+-- planner-side indextlist that set_plain_rel_pathlist_hook() builds.
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+SET enable_indexscan = off;
+-- 1. Duplicate columns inside the secondary index (key + key, key + INCLUDE)
+CREATE TABLE o_ios_sk_dup (val_2 int, val_1 int) USING orioledb;
+CREATE INDEX o_ios_sk_dup_ix ON o_ios_sk_dup (val_1, val_2, val_1) INCLUDE (val_1);
+INSERT INTO o_ios_sk_dup SELECT v, v * 10 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF)
+	SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
+(1 row)
+
+SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+ val_1 
+-------
+    10
+    20
+    30
+    40
+    50
+(5 rows)
+
+EXPLAIN (COSTS OFF)
+	SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
+(1 row)
+
+SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+ val_1 | val_2 
+-------+-------
+    10 |     1
+    20 |     2
+    30 |     3
+    40 |     4
+    50 |     5
+(5 rows)
+
+DROP TABLE o_ios_sk_dup;
+-- 2. Duplicate columns inside the *unique* secondary index that
+-- becomes the table's primary in OrioleDB (no explicit PRIMARY KEY).
+CREATE TABLE o_ios_pk_dup (a int NOT NULL, b text NOT NULL) USING orioledb;
+CREATE UNIQUE INDEX o_ios_pk_dup_ix ON o_ios_pk_dup (a, b, a);
+INSERT INTO o_ios_pk_dup
+	SELECT v, repeat('x', v) FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_pk_dup_ix on o_ios_pk_dup
+(1 row)
+
+SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+ a |   b   
+---+-------
+ 1 | x
+ 2 | xx
+ 3 | xxx
+ 4 | xxxx
+ 5 | xxxxx
+(5 rows)
+
+DROP TABLE o_ios_pk_dup;
+-- 3. Overlap between secondary index columns and PK columns.  The PK
+-- column `a` appears in the SK; `c` does not.  fill_itup must produce
+-- (a, b, c) on the SK side -- not (a, b) (would miss c) and not (a, b,
+-- a, c) (would mis-shape).
+CREATE TABLE o_ios_pk_sk_dup
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a, c)) USING orioledb;
+CREATE INDEX o_ios_pk_sk_dup_ix ON o_ios_pk_sk_dup (a, b);
+INSERT INTO o_ios_pk_sk_dup
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Index Only Scan using o_ios_pk_sk_dup_ix on o_ios_pk_sk_dup
+(1 row)
+
+SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+ a | b  |  c  
+---+----+-----
+ 1 | 10 | 100
+ 2 | 20 | 200
+ 3 | 30 | 300
+ 4 | 40 | 400
+ 5 | 50 | 500
+(5 rows)
+
+DROP TABLE o_ios_pk_sk_dup;
+-- 4. INCLUDE columns on the PK.  set_plain_rel_pathlist_hook() must
+-- iterate only PK key columns (not its INCLUDE list) when extending
+-- the secondary's indextlist, otherwise the INCLUDE'd column of PK
+-- would be appended on the planner side but not present on the
+-- orioledb-itupdesc side -- a natts mismatch on every IOS.
+CREATE TABLE o_ios_pk_include
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a) INCLUDE (c)) USING orioledb;
+CREATE INDEX o_ios_pk_include_ix ON o_ios_pk_include (b);
+INSERT INTO o_ios_pk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_include ORDER BY b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Index Only Scan using o_ios_pk_include_ix on o_ios_pk_include
+(1 row)
+
+SELECT a, b FROM o_ios_pk_include ORDER BY b;
+ a | b  
+---+----
+ 1 | 10
+ 2 | 20
+ 3 | 30
+ 4 | 40
+ 5 | 50
+(5 rows)
+
+DROP TABLE o_ios_pk_include;
+-- 5. INCLUDE columns on the secondary index itself.
+CREATE TABLE o_ios_sk_include
+	(a int NOT NULL PRIMARY KEY, b int NOT NULL, c int NOT NULL)
+	USING orioledb;
+CREATE INDEX o_ios_sk_include_ix ON o_ios_sk_include (b) INCLUDE (c);
+INSERT INTO o_ios_sk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Index Only Scan using o_ios_sk_include_ix on o_ios_sk_include
+(1 row)
+
+SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+ a | b  |  c  
+---+----+-----
+ 1 | 10 | 100
+ 2 | 20 | 200
+ 3 | 30 | 300
+ 4 | 40 | 400
+ 5 | 50 | 500
+(5 rows)
+
+DROP TABLE o_ios_sk_include;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET enable_indexscan;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -8946,6 +8946,165 @@ SELECT count(*) FROM o_test_null_mixed
 (1 row)
 
 RESET enable_seqscan;
+-- Index-only scan coverage for secondary indexes.  These all force
+-- enable_seqscan = off + enable_bitmapscan = off so the planner picks
+-- IOS, then verify the plan uses the secondary AND the rows are
+-- returned correctly.  Together they exercise the column-count /
+-- column-order alignment between OrioleDB's itupdesc layout and the
+-- planner-side indextlist that set_plain_rel_pathlist_hook() builds.
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+SET enable_indexscan = off;
+-- 1. Duplicate columns inside the secondary index (key + key, key + INCLUDE)
+CREATE TABLE o_ios_sk_dup (val_2 int, val_1 int) USING orioledb;
+CREATE INDEX o_ios_sk_dup_ix ON o_ios_sk_dup (val_1, val_2, val_1) INCLUDE (val_1);
+INSERT INTO o_ios_sk_dup SELECT v, v * 10 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF)
+	SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
+   Disabled: true
+(2 rows)
+
+SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+ val_1 
+-------
+    10
+    20
+    30
+    40
+    50
+(5 rows)
+
+EXPLAIN (COSTS OFF)
+	SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
+   Disabled: true
+(2 rows)
+
+SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+ val_1 | val_2 
+-------+-------
+    10 |     1
+    20 |     2
+    30 |     3
+    40 |     4
+    50 |     5
+(5 rows)
+
+DROP TABLE o_ios_sk_dup;
+-- 2. Duplicate columns inside the *unique* secondary index that
+-- becomes the table's primary in OrioleDB (no explicit PRIMARY KEY).
+CREATE TABLE o_ios_pk_dup (a int NOT NULL, b text NOT NULL) USING orioledb;
+CREATE UNIQUE INDEX o_ios_pk_dup_ix ON o_ios_pk_dup (a, b, a);
+INSERT INTO o_ios_pk_dup
+	SELECT v, repeat('x', v) FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Index Only Scan using o_ios_pk_dup_ix on o_ios_pk_dup
+   Disabled: true
+(2 rows)
+
+SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+ a |   b   
+---+-------
+ 1 | x
+ 2 | xx
+ 3 | xxx
+ 4 | xxxx
+ 5 | xxxxx
+(5 rows)
+
+DROP TABLE o_ios_pk_dup;
+-- 3. Overlap between secondary index columns and PK columns.  The PK
+-- column `a` appears in the SK; `c` does not.  fill_itup must produce
+-- (a, b, c) on the SK side -- not (a, b) (would miss c) and not (a, b,
+-- a, c) (would mis-shape).
+CREATE TABLE o_ios_pk_sk_dup
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a, c)) USING orioledb;
+CREATE INDEX o_ios_pk_sk_dup_ix ON o_ios_pk_sk_dup (a, b);
+INSERT INTO o_ios_pk_sk_dup
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Index Only Scan using o_ios_pk_sk_dup_ix on o_ios_pk_sk_dup
+   Disabled: true
+(2 rows)
+
+SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+ a | b  |  c  
+---+----+-----
+ 1 | 10 | 100
+ 2 | 20 | 200
+ 3 | 30 | 300
+ 4 | 40 | 400
+ 5 | 50 | 500
+(5 rows)
+
+DROP TABLE o_ios_pk_sk_dup;
+-- 4. INCLUDE columns on the PK.  set_plain_rel_pathlist_hook() must
+-- iterate only PK key columns (not its INCLUDE list) when extending
+-- the secondary's indextlist, otherwise the INCLUDE'd column of PK
+-- would be appended on the planner side but not present on the
+-- orioledb-itupdesc side -- a natts mismatch on every IOS.
+CREATE TABLE o_ios_pk_include
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a) INCLUDE (c)) USING orioledb;
+CREATE INDEX o_ios_pk_include_ix ON o_ios_pk_include (b);
+INSERT INTO o_ios_pk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_include ORDER BY b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Index Only Scan using o_ios_pk_include_ix on o_ios_pk_include
+   Disabled: true
+(2 rows)
+
+SELECT a, b FROM o_ios_pk_include ORDER BY b;
+ a | b  
+---+----
+ 1 | 10
+ 2 | 20
+ 3 | 30
+ 4 | 40
+ 5 | 50
+(5 rows)
+
+DROP TABLE o_ios_pk_include;
+-- 5. INCLUDE columns on the secondary index itself.
+CREATE TABLE o_ios_sk_include
+	(a int NOT NULL PRIMARY KEY, b int NOT NULL, c int NOT NULL)
+	USING orioledb;
+CREATE INDEX o_ios_sk_include_ix ON o_ios_sk_include (b) INCLUDE (c);
+INSERT INTO o_ios_sk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Index Only Scan using o_ios_sk_include_ix on o_ios_sk_include
+   Disabled: true
+(2 rows)
+
+SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+ a | b  |  c  
+---+----+-----
+ 1 | 10 | 100
+ 2 | 20 | 200
+ 3 | 30 | 300
+ 4 | 40 | 400
+ 5 | 50 | 500
+(5 rows)
+
+DROP TABLE o_ios_sk_include;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET enable_indexscan;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/sql/indices.sql
+++ b/test/sql/indices.sql
@@ -2147,6 +2147,82 @@ SET enable_seqscan = OFF;
 SELECT count(*) FROM o_test_null_mixed
 	WHERE unique1 IS NULL AND unique2 IS NOT NULL;
 RESET enable_seqscan;
+-- Index-only scan coverage for secondary indexes.  These all force
+-- enable_seqscan = off + enable_bitmapscan = off so the planner picks
+-- IOS, then verify the plan uses the secondary AND the rows are
+-- returned correctly.  Together they exercise the column-count /
+-- column-order alignment between OrioleDB's itupdesc layout and the
+-- planner-side indextlist that set_plain_rel_pathlist_hook() builds.
+
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+SET enable_indexscan = off;
+
+-- 1. Duplicate columns inside the secondary index (key + key, key + INCLUDE)
+CREATE TABLE o_ios_sk_dup (val_2 int, val_1 int) USING orioledb;
+CREATE INDEX o_ios_sk_dup_ix ON o_ios_sk_dup (val_1, val_2, val_1) INCLUDE (val_1);
+INSERT INTO o_ios_sk_dup SELECT v, v * 10 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF)
+	SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
+EXPLAIN (COSTS OFF)
+	SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
+DROP TABLE o_ios_sk_dup;
+
+-- 2. Duplicate columns inside the *unique* secondary index that
+-- becomes the table's primary in OrioleDB (no explicit PRIMARY KEY).
+CREATE TABLE o_ios_pk_dup (a int NOT NULL, b text NOT NULL) USING orioledb;
+CREATE UNIQUE INDEX o_ios_pk_dup_ix ON o_ios_pk_dup (a, b, a);
+INSERT INTO o_ios_pk_dup
+	SELECT v, repeat('x', v) FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
+DROP TABLE o_ios_pk_dup;
+
+-- 3. Overlap between secondary index columns and PK columns.  The PK
+-- column `a` appears in the SK; `c` does not.  fill_itup must produce
+-- (a, b, c) on the SK side -- not (a, b) (would miss c) and not (a, b,
+-- a, c) (would mis-shape).
+CREATE TABLE o_ios_pk_sk_dup
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a, c)) USING orioledb;
+CREATE INDEX o_ios_pk_sk_dup_ix ON o_ios_pk_sk_dup (a, b);
+INSERT INTO o_ios_pk_sk_dup
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
+DROP TABLE o_ios_pk_sk_dup;
+
+-- 4. INCLUDE columns on the PK.  set_plain_rel_pathlist_hook() must
+-- iterate only PK key columns (not its INCLUDE list) when extending
+-- the secondary's indextlist, otherwise the INCLUDE'd column of PK
+-- would be appended on the planner side but not present on the
+-- orioledb-itupdesc side -- a natts mismatch on every IOS.
+CREATE TABLE o_ios_pk_include
+	(a int NOT NULL, b int NOT NULL, c int NOT NULL,
+	 PRIMARY KEY (a) INCLUDE (c)) USING orioledb;
+CREATE INDEX o_ios_pk_include_ix ON o_ios_pk_include (b);
+INSERT INTO o_ios_pk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_include ORDER BY b;
+SELECT a, b FROM o_ios_pk_include ORDER BY b;
+DROP TABLE o_ios_pk_include;
+
+-- 5. INCLUDE columns on the secondary index itself.
+CREATE TABLE o_ios_sk_include
+	(a int NOT NULL PRIMARY KEY, b int NOT NULL, c int NOT NULL)
+	USING orioledb;
+CREATE INDEX o_ios_sk_include_ix ON o_ios_sk_include (b) INCLUDE (c);
+INSERT INTO o_ios_sk_include
+	SELECT v, v * 10, v * 100 FROM generate_series(1, 5) v;
+EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
+DROP TABLE o_ios_sk_include;
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET enable_indexscan;
 
 SELECT orioledb_parallel_debug_stop();
 DROP EXTENSION orioledb CASCADE;


### PR DESCRIPTION
OrioleDB secondary indexes internally store PK fields in leaf tuples, and scan.c adds matching PK columns to indextlist so the planner can use index-only scans.  However fill_itup() produced index tuples using the internal itupdesc (which includes hidden PK fields at different positions), causing a column count mismatch with the planner's slot. PostgreSQL's StoreIndexTuple() asserts slot->natts == itupdesc->natts, leading to a crash.

Reproducer:

```sql
CREATE TABLE t2 (a int4 NOT NULL, b int4 NOT NULL, c int4, d int4,
                 PRIMARY KEY(a, b) INCLUDE(c)) USING orioledb;
CREATE INDEX t2_d_idx ON t2 (d);
INSERT INTO t2 SELECT i, i*2, i*3, i*4 FROM generate_series(1, 200) AS i;
ANALYZE t2;

SET enable_seqscan = off;
EXPLAIN (COSTS OFF) SELECT d FROM t2 WHERE d > 500;
SELECT d FROM t2 WHERE d > 500 LIMIT 5;
```

Two fixes:

1. scan.c: Use nkeyfields instead of nfields when iterating PK columns to add to indextlist.  nfields includes INCLUDE columns of the PK, which should not be added since they are not part of the PK key.

2. handler.c fill_itup: For secondary indexes, build an extended index tuple matching the planner's indextlist (rd_att columns + extra PK fields) instead of using the internal itupdesc.

Assisted-by: Crush:glm-5.1