### PR TITLE
ci: drop generated_virtual hunks on regress_user11 role race

### DIFF
--- a/ci/filter_regression_diff.py
+++ b/ci/filter_regression_diff.py
@@ -119,13 +119,10 @@ knownErrors = {
 	r"ERROR:  cannot refresh collation \"en-x-icu\" because orioledb (table|index) \"[a-z0-9_]+\" uses it": ["collate.icu.utf8"],
 
 	# generated_stored and generated_virtual run in the same parallel
-	# group and both CREATE/DROP regress_user11.  Whichever lands first
-	# creates the role; the other test's CREATE USER errors out, and the
-	# DROP USER in generated_virtual fails on the leftover privileges from
-	# generated_stored.  Accept both shapes plus the dependent-object
-	# detail lines so the role-sharing test ordering doesn't break CI.
-	r"ERROR:  role \"regress_user11\" already exists": ["generated_stored"],
-	r"ERROR:  role \"regress_user11\" cannot be dropped because some objects depend on it": ["generated_virtual"],
+	# group and both CREATE/DROP regress_user11.  The role-collision
+	# cascade is dropped wholesale via skip_hunk_errors below; only the
+	# psql \dp privilege-listing diff remains as a line-level filter
+	# (it appears outside the cascade hunk).
 	r"privileges for (column \w+ of table|table) generated_stored_tests\.\w+": ["generated_virtual"],
 }
 
@@ -138,6 +135,21 @@ skip_hunk_errors = {
 	# whole hunk so the cascaded "transaction is aborted" lines disappear.
 	r"ERROR:  orioledb does not support TID scan":
 	["generated_virtual"],
+	# generated_stored and generated_virtual both CREATE/DROP the shared
+	# role regress_user11.  Depending on which test the parallel scheduler
+	# starts first the other can hit CREATE USER ("already exists"),
+	# SET ROLE / GRANT ("does not exist"), or DROP USER ("cannot be
+	# dropped because some objects depend on it" / "does not exist").
+	# Each of those errors cascades: SELECT/CALL statements gated by
+	# SET ROLE return real rows instead of "permission denied", which
+	# leaves a multi-line table-vs-error diff -- sometimes in the same
+	# hunk as the role error, sometimes in a separate hunk further down
+	# whose only marker is the missing "permission denied" line.  Drop
+	# both shapes.
+	r"ERROR:  role \"regress_user11\" (already exists|does not exist|cannot be dropped because some objects depend on it)":
+	["generated_stored", "generated_virtual"],
+	r"ERROR:  permission denied for (table gtest\w+|function gf\w+)":
+	["generated_stored", "generated_virtual"],
 }
 
 def can_drop_hunk(testName, line):


### PR DESCRIPTION
## Summary

- `generated_stored` and `generated_virtual` share the role `regress_user11` and run in the same parallel group inside `t/027_stream_regress.pl`'s in-tree regression suite.  Depending on which test the scheduler starts first, the other test hits a different role error (`CREATE USER "already exists"`, `SET ROLE / GRANT "does not exist"`, or `DROP USER "cannot be dropped" / "does not exist"`), and each error cascades into `SELECT` / `CALL` statements gated by `SET ROLE` returning real rows instead of `permission denied`.
- The line-level filter in `ci/filter_regression_diff.py` already handled one scheduling order.  Another order (e.g. the failure in run [27255933502](https://github.com/orioledb/orioledb/actions/runs/27255933502) on PR #892) leaves residual hunks in `postgresql/src/test/recovery/tmp_check/regression.diffs` and intermittently fails the `pg_tests` CI step on PG18.
- Move the role-error patterns into `skip_hunk_errors` for both tests so every scheduling permutation drops the whole hunk; add a matching rule for the orphan `permission denied for ... gtest\w+ / gf\w+` hunk that lands in a separate diff group when the cascade is spatially detached from its role error.

## Test plan

- [x] Verify the new regex matches all three role error variants.
- [x] Run the updated filter against the residual `regression.diffs` from the failing CI run — `generated_virtual` portion reduces to zero residual lines (was 4 hunks, 48 lines).
- [ ] Wait for green PG18 `pg_tests` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)