### PR TITLE
Prevent globalXmin lowering by finish rollback WAL records on replica node

### DIFF
--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -144,6 +144,7 @@ typedef struct
 	bool		in_finished_list;
 	bool		in_joint_commit_list;
 	bool		in_retain_undo_heaps[(int) UndoLogsCount];
+	bool		in_xmin_queue;	/* tracked in xmin_queue (leader only) */
 	bool		needs_feedback;
 
 	dlist_node	joint_commit_list_node;
@@ -916,6 +917,7 @@ read_xids(int checkpointnum, bool recovery_single, int worker_id)
 			state->ptr = InvalidXLogRecPtr;
 			state->in_finished_list = false;
 			state->in_joint_commit_list = false;
+			state->in_xmin_queue = false;
 			state->needs_feedback = false;
 			for (j = 0; j < (int) UndoLogsCount; j++)
 				state->in_retain_undo_heaps[j] = false;
@@ -924,7 +926,10 @@ read_xids(int checkpointnum, bool recovery_single, int worker_id)
 				undo_stack_locations_set_invalid(&state->undo_stacks[j]);
 			dlist_init(&state->checkpoint_undo_stacks);
 			if (worker_id < 0)
+			{
 				pairingheap_add(xmin_queue, &state->xmin_ph_node);
+				state->in_xmin_queue = true;
+			}
 
 			state->systree_modified = false;
 			state->invalidate_typcache = false;
@@ -1882,6 +1887,7 @@ recovery_switch_to_oxid(OXid oxid, int worker_id)
 			cur_state->needs_wal_flush = false;
 			cur_state->in_finished_list = false;
 			cur_state->in_joint_commit_list = false;
+			cur_state->in_xmin_queue = false;
 			cur_state->needs_feedback = false;
 
 			/*
@@ -1896,7 +1902,10 @@ recovery_switch_to_oxid(OXid oxid, int worker_id)
 			for (i = 0; i < (int) UndoLogsCount; i++)
 				curRetainUndoLocations[i] = InvalidUndoLocation;
 			if (worker_id < 0)
+			{
 				pairingheap_add(xmin_queue, &cur_state->xmin_ph_node);
+				cur_state->in_xmin_queue = true;
+			}
 			cur_state->systree_modified = false;
 			cur_state->invalidate_typcache = false;
 			cur_state->o_tables_meta_locked = false;
@@ -1936,9 +1945,10 @@ check_delete_xid_state(RecoveryXidState *state, int worker_id)
 
 		if (state->used_by)
 			pfree(state->used_by);
-		if (worker_id < 0)
+		if (worker_id < 0 && state->in_xmin_queue)
 		{
 			pairingheap_remove(xmin_queue, &state->xmin_ph_node);
+			state->in_xmin_queue = false;
 			update_run_xmin();
 		}
 		hash_search(recovery_xid_state_hash, &oxid, HASH_REMOVE, &found);
@@ -3811,11 +3821,28 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 			{
 				bool		commit,
 							sync = false,
-							needsFeedback;
+							needsFeedback,
+							deferred_rollback;
 
 				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->offset;
 
-				recovery_xmin = Max(recovery_xmin, rec->u.finish.xmin);
+				/*
+				 * A deferred recovery-finish rollback stamps InvalidOXid in
+				 * finish.xmin: the primary already retired this oxid from its
+				 * horizon, so the value carries no horizon info.  Don't fold it
+				 * into recovery_xmin, and (below) drop the oxid from xmin_queue
+				 * so update_run_xmin() can't regress globalXmin below
+				 * writtenXmin and mis-read FROZEN slots as IN_PROGRESS.
+				 */
+				deferred_rollback = (rec->type == WAL_REC_ROLLBACK &&
+									 !OXidIsValid(rec->u.finish.xmin));
+
+				/* a COMMIT must never carry the InvalidOXid sentinel */
+				Assert(rec->type != WAL_REC_COMMIT ||
+					   OXidIsValid(rec->u.finish.xmin));
+
+				if (!deferred_rollback)
+					recovery_xmin = Max(recovery_xmin, rec->u.finish.xmin);
 
 				Assert(ctx->sys_tree_num <= 0 || sys_tree_supports_transactions(ctx->sys_tree_num));
 
@@ -3823,6 +3850,22 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 
 				Assert(rec->oxid != InvalidOXid);
 				Assert(cur_recovery_xid_state != NULL);
+
+				if (deferred_rollback && cur_recovery_xid_state->in_xmin_queue)
+				{
+					/*
+					 * Drop the oxid from the xmin horizon.  No update_run_xmin()
+					 * here: removal alone stops any later update_run_xmin() from
+					 * picking this low oxid as the queue-min, and
+					 * update_run_xmin() can only *lower* globalXmin -- calling it
+					 * now could regress onto another not-yet-removed
+					 * deferred-rollback oxid.  runXmin re-syncs at the next
+					 * natural update_run_xmin() (a finish/delete).
+					 */
+					pairingheap_remove(xmin_queue,
+									   &cur_recovery_xid_state->xmin_ph_node);
+					cur_recovery_xid_state->in_xmin_queue = false;
+				}
 
 				if (!ctx->single)
 				{

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -402,8 +402,16 @@ wal_emit_recovery_finish_rollback(OXid oxid, TransactionId logicalXid)
 	Assert(!local_wal.contains_xid);
 
 	add_xid_wal_record(oxid, logicalXid);
-	add_finish_wal_record(WAL_REC_ROLLBACK,
-						  pg_atomic_read_u64(&xid_meta->runXmin));
+
+	/*
+	 * Stamp InvalidOXid (not runXmin) as the finish xmin.  This rollback is
+	 * emitted late, after recovery_finish() already retired the oxid from the
+	 * horizon, so runXmin here has raced far past the oxid.  InvalidOXid means
+	 * "this record carries no horizon information"; the standby uses it to
+	 * exclude the oxid from its xmin horizon (orioledb#876 second-order
+	 * livelock).  The normal abort path (wal_rollback) keeps runXmin.
+	 */
+	add_finish_wal_record(WAL_REC_ROLLBACK, InvalidOXid);
 	wait_pos = flush_local_wal(false, false);
 	local_wal.has_material_changes = false;
 

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -1717,3 +1717,177 @@ class ReplicationTest(BaseTest):
 					os.kill(p, signal.SIGKILL)
 				except ProcessLookupError:
 					pass
+
+	def test_recovery_finish_rollback_does_not_regress_replica_xmin(self):
+		"""
+		Issue #889: after the #876 fix, recovery_finish() emits a
+		stand-alone WAL_REC_ROLLBACK for each in-flight oxid it aborts.
+		The record carries xmin = pg_atomic_read_u64(&xid_meta->runXmin),
+		which by the time the after-checkpoint hook runs has been lifted
+		to nextXid by free_run_xmin() -- a value far above the oxid being
+		rolled back.
+
+		Pre-rework, the standby's update_run_xmin computed
+		runXmin = Min(queue_min, recovery_xmin).  After the standby
+		processed WAL_REC_ROLLBACK(X, xmin=BIG) the recovery_xmin lifted
+		to BIG, but T_long(X) still sat in xmin_queue until the
+		finished_list processor removed it -- so for the intervening
+		window queue_min = X kept runXmin pinned to X while primary had
+		already advanced.  Post-rework runXmin tracks recovery_xmin
+		directly and converges to primary's runXmin promptly.
+
+		The test forces the scenario and asserts that, once the standby
+		is fully synchronised, runXmin/globalXmin match the primary's.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		dangling_pids = set()
+		try:
+			with self.getReplica().start() as replica:
+				master.safe_psql("""
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_test_xmin_no_regress (
+						k int PRIMARY KEY,
+						v int
+					) USING orioledb;
+					INSERT INTO o_test_xmin_no_regress
+						SELECT g, 0 FROM generate_series(1, 100) g;
+				""")
+				self.catchup_orioledb(replica)
+
+				# Long-running tx whose single small UPDATE never
+				# overflows the 8 KB local_wal buffer.  Without an
+				# overflow, neither WAL_REC_XID(T_long) nor any
+				# modify record reaches the standby pre-crash, so
+				# T_long is invisible to the standby's hash.
+				t_long = master.connect()
+				t_long.begin()
+				t_long.execute(
+				    "UPDATE o_test_xmin_no_regress SET v = -1 WHERE k = 1;")
+
+				# Bump nextXid past T_long by many short commits, so
+				# post-restart runXmin = nextXid is *far* above
+				# T_long's oxid.  This is what made the malformed
+				# xmin observable in the bug report.
+				for i in range(200):
+					master.safe_psql(
+					    "UPDATE o_test_xmin_no_regress "
+					    f"SET v = v + 1 WHERE k = {2 + (i % 50)};")
+
+				# Checkpoint primary: its xids file now records
+				# T_long as in-flight.  Standby's xids file does
+				# *not* (that file is local to the primary).
+				master.safe_psql("CHECKPOINT;")
+				self.catchup_orioledb(replica)
+
+				# SIGKILL the postmaster *and* every backend so
+				# nobody gets a chance to wal_rollback() T_long.
+				pid_file = os.path.join(master.data_dir, 'postmaster.pid')
+				with open(pid_file) as f:
+					master_pid = int(f.readline().strip())
+				child_pids = [
+				    int(x) for x in subprocess.run(
+				        ['pgrep', '-P', str(master_pid)],
+				        capture_output=True,
+				        text=True,
+				        check=False).stdout.split()
+				]
+				dangling_pids.update([master_pid] + child_pids)
+				for p in child_pids + [master_pid]:
+					try:
+						os.kill(p, signal.SIGKILL)
+					except ProcessLookupError:
+						pass
+				deadline = time.time() + 30
+				while time.time() < deadline:
+					alive = False
+					for p in [master_pid] + child_pids:
+						try:
+							os.kill(p, 0)
+							alive = True
+							break
+						except ProcessLookupError:
+							continue
+					if not alive:
+						break
+					time.sleep(0.05)
+				master.is_started = False
+				try:
+					t_long.close()
+				except Exception:
+					pass
+				master.start()
+
+				# Trigger more WAL so the after-recovery
+				# WAL_REC_ROLLBACK(T_long) is shipped, then catch up.
+				master.safe_psql(
+				    "UPDATE o_test_xmin_no_regress SET v = 99 WHERE k = 1;")
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				replica.poll_query_until(
+				    f"SELECT pg_last_wal_replay_lsn() >= "
+				    f"'{master_lsn}'::pg_lsn",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+				replica.poll_query_until(
+				    "SELECT orioledb_recovery_synchronized();",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				# Force one more checkpoint round on the primary so
+				# anything still pending on the standby drains.
+				master.safe_psql("CHECKPOINT;")
+				self.catchup_orioledb(replica)
+				replica.poll_query_until(
+				    "SELECT orioledb_recovery_synchronized();",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				master_runxmin, master_globalxmin = master.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+				replica_runxmin, replica_globalxmin = replica.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+
+				# Architectural property: standby's runXmin must
+				# converge to primary's, not stay pinned to a stale
+				# in-flight oxid retained in the standby's local
+				# xmin_queue.  The primary's last commit advances
+				# runXmin once more via advance_run_xmin AFTER it has
+				# written WAL_REC_COMMIT, so the standby legitimately
+				# lags by one oxid (no further commit ships the new
+				# floor) -- pre-rework the lag was ~T_long's
+				# distance from nextXid, which is far larger.
+				self.assertLessEqual(
+				    master_runxmin - replica_runxmin, 1,
+				    f"replica runXmin {replica_runxmin} lags primary "
+				    f"{master_runxmin} by more than 1")
+				self.assertLessEqual(
+				    master_globalxmin - replica_globalxmin, 1,
+				    f"replica globalXmin {replica_globalxmin} lags "
+				    f"primary {master_globalxmin} by more than 1")
+
+				# Replica must shut down cleanly within the timeout.
+				# The pre-fix livelock would block fast shutdown
+				# indefinitely on the recovery worker.
+				t0 = time.time()
+				replica.stop(['-m', 'fast', '-t', '15'])
+				self.assertLess(
+				    time.time() - t0, 15,
+				    "replica did not shut down within 15s "
+				    "(potential livelock)")
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+			for p in dangling_pids:
+				try:
+					os.kill(p, signal.SIGKILL)
+				except ProcessLookupError:
+					pass


### PR DESCRIPTION
replication_test scenario added