### PR TITLE
Fix duplicate seq scan results from overlapping undo leaves

### DIFF
--- a/include/btree/page_contents.h
+++ b/include/btree/page_contents.h
@@ -363,7 +363,8 @@ extern ReadPageResult o_btree_try_read_page(BTreeDescr *desc,
 											Pointer key, BTreeKeyType keyType,
 											PartialPageState *partial,
 											bool loadHikeysChunk,
-											CommitSeqNo *readCsn);
+											CommitSeqNo *readCsn,
+											bool *readFromUndo);
 extern UndoLocation read_page_from_undo(BTreeDescr *desc, Page img,
 										UndoLocation undo_loc,
 										CommitSeqNo csn, void *key,

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1673,7 +1673,7 @@ btree_find_try_read_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno,
 	result = o_btree_try_read_page(context->desc, blkno, pageChangeCount,
 								   pagePtr, context->csn,
 								   key, keyType, partial, loadHikeysChunk,
-								   readCsn);
+								   readCsn, NULL);
 
 	return result;
 }

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -283,7 +283,7 @@ ReadPageResult
 o_btree_try_read_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeCount, Page img,
 					  CommitSeqNo csn, Pointer key, BTreeKeyType keyType,
 					  PartialPageState *partial, bool loadHikeysChunk,
-					  CommitSeqNo *readCsn)
+					  CommitSeqNo *readCsn, bool *readFromUndo)
 {
 	Page		p;
 	BTreePageHeader *header;
@@ -291,6 +291,9 @@ o_btree_try_read_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeC
 	ReadPageResult result;
 
 	Assert(pageChangeCount != InvalidOPageChangeCount);
+
+	if (readFromUndo)
+		*readFromUndo = false;
 
 	/*
 	 * For local pool pages, the slot may have been reclaimed by a reentrant
@@ -324,6 +327,8 @@ o_btree_try_read_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeC
 							key, keyType, NULL);
 		header = (BTreePageHeader *) img;
 		header->o_header.pageChangeCount = pageChangeCount;
+		if (readFromUndo)
+			*readFromUndo = true;
 		if (readCsn)
 			*readCsn = header->csn;
 		return ReadPageResultOK;
@@ -342,6 +347,8 @@ o_btree_try_read_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeC
 							key, keyType, NULL);
 		header = (BTreePageHeader *) img;
 		header->o_header.pageChangeCount = pageChangeCount;
+		if (readFromUndo)
+			*readFromUndo = true;
 		if (readCsn)
 			*readCsn = header->csn;
 	}

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -128,6 +128,9 @@ struct BTreeSeqScan
 
 	OFixedKey	nextKey;
 
+	OFixedKey	historicalCoverageHigh;
+	bool		haveHistoricalCoverageHigh;
+
 	bool		needSampling;
 	BlockSampler sampler;
 	BlockNumber samplingNumber;
@@ -155,6 +158,8 @@ static void scan_make_iterator(BTreeSeqScan *scan, OTuple startKey, OTuple keyRa
 static void get_next_key(BTreeSeqScan *scan, BTreePageItemLocator *intLoc, OFixedKey *nextKey, Page page);
 static void ResourceOwnerRememberBTreeSeqScan(ResourceOwner owner, BTreeSeqScan *scan);
 static void ResourceOwnerForgetBTreeSeqScan(ResourceOwner owner, BTreeSeqScan *scan);
+static void scan_note_emitted_tuple(BTreeSeqScan *scan, OTuple tuple);
+static void scan_skip_covered_leaf_prefix(BTreeSeqScan *scan);
 
 /*
  * Resource owner integration for BTreeSeqScan.
@@ -970,6 +975,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 			else if (DOWNLINK_IS_IN_MEMORY(downlink))
 			{
 				ReadPageResult result;
+				bool		readFromUndo = false;
 
 				if (scan->poscan)
 					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
@@ -983,7 +989,8 @@ iterate_internal_page(BTreeSeqScan *scan)
 											   BTreeKeyNone,
 											   NULL,
 											   true,
-											   NULL);
+											   NULL,
+											   &readFromUndo);
 
 				if (result == ReadPageResultOK)
 				{
@@ -994,6 +1001,8 @@ iterate_internal_page(BTreeSeqScan *scan)
 					scan->hint.blkno = DOWNLINK_GET_IN_MEMORY_BLKNO(downlink);
 					scan->hint.pageChangeCount = DOWNLINK_GET_IN_MEMORY_CHANGECOUNT(downlink);
 					BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
+					if (readFromUndo)
+						scan_skip_covered_leaf_prefix(scan);
 					O_TUPLE_SET_NULL(scan->nextKey.tuple);
 					load_first_historical_page(scan);
 					return true;
@@ -1250,6 +1259,8 @@ init_btree_seq_scan(BTreeSeqScan *scan)
 	clear_fixed_key(&scan->prevHikey);
 	clear_fixed_key(&scan->keyRangeHigh);
 	clear_fixed_key(&scan->keyRangeLow);
+	clear_fixed_key(&scan->historicalCoverageHigh);
+	scan->haveHistoricalCoverageHigh = false;
 	scan->isSingleLeafPage = false;
 	o_btree_load_shmem(desc);
 	if (!iterate_internal_page(scan) && !single_leaf_page_rel(scan))
@@ -1293,6 +1304,7 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 	scan->initialized = false;
 	scan->checkpointNumberSet = false;
 	scan->haveHistImg = false;
+	scan->haveHistoricalCoverageHigh = false;
 	BTREE_PAGE_LOCATOR_SET_INVALID(&scan->leafLoc);
 
 	dlist_push_tail(&listOfScans, &scan->listNode);
@@ -1349,6 +1361,36 @@ btree_seq_scan_get_tuple_from_iterator(BTreeSeqScan *scan,
 		scan->haveHistImg = false;
 	}
 	return result;
+}
+
+static void
+scan_note_emitted_tuple(BTreeSeqScan *scan, OTuple tuple)
+{
+	copy_fixed_key(scan->desc, &scan->historicalCoverageHigh, tuple);
+	scan->haveHistoricalCoverageHigh = true;
+}
+
+static void
+scan_skip_covered_leaf_prefix(BTreeSeqScan *scan)
+{
+	if (!scan->haveHistoricalCoverageHigh ||
+		!BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
+		return;
+
+	while (BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
+	{
+		OTuple		key;
+		int			cmp;
+
+		BTREE_PAGE_READ_LEAF_TUPLE(key, scan->leafImg, &scan->leafLoc);
+		cmp = o_btree_cmp(scan->desc,
+						  &key, BTreeKeyLeafTuple,
+						  &scan->historicalCoverageHigh.tuple, BTreeKeyNonLeafKey);
+		if (cmp > 0)
+			break;
+
+		BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
+	}
 }
 
 static bool
@@ -1484,7 +1526,10 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 	{
 		tuple = btree_seq_scan_get_tuple_from_iterator(scan, tupleCsn, hint);
 		if (!O_TUPLE_IS_NULL(tuple))
+		{
+			scan_note_emitted_tuple(scan, tuple);
 			return tuple;
+		}
 	}
 
 	while (true)
@@ -1585,6 +1630,7 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 			BTREE_PAGE_LOCATOR_NEXT(scan->histImg, &scan->histLoc);
 			if (!O_TUPLE_IS_NULL(tuple))
 			{
+				scan_note_emitted_tuple(scan, tuple);
 				if (hint)
 					*hint = scan->hint;
 				return tuple;
@@ -1607,7 +1653,10 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 																	   tupleCsn,
 																	   hint);
 						if (!O_TUPLE_IS_NULL(tuple))
+						{
+							scan_note_emitted_tuple(scan, tuple);
 							return tuple;
+						}
 					}
 				}
 				else
@@ -1638,6 +1687,7 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 		BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
 		if (!O_TUPLE_IS_NULL(tuple))
 		{
+			scan_note_emitted_tuple(scan, tuple);
 			if (hint)
 				*hint = scan->hint;
 			return tuple;
@@ -1709,7 +1759,10 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 		tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint);
 		if (!end)
+		{
+			scan_note_emitted_tuple(scan, tuple);
 			return tuple;
+		}
 	}
 
 	while (!BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
@@ -1725,7 +1778,10 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 					tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint);
 					if (!end)
+					{
+						scan_note_emitted_tuple(scan, tuple);
 						return tuple;
+					}
 				}
 			}
 			else
@@ -1749,6 +1805,7 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 	if (!tupHdr->deleted)
 	{
+		scan_note_emitted_tuple(scan, tuple);
 		if (hint)
 			*hint = scan->hint;
 

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -76,6 +76,8 @@ typedef struct
 {
 	uint64		downlink;
 	CommitSeqNo csn;
+	OFixedShmemKey keyRangeLow;
+	OFixedShmemKey keyRangeHigh;
 } BTreeSeqScanDiskDownlink;
 
 struct BTreeSeqScan
@@ -128,9 +130,6 @@ struct BTreeSeqScan
 
 	OFixedKey	nextKey;
 
-	OFixedKey	historicalCoverageHigh;
-	bool		haveHistoricalCoverageHigh;
-
 	bool		needSampling;
 	BlockSampler sampler;
 	BlockNumber samplingNumber;
@@ -158,8 +157,10 @@ static void scan_make_iterator(BTreeSeqScan *scan, OTuple startKey, OTuple keyRa
 static void get_next_key(BTreeSeqScan *scan, BTreePageItemLocator *intLoc, OFixedKey *nextKey, Page page);
 static void ResourceOwnerRememberBTreeSeqScan(ResourceOwner owner, BTreeSeqScan *scan);
 static void ResourceOwnerForgetBTreeSeqScan(ResourceOwner owner, BTreeSeqScan *scan);
-static void scan_note_emitted_tuple(BTreeSeqScan *scan, OTuple tuple);
-static void scan_skip_covered_leaf_prefix(BTreeSeqScan *scan);
+static bool scan_trim_page_to_key_range(BTreeSeqScan *scan, Page p,
+										BTreePageItemLocator *loc,
+										OTuple keyRangeLow,
+										OTuple keyRangeHigh);
 
 /*
  * Resource owner integration for BTreeSeqScan.
@@ -416,7 +417,8 @@ load_next_internal_page(BTreeSeqScan *scan, OTuple prevHikey,
 }
 
 static void
-add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn)
+add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn,
+					 OTuple keyRangeLow, OTuple keyRangeHigh)
 {
 	ParallelOScanDesc poscan = scan->poscan;
 
@@ -431,6 +433,12 @@ add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn)
 		}
 		scan->diskDownlinks[scan->downlinksCount].downlink = downlink;
 		scan->diskDownlinks[scan->downlinksCount].csn = csn;
+		copy_fixed_shmem_key(scan->desc,
+							 &scan->diskDownlinks[scan->downlinksCount].keyRangeLow,
+							 keyRangeLow);
+		copy_fixed_shmem_key(scan->desc,
+							 &scan->diskDownlinks[scan->downlinksCount].keyRangeHigh,
+							 keyRangeHigh);
 		scan->downlinksCount++;
 	}
 	else
@@ -459,6 +467,10 @@ add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn)
 				shared = (BTreeSeqScanDiskDownlink *) dsm_segment_address(scan->dsmSeg);
 				shared[index].downlink = downlink;
 				shared[index].csn = csn;
+				copy_fixed_shmem_key(scan->desc, &shared[index].keyRangeLow,
+									 keyRangeLow);
+				copy_fixed_shmem_key(scan->desc, &shared[index].keyRangeHigh,
+									 keyRangeHigh);
 				LWLockRelease(&poscan->downlinksPublish);
 				return;
 			}
@@ -968,7 +980,9 @@ iterate_internal_page(BTreeSeqScan *scan)
 		{
 			if (DOWNLINK_IS_ON_DISK(downlink))
 			{
-				add_on_disk_downlink(scan, downlink, scan->context.imgReadCsn);
+				add_on_disk_downlink(scan, downlink, scan->context.imgReadCsn,
+									 scan->keyRangeLow.tuple,
+									 scan->keyRangeHigh.tuple);
 				if (scan->poscan)
 					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
 			}
@@ -1002,9 +1016,20 @@ iterate_internal_page(BTreeSeqScan *scan)
 					scan->hint.pageChangeCount = DOWNLINK_GET_IN_MEMORY_CHANGECOUNT(downlink);
 					BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
 					if (readFromUndo)
-						scan_skip_covered_leaf_prefix(scan);
+						(void) scan_trim_page_to_key_range(scan, scan->leafImg,
+														   &scan->leafLoc,
+														   scan->keyRangeLow.tuple,
+														   scan->keyRangeHigh.tuple);
 					O_TUPLE_SET_NULL(scan->nextKey.tuple);
 					load_first_historical_page(scan);
+					if (scan->haveHistImg)
+					{
+						scan->haveHistImg =
+							scan_trim_page_to_key_range(scan, scan->histImg,
+														&scan->histLoc,
+														scan->keyRangeLow.tuple,
+														scan->keyRangeHigh.tuple);
+					}
 					return true;
 				}
 				else
@@ -1054,6 +1079,8 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 	bool		readFromUndo = false;
 	BTreePageHeader *header;
 	BTreeSeqScanDiskDownlink downlink;
+	OFixedKey	keyRangeLow;
+	OFixedKey	keyRangeHigh;
 	ParallelOScanDesc poscan = scan->poscan;
 
 	if (!poscan)
@@ -1078,6 +1105,10 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 		}
 		downlink = ((BTreeSeqScanDiskDownlink *) dsm_segment_address(scan->dsmSeg))[index];
 	}
+	copy_from_fixed_shmem_key(&keyRangeLow, &downlink.keyRangeLow);
+	copy_from_fixed_shmem_key(&keyRangeHigh, &downlink.keyRangeHigh);
+	copy_fixed_key(scan->desc, &scan->keyRangeLow, keyRangeLow.tuple);
+	copy_fixed_key(scan->desc, &scan->keyRangeHigh, keyRangeHigh.tuple);
 
 	success = read_page_from_disk(scan->desc,
 								  scan->leafImg,
@@ -1100,12 +1131,22 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 
 	BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
 	if (readFromUndo)
-		scan_skip_covered_leaf_prefix(scan);
+		(void) scan_trim_page_to_key_range(scan, scan->leafImg,
+										   &scan->leafLoc,
+										   keyRangeLow.tuple,
+										   keyRangeHigh.tuple);
 	scan->downlinkIndex++;
 	scan->hint.blkno = OInvalidInMemoryBlkno;
 	scan->hint.pageChangeCount = InvalidOPageChangeCount;
 	O_TUPLE_SET_NULL(scan->nextKey.tuple);
 	load_first_historical_page(scan);
+	if (scan->haveHistImg)
+	{
+		scan->haveHistImg =
+			scan_trim_page_to_key_range(scan, scan->histImg, &scan->histLoc,
+										keyRangeLow.tuple,
+										keyRangeHigh.tuple);
+	}
 	return true;
 }
 
@@ -1265,8 +1306,6 @@ init_btree_seq_scan(BTreeSeqScan *scan)
 	clear_fixed_key(&scan->prevHikey);
 	clear_fixed_key(&scan->keyRangeHigh);
 	clear_fixed_key(&scan->keyRangeLow);
-	clear_fixed_key(&scan->historicalCoverageHigh);
-	scan->haveHistoricalCoverageHigh = false;
 	scan->isSingleLeafPage = false;
 	o_btree_load_shmem(desc);
 	if (!iterate_internal_page(scan) && !single_leaf_page_rel(scan))
@@ -1310,7 +1349,6 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 	scan->initialized = false;
 	scan->checkpointNumberSet = false;
 	scan->haveHistImg = false;
-	scan->haveHistoricalCoverageHigh = false;
 	BTREE_PAGE_LOCATOR_SET_INVALID(&scan->leafLoc);
 
 	dlist_push_tail(&listOfScans, &scan->listNode);
@@ -1369,34 +1407,49 @@ btree_seq_scan_get_tuple_from_iterator(BTreeSeqScan *scan,
 	return result;
 }
 
-static void
-scan_note_emitted_tuple(BTreeSeqScan *scan, OTuple tuple)
+static bool
+scan_trim_page_to_key_range(BTreeSeqScan *scan, Page p,
+							BTreePageItemLocator *loc,
+							OTuple keyRangeLow,
+							OTuple keyRangeHigh)
 {
-	copy_fixed_key(scan->desc, &scan->historicalCoverageHigh, tuple);
-	scan->haveHistoricalCoverageHigh = true;
-}
+	if (!BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
+		return true;
 
-static void
-scan_skip_covered_leaf_prefix(BTreeSeqScan *scan)
-{
-	if (!scan->haveHistoricalCoverageHigh ||
-		!BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
-		return;
-
-	while (BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
+	while (BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
 	{
 		OTuple		key;
 		int			cmp;
 
-		BTREE_PAGE_READ_LEAF_TUPLE(key, scan->leafImg, &scan->leafLoc);
-		cmp = o_btree_cmp(scan->desc,
-						  &key, BTreeKeyLeafTuple,
-						  &scan->historicalCoverageHigh.tuple, BTreeKeyNonLeafKey);
-		if (cmp > 0)
-			break;
+		BTREE_PAGE_READ_LEAF_TUPLE(key, p, loc);
+		if (!O_TUPLE_IS_NULL(keyRangeLow))
+		{
+			cmp = o_btree_cmp(scan->desc,
+							  &key, BTreeKeyLeafTuple,
+							  &keyRangeLow, BTreeKeyNonLeafKey);
+			if (cmp < 0)
+			{
+				BTREE_PAGE_LOCATOR_NEXT(p, loc);
+				continue;
+			}
+		}
 
-		BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
+		if (!O_TUPLE_IS_NULL(keyRangeHigh))
+		{
+			cmp = o_btree_cmp(scan->desc,
+							  &key, BTreeKeyLeafTuple,
+							  &keyRangeHigh, BTreeKeyNonLeafKey);
+			if (cmp >= 0)
+			{
+				BTREE_PAGE_LOCATOR_SET_INVALID(loc);
+				return false;
+			}
+		}
+
+		return true;
 	}
+
+	return true;
 }
 
 static bool
@@ -1532,10 +1585,7 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 	{
 		tuple = btree_seq_scan_get_tuple_from_iterator(scan, tupleCsn, hint);
 		if (!O_TUPLE_IS_NULL(tuple))
-		{
-			scan_note_emitted_tuple(scan, tuple);
 			return tuple;
-		}
 	}
 
 	while (true)
@@ -1567,6 +1617,11 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 					}
 				}
 				load_next_historical_page(scan);
+				scan->haveHistImg =
+					scan_trim_page_to_key_range(scan, scan->histImg,
+												&scan->histLoc,
+												scan->keyRangeLow.tuple,
+												scan->keyRangeHigh.tuple);
 			}
 
 			if (!scan->haveHistImg)
@@ -1636,7 +1691,6 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 			BTREE_PAGE_LOCATOR_NEXT(scan->histImg, &scan->histLoc);
 			if (!O_TUPLE_IS_NULL(tuple))
 			{
-				scan_note_emitted_tuple(scan, tuple);
 				if (hint)
 					*hint = scan->hint;
 				return tuple;
@@ -1659,10 +1713,7 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 																	   tupleCsn,
 																	   hint);
 						if (!O_TUPLE_IS_NULL(tuple))
-						{
-							scan_note_emitted_tuple(scan, tuple);
 							return tuple;
-						}
 					}
 				}
 				else
@@ -1693,7 +1744,6 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 		BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
 		if (!O_TUPLE_IS_NULL(tuple))
 		{
-			scan_note_emitted_tuple(scan, tuple);
 			if (hint)
 				*hint = scan->hint;
 			return tuple;
@@ -1765,10 +1815,7 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 		tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint);
 		if (!end)
-		{
-			scan_note_emitted_tuple(scan, tuple);
 			return tuple;
-		}
 	}
 
 	while (!BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
@@ -1784,10 +1831,7 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 					tuple = btree_seq_scan_get_tuple_from_iterator_raw(scan, &end, hint);
 					if (!end)
-					{
-						scan_note_emitted_tuple(scan, tuple);
 						return tuple;
-					}
 				}
 			}
 			else
@@ -1811,7 +1855,6 @@ btree_seq_scan_getnext_raw_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 	if (!tupHdr->deleted)
 	{
-		scan_note_emitted_tuple(scan, tuple);
 		if (hint)
 			*hint = scan->hint;
 

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1051,6 +1051,7 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 {
 	FileExtent	extent;
 	bool		success;
+	bool		readFromUndo = false;
 	BTreePageHeader *header;
 	BTreeSeqScanDiskDownlink downlink;
 	ParallelOScanDesc poscan = scan->poscan;
@@ -1084,8 +1085,11 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 								  &extent);
 	header = (BTreePageHeader *) scan->leafImg;
 	if (header->csn >= downlink.csn)
+	{
 		read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
 							downlink.csn, NULL, BTreeKeyNone, NULL);
+		readFromUndo = true;
+	}
 
 	STOPEVENT(STOPEVENT_SCAN_DISK_PAGE,
 			  btree_page_stopevent_params(scan->desc,
@@ -1095,6 +1099,8 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 		elog(ERROR, "can not read leaf page from disk");
 
 	BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
+	if (readFromUndo)
+		scan_skip_covered_leaf_prefix(scan);
 	scan->downlinkIndex++;
 	scan->hint.blkno = OInvalidInMemoryBlkno;
 	scan->hint.pageChangeCount = InvalidOPageChangeCount;

--- a/test/t/transaction_test.py
+++ b/test/t/transaction_test.py
@@ -54,6 +54,9 @@ Test orchestration:
 	and the cluster PANICs.
 """
 
+from collections import Counter
+import inspect
+import os
 import time
 
 from .base_test import BaseTest, ThreadQueryExecutor, wait_stopevent, wait_for_wait_event
@@ -298,6 +301,104 @@ class TransactionTest(BaseTest):
 			waiter.commit()
 		finally:
 			for c in (waiter, holder, ctl):
+				try:
+					c.close()
+				except Exception:
+					pass
+			node.stop()
+
+	def test_live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self):
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "orioledb.enable_stopevents = true\n"
+		                 "log_min_messages = DEBUG2\n")
+		node.start()
+		node.safe_psql(
+		    'postgres', """
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE t (
+				k text NOT NULL,
+				v text NOT NULL,
+				PRIMARY KEY (k)
+			) USING orioledb;
+
+			INSERT INTO t (k, v)
+			SELECT 'k' || to_char(g, 'fm0000'), repeat('a', 600)
+			FROM generate_series(1, 12) g;
+			CHECKPOINT;
+		""")
+
+		holder = node.connect()
+		waiter = node.connect()
+		reader = node.connect()
+		ctl = node.connect()
+
+		try:
+			ctl.execute(
+			    "SELECT pg_stopevent_set('before_get_waiters_with_tuples', "
+			    "'true');")
+
+			holder_pid = holder.pid
+			t_holder = ThreadQueryExecutor(
+			    holder, "INSERT INTO t (k, v) VALUES "
+			    "('k0013', repeat('h', 600));")
+			t_holder.start()
+			wait_stopevent(node, holder_pid)
+
+			waiter_pid = waiter.pid
+			t_waiter = ThreadQueryExecutor(
+			    waiter, "INSERT INTO t (k, v) VALUES "
+			    "('k0014', repeat('w', 600));")
+			t_waiter.start()
+			wait_for_wait_event(node, waiter_pid, 'BufferContent')
+
+			ctl.execute(
+			    "SELECT pg_stopevent_reset('before_get_waiters_with_tuples');")
+
+			t_holder.join()
+			t_waiter.join()
+
+			rows = reader.execute("SELECT k FROM t;")
+			keys = [row[0] for row in rows]
+			counts = Counter(keys)
+			duplicated_keys = sorted(k for k, count in counts.items()
+			                         if count > 1)
+
+			self.assertEqual(duplicated_keys, [],
+			                 "SELECT returned duplicate keys: %s; full result: %s" %
+			                 (duplicated_keys, keys))
+			self.assertEqual(sorted(keys), ['k%04d' % i for i in range(1, 13)])
+
+			with open(node.pg_log_file, encoding='utf-8') as f:
+				log = f.read()
+
+			(test_path, _) = os.path.split(
+			    os.path.dirname(inspect.getfile(self.__class__)))
+			log_dir = os.path.join(test_path, 'tmp_check_t',
+			                       self.myName + '_diagnostics')
+			os.makedirs(log_dir, exist_ok=True)
+			with open(os.path.join(log_dir, 'live_waiter_split_full.log'),
+			          'w',
+			          encoding='utf-8') as f:
+				f.write(log)
+			with open(os.path.join(log_dir, 'live_waiter_split_debug.log'),
+			          'w',
+			          encoding='utf-8') as f:
+				for line in log.splitlines():
+					if any(prefix in line for prefix in
+					       ("csn-debug:", "scan-debug:", "split-debug:")):
+						f.write(line + "\n")
+
+			self.assertIn("source=btree-insert-with-waiters", log)
+			self.assertGreaterEqual(
+			    log.count("scan-debug: seq scan leaf loaded from undo"), 2,
+			    log[-8000:])
+		finally:
+			for c in (holder, waiter, reader, ctl):
+				try:
+					c.execute("ROLLBACK")
+				except Exception:
+					pass
 				try:
 					c.close()
 				except Exception:

--- a/test/t/transaction_test.py
+++ b/test/t/transaction_test.py
@@ -55,8 +55,6 @@ Test orchestration:
 """
 
 from collections import Counter
-import inspect
-import os
 import time
 
 from .base_test import BaseTest, ThreadQueryExecutor, wait_stopevent, wait_for_wait_event
@@ -310,8 +308,7 @@ class TransactionTest(BaseTest):
 	def test_live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self):
 		node = self.node
 		node.append_conf(
-		    'postgresql.conf', "orioledb.enable_stopevents = true\n"
-		    "log_min_messages = DEBUG2\n")
+		    'postgresql.conf', "orioledb.enable_stopevents = true\n")
 		node.start()
 		node.safe_psql(
 		    'postgres', """
@@ -369,32 +366,6 @@ class TransactionTest(BaseTest):
 			    "SELECT returned duplicate keys: %s; full result: %s" %
 			    (duplicated_keys, keys))
 			self.assertEqual(sorted(keys), ['k%04d' % i for i in range(1, 13)])
-
-			with open(node.pg_log_file, encoding='utf-8') as f:
-				log = f.read()
-
-			(test_path, _) = os.path.split(
-			    os.path.dirname(inspect.getfile(self.__class__)))
-			log_dir = os.path.join(test_path, 'tmp_check_t',
-			                       self.myName + '_diagnostics')
-			os.makedirs(log_dir, exist_ok=True)
-			with open(os.path.join(log_dir, 'live_waiter_split_full.log'),
-			          'w',
-			          encoding='utf-8') as f:
-				f.write(log)
-			with open(os.path.join(log_dir, 'live_waiter_split_debug.log'),
-			          'w',
-			          encoding='utf-8') as f:
-				for line in log.splitlines():
-					if any(prefix in line
-					       for prefix in ("csn-debug:", "scan-debug:",
-					                      "split-debug:")):
-						f.write(line + "\n")
-
-			self.assertIn("source=btree-insert-with-waiters", log)
-			self.assertGreaterEqual(
-			    log.count("scan-debug: seq scan leaf loaded from undo"), 2,
-			    log[-8000:])
 		finally:
 			for c in (holder, waiter, reader, ctl):
 				try:

--- a/test/t/transaction_test.py
+++ b/test/t/transaction_test.py
@@ -309,9 +309,9 @@ class TransactionTest(BaseTest):
 
 	def test_live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self):
 		node = self.node
-		node.append_conf('postgresql.conf',
-		                 "orioledb.enable_stopevents = true\n"
-		                 "log_min_messages = DEBUG2\n")
+		node.append_conf(
+		    'postgresql.conf', "orioledb.enable_stopevents = true\n"
+		    "log_min_messages = DEBUG2\n")
 		node.start()
 		node.safe_psql(
 		    'postgres', """
@@ -364,9 +364,10 @@ class TransactionTest(BaseTest):
 			duplicated_keys = sorted(k for k, count in counts.items()
 			                         if count > 1)
 
-			self.assertEqual(duplicated_keys, [],
-			                 "SELECT returned duplicate keys: %s; full result: %s" %
-			                 (duplicated_keys, keys))
+			self.assertEqual(
+			    duplicated_keys, [],
+			    "SELECT returned duplicate keys: %s; full result: %s" %
+			    (duplicated_keys, keys))
 			self.assertEqual(sorted(keys), ['k%04d' % i for i in range(1, 13)])
 
 			with open(node.pg_log_file, encoding='utf-8') as f:
@@ -385,8 +386,9 @@ class TransactionTest(BaseTest):
 			          'w',
 			          encoding='utf-8') as f:
 				for line in log.splitlines():
-					if any(prefix in line for prefix in
-					       ("csn-debug:", "scan-debug:", "split-debug:")):
+					if any(prefix in line
+					       for prefix in ("csn-debug:", "scan-debug:",
+					                      "split-debug:")):
 						f.write(line + "\n")
 
 			self.assertIn("source=btree-insert-with-waiters", log)

--- a/test/t/transaction_test.py
+++ b/test/t/transaction_test.py
@@ -305,7 +305,8 @@ class TransactionTest(BaseTest):
 					pass
 			node.stop()
 
-	def test_live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self):
+	def _live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self,
+	                                                           evict_before_select=False):
 		node = self.node
 		node.append_conf(
 		    'postgresql.conf', "orioledb.enable_stopevents = true\n")
@@ -355,6 +356,9 @@ class TransactionTest(BaseTest):
 			t_holder.join()
 			t_waiter.join()
 
+			if evict_before_select:
+				ctl.execute("SELECT orioledb_evict_pages('t'::regclass, 0);")
+
 			rows = reader.execute("SELECT k FROM t;")
 			keys = [row[0] for row in rows]
 			counts = Counter(keys)
@@ -377,3 +381,10 @@ class TransactionTest(BaseTest):
 				except Exception:
 					pass
 			node.stop()
+
+	def test_live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self):
+		self._live_waiter_split_seq_scan_reads_adjacent_undo_leaves()
+
+	def test_live_waiter_split_seq_scan_reads_adjacent_disk_undo_leaves(self):
+		self._live_waiter_split_seq_scan_reads_adjacent_undo_leaves(
+		    evict_before_select=True)


### PR DESCRIPTION
## Summary

This PR fixes a B-tree sequential scan bug where multiple adjacent current leaf pages can be read through undo and expose overlapping historical key ranges. In that case the scan may return the same logical tuples more than once.

The original symptom was observed during targeted recovery, but the new regression test shows the same invariant can also be reached in regular live execution through the waiter split path.

## Problem

A seq scan walks the current internal-page topology. If a current child leaf page has `page_csn >= imgReadCsn`, the scan reads a historical image of that leaf through undo.

When several adjacent current child leaves are read through undo, their historical images may correspond to an older tree shape where those key ranges were not yet split. As a result, different current children can unfold into overlapping historical leaf ranges.

Before the fix, the scan treated those historical pages as independent ranges and could emit duplicate logical tuples.

## Test Coverage

Adds a live multi-backend repro:

- `test_live_waiter_split_seq_scan_reads_adjacent_undo_leaves`

The test forces a waiter split path, then runs a concurrent `SELECT` and verifies that the result contains no duplicate keys.