### PR TITLE
Fix PG16 wrong results for contradictory NULL scan keys

### DIFF
--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -279,10 +279,10 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	MemoryContext oldcontext;
 	bool		result = true;
 
-#if PG_VERSION_NUM >= 170000
-
 	if (!so->qual_ok)
 		return false;
+
+#if PG_VERSION_NUM >= 170000
 
 	if (so->numArrayKeys)
 	{

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -8753,6 +8753,85 @@ ERROR:  duplicate key value violates unique constraint "o_test_uq"
 DETAIL:  Key (val)=(one) already exists.
 -- Cleanup
 DROP TABLE o_test_add_index_constraint CASCADE;
+-- Contradictory scan keys (e.g. "col IS NULL AND col = N") must return
+-- zero rows even when an index is forced.  _bt_preprocess_keys sets
+-- so->qual_ok = false; switch_to_next_range must honor that on every
+-- supported PG major.  Before the fix, PG16 returned the whole table
+-- (the qual_ok check was nested inside a PG17-only #ifdef).  Both the
+-- index-scan and the bitmap-scan paths are exercised because they go
+-- through the same switch_to_next_range entry point.
+CREATE TABLE o_test_qual_contradiction (
+	a int,
+	b int
+) USING orioledb;
+INSERT INTO o_test_qual_contradiction
+	SELECT i, i FROM generate_series(1, 1000) i;
+INSERT INTO o_test_qual_contradiction (a, b) VALUES (NULL, -1), (NULL, NULL);
+CREATE INDEX o_test_qual_contradiction_a_idx
+	ON o_test_qual_contradiction (a);
+ANALYZE o_test_qual_contradiction;
+SET enable_seqscan = OFF;
+-- IS NULL AND = N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a = 500;
+ count 
+-------
+     0
+(1 row)
+
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a = 500;
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+-- IS NULL AND > N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a > 500;
+ count 
+-------
+     0
+(1 row)
+
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a > 500;
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+-- IS NULL AND < N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a < 500;
+ count 
+-------
+     0
+(1 row)
+
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a < 500;
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+-- Negative control: just a = N (no contradiction) must still find row 500.
+SELECT count(*) FROM o_test_qual_contradiction WHERE a = 500;
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE o_test_qual_contradiction;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -8739,6 +8739,85 @@ ERROR:  duplicate key value violates unique constraint "o_test_uq"
 DETAIL:  Key (val)=(one) already exists.
 -- Cleanup
 DROP TABLE o_test_add_index_constraint CASCADE;
+-- Contradictory scan keys (e.g. "col IS NULL AND col = N") must return
+-- zero rows even when an index is forced.  _bt_preprocess_keys sets
+-- so->qual_ok = false; switch_to_next_range must honor that on every
+-- supported PG major.  Before the fix, PG16 returned the whole table
+-- (the qual_ok check was nested inside a PG17-only #ifdef).  Both the
+-- index-scan and the bitmap-scan paths are exercised because they go
+-- through the same switch_to_next_range entry point.
+CREATE TABLE o_test_qual_contradiction (
+	a int,
+	b int
+) USING orioledb;
+INSERT INTO o_test_qual_contradiction
+	SELECT i, i FROM generate_series(1, 1000) i;
+INSERT INTO o_test_qual_contradiction (a, b) VALUES (NULL, -1), (NULL, NULL);
+CREATE INDEX o_test_qual_contradiction_a_idx
+	ON o_test_qual_contradiction (a);
+ANALYZE o_test_qual_contradiction;
+SET enable_seqscan = OFF;
+-- IS NULL AND = N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a = 500;
+ count 
+-------
+     0
+(1 row)
+
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a = 500;
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+-- IS NULL AND > N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a > 500;
+ count 
+-------
+     0
+(1 row)
+
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a > 500;
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+-- IS NULL AND < N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a < 500;
+ count 
+-------
+     0
+(1 row)
+
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a < 500;
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+-- Negative control: just a = N (no contradiction) must still find row 500.
+SELECT count(*) FROM o_test_qual_contradiction WHERE a = 500;
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE o_test_qual_contradiction;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/sql/indices.sql
+++ b/test/sql/indices.sql
@@ -2043,6 +2043,57 @@ INSERT INTO o_test_add_index_constraint VALUES (6, 'one');  -- Should fail (UNIQ
 -- Cleanup
 DROP TABLE o_test_add_index_constraint CASCADE;
 
+-- Contradictory scan keys (e.g. "col IS NULL AND col = N") must return
+-- zero rows even when an index is forced.  _bt_preprocess_keys sets
+-- so->qual_ok = false; switch_to_next_range must honor that on every
+-- supported PG major.  Before the fix, PG16 returned the whole table
+-- (the qual_ok check was nested inside a PG17-only #ifdef).  Both the
+-- index-scan and the bitmap-scan paths are exercised because they go
+-- through the same switch_to_next_range entry point.
+CREATE TABLE o_test_qual_contradiction (
+	a int,
+	b int
+) USING orioledb;
+INSERT INTO o_test_qual_contradiction
+	SELECT i, i FROM generate_series(1, 1000) i;
+INSERT INTO o_test_qual_contradiction (a, b) VALUES (NULL, -1), (NULL, NULL);
+CREATE INDEX o_test_qual_contradiction_a_idx
+	ON o_test_qual_contradiction (a);
+ANALYZE o_test_qual_contradiction;
+
+SET enable_seqscan = OFF;
+
+-- IS NULL AND = N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a = 500;
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a = 500;
+RESET enable_indexscan;
+
+-- IS NULL AND > N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a > 500;
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a > 500;
+RESET enable_indexscan;
+
+-- IS NULL AND < N -- contradicts; expect 0
+SET enable_bitmapscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a < 500;
+SET enable_bitmapscan = ON;
+SET enable_indexscan = OFF;
+SELECT count(*) FROM o_test_qual_contradiction WHERE a IS NULL AND a < 500;
+RESET enable_indexscan;
+
+-- Negative control: just a = N (no contradiction) must still find row 500.
+SELECT count(*) FROM o_test_qual_contradiction WHERE a = 500;
+
+DROP TABLE o_test_qual_contradiction;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+
 SELECT orioledb_parallel_debug_stop();
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA indices CASCADE;


### PR DESCRIPTION
Picks up #874 (by @fatih-akatlar) with a regression test added.

## Original fix

On PG16, queries like `WHERE col IS NULL AND col > 500` returned all rows
instead of 0.  `_bt_preprocess_keys()` correctly detects the contradiction
and sets `qual_ok = false`, but the `qual_ok` check in
`switch_to_next_range()` was inside a PG17-only `#ifdef` block, so PG16
skipped it and proceeded with an unbounded range.

The fix hoists the `qual_ok` check out of the version gate so both PG16
and PG17 benefit.  `bitmap_scan.c` already had its `qual_ok` short-circuit
outside the version gate — this aligns the index-scan path with that.

## Regression test

`test/sql/indices.sql` grows a new block that:

* builds a 1000-row + 2 NULL-row table indexed on `a`,
* forces index-scan (then bitmap-scan) and runs
  `WHERE a IS NULL AND a {=,>,<} 500` — all six probes must return 0,
* uses `WHERE a = 500` as a negative control (must still return 1).

Verified manually on PG16: reverting the `qual_ok` hoist makes the
index-scan probe return `1002` (whole table); restoring it makes all
contradictory probes return 0.

`indices_1.out` (PG17 expected) gets the same new block since the SQL
behaves identically post-fix.

Supersedes #874.

Co-Authored-By: Fatih Akatlar <fatih.akatlar@proton.me>