### PR TITLE
ci: enable nightly cron schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,8 @@
 name: nightly
 
 on:
-  # Cron disabled until the first manual workflow_dispatch from `main` is
-  # validated. Re-enable in a follow-up PR once the publish path (docker push +
-  # GitHub Release) has been confirmed end-to-end.
-  # schedule:
-  #   - cron: '0 2 * * *'  # 02:00 UTC daily
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC daily
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI follow-up — enables the nightly cron schedule that was intentionally left commented out when #870 merged.

## What is the current behavior?

`nightly.yml` only fires via `workflow_dispatch` (manual). The `schedule: cron` line was added in #870 but commented out so the publish path (docker push + GitHub Release + git tag) could be validated by hand before fully automating.

## What is the new behavior?

Cron enabled — nightly builds fire automatically at **02:00 UTC daily**, plus the existing `workflow_dispatch` for manual runs.

## Additional information

Validation done before this PR: a [manually triggered run](https://github.com/orioledb/orioledb/actions/runs/26802376083) from `main` (`fdce96a`) produced all 8 Docker Hub tags (`pg{16,17}-nightly[-20260602-fdce96a][-ubuntu]`), created the `nightly-2026-06-02-fdce96a` GitHub Release as a Pre-release, and the resulting `orioledb/orioledb:pg17-nightly` image pulled cleanly, started in 3 seconds, and a `CREATE TABLE ... USING orioledb` smoke test succeeded end-to-end.
