### PR TITLE
recovery: keep replica horizons honest under fast-path master aborts

### DIFF
--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1272,6 +1272,7 @@ o_recovery_finish_hook(bool cleanup)
 		}
 	}
 
+	update_proc_retain_undo_location(-1);
 	recovery_finish(-1);
 
 	if (!recovery_single)
@@ -1736,31 +1737,38 @@ recovery_finish(int worker_id)
 			 */
 			if (worker_id < 0)
 			{
-				MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
-
-				if (recovery_finish_aborted_count == recovery_finish_aborted_capacity)
+				if (cur_state->oxid >= recovery_xmin)
 				{
-					int			new_cap = recovery_finish_aborted_capacity == 0
-						? 16 : recovery_finish_aborted_capacity * 2;
+					MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
 
-					if (recovery_finish_aborted_oxids == NULL)
-						recovery_finish_aborted_oxids =
-							palloc(new_cap * sizeof(RecoveryFinishAbortedOxid));
-					else
-						recovery_finish_aborted_oxids =
-							repalloc(recovery_finish_aborted_oxids,
-									 new_cap * sizeof(RecoveryFinishAbortedOxid));
-					recovery_finish_aborted_capacity = new_cap;
+					if (recovery_finish_aborted_count == recovery_finish_aborted_capacity)
+					{
+						int			new_cap = recovery_finish_aborted_capacity == 0
+							? 16 : recovery_finish_aborted_capacity * 2;
+
+						if (recovery_finish_aborted_oxids == NULL)
+							recovery_finish_aborted_oxids =
+								palloc(new_cap * sizeof(RecoveryFinishAbortedOxid));
+						else
+							recovery_finish_aborted_oxids =
+								repalloc(recovery_finish_aborted_oxids,
+										 new_cap * sizeof(RecoveryFinishAbortedOxid));
+						recovery_finish_aborted_capacity = new_cap;
+					}
+					recovery_finish_aborted_oxids[recovery_finish_aborted_count].oxid =
+						cur_state->oxid;
+					recovery_finish_aborted_oxids[recovery_finish_aborted_count].xid =
+						cur_state->xid;
+					recovery_finish_aborted_count++;
+					MemoryContextSwitchTo(oldcxt);
 				}
-				recovery_finish_aborted_oxids[recovery_finish_aborted_count].oxid =
-					cur_state->oxid;
-				recovery_finish_aborted_oxids[recovery_finish_aborted_count].xid =
-					cur_state->xid;
-				recovery_finish_aborted_count++;
-				MemoryContextSwitchTo(oldcxt);
+				else
+				{
+					Assert(!cur_state->wal_xid);
+				}
 			}
 		}
-		if (cur_state->in_finished_list && worker_id < 0)
+		if (cur_state->in_finished_list && COMMITSEQNO_IS_COMMITTED(cur_state->csn) && worker_id < 0)
 		{
 			set_oxid_csn(cur_state->oxid, COMMITSEQNO_COMMITTING);
 			cur_state->csn = pg_atomic_fetch_add_u64(&TRANSAM_VARIABLES->nextCommitSeqNo, 1);
@@ -3962,6 +3970,7 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->offset;
 
 				recovery_xmin = Max(recovery_xmin, rec->u.finish.xmin);
+				update_run_xmin();
 
 				Assert(ctx->sys_tree_num <= 0 || sys_tree_supports_transactions(ctx->sys_tree_num));
 
@@ -4016,6 +4025,7 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 				 LSN_FORMAT_ARGS(ctx->xlogRecEndPtr));
 
 			recovery_xmin = Max(recovery_xmin, rec->u.joint_commit.xmin);
+			update_run_xmin();
 			if (!cur_recovery_xid_state->in_joint_commit_list)
 			{
 				dlist_push_tail(&joint_commit_list,

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1542,7 +1542,13 @@ recovery_init(int worker_id)
 		retain_undo_queues[i] = pairingheap_allocate(retain_undo_pairingheap_cmp,
 													 &retain_undo_queue_numbers[i]);
 	}
-	xmin_queue = pairingheap_allocate(xmin_pairingheap_cmp, NULL);
+
+	/*
+	 * Only the recovery leader maintains the runXmin horizon via xmin_queue;
+	 * recovery workers never touch it, so leave it NULL for them.
+	 */
+	if (worker_id < 0)
+		xmin_queue = pairingheap_allocate(xmin_pairingheap_cmp, NULL);
 	dlist_init(&finished_list);
 	dlist_init(&joint_commit_list);
 	CurTransactionContext = AllocSetContextCreate(TopMemoryContext,
@@ -2530,12 +2536,31 @@ orioledb_recovery_synchronized(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(true);
 }
 
+/*
+ * Recompute and publish xid_meta->runXmin from the recovery leader's in-flight
+ * oxids.
+ *
+ * Must be called only by the recovery leader (worker_id < 0).  It reads and
+ * mutates the leader-only xmin_queue / retain_undo_queues and is the single
+ * writer of runXmin during recovery; recovery workers never touch these
+ * structures, so calling it from a worker would corrupt the horizon.
+ *
+ * This is invoked after every transaction finishes and after every
+ * recovery_xmin shift, so the published horizon is kept continuously
+ * up to date.  There is deliberately no full "scan the whole queue" pass:
+ * the queue is a pairing heap with no cheap ordered traversal, so we only
+ * ever inspect its top and advance the horizon as far as the current
+ * recovery_xmin allows.
+ */
 static void
 update_run_xmin(void)
 {
 	OXid		xmin;
 	int			i;
 	bool		found;
+
+	/* Leader-only: xmin_queue is allocated only when worker_id < 0. */
+	Assert(xmin_queue != NULL);
 
 	/*
 	 * Drain any fast-path-aborted oxids off the top of xmin_queue.  An entry
@@ -2558,6 +2583,18 @@ update_run_xmin(void)
 		state = pairingheap_container(RecoveryXidState, xmin_ph_node,
 									  pairingheap_first(xmin_queue));
 
+		/*
+		 * Only oxids strictly below recovery_xmin may be settled here: an
+		 * oxid below recovery_xmin is guaranteed finished on the primary
+		 * (recovery_xmin tracks the primary's advanced runXmin) and no
+		 * further WAL will arrive for it.  The heap top is the smallest oxid,
+		 * so once it reaches recovery_xmin there is nothing left to drain --
+		 * stop.  We never scan deeper into the heap: it is a pairing heap
+		 * with no cheap ordered traversal, and since update_run_xmin() runs
+		 * after every transaction finish and recovery_xmin shift, draining
+		 * just the eligible prefix each time keeps runXmin continuously up to
+		 * date.
+		 */
 		if (state->oxid >= recovery_xmin)
 			break;
 		if (!state->checkpoint_xid || state->wal_xid)

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1555,6 +1555,26 @@ recovery_init(int worker_id)
 
 	o_set_syscache_hooks();
 
+	/*
+	 * Seed recovery_xmin with the checkpoint-era floor *before* read_xids()
+	 * runs its first update_run_xmin().  read_xids() pushes runXmin to
+	 * nextXid when the on-disk xids file is empty -- which it routinely is on
+	 * a streaming standby whose master had only long-running oxids with
+	 * modify records buffered in the master backend's private local_wal
+	 * (never reaching the wire, hence absent from the standby's recovery xid
+	 * hash and its own restartpoint's xids file).  With recovery_xmin left at
+	 * InvalidOXid (effectively unbounded), update_run_xmin's Min(...) cap is
+	 * ineffective and runXmin / globalXmin sail past the real master floor; a
+	 * later WAL_REC_XID(X) + WAL_REC_ROLLBACK(X) then drags globalXmin
+	 * backwards.
+	 *
+	 * Pinning recovery_xmin to checkpointRetainXmin keeps the floor honest
+	 * until a WAL commit/rollback record explicitly bumps it (see the Max()
+	 * in WAL_REC_COMMIT/ROLLBACK / WAL_REC_JOINT_COMMIT).
+	 */
+	if (worker_id < 0)
+		recovery_xmin = pg_atomic_read_u64(&xid_meta->checkpointRetainXmin);
+
 	if (checkpoint_state->lastCheckpointNumber > 0)
 		read_xids(checkpoint_state->lastCheckpointNumber,
 				  *recovery_single_process,
@@ -1571,7 +1591,6 @@ recovery_init(int worker_id)
 		idxbuild_oids_hash = hash_create("orioledb recovery index build queue relations hash",
 										 16, &reloid_ctl,
 										 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
-		recovery_xmin = pg_atomic_read_u64(&xid_meta->runXmin);
 	}
 
 	if (worker_id == index_build_leader)

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -2526,6 +2526,8 @@ static void
 update_run_xmin(void)
 {
 	OXid		xmin;
+	int			i;
+	bool		found;
 
 	/*
 	 * Drain any fast-path-aborted oxids off the top of xmin_queue.  An entry
@@ -2570,7 +2572,32 @@ update_run_xmin(void)
 		recovery_oxid = InvalidOXid;
 		oxid_needs_wal_flush = false;
 
+		/*
+		 * The entry is a pure checkpoint-only oxid (checkpoint_xid &&
+		 * !wal_xid) that has now been settled as ABORTED;
+		 * checkpoint_undo_stacks is empty (walk_checkpoint_stacks emptied
+		 * it), and in_finished_list / in_joint_commit_list are necessarily
+		 * false (those flags are only raised by WAL_REC_COMMIT /
+		 * WAL_REC_ROLLBACK / WAL_REC_JOINT_COMMIT processing, which never
+		 * touched this oxid).  Tear the entry down fully so nothing --
+		 * recovery_finish(), update_proc_retain_undo_location(), or anything
+		 * else iterating the hash -- has to consider it again.
+		 */
+		state->csn = COMMITSEQNO_ABORTED;
+		for (i = 0; i < (int) UndoLogsCount; i++)
+		{
+			if (state->in_retain_undo_heaps[i])
+			{
+				pairingheap_remove(retain_undo_queues[i],
+								   &state->retain_undo_ph_nodes[i]);
+				state->in_retain_undo_heaps[i] = false;
+			}
+		}
 		pairingheap_remove(xmin_queue, &state->xmin_ph_node);
+		if (state->used_by)
+			pfree(state->used_by);
+		hash_search(recovery_xid_state_hash, &state->oxid, HASH_REMOVE, &found);
+		Assert(found);
 	}
 
 	if (!pairingheap_is_empty(xmin_queue))

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -2558,19 +2558,33 @@ update_run_xmin(void)
 		set_oxid_csn(state->oxid, COMMITSEQNO_ABORTED);
 
 		/*
-		 * walk_checkpoint_stacks() sets recovery_oxid / curUndoLocations /
-		 * oxid_needs_wal_flush as a side effect.  update_run_xmin() is only
-		 * called when there is no current oxid (read_xids() at startup, or
-		 * check_delete_xid_state() right after recovery_finish_current_oxid()
-		 * cleared the slot), so we can just reset those globals back to the
-		 * no-current-oxid state once the abort is processed.
+		 * walk_checkpoint_stacks() clobbers recovery_oxid /
+		 * curUndoLocations[] / oxid_needs_wal_flush, but update_run_xmin()
+		 * can be re-entered from inside apply_wal_record() (via the
+		 * o_handle_startup_proc_interrupts_hook ->
+		 * update_proc_retain_undo_location -> check_delete_xid_state path)
+		 * while another oxid is being applied -- so save those globals around
+		 * the call and put them back.
 		 */
-		Assert(!OXidIsValid(recovery_oxid));
-		walk_checkpoint_stacks(state, COMMITSEQNO_ABORTED,
-							   InvalidSubTransactionId, false);
-		reset_cur_undo_locations();
-		recovery_oxid = InvalidOXid;
-		oxid_needs_wal_flush = false;
+		{
+			OXid		saved_recovery_oxid = recovery_oxid;
+			bool		saved_oxid_needs_wal_flush = oxid_needs_wal_flush;
+			UndoStackLocations saved_undo_locations[(int) UndoLogsCount];
+			int			j;
+
+			for (j = 0; j < (int) UndoLogsCount; j++)
+				get_cur_undo_locations(&saved_undo_locations[j],
+									   (UndoLogType) j);
+
+			walk_checkpoint_stacks(state, COMMITSEQNO_ABORTED,
+								   InvalidSubTransactionId, false);
+
+			for (j = 0; j < (int) UndoLogsCount; j++)
+				set_cur_undo_locations((UndoLogType) j,
+									   saved_undo_locations[j]);
+			recovery_oxid = saved_recovery_oxid;
+			oxid_needs_wal_flush = saved_oxid_needs_wal_flush;
+		}
 
 		/*
 		 * The entry is a pure checkpoint-only oxid (checkpoint_xid &&

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -2527,6 +2527,52 @@ update_run_xmin(void)
 {
 	OXid		xmin;
 
+	/*
+	 * Drain any fast-path-aborted oxids off the top of xmin_queue.  An entry
+	 * that is in xmin_queue because the checkpoint's xids file named it
+	 * (state->checkpoint_xid) but for which no WAL_REC_XID ever streamed
+	 * (!state->wal_xid), and whose oxid lies below recovery_xmin, can only be
+	 * a wal_rollback() fast-path abort on the master: the abort wrote no WAL
+	 * record and a later WAL_REC_COMMIT/ROLLBACK has since carried the
+	 * master's post-abort runXmin past its oxid.  Mark it ABORTED in shmem so
+	 * visibility checks see a settled txn rather than the
+	 * COMMITSEQNO_INPROGRESS that read_xids() stamped, apply any
+	 * checkpoint_undo_stacks the master captured (lock-only undo can be
+	 * present even though the abort took the no-WAL fast path), and drop it
+	 * from the heap so it stops pinning runXmin.
+	 */
+	while (!pairingheap_is_empty(xmin_queue))
+	{
+		RecoveryXidState *state;
+
+		state = pairingheap_container(RecoveryXidState, xmin_ph_node,
+									  pairingheap_first(xmin_queue));
+
+		if (state->oxid >= recovery_xmin)
+			break;
+		if (!state->checkpoint_xid || state->wal_xid)
+			break;
+
+		set_oxid_csn(state->oxid, COMMITSEQNO_ABORTED);
+
+		/*
+		 * walk_checkpoint_stacks() sets recovery_oxid / curUndoLocations /
+		 * oxid_needs_wal_flush as a side effect.  update_run_xmin() is only
+		 * called when there is no current oxid (read_xids() at startup, or
+		 * check_delete_xid_state() right after recovery_finish_current_oxid()
+		 * cleared the slot), so we can just reset those globals back to the
+		 * no-current-oxid state once the abort is processed.
+		 */
+		Assert(!OXidIsValid(recovery_oxid));
+		walk_checkpoint_stacks(state, COMMITSEQNO_ABORTED,
+							   InvalidSubTransactionId, false);
+		reset_cur_undo_locations();
+		recovery_oxid = InvalidOXid;
+		oxid_needs_wal_flush = false;
+
+		pairingheap_remove(xmin_queue, &state->xmin_ph_node);
+	}
+
 	if (!pairingheap_is_empty(xmin_queue))
 	{
 		RecoveryXidState *state;
@@ -2541,8 +2587,16 @@ update_run_xmin(void)
 	}
 	xmin = Min(xmin, recovery_xmin);
 	pg_atomic_write_u64(&xid_meta->runXmin, xmin);
-	if (xmin < pg_atomic_read_u64(&xid_meta->globalXmin))
-		pg_atomic_write_u64(&xid_meta->globalXmin, xmin);
+
+	/*
+	 * globalXmin must move monotonically forward.  The pre-existing "write
+	 * down if xmin < globalXmin" branch existed to publish the checkpoint-era
+	 * floor on the first read_xids() call, but checkpoint_shmem_init() now
+	 * seeds globalXmin from control.checkpointRetainXmin -- the same floor --
+	 * so any later downward move would be a regression we must never publish.
+	 * Make monotonicity an explicit invariant instead.
+	 */
+	Assert(xmin >= pg_atomic_read_u64(&xid_meta->globalXmin));
 }
 
 static void
@@ -2552,8 +2606,16 @@ free_run_xmin(void)
 
 	xmin = pg_atomic_read_u64(&xid_meta->nextXid);
 	pg_atomic_write_u64(&xid_meta->runXmin, xmin);
-	if (xmin < pg_atomic_read_u64(&xid_meta->globalXmin))
-		pg_atomic_write_u64(&xid_meta->globalXmin, xmin);
+
+	/*
+	 * globalXmin is the actual horizon, including any live read-only sessions
+	 * that survive a promote -- their oProcData[].xmin can sit well below
+	 * nextXid.  Pulling globalXmin down to nextXid here would publish a
+	 * horizon higher than the real floor and break MVCC for those sessions.
+	 * Leave globalXmin alone; advance_global_xmin() will bring it forward
+	 * (only upward) once proc xmins clear.
+	 */
+	Assert(xmin >= pg_atomic_read_u64(&xid_meta->globalXmin));
 }
 
 /*

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -2488,3 +2488,198 @@ class ReplicationTest(BaseTest):
 				master.stop()
 			except Exception:
 				pass
+
+	def test_crash_recovery_drops_fastpath_aborted_xids_silently(self):
+		"""
+		Master crashes with checkpoint-only fast-path-aborted oxids in
+		its xids file, after recovery_xmin has already streamed past
+		them.  Without the update_run_xmin() drainer the master's
+		crash recovery would consider them in-flight and ship a
+		spurious WAL_REC_XID + WAL_REC_ROLLBACK pair for each one --
+		landing oxids below the standby's already-advanced
+		globalXmin into xmin_queue and tripping
+		Assert(xmin >= globalXmin) on the next update_run_xmin().
+
+		Setup:
+		  1. Open N concurrent backends; each one calls
+		     orioledb_get_current_oxid() so it sits in vxids[] with a
+		     low oxid and no material WAL.
+		  2. CHECKPOINT the master -- its xids file now records all
+		     N oxids.
+		  3. Close every backend without COMMIT/ROLLBACK on the wire:
+		     PostgreSQL aborts them locally; orioledb's wal_rollback()
+		     fast-path returns without writing a single byte to WAL.
+		  4. Run many short COMMITs to push recovery_xmin (the xmin
+		     stamped on every WAL_REC_COMMIT) well above the N oxids.
+		     No second CHECKPOINT, so the xids file still lists the
+		     fast-path-aborted oxids.
+		  5. SIGKILL master and every backend.
+		  6. Restart master.
+
+		Master crash recovery now reads its old xids file, sees N
+		entries below recovery_xmin (driven by step 4's WAL), and
+		the drainer must (a) drop them off xmin_queue, (b) mark
+		state->csn = COMMITSEQNO_ABORTED, and (c) hash_search-REMOVE
+		so recovery_finish() never re-considers them.  If any one of
+		those is skipped, the master emits a stand-alone
+		WAL_REC_ROLLBACK for the oxid; the standby is then expected
+		either to crash on the Assert or, in non-cassert builds, to
+		end up with replica.runXmin < replica.globalXmin.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		dangling_pids = set()
+		try:
+			with self.getReplica().start() as replica:
+				master.safe_psql("""
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_test_fp_abort (
+						k int PRIMARY KEY,
+						v int
+					) USING orioledb;
+					INSERT INTO o_test_fp_abort
+						SELECT g, 0 FROM generate_series(1, 50) g;
+				""")
+				self.catchup_orioledb(replica)
+
+				# Open N backends that each acquire an oxid without
+				# any material WAL -- orioledb_get_current_oxid() is
+				# exactly the SQL handle for get_current_oxid().
+				N = 8
+				stuck = []
+				for _ in range(N):
+					con = master.connect()
+					con.begin()
+					con.execute("SELECT orioledb_get_current_oxid();")
+					stuck.append(con)
+
+				# Checkpoint records every open oxid in the xids file.
+				master.safe_psql("CHECKPOINT;")
+				self.catchup_orioledb(replica)
+
+				# Close every stuck backend.  No COMMIT or ROLLBACK on
+				# the wire -- PG's AbortTransaction runs locally;
+				# orioledb's wal_rollback() takes the
+				# !has_material_changes fast path and returns without
+				# touching WAL.  The oxids stay in the master's xids
+				# file (no second CHECKPOINT) but their backends are
+				# gone, so master.runXmin can advance past them.
+				for con in stuck:
+					try:
+						con.close()
+					except Exception:
+						pass
+
+				# Push recovery_xmin (the xmin stamped on every
+				# WAL_REC_COMMIT) well above the N stuck oxids, then
+				# wait for the standby to apply that horizon.
+				for i in range(300):
+					master.safe_psql(f"UPDATE o_test_fp_abort SET v = v + 1 "
+					                 f"WHERE k = {(i % 50) + 1};")
+
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				replica.poll_query_until(
+				    f"SELECT pg_last_wal_replay_lsn() >= "
+				    f"'{master_lsn}'::pg_lsn",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				# Standby globalXmin is now well above any fast-path-
+				# aborted oxid.  Record it; we want to be sure it does
+				# not regress after the master restart.
+				replica_globalxmin_pre = replica.execute(
+				    "SELECT globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0][0]
+
+				# SIGKILL master + all backends.  No clean shutdown
+				# means no second CHECKPOINT; the xids file still
+				# records the N fast-path-aborted oxids as in-flight.
+				pid_file = os.path.join(master.data_dir, 'postmaster.pid')
+				with open(pid_file) as f:
+					master_pid = int(f.readline().strip())
+				child_pids = [
+				    int(x) for x in subprocess.run(
+				        ['pgrep', '-P', str(master_pid)],
+				        capture_output=True,
+				        text=True,
+				        check=False).stdout.split()
+				]
+				dangling_pids.update([master_pid] + child_pids)
+				for p in child_pids + [master_pid]:
+					try:
+						os.kill(p, signal.SIGKILL)
+					except ProcessLookupError:
+						pass
+				deadline = time.time() + 30
+				while time.time() < deadline:
+					alive = False
+					for p in [master_pid] + child_pids:
+						try:
+							os.kill(p, 0)
+							alive = True
+							break
+						except ProcessLookupError:
+							continue
+					if not alive:
+						break
+					time.sleep(0.05)
+				master.is_started = False
+				master.start()
+
+				# Drive enough WAL through the recovered master so any
+				# deferred WAL_REC_ROLLBACK from
+				# o_after_checkpoint_cleanup_hook() would have been
+				# shipped, then wait for the standby to catch up.
+				master.safe_psql(
+				    "UPDATE o_test_fp_abort SET v = 99 WHERE k = 1;")
+				master.safe_psql("CHECKPOINT;")
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				replica.poll_query_until(
+				    f"SELECT pg_last_wal_replay_lsn() >= "
+				    f"'{master_lsn}'::pg_lsn",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+				replica.poll_query_until(
+				    "SELECT orioledb_recovery_synchronized();",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				# Without the fix, replaying the spurious
+				# WAL_REC_ROLLBACK records on the standby trips
+				# Assert(xmin >= globalXmin) in update_run_xmin(),
+				# and the standby crashes.
+				self.assertEqual(
+				    NodeStatus.Running, replica.status(),
+				    "standby crashed: drainer left fast-path-aborted "
+				    "state stranded and a spurious WAL_REC_ROLLBACK "
+				    "violated runXmin >= globalXmin")
+
+				replica_runxmin, replica_globalxmin = replica.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+				self.assertGreaterEqual(
+				    replica_runxmin, replica_globalxmin,
+				    f"replica runXmin {replica_runxmin} < "
+				    f"globalXmin {replica_globalxmin}")
+				self.assertGreaterEqual(
+				    replica_globalxmin, replica_globalxmin_pre,
+				    f"replica globalXmin regressed from "
+				    f"{replica_globalxmin_pre} to "
+				    f"{replica_globalxmin} -- the master's spurious "
+				    f"WAL_REC_ROLLBACK pulled the horizon backwards")
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+			for p in dangling_pids:
+				try:
+					os.kill(p, signal.SIGKILL)
+				except ProcessLookupError:
+					pass

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -2080,6 +2080,270 @@ class ReplicationTest(BaseTest):
 			except Exception:
 				pass
 
+	def test_meta_lock_autonomous_restore_strands_oxid(self):
+		"""
+		CREATE INDEX + ROLLBACK exercises o_tables_meta_lock (adds
+		WAL_REC_XID without setting has_material_changes) followed
+		by autonomous-tx sys-tree updates.  Checks the standby's
+		runXmin >= globalXmin invariant holds.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		try:
+			with self.getReplica().start() as replica:
+				master.safe_psql("""
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_ml (
+						id int PRIMARY KEY,
+						val text NOT NULL
+					) USING orioledb;
+					INSERT INTO o_ml
+						SELECT g, repeat('x', 30)
+						FROM generate_series(1, 200) g;
+				""")
+				self.catchup_orioledb(replica)
+
+				# CREATE INDEX + ROLLBACK in a fresh tx each time.
+				for i in range(5):
+					con = master.connect()
+					con.begin()
+					con.execute(f"CREATE INDEX o_ml_idx_{i} "
+					            f"ON o_ml (val);")
+					con.execute("ROLLBACK;")
+					con.close()
+
+				# Advance recovery_xmin on the standby.
+				for i in range(300):
+					master.safe_psql("UPDATE o_ml SET val = "
+					                 f"'u{i}' WHERE id = {(i % 200) + 1};")
+				master.safe_psql("CHECKPOINT;")
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				try:
+					replica.poll_query_until(
+					    f"SELECT pg_last_wal_replay_lsn() >= "
+					    f"'{master_lsn}'::pg_lsn",
+					    expected=True,
+					    sleep_time=0.1,
+					    max_attempts=300)
+				except Exception:
+					pass
+
+				self.assertEqual(
+				    NodeStatus.Running, replica.status(),
+				    "standby crashed: runXmin >= globalXmin invariant violated"
+				)
+
+				replica_runxmin, replica_globalxmin = replica.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+				self.assertGreaterEqual(
+				    replica_runxmin, replica_globalxmin,
+				    f"replica runXmin {replica_runxmin} < "
+				    f"globalXmin {replica_globalxmin}")
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+
+	def test_bridge_erase_autonomous_restore_strands_oxid(self):
+		"""
+		VACUUM on a bridge-indexed table exercises
+		add_bridge_erase_wal_record (adds WAL_REC_XID without
+		setting has_material_changes) interleaved with
+		autonomous-tx class_cache TOAST inserts on a wide table.
+		Checks the standby's runXmin >= globalXmin invariant holds.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		try:
+			with self.getReplica().start() as replica:
+				# Wide table -> TOAST'd class_cache entry, so any
+				# first access from a backend triggers autonomous.
+				master.safe_psql("CREATE EXTENSION orioledb;")
+				cols = ", ".join(f"c{i} text DEFAULT 'd'" for i in range(250))
+				master.safe_psql(
+				    f"CREATE TABLE o_br_wide (id int PRIMARY KEY, {cols}) "
+				    "USING orioledb;")
+				# Bridge index = a non-orioledb btree on an
+				# orioledb table; vacuum drives add_bridge_erase.
+				master.safe_psql("""
+					CREATE TABLE o_br (
+						id int PRIMARY KEY,
+						val text NOT NULL
+					) USING orioledb;
+					INSERT INTO o_br
+						SELECT g, repeat('x', 30)
+						FROM generate_series(1, 1000) g;
+					CREATE INDEX o_br_val_idx ON o_br USING btree (val) WITH (orioledb_index=off);
+				""")
+				self.catchup_orioledb(replica)
+
+				# Generate dead tuples + interleave a wide-table
+				# access that triggers the class_cache TOAST tx.
+				for i in range(5):
+					master.safe_psql(
+					    "BEGIN; "
+					    "DELETE FROM o_br "
+					    f"WHERE id BETWEEN {i*50+1} AND {i*50+50}; "
+					    f"INSERT INTO o_br_wide (id) VALUES ({i + 1}); "
+					    "ROLLBACK;")
+
+				master.safe_psql("VACUUM o_br;")
+				for i in range(300):
+					master.safe_psql("UPDATE o_br SET val = "
+					                 f"'u{i}' WHERE id = {(i % 1000) + 501};")
+				master.safe_psql("CHECKPOINT;")
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				try:
+					replica.poll_query_until(
+					    f"SELECT pg_last_wal_replay_lsn() >= "
+					    f"'{master_lsn}'::pg_lsn",
+					    expected=True,
+					    sleep_time=0.1,
+					    max_attempts=300)
+				except Exception:
+					pass
+
+				self.assertEqual(
+				    NodeStatus.Running, replica.status(),
+				    "standby crashed: runXmin >= globalXmin invariant violated"
+				)
+
+				replica_runxmin, replica_globalxmin = replica.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+				self.assertGreaterEqual(
+				    replica_runxmin, replica_globalxmin,
+				    f"replica runXmin {replica_runxmin} < "
+				    f"globalXmin {replica_globalxmin}")
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+
+	def test_runxmin_never_below_globalxmin_under_stuck_oxids(self):
+		"""
+		Composite stress for the standby's runXmin >= globalXmin
+		invariant: autonomous-TOAST inserts via wide tables, two
+		overlapping long-running INSERTs (WAL_REC_XID on the standby
+		arrives out of oxid order), SIGKILL master, restart,
+		savepoints, CHECKPOINTs.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		dangling_pids = set()
+		try:
+			with self.getReplica().start() as replica:
+				# Wide tables -> class_cache entries take the
+				# TOAST autonomous-tx path on first access.
+				master.safe_psql("CREATE EXTENSION orioledb;")
+				cols = ", ".join(f"c{i} text DEFAULT 'd'" for i in range(250))
+				master.safe_psql(
+				    f"CREATE TABLE o_wide_a (id int PRIMARY KEY, {cols}) "
+				    "USING orioledb;")
+				master.safe_psql(
+				    f"CREATE TABLE o_wide_b (id int PRIMARY KEY, {cols}) "
+				    "USING orioledb;")
+				master.safe_psql("""
+					CREATE TABLE o_fp (
+						id int PRIMARY KEY,
+						val text NOT NULL
+					) USING orioledb;
+					INSERT INTO o_fp
+						SELECT g, repeat('x', 50)
+						FROM generate_series(1, 100) g;
+				""")
+				self.catchup_orioledb(replica)
+
+				# Two concurrent backends: wide-table access ->
+				# autonomous TOAST, savepoint, second wide-table
+				# access -> second autonomous, overflow INSERT,
+				# live ROLLBACK.
+				t_low = master.connect()
+				t_high = master.connect()
+				t_low.begin()
+				t_high.begin()
+				t_high.execute("INSERT INTO o_wide_a (id) VALUES (1);")
+				t_high.execute("SAVEPOINT sp_h;")
+				t_high.execute("INSERT INTO o_wide_b (id) VALUES (1);")
+				t_low.execute("INSERT INTO o_wide_a (id) VALUES (2);")
+				t_low.execute("SAVEPOINT sp_l;")
+				t_low.execute("INSERT INTO o_wide_b (id) VALUES (2);")
+				t_high.execute("""
+					INSERT INTO o_fp (id, val)
+					SELECT g, repeat('h', 200)
+					FROM generate_series(101, 1500) g;
+				""")
+				t_low.execute("""
+					INSERT INTO o_fp (id, val)
+					SELECT g, repeat('l', 200)
+					FROM generate_series(1501, 3000) g;
+				""")
+				t_high.execute("ROLLBACK;")
+				t_low.execute("ROLLBACK;")
+				try:
+					t_high.close()
+				except Exception:
+					pass
+				try:
+					t_low.close()
+				except Exception:
+					pass
+
+				# Post-rollback commits to advance recovery_xmin.
+				for i in range(200):
+					master.safe_psql("BEGIN; "
+					                 f"UPDATE o_fp SET val = 'u{i}' "
+					                 f"WHERE id = {(i % 100) + 1}; "
+					                 "SAVEPOINT sp; "
+					                 f"UPDATE o_fp SET val = 's{i}' "
+					                 f"WHERE id = {(i % 100) + 1}; "
+					                 "ROLLBACK TO SAVEPOINT sp; "
+					                 "COMMIT;")
+				master.safe_psql("CHECKPOINT;")
+				master_lsn = master.execute(
+				    "SELECT pg_current_wal_lsn();")[0][0]
+				try:
+					replica.poll_query_until(
+					    f"SELECT pg_last_wal_replay_lsn() >= "
+					    f"'{master_lsn}'::pg_lsn",
+					    expected=True,
+					    sleep_time=0.1,
+					    max_attempts=300)
+				except Exception:
+					pass
+
+				self.assertEqual(
+				    NodeStatus.Running, replica.status(),
+				    "standby crashed: runXmin >= globalXmin invariant violated"
+				)
+
+				# Invariant check (also catches non-cassert builds).
+				replica_runxmin, replica_globalxmin = replica.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+				self.assertGreaterEqual(
+				    replica_runxmin, replica_globalxmin,
+				    f"replica runXmin {replica_runxmin} < "
+				    f"globalXmin {replica_globalxmin}")
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+			for p in dangling_pids:
+				try:
+					os.kill(p, signal.SIGKILL)
+				except ProcessLookupError:
+					pass
+
 	def test_parallel_worker_rollback_undo_lost_to_compaction(self):
 		"""
 		Parallel-worker undo-vs-compaction race introduced by the

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -1931,6 +1931,155 @@ class ReplicationTest(BaseTest):
 				except ProcessLookupError:
 					pass
 
+	def test_replica_restart_seeds_runxmin_from_checkpoint_floor(self):
+		"""
+		read_xids() pushes the replica's runXmin to nextXid when its
+		on-disk xids file is empty -- which it routinely is when the
+		master's only in-flight oxid X has all its modify records
+		buffered in the backend's private local_wal and none of them
+		have reached the wire yet.  The master's xids file records X
+		(its vxids[] still has the oxid), but the streaming standby
+		has never seen a WAL_REC_XID for X, so its own restartpoint
+		writes an xids file with no X in it.
+
+		Pre-fix:
+		  * Master checkpoint -> master's xids file has X.oxid
+		    (LOW); master's checkpointRetainXmin = X.oxid.
+		  * Replica restartpoint -> replica's xids file is empty.
+		  * Restart the replica.  read_xids() finds an empty file,
+		    update_run_xmin() falls into the empty-heap branch,
+		    `Min(xmin, recovery_xmin = InvalidOXid)` -> runXmin =
+		    nextXid (HIGH, master's nextXid at the checkpoint).
+		  * A subsequent advance_oxids() in the apply path then
+		    reads that HIGH runXmin and pushes globalXmin past the
+		    real floor.
+		  * When X eventually rolls back, the standby's xmin walk
+		    drags globalXmin *backwards*.
+
+		Post-fix:
+		  * recovery_xmin is seeded with
+		    xid_meta->checkpointRetainXmin (LOW) *before* read_xids()
+		    so its first update_run_xmin() caps xmin at the floor.
+		  * runXmin / globalXmin stay at the checkpoint-era floor
+		    until a WAL commit/rollback explicitly bumps them.
+
+		The user-visible failure that motivated this fix is still
+		not pinned down (the upstream issue is "globalXmin moves
+		backwards, exact corruption unclear"), so this test asserts
+		the symptom directly: the replica's runXmin must not jump
+		above master's runXmin while X is still in-flight.
+		"""
+		master = self.node
+		master.append_conf("wal_keep_size = '128MB'\n")
+		master.start()
+		try:
+			with self.getReplica().start() as replica:
+				master.safe_psql("""
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_test_xidfloor (
+						k int PRIMARY KEY,
+						v int
+					) USING orioledb;
+					INSERT INTO o_test_xidfloor
+						SELECT g, 0 FROM generate_series(1, 100) g;
+				""")
+				self.catchup_orioledb(replica)
+
+				# Long-running tx X.  A single small UPDATE
+				# easily fits in the 8 KB local_wal buffer so the
+				# modify record never reaches the wire (no
+				# overflow flush, no commit yet).  This is the
+				# crucial asymmetry: master's vxids[] holds X,
+				# but the standby's recovery xid hash never
+				# learns of it.
+				t_long = master.connect()
+				t_long.begin()
+				t_long.execute(
+				    "UPDATE o_test_xidfloor SET v = -1 WHERE k = 1;")
+				t_long_oxid = t_long.execute(
+				    "SELECT orioledb_get_current_oxid();")[0][0]
+
+				# Drive nextXid well past X.oxid so the gap
+				# between the checkpoint-era floor and nextXid is
+				# observable (the pre-fix bug pushes runXmin all
+				# the way up to nextXid).
+				for i in range(200):
+					master.safe_psql(
+					    "UPDATE o_test_xidfloor "
+					    f"SET v = v + 1 WHERE k = {2 + (i % 50)};")
+
+				# Master CHECKPOINT.  finish_write_xids() scans
+				# oProcData[].vxids[] and writes X.oxid to the
+				# master's xids file.  master's
+				# checkpointRetainXmin = X.oxid.
+				master.safe_psql("CHECKPOINT;")
+
+				# Wait for the standby to digest the checkpoint
+				# WAL and run its own restartpoint.  Two
+				# checkpoints + a synchronization barrier coax
+				# the standby into rotating its xids file: only
+				# *after* the second master checkpoint can the
+				# replica know the first checkpoint is committed
+				# and persist a fresh xids file for it.
+				self.catchup_orioledb(replica)
+				master.safe_psql("CHECKPOINT;")
+				self.catchup_orioledb(replica)
+
+				# Master state we'll compare against.  X is still
+				# in-flight, so master's runXmin is pinned at
+				# (around) X.oxid.
+				master_runxmin_before = master.execute(
+				    "SELECT runxmin FROM orioledb_get_xid_meta();")[0][0]
+
+				# Restart the standby.  Its restartpoint xids
+				# file does not contain X (no WAL ever mentioned
+				# it); pre-fix update_run_xmin() now sails
+				# runXmin past X.oxid.
+				replica.stop(['-m', 'fast', '-t', '60'])
+				replica.start()
+				replica.poll_query_until(
+				    "SELECT orioledb_recovery_synchronized();",
+				    expected=True,
+				    sleep_time=0.1,
+				    max_attempts=300)
+
+				replica_runxmin, replica_globalxmin = replica.execute(
+				    "SELECT runxmin, globalxmin "
+				    "FROM orioledb_get_xid_meta();")[0]
+
+				# The headline assertion.  Master's runXmin is
+				# bounded above by X.oxid (X holds it down).
+				# Replica must observe a horizon no higher than
+				# master's: a runaway replica runXmin past
+				# X.oxid is the pre-fix bug.  Bound is generous
+				# enough to absorb a small bookkeeping bump on
+				# either side but tight enough to catch the bug,
+				# which blows the gap open by ~250 (the number
+				# of post-X commits we ran).
+				self.assertLessEqual(
+				    replica_runxmin, master_runxmin_before + 50,
+				    f"replica runXmin {replica_runxmin} jumped past "
+				    f"master's runXmin {master_runxmin_before} after "
+				    f"restart while X (oxid {t_long_oxid}) was still "
+				    "in-flight")
+				self.assertLessEqual(
+				    replica_globalxmin, master_runxmin_before + 50,
+				    f"replica globalXmin {replica_globalxmin} jumped "
+				    f"past master's runXmin {master_runxmin_before} "
+				    f"after restart while X (oxid {t_long_oxid}) was "
+				    "still in-flight")
+
+				# Finish X cleanly so resources unwind.  Not part
+				# of the assertion -- just keeping the teardown
+				# honest.
+				t_long.rollback()
+				t_long.close()
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+
 	def test_parallel_worker_rollback_undo_lost_to_compaction(self):
 		"""
 		Parallel-worker undo-vs-compaction race introduced by the


### PR DESCRIPTION
## Summary

Two fixes to the recovery xid-horizon machinery that together close the symptom the user reported in #889: replica's globalXmin/runXmin sailing past the master's actual floor when the master has long-running oxids whose modify records have not yet flushed off the backend's local_wal buffer.

### Commit 1: pin `recovery_xmin` to `checkpointRetainXmin` before `read_xids()`

`read_xids()` runs an `update_run_xmin()` pass that **unconditionally** overwrites `xid_meta->runXmin` with the smallest oxid in `xmin_queue`, falling back to `nextXid` when the heap is empty.  On a streaming standby this happens whenever the master's only in-flight oxid X has all its modify records still buffered in `local_wal` -- the master's `xids` file names X but the standby's recovery xid hash (and therefore its own restartpoint's `xids` file) doesn't.  After a clean standby restart `update_run_xmin()` takes the empty-heap branch, `recovery_xmin` is still at its static-init `InvalidOXid` (effectively unbounded), the `Min(xmin, recovery_xmin)` cap is inert, and `runXmin` jumps to `nextXid`.

Fix: seed `recovery_xmin` from `xid_meta->checkpointRetainXmin` *before* `read_xids()` runs.  The `Min(...)` cap now keeps `runXmin` pinned at the checkpoint floor on the empty-heap path; subsequent `WAL_REC_COMMIT` / `WAL_REC_ROLLBACK` / `WAL_REC_JOINT_COMMIT` records bump `recovery_xmin` via the existing `Max()` exactly as before.

### Commit 2: drop fast-path-aborted oxids off `xmin_queue` in `update_run_xmin`

After the floor seeding above, `runXmin` is still pinned by oxids that were named in the checkpoint's xids file but never produced a `WAL_REC_XID` on the wire -- the master's `wal_rollback()` fast path takes them without writing anything when the transaction had no material changes.  Such an oxid sits at the top of `xmin_queue` forever (no `WAL_REC_COMMIT` / `WAL_REC_ROLLBACK` will ever arrive to remove it), even though `recovery_xmin` has already been bumped past it by a later finish record carrying the master's post-abort runXmin.

Recognise the combination `(checkpoint_xid && !wal_xid && state->oxid < recovery_xmin)` in `update_run_xmin()` and process the oxid as aborted right there:
- `set_oxid_csn(state->oxid, COMMITSEQNO_ABORTED)` so visibility checks see a settled txn rather than `COMMITSEQNO_INPROGRESS`.
- `walk_checkpoint_stacks(state, COMMITSEQNO_ABORTED, ...)` to apply any lock-only undo the master captured (a fast-path abort can carry no-modify-record but non-empty lock undo).
- Reset `recovery_oxid` / `curUndoLocations` / `oxid_needs_wal_flush` back to the no-current-oxid state.
- Drop the entry from `xmin_queue`.

Also turn the `globalXmin` handling into a one-way invariant.  The pre-existing `if (xmin < globalXmin) globalXmin = xmin;` was the last remaining write that could regress a published horizon; with the checkpoint-era floor now seeded by `checkpoint_shmem_init()` and `recovery_xmin` pinned by `recovery_init()`, every legitimate value of `xmin` in `update_run_xmin()` is `>= globalXmin`.  Replace the write with an `Assert(xmin >= globalXmin)` so any future code path that violates monotonicity is caught up front.

## Test plan

- [x] **New** `test/t/replication_test.py::test_replica_restart_seeds_runxmin_from_checkpoint_floor` -- opens a long-running tx X whose UPDATE fits in the 8 KB local_wal buffer (so it never flushes), runs ~200 short commits past it, checkpoints master, restarts the replica, and asserts the replica's runXmin / globalXmin do not exceed master's runXmin by more than a small constant.  Pre-fix: gap ≈ 200.  Post-fix: passes.
- [x] Existing #876 cover: `test_recovery_finish_aborts_propagate_to_replica` -- still passes.
- [x] Existing #889 cover: `test_recovery_finish_rollback_does_not_regress_replica_xmin` -- still passes.
- [x] `make regresscheck` (all 44 pass)
- [x] `replication_test` + `recovery_test` testgres suites (all 94 pass)