### PR TITLE
Don't emit wal_rollback record for oxid below recoveryXmin

### DIFF
--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1820,6 +1820,8 @@ o_emit_recovery_finish_rollbacks(void)
 
 	for (i = 0; i < recovery_finish_aborted_count; i++)
 	{
+		if (recovery_finish_aborted_oxids[i].oxid < recovery_xmin)
+			continue;
 		elog(LOG, "orioledb: emitting WAL_REC_ROLLBACK for in-flight oxid " UINT64_FORMAT " aborted by recovery_finish",
 			 recovery_finish_aborted_oxids[i].oxid);
 		wal_emit_recovery_finish_rollback(recovery_finish_aborted_oxids[i].oxid,


### PR DESCRIPTION
Txs aborted without any persistent wal records (e.g. has_material_changes = false wal_rollback path) are considered as an in-flight during the deferred wal emiting. Thereby, if the replica node has already received some commit/rollback wal records  with rised oxid horizon, it would have lowered globalXmin on replica under the horizon, breaking the invariants.

recovery_xmin extracts such oxid horizon invariant from the whole wal sequence, it fully reflects the replica side horizon at the crash-recovery time.