### PR TITLE
ci: skip non-postgres core dumps in check_output.sh

### DIFF
--- a/ci/check_output.sh
+++ b/ci/check_output.sh
@@ -97,18 +97,53 @@ fi
 
 if [ -n "$cores" ]; then
 	for corefile in $cores ; do
-		if [[ $corefile != *_3.core ]]; then
-			if [ $CHECK_TYPE = "valgrind_1" ] || [ $CHECK_TYPE = "valgrind_2" ]; then
-				# Valgring core dumps have not auxiliary vector. We can't detect a binary file dynamically
-				# but this value is valid for most cases.
-				binary=tmp_install/usr/local/pgsql/bin/postgres
-			else
-				binary=$(gdb -quiet -core $corefile -batch -ex 'info auxv' | grep AT_EXECFN | perl -pe "s/^.*\"(.*)\"\$/\$1/g")
-			fi
-			echo dumping $corefile for $binary
-			gdb --batch --quiet -x ./orioledb/ci/cmds.gdb $binary $corefile
-			status=1
+		if [[ $corefile == *_3.core ]]; then
+			continue
 		fi
+
+		# Filter out cores that don't belong to a postgres process.  The
+		# kernel can drop a core into the same directory for any process
+		# the tests happen to spawn -- shell wrappers, `cp` invoked from
+		# perl recovery tests, etc.  Those are unrelated to orioledb /
+		# PostgreSQL and trying to read PG symbols out of them just makes
+		# `cmds.gdb` error out and tank the whole job.
+		#
+		# `file` parses the ELF psinfo / NT_AUXV notes and prints
+		#   "from '<argv0> <argv1>...', ..., execfn: '<path>'"
+		# We accept the core if either:
+		#   - argv0 starts with "postgres" (followed by space, ':',
+		#     end-of-quote -- this matches the postmaster as well as
+		#     backends renamed via set_ps_display, e.g. "postgres: io
+		#     worker 0"), or
+		#   - execfn ends in "/postgres" (canonical for the temp-install
+		#     postgres binary).
+		# That works for both plain cores and the valgrind-produced ones
+		# (the existing code couldn't use `info auxv` for the latter,
+		# but `file` extracts argv0 from NT_PRPSINFO).
+		file_out=$(file -b "$corefile" 2>/dev/null || true)
+		if ! { echo "$file_out" | grep -Eq "from 'postgres[ :']|execfn: '[^']*/postgres'"; }; then
+			echo "skipping non-postgres core $corefile: $file_out"
+			continue
+		fi
+
+		if [ $CHECK_TYPE = "valgrind_1" ] || [ $CHECK_TYPE = "valgrind_2" ]; then
+			# Valgrind core dumps do not have an auxiliary vector.  Fall
+			# back to the well-known postgres path used by the temp
+			# install used in CI.
+			binary=tmp_install/usr/local/pgsql/bin/postgres
+		else
+			binary=$(gdb -quiet -core $corefile -batch -ex 'info auxv' 2>/dev/null \
+				| grep AT_EXECFN | perl -pe "s/^.*\"(.*)\"\$/\$1/g")
+			if [ -z "$binary" ]; then
+				# Fall back to the temp-install postgres if we have
+				# already verified above that the core belongs to a
+				# postgres process.
+				binary=tmp_install/usr/local/pgsql/bin/postgres
+			fi
+		fi
+		echo dumping $corefile for $binary
+		gdb --batch --quiet -x ./orioledb/ci/cmds.gdb $binary $corefile
+		status=1
 	done
 	tar -czf /tmp/cores-$GITHUB_SHA-$TIMESTAMP.tar.gz . $cores
 fi

--- a/ci/check_output.sh
+++ b/ci/check_output.sh
@@ -88,64 +88,54 @@ if [ $CHECK_TYPE = "valgrind_1" ] || [ $CHECK_TYPE = "valgrind_2" ]; then
 	done
 fi
 
-# check core dumps if any
-if [ $CHECK_TYPE = "valgrind_1" ] || [ $CHECK_TYPE = "valgrind_2" ]; then
-	cores=$(find orioledb/ -name '*.core.*' 2>/dev/null)
-else
+# Check core dumps (plain path only).  Under valgrind we do NOT inspect cores:
+# vgcore files lack the .auxv note, so gdb cannot locate the (PIE) executable
+# base and produces a bogus, mis-symbolized backtrace.  The authoritative
+# backtrace there is the one valgrind itself prints in the pid-*.log files,
+# already surfaced above.
+if [ $CHECK_TYPE != "valgrind_1" ] && [ $CHECK_TYPE != "valgrind_2" ]; then
 	cores=$(find /tmp/cores-$GITHUB_SHA-$TIMESTAMP/ -name '*.core' 2>/dev/null)
-fi
 
-if [ -n "$cores" ]; then
-	for corefile in $cores ; do
-		if [[ $corefile == *_3.core ]]; then
-			continue
-		fi
+	if [ -n "$cores" ]; then
+		for corefile in $cores ; do
+			if [[ $corefile == *_3.core ]]; then
+				continue
+			fi
 
-		# Filter out cores that don't belong to a postgres process.  The
-		# kernel can drop a core into the same directory for any process
-		# the tests happen to spawn -- shell wrappers, `cp` invoked from
-		# perl recovery tests, etc.  Those are unrelated to orioledb /
-		# PostgreSQL and trying to read PG symbols out of them just makes
-		# `cmds.gdb` error out and tank the whole job.
-		#
-		# `file` parses the ELF psinfo / NT_AUXV notes and prints
-		#   "from '<argv0> <argv1>...', ..., execfn: '<path>'"
-		# We accept the core if either:
-		#   - argv0 starts with "postgres" (followed by space, ':',
-		#     end-of-quote -- this matches the postmaster as well as
-		#     backends renamed via set_ps_display, e.g. "postgres: io
-		#     worker 0"), or
-		#   - execfn ends in "/postgres" (canonical for the temp-install
-		#     postgres binary).
-		# That works for both plain cores and the valgrind-produced ones
-		# (the existing code couldn't use `info auxv` for the latter,
-		# but `file` extracts argv0 from NT_PRPSINFO).
-		file_out=$(file -b "$corefile" 2>/dev/null || true)
-		if ! { echo "$file_out" | grep -Eq "from 'postgres[ :']|execfn: '[^']*/postgres'"; }; then
-			echo "skipping non-postgres core $corefile: $file_out"
-			continue
-		fi
+			# Filter out cores that don't belong to a postgres process.  The
+			# kernel can drop a core into the same directory for any process
+			# the tests happen to spawn -- shell wrappers, `cp` invoked from
+			# perl recovery tests, etc.  Those are unrelated to orioledb /
+			# PostgreSQL and trying to read PG symbols out of them just makes
+			# `cmds.gdb` error out and tank the whole job.
+			#
+			# `file` parses the ELF psinfo / NT_AUXV notes and prints
+			#   "from '<argv0> <argv1>...', ..., execfn: '<path>'"
+			# We accept the core if either:
+			#   - argv0 starts with "postgres" (followed by space, ':',
+			#     end-of-quote -- this matches the postmaster as well as
+			#     backends renamed via set_ps_display, e.g. "postgres: io
+			#     worker 0"), or
+			#   - execfn ends in "/postgres".
+			file_out=$(file -b "$corefile" 2>/dev/null || true)
+			if ! { echo "$file_out" | grep -Eq "from 'postgres[ :']|execfn: '[^']*/postgres'"; }; then
+				echo "skipping non-postgres core $corefile: $file_out"
+				continue
+			fi
 
-		if [ $CHECK_TYPE = "valgrind_1" ] || [ $CHECK_TYPE = "valgrind_2" ]; then
-			# Valgrind core dumps do not have an auxiliary vector.  Fall
-			# back to the well-known postgres path used by the temp
-			# install used in CI.
-			binary=tmp_install/usr/local/pgsql/bin/postgres
-		else
 			binary=$(gdb -quiet -core $corefile -batch -ex 'info auxv' 2>/dev/null \
 				| grep AT_EXECFN | perl -pe "s/^.*\"(.*)\"\$/\$1/g")
 			if [ -z "$binary" ]; then
-				# Fall back to the temp-install postgres if we have
-				# already verified above that the core belongs to a
-				# postgres process.
-				binary=tmp_install/usr/local/pgsql/bin/postgres
+				# Fall back to the installed postgres if we have already
+				# verified above that the core belongs to a postgres process.
+				binary="$GITHUB_WORKSPACE/pgsql/bin/postgres"
 			fi
-		fi
-		echo dumping $corefile for $binary
-		gdb --batch --quiet -x ./orioledb/ci/cmds.gdb $binary $corefile
-		status=1
-	done
-	tar -czf /tmp/cores-$GITHUB_SHA-$TIMESTAMP.tar.gz . $cores
+			echo dumping $corefile for $binary
+			gdb --batch --quiet -x ./orioledb/ci/cmds.gdb $binary $corefile
+			status=1
+		done
+		tar -czf /tmp/cores-$GITHUB_SHA-$TIMESTAMP.tar.gz . $cores
+	fi
 fi
 
 rm -rf /tmp/cores-$GITHUB_SHA-$TIMESTAMP


### PR DESCRIPTION
## Summary

Two fixes to how `check_output.sh` handles core dumps after a CI run.

### 1. Skip non-postgres core dumps

The kernel drops core files for *every* process the test harness spawns, not just `postgres`.  In particular recovery TAP tests use shell helpers that `cp` data directories, and when one of those children is killed (e.g. by SIGQUIT during cleanup) the resulting `/bin/sh` core lands in the same directory we sweep for postgres cores.  `cmds.gdb` then tries to print postgres-only symbols against it, fails with `No symbol "num_held_lwlocks" in current context`, and the whole job is marked failed -- even though all tests had reported PASS.

Example: https://github.com/orioledb/orioledb/actions/runs/27289262730/job/80605073139 -- arm64-17-gcc-pg_tests on main, no postgres crash, only an `sh -c -- cp ...` core that received SIGQUIT.

Fix: filter `*.core` files by `file -b <corefile>`: only feed gdb the ones whose argv0 starts with "postgres" (postmaster / set_ps_display'd backends) or whose execfn ends in "/postgres".  Skipped cores are logged so they remain visible in the CI output.

### 2. Inspect cores only on the plain (non-valgrind) path

Under valgrind, the produced `vgcore.*` files lack the `.auxv` note, so gdb cannot locate the (PIE) executable's load base and produces a bogus, mis-symbolized backtrace -- it mis-resolves functions and can't load shared-library symbols.  That backtrace is actively misleading (it does not match the real crash).

The authoritative crash backtrace under valgrind is the one valgrind itself writes to the `pid-*.log` files, which `check_output.sh` already surfaces.  Backtraces for *live* (stuck) processes under valgrind are likewise available via the "Show stuck processes" step.  So we no longer sweep for vgcore files at all -- core inspection now runs only on the non-valgrind paths.

While here, fix the fallback postgres binary path used for symbol lookup: `build.sh` installs with `--prefix=$GITHUB_WORKSPACE/pgsql`, not the old `tmp_install/usr/local/pgsql`.

## Test plan

- [x] Verified the `file` regex matches only true postgres cores (postmaster, set_ps_display'd backends, io workers) and rejects sh/cp/python wrappers that happen to mention "postgres".
- [x] Verified, via a temporary 1-minute Check timeout, that live valgrind backtraces are visible through the "Show stuck processes" step when a run is killed mid-test.
- [x] CI passes.