### PR TITLE
Fix replica livelock after primary crash recovery (#876)

### DIFF
--- a/include/recovery/recovery.h
+++ b/include/recovery/recovery.h
@@ -22,6 +22,7 @@ extern void o_recovery_start_hook(void);
 extern void orioledb_redo(XLogReaderState *record);
 extern void o_xact_redo_hook(TransactionId xid, XLogRecPtr lsn, bool commit);
 extern void o_recovery_finish_hook(bool cleanup);
+extern void o_emit_recovery_finish_rollbacks(void);
 
 extern Size recovery_shmem_needs(void);
 extern void recovery_shmem_init(Pointer ptr, bool found);

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -214,6 +214,8 @@ extern XLogRecPtr wal_joint_commit(OXid oxid, TransactionId logicalXid,
 extern void wal_after_commit(void);
 extern void wal_rollback(OXid oxid, TransactionId logicalXid,
 						 bool isAutonomous);
+extern void wal_emit_recovery_finish_rollback(OXid oxid,
+											  TransactionId logicalXid);
 extern void o_wal_insert(BTreeDescr *desc, OTuple tuple, char relreplident, uint32 version);
 extern void o_wal_update(BTreeDescr *desc, OTuple tuple, OTuple oldtuple, char relreplident, uint32 version);
 extern void o_wal_delete(BTreeDescr *desc, OTuple tuple, char relreplident, uint32 version);

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -1867,6 +1867,15 @@ o_after_checkpoint_cleanup_hook(XLogRecPtr checkPointRedo, int flags)
 	/* called at the end of StartupXLOG */
 	*was_in_recovery = flags == 0;
 
+	/*
+	 * Right after end-of-recovery, XLog inserts have just been enabled. Flush
+	 * WAL_REC_ROLLBACK markers for in-flight oxids that recovery_finish()
+	 * aborted in memory, so streaming standbys can resolve them too (issue
+	 * #876).
+	 */
+	if (flags == 0)
+		o_emit_recovery_finish_rollbacks();
+
 	if (!(flags & (CHECKPOINT_IS_SHUTDOWN | CHECKPOINT_END_OF_RECOVERY)))
 	{
 		o_sys_caches_delete_by_lsn(checkPointRedo);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -287,6 +287,23 @@ static bool unexpected_worker_detach = false;
 static bool iam_recovery = false;
 
 /*
+ * In-flight oxids that recovery_finish() aborted in memory.  These were left
+ * COMMITSEQNO_INPROGRESS at end-of-redo with no COMMIT/ROLLBACK on the wire,
+ * so a streaming standby cannot resolve them on its own.  Captured here for
+ * the after-checkpoint hook to flush as WAL_REC_ROLLBACK once
+ * LocalSetXLogInsertAllowed() has run (issue #876).
+ */
+typedef struct
+{
+	OXid		oxid;
+	TransactionId xid;
+} RecoveryFinishAbortedOxid;
+
+static RecoveryFinishAbortedOxid *recovery_finish_aborted_oxids = NULL;
+static int	recovery_finish_aborted_count = 0;
+static int	recovery_finish_aborted_capacity = 0;
+
+/*
  * Current orioledb transaction recovery id
  */
 OXid		recovery_oxid = InvalidOXid;
@@ -1691,6 +1708,38 @@ recovery_finish(int worker_id)
 			walk_checkpoint_stacks(cur_state, COMMITSEQNO_ABORTED,
 								   InvalidSubTransactionId,
 								   flush_undo_pos);
+
+			/*
+			 * Remember this oxid so the after-checkpoint hook can emit a
+			 * WAL_REC_ROLLBACK for it once XLog inserts are allowed. Workers
+			 * don't write WAL: only the main recovery process does. See issue
+			 * #876.
+			 */
+			if (worker_id < 0)
+			{
+				MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+
+				if (recovery_finish_aborted_count == recovery_finish_aborted_capacity)
+				{
+					int			new_cap = recovery_finish_aborted_capacity == 0
+						? 16 : recovery_finish_aborted_capacity * 2;
+
+					if (recovery_finish_aborted_oxids == NULL)
+						recovery_finish_aborted_oxids =
+							palloc(new_cap * sizeof(RecoveryFinishAbortedOxid));
+					else
+						recovery_finish_aborted_oxids =
+							repalloc(recovery_finish_aborted_oxids,
+									 new_cap * sizeof(RecoveryFinishAbortedOxid));
+					recovery_finish_aborted_capacity = new_cap;
+				}
+				recovery_finish_aborted_oxids[recovery_finish_aborted_count].oxid =
+					cur_state->oxid;
+				recovery_finish_aborted_oxids[recovery_finish_aborted_count].xid =
+					cur_state->xid;
+				recovery_finish_aborted_count++;
+				MemoryContextSwitchTo(oldcxt);
+			}
 		}
 		if (cur_state->in_finished_list && worker_id < 0)
 		{
@@ -1738,6 +1787,38 @@ recovery_finish(int worker_id)
 	iam_recovery = false;
 
 	o_unset_syscache_hooks();
+}
+
+/*
+ * Emit a WAL_REC_ROLLBACK for every oxid that recovery_finish() aborted in
+ * memory.  Called from the after_checkpoint_cleanup_hook at end of recovery,
+ * once LocalSetXLogInsertAllowed() has run so XLogInsert is permitted.
+ *
+ * Without this, streaming standbys that eagerly applied the in-flight txn's
+ * modify records hold the oxid INPROGRESS forever, and any later replayed
+ * modify targeting the same row spins in o_btree_modify_handle_conflicts
+ * (issue #876).
+ */
+void
+o_emit_recovery_finish_rollbacks(void)
+{
+	int			i;
+
+	if (recovery_finish_aborted_count == 0)
+		return;
+
+	for (i = 0; i < recovery_finish_aborted_count; i++)
+	{
+		elog(LOG, "orioledb: emitting WAL_REC_ROLLBACK for in-flight oxid %lu aborted by recovery_finish",
+			 recovery_finish_aborted_oxids[i].oxid);
+		wal_emit_recovery_finish_rollback(recovery_finish_aborted_oxids[i].oxid,
+										  recovery_finish_aborted_oxids[i].xid);
+	}
+
+	pfree(recovery_finish_aborted_oxids);
+	recovery_finish_aborted_oxids = NULL;
+	recovery_finish_aborted_count = 0;
+	recovery_finish_aborted_capacity = 0;
 }
 
 /*

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -374,6 +374,45 @@ wal_rollback(OXid oxid, TransactionId logicalXid, bool isAutonomous)
 		XLogFlush(wait_pos);
 }
 
+/*
+ * Emit a stand-alone WAL_REC_ROLLBACK on behalf of an in-flight oxid that
+ * recovery_finish() aborted in memory after end-of-redo.
+ *
+ * Streaming standbys eagerly apply each modify record marked
+ * COMMITSEQNO_INPROGRESS and rely on a later WAL_REC_COMMIT/ROLLBACK to
+ * resolve the verdict.  The primary's normal abort path (wal_rollback) gates
+ * on local_wal.has_material_changes — but the startup process that runs
+ * recovery_finish() never wrote those records into its own local_wal buffer
+ * (the original primary did, before it crashed), so wal_rollback() would
+ * silently no-op.  Without an explicit ROLLBACK marker on the wire, the
+ * standby holds the oxid INPROGRESS forever and livelocks on the next
+ * conflicting modify (orioledb/orioledb#876).
+ *
+ * Must be called after LocalSetXLogInsertAllowed() — i.e. from the
+ * after_checkpoint_cleanup_hook with flags=0, not from inside rm_cleanup
+ * itself, which still runs with XLogInsertAllowed() == false.
+ */
+void
+wal_emit_recovery_finish_rollback(OXid oxid, TransactionId logicalXid)
+{
+	XLogRecPtr	wait_pos;
+
+	Assert(!is_recovery_process());
+	Assert(local_wal.buffer_offset == 0);
+	Assert(!local_wal.contains_xid);
+
+	add_xid_wal_record(oxid, logicalXid);
+	add_finish_wal_record(WAL_REC_ROLLBACK,
+						  pg_atomic_read_u64(&xid_meta->runXmin));
+	wait_pos = flush_local_wal(false, false);
+	local_wal.has_material_changes = false;
+
+	elog(DEBUG1, "recovery-finish ROLLBACK oxid %lu logicalXid %u %X/%X",
+		 oxid, logicalXid, LSN_FORMAT_ARGS(wait_pos));
+
+	XLogFlush(wait_pos);
+}
+
 static void
 add_finish_wal_record(uint8 rec_type, OXid xmin)
 {

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -3,6 +3,7 @@
 
 import os
 import re
+import signal
 import subprocess
 import time
 from testgres import NodeStatus
@@ -1520,3 +1521,199 @@ class ReplicationTest(BaseTest):
 
 				count = replica.execute("SELECT COUNT(*) FROM foo;")[0][0]
 				self.assertEqual(100, count)
+
+	def test_recovery_finish_aborts_propagate_to_replica(self):
+		"""
+		Issue #876: in-flight orioledb txns that the primary aborts in
+		memory at end-of-crash-recovery must be advertised to streaming
+		standbys via WAL_REC_ROLLBACK.  Otherwise the standby holds the
+		oxid INPROGRESS forever, and any later replayed modify against a
+		row touched by that txn spins forever in
+		o_btree_modify_handle_conflicts.
+
+		Repro recipe:
+		  1. Long-running INSERT on the primary that overflows the 8 KB
+		     local_wal buffer many times — its modify records stream to
+		     the standby while the txn is still INPROGRESS.
+		  2. Wait for the standby to apply the streamed records.
+		  3. Force-crash the primary (-m immediate): the txn never
+		     reaches COMMIT or ROLLBACK; its oxid stays INPROGRESS on
+		     the standby.
+		  4. Restart the primary.  recovery_finish() aborts the in-flight
+		     oxid in memory; with the fix it also flushes a stand-alone
+		     WAL_REC_ROLLBACK so the standby can resolve it.
+		  5. UPDATE a row the aborted txn had inserted.  Streams to the
+		     standby; without the fix the standby's recovery worker
+		     livelocks; with the fix the conflict resolves immediately.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		# Track every postgres pid we ever see under the master so we can
+		# reap stragglers in case the test fails mid-flight; otherwise a
+		# pre-fix livelock leaves spinning recovery workers across runs.
+		dangling_pids = set()
+		try:
+			with self.getReplica().start() as replica:
+				master.safe_psql("""
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_test_recovery_abort (
+						id int NOT NULL,
+						val text NOT NULL,
+						PRIMARY KEY (id)
+					) USING orioledb;
+				""")
+				self.catchup_orioledb(replica)
+
+				# Open a long-running tx whose INSERTs overflow the
+				# 8 KB local_wal buffer enough times to guarantee the
+				# modify records reach the standby before commit.
+				con = master.connect()
+				con.begin()
+				con.execute("""
+					INSERT INTO o_test_recovery_abort (id, val)
+					SELECT g, repeat('x', 200)
+					FROM generate_series(1, 2000) g;
+				""")
+
+				# Force the in-flight records onto disk before the kill
+				# (pg_switch_wal also wakes the WAL sender, so the standby
+				# is guaranteed to receive them).  Without this, the records
+				# can sit in the master's WAL buffer at SIGKILL time, so
+				# crash recovery doesn't see the in-flight oxid -- there's
+				# nothing for recovery_finish() to abort, and the bug never
+				# fires.
+				master.safe_psql("SELECT pg_switch_wal();")
+
+				# Wait for the standby's redo to apply at least up to
+				# the eagerly-flushed records (last LSN visible to the
+				# master right now).
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				replica.poll_query_until(
+				    f"SELECT pg_last_wal_replay_lsn() >= "
+				    f"'{master_lsn}'::pg_lsn",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				# MVCC must not expose the in-flight rows yet.
+				self.assertEqual(
+				    0,
+				    replica.execute(
+				        "SELECT count(*) FROM o_test_recovery_abort;")[0][0])
+
+				# But the standby's on-disk btree must contain them
+				# (otherwise the bug repro has nothing to conflict
+				# against).  Verify via orioledb_relation_size,
+				# which reports physical bytes regardless of MVCC.
+				# orioledb_tbl_structure was the natural fit here but
+				# crashes on this kind of tree state in some builds —
+				# the bug it trips is orthogonal to this test, see
+				# the postmaster log on a debug build for
+				# `invalid memory alloc request size`.
+				rel_size = replica.execute(
+				    "SELECT orioledb_relation_size("
+				    "  'o_test_recovery_abort'::regclass);")[0][0]
+				self.assertGreater(
+				    rel_size, 0, "standby's on-disk btree should contain the "
+				    "in-flight rows already, so the post-crash "
+				    "conflict has something to resolve against")
+
+				# Force-crash the master.  SIGKILL every postgres child
+				# of the master postmaster + the postmaster itself.
+				# pg_ctl stop -m immediate (SIGQUIT to backends) and
+				# plain SIGKILL of postmaster alone both let backends
+				# run AbortTransaction + wal_rollback before exiting,
+				# emitting the WAL_REC_ROLLBACK whose absence the fix
+				# repairs -- so the bug would never repro without
+				# killing every backend instantly.
+				pid_file = os.path.join(master.data_dir, 'postmaster.pid')
+				with open(pid_file) as f:
+					master_pid = int(f.readline().strip())
+				child_pids = [
+				    int(x) for x in subprocess.run(
+				        ['pgrep', '-P', str(master_pid)],
+				        capture_output=True,
+				        text=True,
+				        check=False).stdout.split()
+				]
+				dangling_pids.update([master_pid] + child_pids)
+				for p in child_pids:
+					try:
+						os.kill(p, signal.SIGKILL)
+					except ProcessLookupError:
+						pass
+				try:
+					os.kill(master_pid, signal.SIGKILL)
+				except ProcessLookupError:
+					pass
+				# Wait for the postmaster *and* every child to actually
+				# exit -- otherwise a lingering child still owns the
+				# listen socket and master.start() below fails with
+				# "Address already in use".
+				deadline = time.time() + 30
+				while time.time() < deadline:
+					alive = False
+					for p in [master_pid] + child_pids:
+						try:
+							os.kill(p, 0)
+							alive = True
+							break
+						except ProcessLookupError:
+							continue
+					if not alive:
+						break
+					time.sleep(0.05)
+				master.is_started = False
+				try:
+					con.close()
+				except Exception:
+					pass
+				master.start()
+
+				# Run conflicting INSERTs on the recovered master.  Each
+				# row streams to the standby where the recovery worker
+				# must resolve the conflict against the dangling
+				# INPROGRESS oxid.  Pre-fix the worker spins forever on
+				# the first one; post-fix the standby has already seen
+				# WAL_REC_ROLLBACK and resolves cleanly.
+				master.safe_psql("""
+					INSERT INTO o_test_recovery_abort (id, val)
+					SELECT g, 'after-' || g
+					FROM generate_series(1, 200) g;
+				""")
+
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				# 30 s ceiling: pre-fix this poll exhausts attempts and
+				# the test fails; post-fix it catches up immediately.
+				replica.poll_query_until(
+				    f"SELECT pg_last_wal_replay_lsn() >= "
+				    f"'{master_lsn}'::pg_lsn",
+				    expected=True,
+				    sleep_time=0.5,
+				    max_attempts=60)
+
+				self.assertEqual(
+				    'after-1',
+				    replica.execute("SELECT val FROM o_test_recovery_abort "
+				                    "WHERE id = 1;")[0][0])
+				self.assertEqual(
+				    200,
+				    replica.execute(
+				        "SELECT count(*) FROM o_test_recovery_abort;")[0][0])
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+			# Reap any postgres process we ever saw under master.  If the
+			# test hit the pre-fix livelock and aborted out of poll, the
+			# orphaned recovery worker would otherwise keep spinning at
+			# 100% CPU between test runs.
+			for p in dangling_pids:
+				try:
+					os.kill(p, signal.SIGKILL)
+				except ProcessLookupError:
+					pass


### PR DESCRIPTION
## Summary
- Primary's `recovery_finish` aborts in-flight oxids in memory but never emits `WAL_REC_ROLLBACK`. Streaming standbys that eagerly applied the txn's modify records hold the oxid INPROGRESS forever, and any later conflicting modify spins forever in `o_btree_modify_handle_conflicts` (`wait_for_oxid` returns immediately because `COMMITSEQNO_INPROGRESS` isn't `SPECIAL`).
- `recovery_finish` now collects each in-flight oxid into a static array in `TopMemoryContext`; `o_emit_recovery_finish_rollbacks` flushes a stand-alone `WAL_REC_ROLLBACK` for each one, hooked into `o_after_checkpoint_cleanup_hook` with `flags==0` (the end-of-recovery slot fired after `LocalSetXLogInsertAllowed()`).
- New testgres repro `test_recovery_finish_aborts_propagate_to_replica` overflows the 8 KB local_wal buffer, forces `pg_switch_wal`, SIGKILLs every postgres child of the master postmaster (so no backend rolls back gracefully and masks the bug), restarts master, then runs conflicting INSERTs. Pre-fix the standby's recovery worker livelocks at 100 % CPU; post-fix it resolves cleanly.

Resolves https://github.com/orioledb/orioledb/issues/876.

## Test plan
- [x] New testgres repro passes with the fix in ~11 s; hangs forever without it.
- [x] All 34 existing replication tests pass.
- [x] All 56 existing recovery tests pass.
- [x] All 44 regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)