### PR TITLE
ci: skip check workflow on PRs from the same repository

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   matrix:
+    # Only run on push events OR pull requests from forks
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}


### PR DESCRIPTION
## Summary

The \`check\` workflow currently triggers on both \`push\` and \`pull_request\` events. For PRs opened from a branch inside \`orioledb/orioledb\` (the common case), each push hits both triggers and the same SHA runs the full matrix twice -- once as the push and once as the PR -- wasting runner time and doubling artifact upload noise.

\`static.yml\` already skips this double-run with a conditional that runs only on \`push\` or on PRs from forks:

\`\`\`yaml
if: |
  github.event_name == 'push' ||
  github.event.pull_request.head.repo.full_name != github.repository
\`\`\`

Apply the same condition to \`check.yml\`. Place it only on the root \`matrix\` job; the other three jobs (\`check\`, \`finish\`, \`cleanup\`) are linked via \`needs:\` so when \`matrix\` is skipped, each dependent's default \`if: success()\` evaluates false and the whole chain skips. No per-job duplication.

## Behavior

- **\`push\` to any branch** -- full workflow runs as before.
- **PR from a fork** (e.g. an external contributor) -- full workflow runs (head repo differs from base).
- **PR from a branch in \`orioledb/orioledb\`** -- \`matrix\` skipped, cascade skips \`check\`/\`finish\`/\`cleanup\`. The same SHA already ran as a push, so the result is reused.

## Test plan

- [ ] Push to a branch inside \`orioledb/orioledb\`: \`check\` workflow runs.
- [ ] Open a PR from that branch (same repo) and re-push: the PR run skips, the push run is the only one.
- [ ] (If a fork PR is available) Open a PR from a fork and confirm the workflow still runs.
- [ ] Branch-protection check: if \`check (...)\` jobs are required for merge, verify that PR mergeability uses the push-side result for the same SHA (this is how \`static.yml\` already works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)