### PR TITLE
Use `pg_dir_create_mode` when calling `pg_mkdir_p`

### DIFF
--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -23,6 +23,7 @@
 #include "catalog/o_sys_cache.h"
 #include "catalog/sys_trees.h"
 #include "checkpoint/checkpoint.h"
+#include "common/file_perm.h"
 #include "indexam/handler.h"
 #include "recovery/logical.h"
 #include "recovery/recovery.h"
@@ -1561,7 +1562,7 @@ o_verify_dir_exists_or_create(char *dirname, bool *created, bool *found)
 			/*
 			 * Does not exist, so create
 			 */
-			if (pg_mkdir_p(dirname, S_IRWXU) == -1)
+			if (pg_mkdir_p(dirname, pg_dir_create_mode) == -1)
 			{
 				if (errno == EEXIST)
 				{
@@ -1593,120 +1594,9 @@ o_verify_dir_exists_or_create(char *dirname, bool *created, bool *found)
 			elog(ERROR, "could not access directory \"%s\": %s",
 				 dirname, errstr);
 			return;
+		default:
+			Assert(false);
 	}
-	return;						/* keep compiler quiet */
-}
-
-/*
- * pg_mkdir_p --- create a directory and, if necessary, parent directories
- *
- * This is equivalent to "mkdir -p" except we don't complain if the target
- * directory already exists.
- *
- * We assume the path is in canonical form, i.e., uses / as the separator.
- *
- * omode is the file permissions bits for the target directory.  Note that any
- * parent directories that have to be created get permissions according to the
- * prevailing umask, but with u+wx forced on to ensure we can create there.
- * (We declare omode as int, not mode_t, to minimize dependencies for port.h.)
- *
- * Returns 0 on success, -1 (with errno set) on failure.
- *
- * Note that on failure, the path arg has been modified to show the particular
- * directory level we had problems with.
- */
-int
-pg_mkdir_p(char *path, int omode)
-{
-	struct stat sb;
-	mode_t		numask,
-				oumask;
-	int			last,
-				retval;
-	char	   *p;
-
-	retval = 0;
-	p = path;
-
-#ifdef WIN32
-	/* skip network and drive specifiers for win32 */
-	if (strlen(p) >= 2)
-	{
-		if (p[0] == '/' && p[1] == '/')
-		{
-			/* network drive */
-			p = strstr(p + 2, "/");
-			if (p == NULL)
-			{
-				errno = EINVAL;
-				return -1;
-			}
-		}
-		else if (p[1] == ':' &&
-				 ((p[0] >= 'a' && p[0] <= 'z') ||
-				  (p[0] >= 'A' && p[0] <= 'Z')))
-		{
-			/* local drive */
-			p += 2;
-		}
-	}
-#endif
-
-	/*
-	 * POSIX 1003.2: For each dir operand that does not name an existing
-	 * directory, effects equivalent to those caused by the following command
-	 * shall occur:
-	 *
-	 * mkdir -p -m $(umask -S),u+wx $(dirname dir) && mkdir [-m mode] dir
-	 *
-	 * We change the user's umask and then restore it, instead of doing
-	 * chmod's.  Note we assume umask() can't change errno.
-	 */
-	oumask = umask(0);
-	numask = oumask & ~(S_IWUSR | S_IXUSR);
-	(void) umask(numask);
-
-	if (p[0] == '/')			/* Skip leading '/'. */
-		++p;
-	for (last = 0; !last; ++p)
-	{
-		if (p[0] == '\0')
-			last = 1;
-		else if (p[0] != '/')
-			continue;
-		*p = '\0';
-		if (!last && p[1] == '\0')
-			last = 1;
-
-		if (last)
-			(void) umask(oumask);
-
-		/* check for pre-existing directory */
-		if (stat(path, &sb) == 0)
-		{
-			if (!S_ISDIR(sb.st_mode))
-			{
-				if (last)
-					errno = EEXIST;
-				else
-					errno = ENOTDIR;
-				retval = -1;
-				break;
-			}
-		}
-		else if (mkdir(path, last ? omode : S_IRWXU | S_IRWXG | S_IRWXO) < 0)
-		{
-			retval = -1;
-			break;
-		}
-		if (!last)
-			*p = '/';
-	}
-
-	/* ensure we restored umask */
-	(void) umask(oumask);
-
-	return retval;
 }
 
 Datum

--- a/src/s3/headers.c
+++ b/src/s3/headers.c
@@ -13,6 +13,7 @@
  */
 #include "postgres.h"
 
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "orioledb.h"
@@ -24,7 +25,6 @@
 #include "s3/worker.h"
 
 #include "catalog/pg_tablespace.h"
-#include "common/file_perm.h"
 #include "common/file_utils.h"
 #include "common/hashfn.h"
 #include "common/pg_prng.h"
@@ -207,7 +207,7 @@ read_from_file(S3HeaderTag tag, uint32 values[S3_HEADER_NUM_VALUES],
 	Assert(headerSize <= BLCKSZ);
 
 	filename = btree_filename(tag.key, tag.segNum, tag.checkpointNum);
-	fd = BasicOpenFilePerm(filename, O_RDWR | O_CREAT | PG_BINARY, pg_file_create_mode);
+	fd = BasicOpenFile(filename, O_RDWR | O_CREAT | PG_BINARY);
 	if (fd <= 0)
 		ereport(FATAL,
 				(errcode_for_file_access(),
@@ -251,7 +251,7 @@ write_to_file(S3HeaderTag tag, uint32 values[S3_HEADER_NUM_VALUES])
 	Assert(headerSize <= BLCKSZ);
 
 	filename = btree_filename(tag.key, tag.segNum, tag.checkpointNum);
-	fd = BasicOpenFilePerm(filename, O_RDWR | O_CREAT | PG_BINARY, pg_file_create_mode);
+	fd = BasicOpenFile(filename, O_RDWR | O_CREAT | PG_BINARY);
 	if (fd <= 0)
 		ereport(FATAL,
 				(errcode_for_file_access(),
@@ -346,7 +346,7 @@ change_buffer(S3HeadersBuffersGroup *group, int index, S3HeaderTag tag)
 
 		filename = btree_filename(prevTag.key, prevTag.segNum,
 								  prevTag.checkpointNum);
-		fd = BasicOpenFilePerm(filename, O_RDWR | PG_BINARY, pg_file_create_mode);
+		fd = BasicOpenFile(filename, O_RDWR | PG_BINARY);
 		pfree(filename);
 		if (fd > 0)
 		{
@@ -1148,7 +1148,7 @@ initial_parts_counting_callback(S3HeaderTag tag)
 	read_from_file(tag, values, &dirty);
 
 	filename = btree_filename(tag.key, tag.segNum, tag.checkpointNum);
-	fd = BasicOpenFilePerm(filename, O_RDWR | PG_BINARY, pg_file_create_mode);
+	fd = BasicOpenFile(filename, O_RDWR | PG_BINARY);
 	if (fd <= 0)
 		ereport(FATAL,
 				(errcode_for_file_access(),
@@ -1227,7 +1227,7 @@ eviction_callback(S3HeaderTag tag)
 	bool		haveLoadedParts = false;
 
 	filename = btree_filename(tag.key, tag.segNum, tag.checkpointNum);
-	fd = BasicOpenFilePerm(filename, O_RDWR | PG_BINARY, pg_file_create_mode);
+	fd = BasicOpenFile(filename, O_RDWR | PG_BINARY);
 	pfree(filename);
 
 	if (fd <= 0)

--- a/test/t/base_test.py
+++ b/test/t/base_test.py
@@ -25,7 +25,7 @@ from testgres.node import PostgresNode
 from testgres.operations.os_ops import OsOperations, ConnectionParams
 from testgres.port_manager import PortManager__Generic
 from testgres.utils import get_pg_version, get_pg_config
-from typing import Any
+from typing import Any, List, Optional
 
 # When USE_DM_LOG_WRITES=1 is passed (via Makefile's USE_DM_LOG_WRITES flag),
 # crash simulations use dm-log-writes to replay only the writes that actually
@@ -327,12 +327,14 @@ class BaseTest(unittest.TestCase):
 
 		return restoredNode
 
-	def initNode(self,
-	             base_port: int,
-	             suffix='tgsn',
-	             has_archiving: bool = False,
-	             allows_streaming: bool = False,
-	             override_base_dir: str = None) -> testgres.PostgresNode:
+	def initNode(
+	        self,
+	        base_port: int,
+	        suffix='tgsn',
+	        has_archiving: bool = False,
+	        allows_streaming: bool = False,
+	        override_base_dir: Optional[str] = None,
+	        initdb_args: Optional[List[str]] = None) -> testgres.PostgresNode:
 		(test_path,
 		 t) = os.path.split(os.path.dirname(inspect.getfile(self.__class__)))
 		if override_base_dir is not None:
@@ -347,7 +349,8 @@ class BaseTest(unittest.TestCase):
 		node = testgres.get_new_node('test',
 		                             base_dir=baseDir,
 		                             port_manager=port_manager)
-		node.init(["--no-locale", "--encoding=UTF8"])  # run initdb
+		node.init(initdb_args if initdb_args is not None else
+		          ["--no-locale", "--encoding=UTF8"])
 		node.append_conf(
 		    'postgresql.conf', "shared_preload_libraries = orioledb\n"
 		    "orioledb.use_sparse_files = true\n"

--- a/test/t/files_test.py
+++ b/test/t/files_test.py
@@ -5,13 +5,14 @@ from itertools import chain, groupby
 import re
 import os
 import glob
+import stat
 import unittest
 
 from .base_test import BaseTest
 from .base_test import ThreadQueryExecutor
 from .base_test import wait_stopevent
 
-from testgres.enums import NodeStatus
+from typing import List, Optional
 
 
 class FilesTest(BaseTest):
@@ -595,3 +596,84 @@ class FilesTest(BaseTest):
 		stat2 = os.stat(fname)
 
 		self.assertEqual(stat1.st_blocks, stat2.st_blocks)
+
+
+class FilesGroupAccessTest(BaseTest):
+
+	def initNode(self,
+	             base_port: int,
+	             suffix='tgsn',
+	             has_archiving: bool = False,
+	             allows_streaming: bool = False,
+	             override_base_dir: Optional[str] = None,
+	             initdb_args: Optional[List[str]] = None):
+		args = list(initdb_args) if initdb_args is not None else [
+		    "--no-locale", "--encoding=UTF8"
+		]
+		if "--allow-group-access" not in args:
+			args.append("--allow-group-access")
+		return super().initNode(base_port,
+		                        suffix=suffix,
+		                        has_archiving=has_archiving,
+		                        allows_streaming=allows_streaming,
+		                        override_base_dir=override_base_dir,
+		                        initdb_args=args)
+
+	def setUp(self):
+		super().setUp()
+		self.node.append_conf('postgresql.conf', "log_min_messages = notice\n")
+
+	def test_group_read_access_mode(self):
+		node = self.node
+		node.start()
+		node.safe_psql("""
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE o_test (
+				id int NOT NULL,
+				val int NOT NULL,
+				PRIMARY KEY (id)
+			) USING orioledb;
+			INSERT INTO o_test
+				SELECT i, i FROM generate_series(1, 100, 1) i;
+			CHECKPOINT;
+			""")
+		node.stop()
+
+		checked_dirs = 0
+		checked_files = 0
+
+		for dir_name in ('orioledb_data', 'orioledb_undo'):
+			dir_path = os.path.join(node.data_dir, dir_name)
+
+			self.assertTrue(os.path.isdir(dir_path))
+
+			dir_mode = os.stat(dir_path).st_mode
+			self.assertEqual(dir_mode & (stat.S_IRGRP | stat.S_IXGRP),
+			                 stat.S_IRGRP | stat.S_IXGRP)
+
+			for child_name in os.listdir(dir_path):
+				child_path = os.path.join(dir_path, child_name)
+				child_mode = os.stat(child_path).st_mode
+
+				# Check data files below specific database directory
+				if os.path.isdir(child_path):
+					self.assertEqual(
+					    child_mode & (stat.S_IRGRP | stat.S_IXGRP),
+					    stat.S_IRGRP | stat.S_IXGRP)
+					checked_dirs += 1
+
+					for db_name in os.listdir(child_path):
+						db_path = os.path.join(child_path, db_name)
+
+						self.assertTrue(os.path.isfile(db_path))
+						self.assertEqual(
+						    os.stat(db_path).st_mode & stat.S_IRGRP,
+						    stat.S_IRGRP)
+
+						checked_files += 1
+				elif os.path.isfile(child_path):
+					self.assertEqual(child_mode & stat.S_IRGRP, stat.S_IRGRP)
+					checked_files += 1
+
+		self.assertGreater(checked_dirs, 0)
+		self.assertGreater(checked_files, 0)


### PR DESCRIPTION
This commit changes:
- `pg_mkdir_p()` now uses `pg_dir_create_mode`
- `BasicOpenFilePerm()` are replaced by `BaseOpenFile()` which uses `pg_file_create_mode` implicitly
- new test `FilesGroupAccessTest.test_group_read_access_mode`