### PR TITLE
Fix PG16 wrong results for contradictory NULL scan keys

### DIFF
--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -279,10 +279,10 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	MemoryContext oldcontext;
 	bool		result = true;
 
-#if PG_VERSION_NUM >= 170000
-
 	if (!so->qual_ok)
 		return false;
+
+#if PG_VERSION_NUM >= 170000
 
 	if (so->numArrayKeys)
 	{


### PR DESCRIPTION
On PG16, queries like "WHERE col IS NULL AND col > 500" returned all rows instead of 0.  _bt_preprocess_keys() correctly detects the contradiction and sets qual_ok=false, but the qual_ok check in switch_to_next_range() was inside a PG17-only #ifdef block, so PG16 skipped it and proceeded with an unbounded range.

Move the qual_ok check before the version #if so both PG16 and PG17 benefit.

Reproducer:

```sql
CREATE TABLE t (a int, b int) USING orioledb;
INSERT INTO t SELECT i, i FROM generate_series(1, 1000) i;
INSERT INTO t (a, b) VALUES (NULL, -1), (NULL, NULL);
CREATE INDEX t_a_idx ON t (a);

SET enable_seqscan = off;

-- BUG: should return 0, returns 1002
-- Planner chooses Index Only Scan for = operator
EXPLAIN (COSTS OFF) SELECT count(*) FROM t WHERE a IS NULL AND a = 500;
SELECT count(*) AS should_be_zero FROM t WHERE a IS NULL AND a = 500;
```

Assisted-by: Crush:glm-5.1