### PR TITLE
Release `drop_index_list` before starting a DDL command

### DIFF
--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -1551,21 +1551,21 @@ orioledb_utility_command(PlannedStmt *pstmt,
 	}
 	else if (IsA(pstmt->utilityStmt, AlterTableStmt))
 	{
-		if (alter_type_exprs)
-		{
-			list_free_deep(alter_type_exprs);
-			alter_type_exprs = NIL;
-		}
-		if (o_alter_generated_column_id)
-		{
-			list_free_deep(o_alter_generated_column_id);
-			o_alter_generated_column_id = NIL;
-		}
-		if (dropped_attrs)
-		{
-			list_free(dropped_attrs);
-			dropped_attrs = NIL;
-		}
+		/*
+		 * We don't need to check the lists for NIL list_free_deep() already
+		 * does that.
+		 */
+		list_free_deep(drop_index_list);
+		drop_index_list = NIL;
+
+		list_free_deep(alter_type_exprs);
+		alter_type_exprs = NIL;
+
+		list_free_deep(o_alter_generated_column_id);
+		o_alter_generated_column_id = NIL;
+
+		list_free(dropped_attrs);
+		dropped_attrs = NIL;
 
 		/*
 		 * Don't free memory explicitly, delegate it to the memory context

--- a/test/expected/alter_type.out
+++ b/test/expected/alter_type.out
@@ -1216,8 +1216,17 @@ SELECT * FROM o_test_alter_type_add_column_default;
  4 | 101 | 1
 (2 rows)
 
+-- Test drop_index_list cleanup
+CREATE TABLE o_test_drop_index_list (
+	id int,
+	phone varchar(15)
+) USING orioledb;
+CREATE INDEX o_test_drop_index_list_ix1 ON o_test_drop_index_list (id) WHERE id > 0;
+CREATE INDEX o_test_drop_index_list_ix2 ON o_test_drop_index_list (phone);
+ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE text;
+ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE varchar(15);
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 14 other objects
 DETAIL:  drop cascades to table o_ddl_check
 drop cascades to table o_test_alter_change_byval
 drop cascades to table o_test_pkey_alter_type
@@ -1231,5 +1240,6 @@ drop cascades to table o_test_alter_type_reuse_index
 drop cascades to table o_test_alter_type_not_reuse_index
 drop cascades to table o_test_alter_type_typmod_changed
 drop cascades to table o_test_alter_type_add_column_default
+drop cascades to table o_test_drop_index_list
 DROP SCHEMA alter_type CASCADE;
 RESET search_path;

--- a/test/sql/alter_type.sql
+++ b/test/sql/alter_type.sql
@@ -360,6 +360,17 @@ ALTER TABLE o_test_alter_type_add_column_default
 	ADD COLUMN y float8 DEFAULT 1.0;
 SELECT * FROM o_test_alter_type_add_column_default;
 
+-- Test drop_index_list cleanup
+CREATE TABLE o_test_drop_index_list (
+	id int,
+	phone varchar(15)
+) USING orioledb;
+CREATE INDEX o_test_drop_index_list_ix1 ON o_test_drop_index_list (id) WHERE id > 0;
+CREATE INDEX o_test_drop_index_list_ix2 ON o_test_drop_index_list (phone);
+
+ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE text;
+ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE varchar(15);
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA alter_type CASCADE;
 RESET search_path;


### PR DESCRIPTION
`drop_index_list` is released only by `o_ddl_cleanup()` which is called only in case of an error by `orioledb_error_cleanup_hook()`.

It leads to the crash which can be reproduced without the fix by the query:
```
CREATE TABLE o_test_drop_index_list (
	id int,
	phone varchar(15)
) USING orioledb;
CREATE INDEX o_test_drop_index_list_ix1 ON o_test_drop_index_list (id) WHERE id > 0;
CREATE INDEX o_test_drop_index_list_ix2 ON o_test_drop_index_list (phone);

ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE text;
ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE varchar(15);
```