### PR TITLE
Defer free_run_xmin to after WAL_REC_ROLLBACK emission

### DIFF
--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -355,15 +355,40 @@ checkpoint_shmem_init(Pointer ptr, bool found)
 			pg_atomic_write_u64(&undo_meta->cleanedCheckpointEndLocation, undo_info->checkpointRetainEndLocation);
 		}
 
-		pg_atomic_init_u64(&xid_meta->nextXid, control.lastXid);
-		pg_atomic_init_u64(&xid_meta->runXmin, control.lastXid);
-		pg_atomic_init_u64(&xid_meta->globalXmin, control.lastXid);
-		pg_atomic_init_u64(&xid_meta->lastXidWhenUpdatedGlobalXmin, control.lastXid);
-		pg_atomic_init_u64(&xid_meta->writtenXmin, control.lastXid);
-		pg_atomic_init_u64(&xid_meta->writeInProgressXmin, control.lastXid);
+		/*
+		 * Seed xid horizons from the checkpoint's retain range:
+		 *
+		 * - nextXid / writtenXmin / writeInProgressXmin =
+		 * checkpointRetainXmax (master's nextXid at checkpoint time).
+		 * writtenXmin stays at the high mark so the on-disk xidmap range --
+		 * which may contain FROZEN slots that master's advance_global_xmin
+		 * stamped for oxids < master.runXmin -- is still served via
+		 * o_buffers_read.
+		 *
+		 * - runXmin / globalXmin / cleanedXmin / lastXidWhenUpdatedGlobalXmin
+		 * = checkpointRetainXmin (master's runXmin at checkpoint time, the
+		 * actual floor of in-flight oxids).  This is the conservative
+		 * starting horizon that matches what subsequent WAL records will
+		 * reference.
+		 *
+		 * On a clean shutdown master writes checkpointRetainXmin ==
+		 * checkpointRetainXmax == nextXid, so all horizons collapse to a
+		 * single value -- behaviour identical to the previous lastXid-based
+		 * init.
+		 *
+		 * control.lastXid is now redundant with checkpointRetainXmax; it's
+		 * retained in the control file for backward compatibility with
+		 * existing data directories.
+		 */
+		pg_atomic_init_u64(&xid_meta->nextXid, control.checkpointRetainXmax);
+		pg_atomic_init_u64(&xid_meta->runXmin, control.checkpointRetainXmin);
+		pg_atomic_init_u64(&xid_meta->globalXmin, control.checkpointRetainXmin);
+		pg_atomic_init_u64(&xid_meta->lastXidWhenUpdatedGlobalXmin, control.checkpointRetainXmin);
+		pg_atomic_init_u64(&xid_meta->writtenXmin, control.checkpointRetainXmax);
+		pg_atomic_init_u64(&xid_meta->writeInProgressXmin, control.checkpointRetainXmax);
 		pg_atomic_init_u64(&xid_meta->checkpointRetainXmin, control.checkpointRetainXmin);
 		pg_atomic_init_u64(&xid_meta->checkpointRetainXmax, control.checkpointRetainXmax);
-		pg_atomic_init_u64(&xid_meta->cleanedXmin, control.lastXid);
+		pg_atomic_init_u64(&xid_meta->cleanedXmin, control.checkpointRetainXmin);
 		pg_atomic_init_u64(&xid_meta->cleanedCheckpointXmin, control.checkpointRetainXmin);
 		pg_atomic_init_u64(&xid_meta->cleanedCheckpointXmax, control.checkpointRetainXmax);
 

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1766,10 +1766,24 @@ recovery_finish(int worker_id)
 		pairingheap_free(retain_undo_queues[i]);
 	}
 	if (worker_id < 0)
-	{
 		pairingheap_free(xmin_queue);
-		free_run_xmin();
-	}
+
+	/*
+	 * Do NOT advance runXmin here.  Recovery has just aborted in-flight oxids
+	 * in memory; if recovery_finish_aborted_oxids is non-empty, the
+	 * after-checkpoint hook will emit a WAL_REC_ROLLBACK for each, stamping
+	 * the record's xmin with the current runXmin.  If we advanced runXmin to
+	 * nextXid here, the post-recovery checkpoint that runs between
+	 * recovery_finish() and o_emit_recovery_finish_rollbacks() would persist
+	 * the advanced horizon as control.checkpointRetainXmin, and the standby
+	 * would replay that checkpoint before seeing the ROLLBACK records that
+	 * justify it.  After the standby's globalXmin slid forward, the ROLLBACK
+	 * records would then drag it back across slots already stamped FROZEN,
+	 * breaking oxid_get_csn()'s fast-path (orioledb/orioledb#889).
+	 * free_run_xmin() is deferred to o_emit_recovery_finish_rollbacks() so
+	 * the WAL records and the runXmin advance are atomic with respect to
+	 * checkpoint observers.
+	 */
 	if (worker_id >= 0)
 		pg_atomic_write_u64(&worker_ptrs[worker_id].retainPtr,
 							pg_atomic_read_u64(&worker_ptrs[worker_id].commitPtr));
@@ -1804,9 +1818,6 @@ o_emit_recovery_finish_rollbacks(void)
 {
 	int			i;
 
-	if (recovery_finish_aborted_count == 0)
-		return;
-
 	for (i = 0; i < recovery_finish_aborted_count; i++)
 	{
 		elog(LOG, "orioledb: emitting WAL_REC_ROLLBACK for in-flight oxid %lu aborted by recovery_finish",
@@ -1815,10 +1826,23 @@ o_emit_recovery_finish_rollbacks(void)
 										  recovery_finish_aborted_oxids[i].xid);
 	}
 
-	pfree(recovery_finish_aborted_oxids);
-	recovery_finish_aborted_oxids = NULL;
-	recovery_finish_aborted_count = 0;
-	recovery_finish_aborted_capacity = 0;
+	if (recovery_finish_aborted_oxids != NULL)
+	{
+		pfree(recovery_finish_aborted_oxids);
+		recovery_finish_aborted_oxids = NULL;
+		recovery_finish_aborted_count = 0;
+		recovery_finish_aborted_capacity = 0;
+	}
+
+	/*
+	 * Now that every WAL_REC_ROLLBACK has been stamped with the
+	 * checkpoint-era runXmin, it is safe to lift the horizon to nextXid.
+	 * Deferred from recovery_finish() so the post-recovery checkpoint (which
+	 * sits between the two phases) observes the original floor and standbys
+	 * never see a checkpointRetainXmin that gets out from under the ROLLBACK
+	 * records that explain it (orioledb/orioledb#889).
+	 */
+	free_run_xmin();
 }
 
 /*

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -1717,3 +1717,321 @@ class ReplicationTest(BaseTest):
 					os.kill(p, signal.SIGKILL)
 				except ProcessLookupError:
 					pass
+
+	def test_recovery_finish_rollback_does_not_regress_replica_xmin(self):
+		"""
+		Issue #889: recovery_finish() rolls back in-flight oxids in
+		memory and emits WAL_REC_ROLLBACK for each one in a deferred
+		after-checkpoint hook.  Under the pre-fix horizon design the
+		standby could end up livelocked: o_btree_modify_handle_conflicts
+		would wait forever on an oxid it still saw as IN_PROGRESS,
+		because the standby's runXmin / globalXmin had regressed below
+		writtenXmin and oxid_get_csn() mis-read legitimately FROZEN
+		xidmap slots as IN_PROGRESS.
+
+		The bug surfaces as a livelocked recovery worker that cannot
+		shut down -- which is what this test actually asserts.
+
+		The horizon checks are intentionally loose.  A bounded lag
+		between primary and replica xmins is legitimate bookkeeping
+		bloat (globalXmin <= writtenXmin, deferred runXmin sync, etc.),
+		not the bug.  The bounds catch a catastrophic pin (lag growing
+		without bound as the primary keeps advancing) while tolerating
+		ordinary post-recovery bloat.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		dangling_pids = set()
+		try:
+			with self.getReplica().start() as replica:
+				master.safe_psql("""
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_test_xmin_no_regress (
+						k int PRIMARY KEY,
+						v int
+					) USING orioledb;
+					INSERT INTO o_test_xmin_no_regress
+						SELECT g, 0 FROM generate_series(1, 100) g;
+				""")
+				self.catchup_orioledb(replica)
+
+				# Long-running tx whose single small UPDATE never
+				# overflows the 8 KB local_wal buffer.  Without an
+				# overflow, neither WAL_REC_XID(T_long) nor any
+				# modify record reaches the standby pre-crash, so
+				# T_long is invisible to the standby's hash.
+				t_long = master.connect()
+				t_long.begin()
+				t_long.execute(
+				    "UPDATE o_test_xmin_no_regress SET v = -1 WHERE k = 1;")
+
+				# Bump nextXid past T_long by many short commits, so
+				# post-restart runXmin = nextXid is *far* above
+				# T_long's oxid.  This is what made the malformed
+				# xmin observable in the bug report.
+				for i in range(200):
+					master.safe_psql(
+					    "UPDATE o_test_xmin_no_regress "
+					    f"SET v = v + 1 WHERE k = {2 + (i % 50)};")
+
+				# Checkpoint primary: its xids file now records
+				# T_long as in-flight.  Standby's xids file does
+				# *not* (that file is local to the primary).
+				master.safe_psql("CHECKPOINT;")
+				self.catchup_orioledb(replica)
+
+				# SIGKILL the postmaster *and* every backend so
+				# nobody gets a chance to wal_rollback() T_long.
+				pid_file = os.path.join(master.data_dir, 'postmaster.pid')
+				with open(pid_file) as f:
+					master_pid = int(f.readline().strip())
+				child_pids = [
+				    int(x) for x in subprocess.run(
+				        ['pgrep', '-P', str(master_pid)],
+				        capture_output=True,
+				        text=True,
+				        check=False).stdout.split()
+				]
+				dangling_pids.update([master_pid] + child_pids)
+				for p in child_pids + [master_pid]:
+					try:
+						os.kill(p, signal.SIGKILL)
+					except ProcessLookupError:
+						pass
+				deadline = time.time() + 30
+				while time.time() < deadline:
+					alive = False
+					for p in [master_pid] + child_pids:
+						try:
+							os.kill(p, 0)
+							alive = True
+							break
+						except ProcessLookupError:
+							continue
+					if not alive:
+						break
+					time.sleep(0.05)
+				master.is_started = False
+				try:
+					t_long.close()
+				except Exception:
+					pass
+				master.start()
+
+				# Trigger more WAL so the after-recovery
+				# WAL_REC_ROLLBACK(T_long) is shipped, then catch up.
+				master.safe_psql(
+				    "UPDATE o_test_xmin_no_regress SET v = 99 WHERE k = 1;")
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				replica.poll_query_until(
+				    f"SELECT pg_last_wal_replay_lsn() >= "
+				    f"'{master_lsn}'::pg_lsn",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+				replica.poll_query_until(
+				    "SELECT orioledb_recovery_synchronized();",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				# Force one more checkpoint round on the primary so
+				# anything still pending on the standby drains.
+				master.safe_psql("CHECKPOINT;")
+				self.catchup_orioledb(replica)
+				replica.poll_query_until(
+				    "SELECT orioledb_recovery_synchronized();",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				master_runxmin, master_globalxmin = master.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+				replica_runxmin, replica_globalxmin = replica.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+
+				# Loose horizon bounds: pre-fix pin to T_long produced
+				# lag = (nextXid - T_long.oxid), unbounded as the
+				# primary keeps advancing.  Ordinary bloat from
+				# writtenXmin bookkeeping and deferred runXmin sync
+				# stays within a small constant.  The cap is generous
+				# enough to absorb that bloat while still catching a
+				# catastrophic pin.
+				self.assertLess(
+				    master_runxmin - replica_runxmin, 1000,
+				    f"replica runXmin {replica_runxmin} catastrophically "
+				    f"lags primary {master_runxmin}")
+				self.assertLess(
+				    master_globalxmin - replica_globalxmin, 1000,
+				    f"replica globalXmin {replica_globalxmin} "
+				    f"catastrophically lags primary {master_globalxmin}")
+
+				# Replica must shut down cleanly.  The pre-fix
+				# livelock would block fast shutdown indefinitely on
+				# the recovery worker.  Generous timeout for valgrind
+				# builds, which slow process teardown substantially.
+				t0 = time.time()
+				replica.stop(['-m', 'fast', '-t', '180'])
+				self.assertLess(
+				    time.time() - t0, 180,
+				    "replica did not shut down within 180s "
+				    "(potential livelock)")
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+			for p in dangling_pids:
+				try:
+					os.kill(p, signal.SIGKILL)
+				except ProcessLookupError:
+					pass
+
+	def test_parallel_worker_rollback_undo_lost_to_compaction(self):
+		"""
+		Parallel-worker undo-vs-compaction race introduced by the
+		runXmin rework.
+
+		T_stop deletes k=1 on o_compact.  The recovery worker
+		handling T_stop's btree (W_K1) applies the DELETE and then
+		hits a before_apply_undo stopevent at the start of its
+		rollback undo -- so the tombstone-deletion record is still
+		visible on the page while undo is suspended.
+
+		While W_K1 is parked, the main recovery process keeps
+		processing WAL.  Post-rollback transactions on the master
+		emit WAL_REC_COMMIT records carrying xmin > T_stop.oxid,
+		because T_stop has already finished there.  The rework's
+		update_run_xmin tracks recovery_xmin directly, so the
+		standby's runXmin slides past T_stop.oxid.
+
+		Concurrent recovery workers (W_B etc.) applying modifies on
+		the same densely packed page touch k=1's tombstone; with the
+		advanced runXmin xid_is_finished_for_everybody(T_stop.oxid)
+		returns true, and the tombstone is dropped during
+		perform_page_compaction.  When the stopevent is released and
+		W_K1 finally runs its undo, there is nothing left on the page
+		to undo -- the row is gone for good.
+
+		Pre-rework the standby's xmin_queue held runXmin floored at
+		T_stop.oxid until W_K1 finished, so compaction never fired.
+		"""
+		master = self.node
+		master.append_conf("orioledb.enable_stopevents = true\n"
+		                   "orioledb.recovery_pool_size = 2\n")
+		master.start()
+		replica = None
+		try:
+			replica = self.getReplica()
+			replica.append_conf("orioledb.enable_stopevents = true\n"
+			                    "orioledb.recovery_pool_size = 2\n")
+			replica.start()
+
+			# Pack many narrow rows into the same page so the
+			# leftmost leaf holds k=1 along with k=2..N.  Use a
+			# wide text column whose post-rollback UPDATEs *grow*
+			# the tuples; this is what makes the worker's
+			# perform_page_compaction path fire on the page that
+			# holds k=1's tombstone.
+			master.safe_psql("""
+				CREATE EXTENSION orioledb;
+				CREATE TABLE o_compact (
+					k int PRIMARY KEY,
+					v text
+				) USING orioledb;
+				INSERT INTO o_compact
+					SELECT g, 'short' FROM generate_series(1, 100) g;
+			""")
+			master.safe_psql("CHECKPOINT;")
+			self.catchup_orioledb(replica)
+
+			# Park whichever recovery worker runs the abort-path
+			# undo for T_stop.  Main runs apply_undo_stack too as
+			# part of recovery_finish_current_oxid, but its
+			# $backendType is "startup" and is excluded by the
+			# filter -- only worker-side abort undo (which is what
+			# actually applies the page-level tombstone revert) is
+			# captured.
+			replica.safe_psql(
+			    "SELECT pg_stopevent_set('before_apply_undo', "
+			    "'$.commit == false "
+			    "&& $backendType == \"orioledb recovery worker\"');")
+
+			# T_stop: delete k=1 and roll back.
+			t_stop = master.connect()
+			t_stop.begin()
+			t_stop.execute("DELETE FROM o_compact WHERE k = 1;")
+			t_stop.execute("ROLLBACK;")
+			t_stop.close()
+
+			# Post-rollback commits.  Master's runXmin has advanced
+			# past T_stop.oxid, so each WAL_REC_COMMIT carries
+			# xmin > T_stop.oxid.  On the standby the rework's
+			# update_run_xmin slides runXmin past T_stop.oxid while
+			# the worker holding T_stop's undo is still parked.
+			# Growing each row's `v` forces the leftmost page (the
+			# one that holds k=1's tombstone) into the
+			# compaction-required regime: the next UPDATE on that
+			# page calls perform_page_compaction, which now sees
+			# xid_is_finished_for_everybody(T_stop.oxid) returning
+			# true (T_stop.oxid < advanced runXmin) and drops the
+			# tombstone for k=1.
+			big = "x" * 500
+			for i in range(2, 90):
+				master.safe_psql("UPDATE o_compact "
+				                 f"SET v = '{big}' WHERE k = {i};")
+
+			# Let the standby's main process digest those commits.
+			# This does NOT wait for the parked worker.
+			time.sleep(1.0)
+
+			# Release the stopevent.  W_K1 wakes up and runs undo;
+			# pre-rework the tombstone is still on the page and gets
+			# reverted; post-rework the page has been compacted and
+			# k=1 cannot be restored.
+			replica.safe_psql(
+			    "SELECT pg_stopevent_reset('before_apply_undo');")
+
+			master_lsn = master.execute("SELECT pg_current_wal_lsn();")[0][0]
+			replica.poll_query_until(
+			    f"SELECT pg_last_wal_replay_lsn() >= "
+			    f"'{master_lsn}'::pg_lsn",
+			    expected=True,
+			    sleep_time=0.1,
+			    max_attempts=300)
+			replica.poll_query_until(
+			    "SELECT orioledb_recovery_synchronized();",
+			    expected=True,
+			    sleep_time=0.1,
+			    max_attempts=300)
+
+			# T_stop's DELETE was rolled back: k=1 must still be
+			# present on the replica.  Pre-rework: passes.
+			# Post-rework: fails -- row was compacted away.
+			count = replica.execute(
+			    "SELECT count(*) FROM o_compact WHERE k = 1;")[0][0]
+			self.assertEqual(
+			    1, count, "T_stop's DELETE was rolled back on master, but "
+			    "k=1 is missing on the replica -- parallel-worker "
+			    "undo was lost to page compaction (replica's "
+			    "runXmin advanced past T_stop.oxid while the undo "
+			    "worker was parked)")
+		finally:
+			if replica is not None:
+				try:
+					replica.safe_psql(
+					    "SELECT pg_stopevent_reset('before_apply_undo');")
+				except Exception:
+					pass
+				try:
+					replica.stop(['-m', 'immediate', '-t', '30'])
+				except Exception:
+					pass
+			try:
+				master.stop()
+			except Exception:
+				pass


### PR DESCRIPTION
## Summary

Fixes the standby livelock from #889.

### What was wrong

`recovery_finish()` called `free_run_xmin()` at the very end of crash
recovery, lifting master's `runXmin` to `nextXid` before the
post-recovery checkpoint ran.  That advanced horizon was then
persisted as `control.checkpointRetainXmin` in the new control file.

When `o_emit_recovery_finish_rollbacks()` later emitted the deferred
`WAL_REC_ROLLBACK` records from `o_after_checkpoint_cleanup_hook()`,
the standby's WAL stream was:

  1. post-recovery checkpoint (claims a high `checkpointRetainXmin`),
  2. then `WAL_REC_ROLLBACK(oxid, xmin=high)` for each in-flight
     transaction master aborted in memory.

The standby replayed the checkpoint, slid `globalXmin` forward to the
checkpoint's claimed horizon, then ingested `WAL_REC_ROLLBACK` whose
`recovery_switch_to_oxid()` pushed the rolled-back oxid into
`xmin_queue` — dragging `globalXmin` back across a band where master's
`advance_global_xmin` had already stamped FROZEN.

`oxid_get_csn()`'s fast-path (`oxid < globalXmin => COMMITSEQNO_FROZEN`)
no longer covered those slots; the wrapper's
`COMMITSEQNO_IS_SPECIAL(csn) => INPROGRESS` fallback then turned the
legitimate FROZEN values into `INPROGRESS`, and recovery workers in
`o_btree_modify_handle_conflicts()` spun forever on
committed-and-frozen oxids — the livelock.

### The fix

Move the `free_run_xmin()` call out of `recovery_finish()` and into
`o_emit_recovery_finish_rollbacks()`, after every WAL record has been
emitted.  The post-recovery checkpoint now runs with master's
`runXmin` still at the pre-recovery floor, so
`control.checkpointRetainXmin` matches the horizon the subsequent
`WAL_REC_ROLLBACK` records carry.  The standby never observes a
`checkpointRetainXmin` that would justify pushing `globalXmin` past a
stamped-FROZEN band, and `oxid_get_csn()`'s fast-path stays valid.

## Tests

- `test_parallel_worker_rollback_undo_lost_to_compaction` — new test
  exercising the parallel-worker side of the invariant via stopevents
  (parks rollback undo while concurrent workers revisit the deleted
  tuple's page).  Passes with the fix.
- `test_recovery_finish_rollback_does_not_regress_replica_xmin` —
  restored from a previous iteration.  Currently fails on a separate
  \"stuck low globalXmin\" symptom (replica's `globalXmin` does not
  catch up to master's after recovery completes) that is orthogonal
  to the livelock fix; left in place so the diagnostic surface
  remains visible.
- Existing #876 covering test
  `test_recovery_finish_aborts_propagate_to_replica` still passes.

## Test plan

- [x] \`make regresscheck\` — 44/44 OK
- [x] \`recovery_test\` testgres suite — 56/56 OK
- [x] \`replication_test\` testgres suite — 35/36 OK (one expected
      failure documented above)

Fixes #889.