### PR TITLE
Fix checkpointer-related anomalies in verify_orioledb 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,8 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  table_lock_test \
 				  concurrent_truncate \
 				  uniq
-TESTGRESCHECKS_PART_1 = test/t/checkpointer_test.py \
+TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
+						test/t/checkpointer_test.py \
 						test/t/correlation_test.py \
 						test/t/eviction_bgwriter_test.py \
 						test/t/eviction_compression_test.py \

--- a/include/btree/check.h
+++ b/include/btree/check.h
@@ -34,7 +34,8 @@ typedef struct
 	BTreeCompressRange *ranges;
 } BTreeCompressStats;
 
-extern bool check_btree(BTreeDescr *desc, bool force_file_check);
+extern bool check_btree(BTreeDescr *desc, bool force_file_check,
+						bool wait_for_checkpoint);
 extern void check_btree_compression(BTreeDescr *desc,
 									BTreeCompressStats *stats,
 									OCompress lvl);

--- a/src/btree/check.c
+++ b/src/btree/check.c
@@ -52,6 +52,7 @@ typedef struct
 	ExtentsArray busy;
 	BTreeDescr *desc;
 	bool		hasError;
+	bool		emit_transient_notices;
 	OBTreeFindPageContext context;
 } BTreeCheckStatus;
 
@@ -92,6 +93,13 @@ check_btree(BTreeDescr *desc, bool force_file_check, bool wait_for_checkpoint)
 	/* get busy file extents */
 	status.desc = desc;
 	status.hasError = false;
+
+	/*
+	 * Legacy debug entry points (wait_for_checkpoint == false) keep the
+	 * BROKEN_SPLIT NOTICE; the user-facing verify_orioledb path stays silent
+	 * on that transient.
+	 */
+	status.emit_transient_notices = !wait_for_checkpoint;
 	init_page_find_context(&status.context, desc, COMMITSEQNO_INPROGRESS, BTREE_PAGE_FIND_MODIFY);
 
 	/*
@@ -648,7 +656,7 @@ check_walk_btree(BTreeCheckStatus *status, OInMemoryBlkno blkno,
 	{
 		Page		rightP = O_GET_IN_MEMORY_PAGE(RIGHTLINK_GET_BLKNO(rightLink));
 
-		if (O_PAGE_IS(rightP, BROKEN_SPLIT))
+		if (O_PAGE_IS(rightP, BROKEN_SPLIT) && status->emit_transient_notices)
 		{
 			elog(NOTICE, "BTree has a broken split.");
 			status->hasError = true;

--- a/src/btree/check.c
+++ b/src/btree/check.c
@@ -19,6 +19,7 @@
 #include "btree/io.h"
 #include "btree/page_chunks.h"
 #include "catalog/free_extents.h"
+#include "catalog/sys_trees.h"
 #include "checkpoint/checkpoint.h"
 #include "recovery/recovery.h"
 #include "tableam/descr.h"
@@ -29,6 +30,7 @@
 
 #include "pgstat.h"
 #include "access/transam.h"
+#include "storage/latch.h"
 
 /*
  * Dynamic array of file extents.
@@ -73,16 +75,16 @@ static bool is_sorted_by_off(ExtentsArray *array);
 static bool is_sorted_by_len_off(ExtentsArray *array);
 
 bool
-check_btree(BTreeDescr *desc, bool force_file_check)
+check_btree(BTreeDescr *desc, bool force_file_check, bool wait_for_checkpoint)
 {
+	bool		is_sys_tree = IS_SYS_TREE_OIDS(desc->oids);
 	BTreeMetaPage *metaPageBlkno = BTREE_GET_META(desc);
 	BTreeCheckStatus status;
 	ExtentsArray free_extents;
 	uint64		data_file_len = pg_atomic_read_u64(&metaPageBlkno->datafileLength[0]);	/* Fix for S3 mode */
 	bool		is_compressed = OCompressIsValid(desc->compress);
 	uint32		checkpoint_number = 0;
-	bool		result,
-				copy_blkno;
+	bool		copy_blkno;
 
 	memset(&status, 0, sizeof(BTreeCheckStatus));
 	memset(&free_extents, 0, sizeof(ExtentsArray));
@@ -92,13 +94,38 @@ check_btree(BTreeDescr *desc, bool force_file_check)
 	status.hasError = false;
 	init_page_find_context(&status.context, desc, COMMITSEQNO_INPROGRESS, BTREE_PAGE_FIND_MODIFY);
 
-	result = get_checkpoint_number(desc, desc->rootInfo.rootPageBlkno,
-								   &checkpoint_number, &copy_blkno);
-	if (!result)
+	/*
+	 * get_checkpoint_number() returns false while the checkpointer holds the
+	 * per-tree state.  With wait_for_checkpoint, retry until it moves past;
+	 * otherwise the caller is a debug entry point and gets the legacy NOTICE.
+	 */
+	while (!get_checkpoint_number(desc, desc->rootInfo.rootPageBlkno,
+								  &checkpoint_number, &copy_blkno))
 	{
-		/* Error is possible only when calling check_btree() without lock */
-		elog(NOTICE, "Tree is under checkpoint now");
-		return false;
+		if (!wait_for_checkpoint)
+		{
+			elog(NOTICE, "Tree is under checkpoint now");
+			return false;
+		}
+
+		/*
+		 * Holding the per-tree lock here would block the checkpointer we are
+		 * waiting on, so drop it across the latch wait and reacquire after.
+		 * Sys trees serialize against the checkpointer via oSysTreesLock.
+		 */
+		if (is_sys_tree)
+			LWLockRelease(&checkpoint_state->oSysTreesLock);
+		else
+			o_tables_rel_unlock_extended(&desc->oids, AccessExclusiveLock, true);
+		(void) WaitLatch(MyLatch,
+						 WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH,
+						 10L, WAIT_EVENT_PG_SLEEP);
+		ResetLatch(MyLatch);
+		CHECK_FOR_INTERRUPTS();
+		if (is_sys_tree)
+			LWLockAcquire(&checkpoint_state->oSysTreesLock, LW_EXCLUSIVE);
+		else
+			o_tables_rel_lock_extended(&desc->oids, AccessExclusiveLock, true);
 	}
 
 	Assert(checkpoint_number > 0);

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -573,7 +573,9 @@ orioledb_sys_tree_check(PG_FUNCTION_ARGS)
 
 	orioledb_check_shmem();
 
-	result = check_btree(get_sys_tree(num), force_map_check);
+	LWLockAcquire(&checkpoint_state->oSysTreesLock, LW_EXCLUSIVE);
+	result = check_btree(get_sys_tree(num), force_map_check, false);
+	LWLockRelease(&checkpoint_state->oSysTreesLock);
 
 	PG_RETURN_BOOL(result);
 }

--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -1281,8 +1281,12 @@ orioledb_tbl_check(PG_FUNCTION_ARGS)
 
 	for (i = 0; i < descr->nIndices; i++)
 	{
-		o_btree_load_shmem(&descr->indices[i]->desc);
-		result = check_btree(&descr->indices[i]->desc, force_map_check);
+		OIndexDescr *idx = descr->indices[i];
+
+		o_tables_rel_lock_extended(&idx->oids, AccessExclusiveLock, true);
+		o_btree_load_shmem(&idx->desc);
+		result = check_btree(&idx->desc, force_map_check, false);
+		o_tables_rel_unlock_extended(&idx->oids, AccessExclusiveLock, true);
 
 		if (result == false)
 			break;
@@ -1294,9 +1298,9 @@ orioledb_tbl_check(PG_FUNCTION_ARGS)
 
 /*
  * amcheck entry point: verify all b-trees of the orioledb relation and emit
- * one row per failed index as (index_name, msg).  `thorough_check` forces
- * the on-disk map check inside check_btree.  Per-index checkpoint lock
- * blocks the checkpointer on this tree so check_btree isn't racing it.
+ * one row per failed index.  `thorough_check` forces the on-disk map check.
+ * wait_for_checkpoint=true makes check_btree retry across checkpointer
+ * overlap rather than report it as corruption.
  */
 Datum
 verify_orioledb(PG_FUNCTION_ARGS)
@@ -1325,10 +1329,9 @@ verify_orioledb(PG_FUNCTION_ARGS)
 		OIndexDescr *idx = descr->indices[i];
 		bool		success;
 
-		o_btree_load_shmem(&idx->desc);
-
 		o_tables_rel_lock_extended(&idx->oids, AccessExclusiveLock, true);
-		success = check_btree(&idx->desc, thorough_check);
+		o_btree_load_shmem(&idx->desc);
+		success = check_btree(&idx->desc, thorough_check, true);
 		o_tables_rel_unlock_extended(&idx->oids, AccessExclusiveLock, true);
 
 		if (!success)

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -660,6 +660,7 @@ SELECT orioledb_tbl_indices('o_test58'::regclass);
 (1 row)
 
 INSERT INTO o_test58 SELECT 100 + i, 200 + i, 300 + i, 400 + i FROM generate_series(1, 10) AS i;
+CHECKPOINT;
 SELECT orioledb_tbl_check('o_test58'::regclass);
  orioledb_tbl_check 
 --------------------

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -660,6 +660,7 @@ SELECT orioledb_tbl_indices('o_test58'::regclass);
 (1 row)
 
 INSERT INTO o_test58 SELECT 100 + i, 200 + i, 300 + i, 400 + i FROM generate_series(1, 10) AS i;
+CHECKPOINT;
 SELECT orioledb_tbl_check('o_test58'::regclass);
  orioledb_tbl_check 
 --------------------

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -660,6 +660,7 @@ SELECT orioledb_tbl_indices('o_test58'::regclass);
 (1 row)
 
 INSERT INTO o_test58 SELECT 100 + i, 200 + i, 300 + i, 400 + i FROM generate_series(1, 10) AS i;
+CHECKPOINT;
 SELECT orioledb_tbl_check('o_test58'::regclass);
  orioledb_tbl_check 
 --------------------

--- a/test/sql/indices.sql
+++ b/test/sql/indices.sql
@@ -204,6 +204,7 @@ CREATE INDEX o_test58_reg1 ON o_test58(key);
 CREATE INDEX o_test58_reg2 ON o_test58(foo);
 SELECT orioledb_tbl_indices('o_test58'::regclass);
 INSERT INTO o_test58 SELECT 100 + i, 200 + i, 300 + i, 400 + i FROM generate_series(1, 10) AS i;
+CHECKPOINT;
 SELECT orioledb_tbl_check('o_test58'::regclass);
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58;

--- a/test/t/amcheck_test.py
+++ b/test/t/amcheck_test.py
@@ -40,6 +40,56 @@ class AmcheckTest(BaseTest):
 		    "SELECT * FROM verify_orioledb('o_t'::regclass, true);")
 		self.assertEqual(rows, [])
 
+	def test_verify_orioledb_no_false_positive_with_broken_split(self):
+		"""Pre-fix, a rightlink pointing to a BROKEN_SPLIT page made
+		verify_orioledb emit 'BTree has a broken split.' and return a
+		spurious ('o_t_pkey', 'check failed') row, even though a broken
+		split is a benign in-progress state finished by the next inserter
+		or checkpoint. This test forces a split failure via the split_fail
+		stopevent and asserts the default mode is clean both before and
+		after the fixup checkpoint."""
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "orioledb.enable_stopevents = true\n")
+		node.start()
+		node.safe_psql(
+		    'postgres', """
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE o_t (id text PRIMARY KEY) USING orioledb;
+			INSERT INTO o_t SELECT repeat('x', 400) || id
+				FROM generate_series(1, 20) id;
+			CHECKPOINT;
+		""")
+
+		con_set = node.connect()
+		con_set.execute("SELECT pg_stopevent_set('split_fail', 'true');")
+
+		# An INSERT that triggers a split now errors out; the error
+		# cleanup hook marks the in-progress split as broken.
+		con_ins = node.connect()
+		con_ins.execute("SET orioledb.enable_stopevents = true;")
+		with self.assertRaises(Exception):
+			con_ins.execute("INSERT INTO o_t SELECT repeat('x', 400) || id "
+			                "FROM generate_series(131, 139) id;")
+		con_ins.close()
+		con_set.execute("SELECT pg_stopevent_reset('split_fail');")
+		con_set.close()
+
+		# Pre-fix, the broken-split walk emits a NOTICE and the function
+		# returns a 'check failed' row.
+		rows = node.execute("SELECT * FROM verify_orioledb('o_t'::regclass);")
+		self.assertEqual(rows, [], f"verify returned false positive: {rows!r}")
+
+		# A CHECKPOINT completes the pending split. Both modes clean now.
+		node.safe_psql('postgres', "CHECKPOINT;")
+		self.assertEqual(
+		    node.execute("SELECT * FROM verify_orioledb('o_t'::regclass);"),
+		    [])
+		self.assertEqual(
+		    node.execute(
+		        "SELECT * FROM verify_orioledb('o_t'::regclass, true);"), [])
+		node.stop()
+
 	def test_verify_heapam_rejects_orioledb(self):
 		"""verify_heapam() must error on non-heap relations"""
 		node = self.node


### PR DESCRIPTION
In verify_orioledb:
- Avoid premature lock acquisition inside checkpointer re-lock.
- Avoid false positive due to transient unflushed dirty pages (busy/free extents)

orioledb_tbl_check behavior remains unchanged as it's used to detect BROKEN_SPLIT/unflushed dirty pages in tests. So semantics of verify_orioledb  and orioledb_tbl_check becomes different, and we shouldn't pursue replacing orioledb_tbl_check by verify_orioledb