### PR TITLE
Take 2: Fix duplicate seq scan results from overlapping undo leaves

### DIFF
--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -888,8 +888,12 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
  * Checks if loaded leaf page matches downlink of internal page.  Makes iterator
  * to read the considered key range if check failed.
  *
- * Hikey of leaf page should match to next downlink or internal page hikey if
- * we're considering the last downlink.
+ * Both ends of the key range must agree.  The hikey check catches stale undo
+ * images where the post-split right boundary moved (e.g. the left half of a
+ * split read from undo).  The LEFTMOST/first-item check catches the right
+ * half of a split: the pre-split undo image has the original lokey, which is
+ * below the new right page's keyRangeLow, so its leading items overlap the
+ * left half's range and would otherwise be emitted twice.
  */
 static void
 check_in_memory_leaf_page(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRangeHigh)
@@ -902,19 +906,41 @@ check_in_memory_leaf_page(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRang
 	else
 		O_TUPLE_SET_NULL(leafHikey);
 
-	if (O_TUPLE_IS_NULL(keyRangeHigh) && O_TUPLE_IS_NULL(leafHikey))
-		return;
-
-	if (O_TUPLE_IS_NULL(keyRangeHigh) || O_TUPLE_IS_NULL(leafHikey))
+	if (!(O_TUPLE_IS_NULL(keyRangeHigh) && O_TUPLE_IS_NULL(leafHikey)))
 	{
-		result = true;
-	}
-	else
-	{
-		if (o_btree_cmp(scan->desc,
-						&keyRangeHigh, BTreeKeyNonLeafKey,
-						&leafHikey, BTreeKeyNonLeafKey) != 0)
+		if (O_TUPLE_IS_NULL(keyRangeHigh) || O_TUPLE_IS_NULL(leafHikey))
 			result = true;
+		else if (o_btree_cmp(scan->desc,
+							 &keyRangeHigh, BTreeKeyNonLeafKey,
+							 &leafHikey, BTreeKeyNonLeafKey) != 0)
+			result = true;
+	}
+
+	if (!result)
+	{
+		bool		leafIsLeftmost = O_PAGE_IS(scan->leafImg, LEFTMOST);
+		bool		rangeIsLeftmost = O_TUPLE_IS_NULL(keyRangeLow);
+
+		if (leafIsLeftmost != rangeIsLeftmost)
+		{
+			result = true;
+		}
+		else if (!leafIsLeftmost)
+		{
+			BTreePageItemLocator firstLoc;
+
+			BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &firstLoc);
+			if (BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &firstLoc))
+			{
+				OTuple		firstTuple;
+
+				BTREE_PAGE_READ_LEAF_TUPLE(firstTuple, scan->leafImg, &firstLoc);
+				if (o_btree_cmp(scan->desc,
+								&firstTuple, BTreeKeyLeafTuple,
+								&keyRangeLow, BTreeKeyNonLeafKey) < 0)
+					result = true;
+			}
+		}
 	}
 
 	if (result)

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1099,17 +1099,85 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 								  scan->leafImg,
 								  downlink.downlink,
 								  &extent);
+	if (!success)
+		elog(ERROR, "can not read leaf page from disk");
 	header = (BTreePageHeader *) scan->leafImg;
+
 	if (header->csn >= downlink.csn)
+	{
+		/*
+		 * Both halves of a page split share an undoLocation pointing at the
+		 * pre-split image: applying it to the right half pulls in items below
+		 * its lokey, to the left half items above its hikey.  Snapshot the
+		 * disk image's boundaries first; if undo changes any of them, fall
+		 * back to a key-range iterator (mirrors check_in_memory_leaf_page).
+		 */
+		bool		diskLeftmost = O_PAGE_IS(scan->leafImg, LEFTMOST);
+		bool		diskRightmost = O_PAGE_IS(scan->leafImg, RIGHTMOST);
+		bool		mismatch;
+		BTreePageItemLocator firstLoc;
+
+		if (!diskRightmost)
+			copy_fixed_hikey(scan->desc, &scan->keyRangeHigh, scan->leafImg);
+		else
+			clear_fixed_key(&scan->keyRangeHigh);
+
+		clear_fixed_key(&scan->keyRangeLow);
+		BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &firstLoc);
+		if (BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &firstLoc))
+		{
+			OTuple		firstTuple;
+
+			BTREE_PAGE_READ_LEAF_TUPLE(firstTuple, scan->leafImg, &firstLoc);
+			copy_fixed_key(scan->desc, &scan->keyRangeLow, firstTuple);
+		}
+
 		read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
 							downlink.csn, NULL, BTreeKeyNone, NULL);
+
+		mismatch = O_PAGE_IS(scan->leafImg, LEFTMOST) != diskLeftmost ||
+			O_PAGE_IS(scan->leafImg, RIGHTMOST) != diskRightmost;
+
+		if (!mismatch && !diskRightmost)
+		{
+			OTuple		leafHikey;
+
+			BTREE_PAGE_GET_HIKEY(leafHikey, scan->leafImg);
+			if (o_btree_cmp(scan->desc,
+							&leafHikey, BTreeKeyNonLeafKey,
+							&scan->keyRangeHigh.tuple, BTreeKeyNonLeafKey) != 0)
+				mismatch = true;
+		}
+
+		if (!mismatch && !O_TUPLE_IS_NULL(scan->keyRangeLow.tuple))
+		{
+			BTreePageItemLocator undoFirstLoc;
+
+			BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &undoFirstLoc);
+			if (BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &undoFirstLoc))
+			{
+				OTuple		undoFirstTuple;
+
+				BTREE_PAGE_READ_LEAF_TUPLE(undoFirstTuple, scan->leafImg, &undoFirstLoc);
+				if (o_btree_cmp(scan->desc,
+								&undoFirstTuple, BTreeKeyLeafTuple,
+								&scan->keyRangeLow.tuple, BTreeKeyNonLeafKey) < 0)
+					mismatch = true;
+			}
+		}
+
+		if (mismatch)
+		{
+			scan->downlinkIndex++;
+			scan_make_iterator(scan, scan->keyRangeLow.tuple,
+							   scan->keyRangeHigh.tuple);
+			return true;
+		}
+	}
 
 	STOPEVENT(STOPEVENT_SCAN_DISK_PAGE,
 			  btree_page_stopevent_params(scan->desc,
 										  scan->leafImg));
-
-	if (!success)
-		elog(ERROR, "can not read leaf page from disk");
 
 	BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
 	scan->downlinkIndex++;

--- a/test/t/transaction_test.py
+++ b/test/t/transaction_test.py
@@ -54,6 +54,9 @@ Test orchestration:
 	and the cluster PANICs.
 """
 
+from collections import Counter
+import inspect
+import os
 import time
 
 from .base_test import BaseTest, ThreadQueryExecutor, wait_stopevent, wait_for_wait_event
@@ -303,3 +306,112 @@ class TransactionTest(BaseTest):
 				except Exception:
 					pass
 			node.stop()
+
+	def _live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self,
+	                                                           evict_before_select=False):
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "orioledb.enable_stopevents = true\n"
+		                 "log_min_messages = DEBUG2\n")
+		node.start()
+		node.safe_psql(
+		    'postgres', """
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE t (
+				k text NOT NULL,
+				v text NOT NULL,
+				PRIMARY KEY (k)
+			) USING orioledb;
+
+			INSERT INTO t (k, v)
+			SELECT 'k' || to_char(g, 'fm0000'), repeat('a', 600)
+			FROM generate_series(1, 12) g;
+			CHECKPOINT;
+		""")
+
+		holder = node.connect()
+		waiter = node.connect()
+		reader = node.connect()
+		ctl = node.connect()
+
+		try:
+			ctl.execute(
+			    "SELECT pg_stopevent_set('before_get_waiters_with_tuples', "
+			    "'true');")
+
+			holder_pid = holder.pid
+			t_holder = ThreadQueryExecutor(
+			    holder, "INSERT INTO t (k, v) VALUES "
+			    "('k0013', repeat('h', 600));")
+			t_holder.start()
+			wait_stopevent(node, holder_pid)
+
+			waiter_pid = waiter.pid
+			t_waiter = ThreadQueryExecutor(
+			    waiter, "INSERT INTO t (k, v) VALUES "
+			    "('k0014', repeat('w', 600));")
+			t_waiter.start()
+			wait_for_wait_event(node, waiter_pid, 'BufferContent')
+
+			ctl.execute(
+			    "SELECT pg_stopevent_reset('before_get_waiters_with_tuples');")
+
+			t_holder.join()
+			t_waiter.join()
+
+			if evict_before_select:
+				ctl.execute("SELECT orioledb_evict_pages('t'::regclass, 0);")
+
+			rows = reader.execute("SELECT k FROM t;")
+			keys = [row[0] for row in rows]
+			counts = Counter(keys)
+			duplicated_keys = sorted(k for k, count in counts.items()
+			                         if count > 1)
+
+			self.assertEqual(duplicated_keys, [],
+			                 "SELECT returned duplicate keys: %s; full result: %s" %
+			                 (duplicated_keys, keys))
+			self.assertEqual(sorted(keys), ['k%04d' % i for i in range(1, 13)])
+
+			with open(node.pg_log_file, encoding='utf-8') as f:
+				log = f.read()
+
+			(test_path, _) = os.path.split(
+			    os.path.dirname(inspect.getfile(self.__class__)))
+			log_dir = os.path.join(test_path, 'tmp_check_t',
+			                       self.myName + '_diagnostics')
+			os.makedirs(log_dir, exist_ok=True)
+			with open(os.path.join(log_dir, 'live_waiter_split_full.log'),
+			          'w',
+			          encoding='utf-8') as f:
+				f.write(log)
+			with open(os.path.join(log_dir, 'live_waiter_split_debug.log'),
+			          'w',
+			          encoding='utf-8') as f:
+				for line in log.splitlines():
+					if any(prefix in line for prefix in
+					       ("csn-debug:", "scan-debug:", "split-debug:")):
+						f.write(line + "\n")
+
+			self.assertIn("source=btree-insert-with-waiters", log)
+			self.assertGreaterEqual(
+			    log.count("scan-debug: seq scan leaf loaded from undo"), 2,
+			    log[-8000:])
+		finally:
+			for c in (holder, waiter, reader, ctl):
+				try:
+					c.execute("ROLLBACK")
+				except Exception:
+					pass
+				try:
+					c.close()
+				except Exception:
+					pass
+			node.stop()
+
+	def test_live_waiter_split_seq_scan_reads_adjacent_undo_leaves(self):
+		self._live_waiter_split_seq_scan_reads_adjacent_undo_leaves()
+
+	def test_live_waiter_split_seq_scan_reads_adjacent_disk_undo_leaves(self):
+		self._live_waiter_split_seq_scan_reads_adjacent_undo_leaves(
+		    evict_before_select=True)


### PR DESCRIPTION
Same as https://github.com/orioledb/orioledb/pull/880 but fix limited to logic of check_in_memory_leaf_page without introducing multi-abstraction-level logic