### PR TITLE
Skip page-level undo when no concurrent readers or local deletes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,8 @@ TESTGRESCHECKS_PART_1 = test/t/checkpointer_test.py \
 						test/t/undo_eviction_test.py \
 						test/t/rewind_xid_test.py \
 						test/t/rewind_xid_evict_large_test.py \
-						test/t/page_fit_items_test.py
+						test/t/page_fit_items_test.py \
+						test/t/page_undo_skip_test.py
 TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/checkpoint_eviction_test.py \
 						test/t/checkpoint_same_trx_test.py \

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ TESTGRESCHECKS_PART_1 = test/t/checkpointer_test.py \
 						test/t/rewind_xid_test.py \
 						test/t/rewind_xid_evict_large_test.py \
 						test/t/page_fit_items_test.py \
+						test/t/page_undo_skip_perf_test.py \
 						test/t/page_undo_skip_test.py
 TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/checkpoint_eviction_test.py \

--- a/doc/usage/configuration.mdx
+++ b/doc/usage/configuration.mdx
@@ -288,6 +288,17 @@ Trace all the stop events to the system log.
 
 Disable bgwriter for debug.
 
+### `orioledb.debug_force_page_undo`
+
+|             |     |
+| ----------- | --- |
+| **Default** | off |
+
+Force page-level undo emission on every leaf split, compaction, and merge,
+bypassing the optimization that skips the page image when no concurrent
+reader or local-delete needs it. Intended for A/B comparisons of undo
+volume against the optimized path.
+
 ### `orioledb.debug_checkpoint_timeout`
 
 |             |                      |

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -95,6 +95,20 @@ typedef struct
 extern bool page_item_rollback(BTreeDescr *desc, Page p, BTreePageItemLocator *locator,
 							   bool loop, BTreeLeafTuphdr *non_lock_tuphdr_ptr,
 							   UndoLocation nonLockUndoLocation);
+extern bool relation_needs_undo(BTreeDescr *desc, OXid opOxid,
+								bool needsUndoForSelfCreated,
+								UndoLocation savepointUndoLoc);
+extern bool page_needs_page_level_undo(BTreeDescr *desc, OInMemoryBlkno blkno,
+									   Page p, uint32 pageChangeCount,
+									   OXid opOxid);
+extern void register_local_page_delete(OInMemoryBlkno blkno,
+									   uint32 pageChangeCount);
+extern bool page_has_local_deletes(OInMemoryBlkno blkno,
+								   uint32 pageChangeCount);
+extern void reset_local_page_deletes(void);
+
+extern bool orioledb_debug_force_page_undo;
+
 extern UndoLocation make_undo_record(BTreeDescr *desc, OTuple tuple,
 									 bool is_tuple,
 									 BTreeOperationType action,

--- a/include/transam/undo.h
+++ b/include/transam/undo.h
@@ -145,6 +145,16 @@ typedef struct
 	pg_atomic_uint64 minRewindRetainLocation;
 
 	/*
+	 * numProcsHoldingSnapshotRetain is the count of backends currently
+	 * holding a valid snapshotRetainUndoLocation for this undo type.
+	 * Lets page_needs_page_level_undo skip the per-proc scan in O(1) when
+	 * no other backend can need the older page state.
+	 *
+	 * Used only in UndoLogRegularPageLevel.
+	 */
+	pg_atomic_uint32 numProcsHoldingSnapshotRetain;
+
+	/*
 	 * minProcReservedLocation is a minimum location (among all backends)
 	 * within the RAM undo log buffer that is actually reserved (obtained) by
 	 * a backend for writing its undo log record to a RAM undo log buffer. The
@@ -438,6 +448,9 @@ extern bool have_retained_undo_location(void);
 extern UndoLocation get_snapshot_retained_undo_location(UndoLogType undoType);
 extern UndoLocation set_my_snapshot_retain_location(UndoLogType undoType);
 extern void clear_my_snapshot_retain_location(UndoLogType undoType);
+extern void write_proc_snapshot_retain(ODBProcData *procData,
+									   UndoLogType undoType,
+									   UndoLocation newValue);
 extern void orioledb_reset_xmin_hook(void);
 
 static inline void

--- a/src/btree/insert.c
+++ b/src/btree/insert.c
@@ -904,18 +904,6 @@ tuple_waiters_check_hikey(BTreeDescr *desc, Page p,
 }
 
 static bool
-o_btree_insert_needs_page_undo(BTreeDescr *desc, Page p)
-{
-	bool		needsUndo = O_PAGE_IS(p, LEAF) && desc->undoType != UndoLogNone;
-
-	if (needsUndo && OXidIsValid(desc->createOxid) &&
-		desc->createOxid == get_current_oxid_if_any())
-		needsUndo = false;
-
-	return needsUndo;
-}
-
-static bool
 o_btree_insert_item_with_waiters(BTreeInsertStackItem *insert_item,
 								 int reserve_kind,
 								 int tupleWaiterProcnums[BTREE_PAGE_MAX_SPLIT_ITEMS],
@@ -1057,7 +1045,15 @@ o_btree_insert_item_with_waiters(BTreeInsertStackItem *insert_item,
 	loc = curContext->items[curContext->index].locator;
 	offset = BTREE_PAGE_LOCATOR_GET_OFFSET(p, &loc);
 
-	needsUndo = o_btree_insert_needs_page_undo(desc, p);
+	/*
+	 * get_current_oxid_if_any() may return InvalidOXid here (e.g., bgwriter
+	 * completing a split mid-flight for a creator-owned page); the
+	 * relation_needs_undo fallback "creator not yet finished" then lets us
+	 * skip undo because creator rollback would wipe the relation.
+	 */
+	needsUndo = page_needs_page_level_undo(desc, blkno, p,
+										   O_PAGE_GET_CHANGE_COUNT(p),
+										   get_current_oxid_if_any());
 
 	/* Get CSN for undo item if needed */
 	if (needsUndo)
@@ -1266,7 +1262,9 @@ o_btree_insert_item_no_waiters(BTreeInsertStackItem *insert_item,
 		offset = BTREE_PAGE_LOCATOR_GET_OFFSET(p, &loc);
 
 		/* Get CSN for undo item if needed */
-		needsUndo = o_btree_insert_needs_page_undo(desc, p);
+		needsUndo = page_needs_page_level_undo(desc, blkno, p,
+											   O_PAGE_GET_CHANGE_COUNT(p),
+											   get_current_oxid_if_any());
 		if (needsUndo)
 			csn = pg_atomic_fetch_add_u64(&TRANSAM_VARIABLES->nextCommitSeqNo, 1);
 		else

--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -159,13 +159,23 @@ btree_try_merge_pages(BTreeDescr *desc,
 
 	/* the right page can not be found in B-Tree after this line */
 
-	left_header->undoLocation = undo_loc;
-
 	/*
-	 * Memory barrier between write undo location and csn.  See comment in the
-	 * o_btree_read_page() for details.
+	 * When no undo image was emitted (skip-undo merge), don't overwrite the
+	 * existing left undoLocation: a concurrent reader can see the old csn but
+	 * the new InvalidUndoLocation and enter the undo branch with a bad
+	 * pointer. The new csn = COMMITSEQNO_INPROGRESS makes the same reader
+	 * skip the undo branch entirely, so preserving the old pointer is safe.
 	 */
-	pg_write_barrier();
+	if (UndoLocationIsValid(undo_loc))
+	{
+		left_header->undoLocation = undo_loc;
+
+		/*
+		 * Memory barrier between write undo location and csn.  See comment in
+		 * the o_btree_read_page() for details.
+		 */
+		pg_write_barrier();
+	}
 	left_header->csn = csn;
 
 	Assert(checkpoint_state->stack[level].hikeyBlkno != left_blkno);

--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -85,10 +85,10 @@ btree_try_merge_pages(BTreeDescr *desc,
 		return false;
 	}
 
-	needsUndo = O_PAGE_IS(left, LEAF) && desc->undoType != UndoLogNone;
-	if (needsUndo && OXidIsValid(desc->createOxid) &&
-		!XACT_INFO_IS_FINISHED(desc->createOxid))
-		needsUndo = false;
+	needsUndo = page_needs_page_level_undo(desc, left_blkno, left,
+										   O_PAGE_GET_CHANGE_COUNT(left), InvalidOXid) ||
+		page_needs_page_level_undo(desc, right_blkno, right,
+								   O_PAGE_GET_CHANGE_COUNT(right), InvalidOXid);
 
 	if (needsUndo)
 		csn = pg_atomic_fetch_add_u64(&TRANSAM_VARIABLES->nextCommitSeqNo, 1);

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -158,12 +158,9 @@ o_btree_modify_internal(OBTreeFindPageContext *pageFindContext,
 
 retry:
 
-	context.needsUndo = desc->undoType != UndoLogNone;
-	if (!(callbackInfo && callbackInfo->needsUndoForSelfCreated) &&
-		OXidIsValid(desc->createOxid) &&
-		desc->createOxid == opOxid &&
-		!UndoLocationIsValid(context.savepointUndoLocation))
-		context.needsUndo = false;
+	context.needsUndo = relation_needs_undo(desc, opOxid,
+											callbackInfo && callbackInfo->needsUndoForSelfCreated,
+											context.savepointUndoLocation);
 	context.leafTuphdr.deleted = deleted;
 	context.leafTuphdr.undoLocation = InvalidUndoLocation;
 	context.leafTuphdr.formatFlags = 0;
@@ -875,6 +872,7 @@ o_btree_modify_delete(BTreeModifyInternalContext *context)
 		undoLocation = make_undo_record(desc, key, key_is_tuple,
 										BTreeOperationDelete, blkno,
 										pageChangeCount, tuphdr);
+		register_local_page_delete(blkno, pageChangeCount);
 
 		/*
 		 * Fire post-undo hook with the freshly created undo location, while

--- a/src/btree/split.c
+++ b/src/btree/split.c
@@ -481,15 +481,24 @@ perform_page_split(BTreeDescr *desc, OInMemoryBlkno blkno,
 	 */
 	page_block_reads(blkno);
 
-	/* Link undo record with pages */
-	left_header->undoLocation = undoLoc;
-	right_header->undoLocation = undoLoc;
-
 	/*
-	 * Memory barrier between write undo location and csn.  See comment in the
-	 * o_btree_read_page() for details.
+	 * When no undo image was emitted (skip-undo split), don't overwrite the
+	 * existing left undoLocation: a concurrent reader can see the old csn but
+	 * the new InvalidUndoLocation and enter the undo branch with a bad
+	 * pointer. The new csn = COMMITSEQNO_INPROGRESS makes the same reader
+	 * skip the undo branch entirely, so preserving the old pointer is safe.
 	 */
-	pg_write_barrier();
+	if (UndoLocationIsValid(undoLoc))
+	{
+		left_header->undoLocation = undoLoc;
+		right_header->undoLocation = undoLoc;
+
+		/*
+		 * Memory barrier between write undo location and csn.  See comment in
+		 * the o_btree_read_page() for details.
+		 */
+		pg_write_barrier();
+	}
 
 	left_header->csn = csn;
 	right_header->csn = csn;

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -57,7 +57,7 @@ typedef struct
 {
 	OInMemoryBlkno blkno;
 	uint32		pageChangeCount;
-}			LocalDeletePageKey;
+} LocalDeletePageKey;
 
 static HTAB *deletedPagesHash = NULL;
 

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -19,6 +19,7 @@
 #include "btree/io.h"
 #include "btree/merge.h"
 #include "btree/page_chunks.h"
+#include "btree/scan.h"
 #include "btree/undo.h"
 #include "catalog/o_sys_cache.h"
 #include "recovery/recovery.h"
@@ -33,8 +34,32 @@
 
 #include "access/transam.h"
 #include "miscadmin.h"
+#include "utils/hsearch.h"
 #include "utils/inval.h"
+#include "utils/memutils.h"
 #include "utils/wait_event.h"
+
+/*
+ * Backend-local hash of leaf pages on which this backend has marked at least
+ * one tuple deleted in the current top-level transaction.  Used to gate the
+ * "no local deletes" condition that lets us skip page-level undo on
+ * split/compact.  Cleared at top-level commit/abort.
+ *
+ * The (blkno, pageChangeCount) key handles page recycling: an evicted-and-
+ * reloaded page bumps its change count, making old entries unreachable.
+ *
+ * Sub-transaction aborts are handled conservatively: stale entries from
+ * rolled-back subxacts remain in the hash, so the parent may emit
+ * unnecessary page-level undo on the affected pages.  Safe (extra undo
+ * is harmless) and avoids the cost of subxid tagging per entry.
+ */
+typedef struct
+{
+	OInMemoryBlkno blkno;
+	uint32		pageChangeCount;
+}			LocalDeletePageKey;
+
+static HTAB *deletedPagesHash = NULL;
 
 static void clean_chain_has_locks_flag(UndoLogType undoType,
 									   UndoLocation location,
@@ -48,6 +73,191 @@ static bool get_prev_leaf_header_from_undo_if_exists(UndoLogType undoType,
 static void update_leaf_header_in_undo(UndoLogType undoType,
 									   BTreeLeafTuphdr *tuphdr,
 									   UndoLocation location);
+
+bool		orioledb_debug_force_page_undo = false;
+
+/*
+ * Relation-scope: should this btree emit undo for the operation?
+ *
+ * Returns false when a rollback would discard the relation whole — the
+ * self-create shortcut: created in this oxid and no savepoint to roll back
+ * to, so any undo we'd emit is unreachable.
+ *
+ * `opOxid` is the operation's OXid.  Pass InvalidOXid when not available
+ * (lazy merge path); the helper then falls back to "creator transaction not
+ * yet finished", equivalent because pre-commit relations are visible only to
+ * their creator.
+ */
+bool
+relation_needs_undo(BTreeDescr *desc, OXid opOxid,
+					bool needsUndoForSelfCreated,
+					UndoLocation savepointUndoLoc)
+{
+	if (desc->undoType == UndoLogNone)
+		return false;
+
+	if (needsUndoForSelfCreated || !OXidIsValid(desc->createOxid))
+		return true;
+
+	if (UndoLocationIsValid(savepointUndoLoc))
+		return true;
+
+	if (OXidIsValid(opOxid))
+		return desc->createOxid != opOxid;
+	return XACT_INFO_IS_FINISHED(desc->createOxid);
+}
+
+/*
+ * Does this leaf split/compact/merge need a page-level undo image?
+ *
+ * Layered on top of relation_needs_undo: a relation-scope skip covers the
+ * page too.  Beyond that, page-level concerns — concurrent readers and
+ * on-page state that a concurrent or rolling-back transaction may still
+ * need to see — are checked in turn below; each gate carries its own
+ * inline WHY.
+ *
+ * Returns false for non-leaf pages; page-level undo applies only to leaves.
+ */
+bool
+page_needs_page_level_undo(BTreeDescr *desc, OInMemoryBlkno blkno, Page p,
+						   uint32 pageChangeCount, OXid opOxid)
+{
+	UndoLogType pageUndoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
+	UndoMeta   *meta;
+	UndoLocation lastUsed;
+	int			i;
+
+	if (!O_PAGE_IS(p, LEAF))
+		return false;
+
+	if (!relation_needs_undo(desc, opOxid, false, InvalidUndoLocation))
+		return false;
+
+	/*
+	 * The skip optimization only applies when we'd extend
+	 * UndoLogRegularPageLevel.  System trees use their own log whose
+	 * retention/visibility the cheap filters below don't model. (UndoLogNone
+	 * was already filtered in relation scope.)
+	 */
+	if (pageUndoType != UndoLogRegularPageLevel)
+		return true;
+
+	if (orioledb_debug_force_page_undo)
+		return true;
+
+	/* Active seq scan may need the pre-split layout to traverse. */
+	if (meta_page_get_num_seq_scans(desc->rootInfo.metaPageBlkno) > 0)
+		return true;
+
+	/* Our own rollback would replay these deletes against the original. */
+	if (page_has_local_deletes(blkno, pageChangeCount))
+		return true;
+
+	/*
+	 * On-page deleted tuples can be physically removed by a pending
+	 * compaction; older snapshots elsewhere may still need them.
+	 */
+	if (PAGE_GET_N_VACATED(p) > 0)
+		return true;
+
+	/*
+	 * Probe other backends' page-level retain.  A retain older than the
+	 * latest page-level write means a concurrent reader may still need the
+	 * older page state.
+	 *
+	 * Subtle: when no page-level undo has been emitted since active snapshots
+	 * were taken, this loop finds no holders even though snapshots exist —
+	 * safe, because the PAGE_GET_N_VACATED check above already rules out
+	 * compaction removing tuples those snapshots could see.
+	 */
+	meta = get_undo_meta_by_type(pageUndoType);
+	lastUsed = pg_atomic_read_u64(&meta->lastUsedLocation);
+	for (i = 0; i < max_procs; i++)
+	{
+		UndoLocation retain;
+
+		if (i == MYPROCNUMBER)
+			continue;
+
+		retain = pg_atomic_read_u64(&oProcData[i].undoRetainLocations[pageUndoType].snapshotRetainUndoLocation);
+		if (UndoLocationIsValid(retain) && retain < lastUsed)
+			return true;
+
+		retain = pg_atomic_read_u64(&oProcData[i].undoRetainLocations[pageUndoType].transactionUndoRetainLocation);
+		if (UndoLocationIsValid(retain) && retain < lastUsed)
+			return true;
+	}
+
+	return false;
+}
+
+/*
+ * Record that the current backend marked a tuple deleted on (blkno,
+ * pageChangeCount).  Called from o_btree_modify_delete after the
+ * BTreeOperationDelete undo record is created.
+ */
+void
+register_local_page_delete(OInMemoryBlkno blkno, uint32 pageChangeCount)
+{
+	LocalDeletePageKey key;
+
+	if (deletedPagesHash == NULL)
+	{
+		HASHCTL		ctl;
+
+		MemSet(&ctl, 0, sizeof(ctl));
+		ctl.keysize = sizeof(LocalDeletePageKey);
+		ctl.entrysize = sizeof(LocalDeletePageKey);
+		ctl.hcxt = TopMemoryContext;
+		deletedPagesHash = hash_create("orioledb local deleted pages",
+									   128, &ctl,
+									   HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+	}
+
+	key.blkno = blkno;
+	key.pageChangeCount = pageChangeCount;
+	(void) hash_search(deletedPagesHash, &key, HASH_ENTER, NULL);
+}
+
+/*
+ * Has the current backend marked any tuple deleted on this page in the
+ * current transaction?  A true result means a split or compaction here may
+ * still need page-level undo so a transaction abort can replay the deletes
+ * against the original page layout.
+ */
+bool
+page_has_local_deletes(OInMemoryBlkno blkno, uint32 pageChangeCount)
+{
+	LocalDeletePageKey key;
+	bool		found;
+
+	if (deletedPagesHash == NULL)
+		return false;
+
+	key.blkno = blkno;
+	key.pageChangeCount = pageChangeCount;
+	(void) hash_search(deletedPagesHash, &key, HASH_FIND, &found);
+	return found;
+}
+
+/*
+ * Drop all entries from the local-deletes hash.  Called at top-level
+ * transaction commit/abort.  Keeps the hash alive across transactions
+ * (with its bucket array and element freelist) to avoid a malloc/free
+ * pair per delete-heavy transaction.
+ */
+void
+reset_local_page_deletes(void)
+{
+	HASH_SEQ_STATUS status;
+	LocalDeletePageKey *entry;
+
+	if (deletedPagesHash == NULL)
+		return;
+	hash_seq_init(&status, deletedPagesHash);
+	while ((entry = hash_seq_search(&status)) != NULL)
+		(void) hash_search(deletedPagesHash, entry, HASH_REMOVE, NULL);
+}
 
 /*
  * Add page image to the undo log.

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -163,7 +163,14 @@ page_needs_page_level_undo(BTreeDescr *desc, OInMemoryBlkno blkno, Page p,
 	/*
 	 * Probe other backends' page-level retain.  A retain older than the
 	 * latest page-level write means a concurrent reader may still need the
-	 * older page state.
+	 * older page state.  load_refind_page.spec is the canonical reproducer
+	 *
+	 * Fast path: meta->numProcsHoldingSnapshotRetain is the count of
+	 * backends that currently hold a valid snapshotRetainUndoLocation for
+	 * this undo type, maintained eagerly on register/unregister.  When the
+	 * count minus our own contribution is zero, no other backend can need
+	 * the older state and we skip the per-proc scan entirely — the common
+	 * case for solo bulk inserts.
 	 *
 	 * Subtle: when no page-level undo has been emitted since active snapshots
 	 * were taken, this loop finds no holders even though snapshots exist —
@@ -171,6 +178,15 @@ page_needs_page_level_undo(BTreeDescr *desc, OInMemoryBlkno blkno, Page p,
 	 * compaction removing tuples those snapshots could see.
 	 */
 	meta = get_undo_meta_by_type(pageUndoType);
+	{
+		uint32		count = pg_atomic_read_u32(&meta->numProcsHoldingSnapshotRetain);
+		UndoLocation myRetain = pg_atomic_read_u64(&GET_CUR_PROCDATA()->undoRetainLocations[pageUndoType].snapshotRetainUndoLocation);
+		uint32		selfContrib = UndoLocationIsValid(myRetain) ? 1 : 0;
+
+		if (count <= selfContrib)
+			return false;
+	}
+
 	lastUsed = pg_atomic_read_u64(&meta->lastUsedLocation);
 	for (i = 0; i < max_procs; i++)
 	{

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -182,10 +182,6 @@ page_needs_page_level_undo(BTreeDescr *desc, OInMemoryBlkno blkno, Page p,
 		retain = pg_atomic_read_u64(&oProcData[i].undoRetainLocations[pageUndoType].snapshotRetainUndoLocation);
 		if (UndoLocationIsValid(retain) && retain < lastUsed)
 			return true;
-
-		retain = pg_atomic_read_u64(&oProcData[i].undoRetainLocations[pageUndoType].transactionUndoRetainLocation);
-		if (UndoLocationIsValid(retain) && retain < lastUsed)
-			return true;
 	}
 
 	return false;

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -275,6 +275,7 @@ checkpoint_shmem_init(Pointer ptr, bool found)
 			pg_atomic_init_u64(&undo_meta->minProcRetainLocation, 0);
 			pg_atomic_init_u64(&undo_meta->minRewindRetainLocation, 0);
 			pg_atomic_init_u64(&undo_meta->minProcTransactionRetainLocation, 0);
+			pg_atomic_init_u32(&undo_meta->numProcsHoldingSnapshotRetain, 0);
 			pg_atomic_init_u64(&undo_meta->minProcReservedLocation, 0);
 			pg_atomic_init_u64(&undo_meta->cleanedLocation, 0);
 			pg_atomic_init_u64(&undo_meta->checkpointRetainStartLocation, 0);
@@ -1407,8 +1408,7 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 		UndoMeta   *undo_meta = get_undo_meta_by_type(undoType);
 
 		checkpoint_start_loc[i] = pg_atomic_read_u64(&undo_meta->minProcTransactionRetainLocation);
-		pg_atomic_write_u64(&my_proc_info->undoRetainLocations[undoType].snapshotRetainUndoLocation,
-							checkpoint_start_loc[i]);
+		write_proc_snapshot_retain(my_proc_info, undoType, checkpoint_start_loc[i]);
 	}
 
 	pg_write_barrier();
@@ -1593,7 +1593,7 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 	{
 		UndoLogType undoType = GetCheckpointableUndoLog(i);
 
-		pg_atomic_write_u64(&my_proc_info->undoRetainLocations[undoType].snapshotRetainUndoLocation, InvalidUndoLocation);
+		write_proc_snapshot_retain(my_proc_info, undoType, InvalidUndoLocation);
 	}
 
 	pg_atomic_write_u64(&my_proc_info->xmin, InvalidOXid);

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -19,6 +19,7 @@
 #include "btree/find.h"
 #include "btree/io.h"
 #include "btree/scan.h"
+#include "btree/undo.h"
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
 #include "catalog/sys_trees.h"
@@ -493,6 +494,19 @@ _PG_init(void)
 							 &debug_disable_pools_limit,
 							 false,
 							 PGC_POSTMASTER,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("orioledb.debug_force_page_undo",
+							 "Force page-level undo emission even when "
+							 "concurrent-reader and local-delete checks "
+							 "would allow skipping it.",
+							 NULL,
+							 &orioledb_debug_force_page_undo,
+							 false,
+							 PGC_USERSET,
 							 0,
 							 NULL,
 							 NULL,

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -984,6 +984,52 @@ set_my_reserved_location(UndoLogType undoType)
 		curRetainUndoLocations[undoType] = lastUsedLocation;
 }
 
+/*
+ * Atomically write a proc's snapshotRetainUndoLocation and maintain the
+ * meta->numProcsHoldingSnapshotRetain counter on Invalid<->Valid transitions.
+ *
+ * Counter is only maintained for UndoLogRegularPageLevel — the only undo
+ * type page_needs_page_level_undo's fast path consults.  Maintaining it for
+ * UndoLogRegular and UndoLogSystem would just add cache-line contention on
+ * every snapshot acquire for no benefit.
+ *
+ * Ordering: increment BEFORE writing a valid value (so a concurrent probe
+ * observing our valid field also sees us in the count), decrement AFTER
+ * writing Invalid (likewise).  This keeps `count >= selfContrib` for every
+ * concurrent observer, so `count - selfContrib` never underflows.
+ */
+void
+write_proc_snapshot_retain(ODBProcData *procData, UndoLogType undoType,
+						   UndoLocation newValue)
+{
+	pg_atomic_uint64 *snapshotRetainUndoLocationPtr =
+		&procData->undoRetainLocations[undoType].snapshotRetainUndoLocation;
+	UndoLocation oldValue = pg_atomic_read_u64(snapshotRetainUndoLocationPtr);
+	bool		wasValid = UndoLocationIsValid(oldValue);
+	bool		isValid = UndoLocationIsValid(newValue);
+
+	if (wasValid != isValid && undoType == UndoLogRegularPageLevel)
+	{
+		pg_atomic_uint32 *numProcsHoldingSnapshotRetainPtr =
+			&get_undo_meta_by_type(undoType)->numProcsHoldingSnapshotRetain;
+
+		if (isValid)
+		{
+			pg_atomic_fetch_add_u32(numProcsHoldingSnapshotRetainPtr, 1);
+			pg_atomic_write_u64(snapshotRetainUndoLocationPtr, newValue);
+		}
+		else
+		{
+			pg_atomic_write_u64(snapshotRetainUndoLocationPtr, newValue);
+			pg_atomic_fetch_sub_u32(numProcsHoldingSnapshotRetainPtr, 1);
+		}
+	}
+	else
+	{
+		pg_atomic_write_u64(snapshotRetainUndoLocationPtr, newValue);
+	}
+}
+
 UndoLocation
 set_my_snapshot_retain_location(UndoLogType undoType)
 {
@@ -999,7 +1045,7 @@ set_my_snapshot_retain_location(UndoLogType undoType)
 
 		if (!UndoLocationIsValid(curSnapshotRetainUndoLocation) ||
 			retainUndoLocation < curSnapshotRetainUndoLocation)
-			pg_atomic_write_u64(&curProcData->undoRetainLocations[undoType].snapshotRetainUndoLocation, retainUndoLocation);
+			write_proc_snapshot_retain(curProcData, undoType, retainUndoLocation);
 
 		pg_memory_barrier();
 
@@ -1022,8 +1068,7 @@ clear_my_snapshot_retain_location(UndoLogType undoType)
 {
 	ODBProcData *curProcData = GET_CUR_PROCDATA();
 
-	pg_atomic_write_u64(&curProcData->undoRetainLocations[undoType].snapshotRetainUndoLocation,
-						InvalidUndoLocation);
+	write_proc_snapshot_retain(curProcData, undoType, InvalidUndoLocation);
 }
 
 static void
@@ -1994,7 +2039,7 @@ orioledb_reset_xmin_hook(void)
 
 		if (pairingheap_is_empty(&retainUndoLocHeaps[undoType]))
 		{
-			pg_atomic_write_u64(&curProcData->undoRetainLocations[undoType].snapshotRetainUndoLocation, InvalidUndoLocation);
+			write_proc_snapshot_retain(curProcData, undoType, InvalidUndoLocation);
 		}
 		else
 		{
@@ -2004,7 +2049,7 @@ orioledb_reset_xmin_hook(void)
 											 pairingheap_first(&retainUndoLocHeaps[undoType]));
 			snapshot = RetainUndoLocationPHNodeGetSnapshot(location, undoType);
 			if (location->undoLocation > pg_atomic_read_u64(&curProcData->undoRetainLocations[undoType].snapshotRetainUndoLocation))
-				pg_atomic_write_u64(&curProcData->undoRetainLocations[undoType].snapshotRetainUndoLocation, location->undoLocation);
+				write_proc_snapshot_retain(curProcData, undoType, location->undoLocation);
 			if (!OXidIsValid(xmin) || snapshot->csnSnapshotData.xmin < xmin)
 				xmin = snapshot->csnSnapshotData.xmin;
 		}
@@ -2355,7 +2400,7 @@ undo_xact_callback(XactEvent event, void *arg)
 						pairingheap_remove_first(&retainUndoLocHeaps[i]);
 
 				for (i = 0; i < (int) UndoLogsCount; i++)
-					pg_atomic_write_u64(&curProcData->undoRetainLocations[i].snapshotRetainUndoLocation, InvalidUndoLocation);
+					write_proc_snapshot_retain(curProcData, (UndoLogType) i, InvalidUndoLocation);
 
 				minParentSubId = InvalidSubTransactionId;
 

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -2065,7 +2065,10 @@ undo_xact_callback(XactEvent event, void *arg)
 	ea_counters = NULL;
 
 	if (event == XACT_EVENT_COMMIT || event == XACT_EVENT_ABORT)
+	{
 		seq_scans_cleanup();
+		reset_local_page_deletes();
+	}
 
 	if (enable_rewind && event == XACT_EVENT_PRE_COMMIT)
 	{

--- a/test/specs/rightlink.spec
+++ b/test/specs/rightlink.spec
@@ -44,7 +44,7 @@ step "s2_select" { SELECT * FROM o_rightlink; }
 step "s2_bselect" { SELECT * FROM o_rightlink ORDER BY id DESC; }
 step "s2_select_struct" { SELECT orioledb_idx_structure('o_rightlink'::regclass,
 														'o_rightlink_pkey',
-														'nue'); }
+														'ne'); }
 step "s2_reset_s1" { SELECT pg_stopevent_reset('page_split'); }
 
 session "s3"

--- a/test/t/functions_test.py
+++ b/test/t/functions_test.py
@@ -14,6 +14,10 @@ class FunctionTest(BaseTest):
 
 		node = self.node
 		node.append_conf('postgresql.conf', "checkpoint_timeout = 86400\n")
+		# Force page-level undo so the size check below remains meaningful;
+		# without this, the skip optimization elides most page undo.
+		node.append_conf('postgresql.conf',
+		                 "orioledb.debug_force_page_undo = on\n")
 		node.start()
 
 		node.safe_psql("""

--- a/test/t/page_undo_skip_perf_test.py
+++ b/test/t/page_undo_skip_perf_test.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# coding: utf-8
+# Performance measurements for the page-level undo elision optimization.
+#
+# Hidden behind ORIOLEDB_RUN_PERF=1 to keep CI fast.  Run locally with:
+#   ORIOLEDB_RUN_PERF=1 python3 -m unittest -v \
+#       test.t.page_undo_skip_perf_test
+
+import os
+import threading
+import time
+import unittest
+
+from .base_test import BaseTest
+
+RUN_PERF = os.environ.get('ORIOLEDB_RUN_PERF', '0') == '1'
+
+
+def page_undo_loc(node, con=None):
+	"""lastusedlocation for the page-level undo log."""
+	q = "SELECT lastusedlocation FROM orioledb_get_undo_meta() WHERE undo_type='page';"
+	if con is not None:
+		return con.execute(q)[0][0]
+	return node.execute(q)[0][0]
+
+
+@unittest.skipUnless(RUN_PERF, 'set ORIOLEDB_RUN_PERF=1 to run perf tests')
+class PageUndoSkipPerfTest(BaseTest):
+
+	NROWS = 300000  # ~60 MB of data, many leaf splits
+	PAYLOAD = 200  # bytes per row
+
+	def _bootstrap(self, name):
+		node = self.node
+		node.append_conf('postgresql.conf', "checkpoint_timeout = 86400\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql(
+		    f"CREATE TABLE {name} (i bigint PRIMARY KEY, t text) USING orioledb;"
+		)
+		return node
+
+	def _bulk_insert(self, node, table, force_undo):
+		"""Bulk insert NROWS and return (undo_bytes_emitted, seconds)."""
+		guc = 'on' if force_undo else 'off'
+		before = page_undo_loc(node)
+		t0 = time.monotonic()
+		node.safe_psql(f"""
+			SET orioledb.debug_force_page_undo = {guc};
+			INSERT INTO {table} SELECT g, repeat('a', {self.PAYLOAD})
+				FROM generate_series(1, {self.NROWS}) g;
+		""")
+		elapsed = time.monotonic() - t0
+		after = page_undo_loc(node)
+		return after - before, elapsed
+
+	def test_bulk_insert_savings(self):
+		"""Measure undo savings on a clean bulk INSERT.  Optimized path
+		should emit < 1% of the unoptimized path's page-level undo."""
+		node = self._bootstrap('perf_bulk_off')
+		off_bytes, off_secs = self._bulk_insert(node, 'perf_bulk_off', True)
+		node.safe_psql(
+		    "CREATE TABLE perf_bulk_on (i bigint PRIMARY KEY, t text) USING orioledb;"
+		)
+		on_bytes, on_secs = self._bulk_insert(node, 'perf_bulk_on', False)
+
+		ratio = on_bytes / max(off_bytes, 1)
+		print(f"\n[perf bulk_insert N={self.NROWS}] "
+		      f"forced={off_bytes/1024:.1f} KB / {off_secs:.2f}s, "
+		      f"optimized={on_bytes/1024:.1f} KB / {on_secs:.2f}s, "
+		      f"ratio={ratio*100:.2f}%, savings={(1-ratio)*100:.2f}%")
+
+		self.assertGreater(off_bytes, 10 * 1024 * 1024,
+		                   "forced path should emit > 10 MB undo")
+		self.assertLess(ratio, 0.01,
+		                "optimized path should emit < 1% of forced path")
+		node.stop()
+
+	def test_concurrent_reader_no_savings(self):
+		"""A held REPEATABLE READ cursor on the relation must defeat the
+		optimization, leaving page-level undo on par with the forced path."""
+		node = self._bootstrap('perf_reader')
+		node.safe_psql("INSERT INTO perf_reader VALUES (0, 'pre');")
+
+		with node.connect() as reader:
+			reader.begin('REPEATABLE READ')
+			# No ORDER BY: forces a sequential scan, which is what registers
+			# numSeqScans and defeats the optimization.
+			reader.execute("DECLARE c CURSOR FOR SELECT i FROM perf_reader;")
+			reader.execute("FETCH FORWARD 1 FROM c;")
+
+			before = page_undo_loc(node)
+			t0 = time.monotonic()
+			node.safe_psql(f"""
+				INSERT INTO perf_reader SELECT g, repeat('a', {self.PAYLOAD})
+					FROM generate_series(1, {self.NROWS}) g;
+			""")
+			elapsed = time.monotonic() - t0
+			after = page_undo_loc(node)
+			reader.execute("CLOSE c;")
+			reader.commit()
+
+		emitted = after - before
+		print(f"\n[perf concurrent_reader N={self.NROWS}] "
+		      f"emitted={emitted/1024:.1f} KB / {elapsed:.2f}s")
+		# Concurrent reader must force the unoptimized amount.
+		self.assertGreater(emitted, 10 * 1024 * 1024)
+		node.stop()
+
+	def test_delete_then_insert_no_savings(self):
+		"""Local deletes on touched leaves must defeat the optimization for
+		those leaves; expect undo growth on the same order as the forced
+		path."""
+		node = self._bootstrap('perf_del')
+		# Seed enough rows that DELETE distributes across many leaves.
+		node.safe_psql(f"""
+			INSERT INTO perf_del SELECT g, repeat('a', {self.PAYLOAD})
+				FROM generate_series(1, {self.NROWS // 10}) g;
+		""")
+
+		with node.connect() as con:
+			con.begin()
+			# mod() instead of '%' to avoid psycopg2 placeholder parsing.
+			con.execute("DELETE FROM perf_del WHERE mod(i, 5) = 0;")
+			before = page_undo_loc(node, con)
+			t0 = time.monotonic()
+			con.execute(f"""
+				INSERT INTO perf_del SELECT g, repeat('a', {self.PAYLOAD})
+					FROM generate_series({self.NROWS // 10 + 1}, {self.NROWS}) g;
+			""")
+			elapsed = time.monotonic() - t0
+			after = page_undo_loc(node, con)
+			con.commit()
+
+		emitted = after - before
+		print(f"\n[perf delete_then_insert N={self.NROWS}] "
+		      f"emitted={emitted/1024:.1f} KB / {elapsed:.2f}s")
+		# Only leaves where a delete AND a later split land emit undo;
+		# the appending insert touches few of those, so just assert that
+		# at least one page image is emitted (vs 0 with no deletes).
+		self.assertGreater(emitted, 4 * 1024)
+		node.stop()
+
+	# ---- concurrent inserters ----------------------------------------
+
+	NWORKERS = 4
+
+	def _run_workers(self, node, table, ranges, force_undo, ordered):
+		"""Spawn NWORKERS connections that INSERT their assigned range.
+		`ordered`=True inserts a contiguous range in PK order; False inserts
+		random PKs across the whole keyspace (worker keeps its slice via
+		mod NWORKERS == worker_id).  Returns (undo_bytes, wall_seconds).
+		"""
+		guc = 'on' if force_undo else 'off'
+		barrier = threading.Barrier(self.NWORKERS)
+		errors = []
+
+		def worker(wid, lo, hi):
+			try:
+				with node.connect() as con:
+					con.execute(f"SET orioledb.debug_force_page_undo = {guc};")
+					con.begin()
+					if ordered:
+						sql = (f"INSERT INTO {table} "
+						       f"SELECT g, repeat('a', {self.PAYLOAD}) "
+						       f"FROM generate_series({lo}, {hi}) g;")
+					else:
+						# Hash-shuffle the key range, keep slices disjoint
+						# across workers so PKs don't collide.
+						sql = (f"INSERT INTO {table} "
+						       f"SELECT (hashint8(g) & x'7fffffff'::bigint) "
+						       f"  * {self.NWORKERS} + {wid}, "
+						       f"  repeat('a', {self.PAYLOAD}) "
+						       f"FROM generate_series({lo}, {hi}) g "
+						       f"ON CONFLICT DO NOTHING;")
+					barrier.wait()
+					con.execute(sql)
+					con.commit()
+			except Exception as e:
+				errors.append((wid, repr(e)))
+
+		per = self.NROWS // self.NWORKERS
+		threads = [
+		    threading.Thread(target=worker,
+		                     args=(w, w * per + 1, (w + 1) * per))
+		    for w in range(self.NWORKERS)
+		]
+		before = page_undo_loc(node)
+		t0 = time.monotonic()
+		for t in threads:
+			t.start()
+		for t in threads:
+			t.join()
+		elapsed = time.monotonic() - t0
+		after = page_undo_loc(node)
+		self.assertFalse(errors, f"worker errors: {errors}")
+		return after - before, elapsed
+
+	def _run_concurrent_pair(self, label, ordered):
+		"""Run the workload twice (forced + optimized) and assert savings."""
+		node = self._bootstrap(f"perf_{label}_off")
+		off_bytes, off_secs = self._run_workers(node, f"perf_{label}_off",
+		                                        None, True, ordered)
+		node.safe_psql(
+		    f"CREATE TABLE perf_{label}_on (i bigint PRIMARY KEY, t text) USING orioledb;"
+		)
+		on_bytes, on_secs = self._run_workers(node, f"perf_{label}_on", None,
+		                                      False, ordered)
+
+		ratio = on_bytes / max(off_bytes, 1)
+		print(f"\n[perf {label} N={self.NROWS} workers={self.NWORKERS}] "
+		      f"forced={off_bytes/1024:.1f} KB / {off_secs:.2f}s, "
+		      f"optimized={on_bytes/1024:.1f} KB / {on_secs:.2f}s, "
+		      f"ratio={ratio*100:.2f}%, savings={(1-ratio)*100:.2f}%")
+
+		# Forced path must still emit substantial undo.
+		self.assertGreater(off_bytes, 10 * 1024 * 1024,
+		                   "forced path should emit > 10 MB undo")
+		# Optimized path should save the vast majority of page-level undo
+		# even with concurrent inserters (each backend's snapshot retain
+		# tracks the same lastUsed so the cross-backend probe doesn't trip).
+		self.assertLess(ratio, 0.1,
+		                "optimized path should emit < 10% of forced path")
+		node.stop()
+
+	def test_concurrent_ordered_inserts_savings(self):
+		"""N workers each insert a disjoint, monotonic PK range."""
+		self._run_concurrent_pair('co_ord', ordered=True)
+
+	def test_concurrent_unordered_inserts_savings(self):
+		"""N workers each insert random PKs across the whole keyspace."""
+		self._run_concurrent_pair('co_rand', ordered=False)

--- a/test/t/page_undo_skip_test.py
+++ b/test/t/page_undo_skip_test.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+# coding: utf-8
+# Tests for the page-level undo elision optimization.
+
+import threading
+
+from .base_test import BaseTest
+
+
+def page_undo_loc(node, con=None):
+	"""lastusedlocation for the page-level undo log."""
+	q = "SELECT lastusedlocation FROM orioledb_get_undo_meta() WHERE undo_type='page';"
+	if con is not None:
+		return con.execute(q)[0][0]
+	return node.execute(q)[0][0]
+
+
+class PageUndoSkipTest(BaseTest):
+
+	# Approximate per-row payload: text repeated 200 chars + tuple overhead.
+	# 30k rows is comfortably > one leaf page so splits are guaranteed.
+	NROWS = 30000
+
+	def _setup_oriole(self):
+		node = self.node
+		node.append_conf('postgresql.conf', "checkpoint_timeout = 86400\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		return node
+
+	def test_bulk_load_no_concurrent_readers_skips_page_undo(self):
+		"""Pre-committed table + bulk insert in a fresh transaction emits
+		no page-level undo when no other backends are active."""
+		node = self._setup_oriole()
+
+		# Defeat the self-create shortcut: CREATE commits in its own txn.
+		node.safe_psql(
+		    "CREATE TABLE bulk (i bigint PRIMARY KEY, t text) USING orioledb;")
+		before = page_undo_loc(node)
+		node.safe_psql(
+		    f"INSERT INTO bulk SELECT g, repeat('a', 200) FROM generate_series(1, {self.NROWS}) g;"
+		)
+		after = page_undo_loc(node)
+
+		# Tolerate a small constant for unrelated activity (system trees,
+		# meta updates).  Optimization is working iff growth << one undo
+		# image (~8KB).
+		self.assertLess(after - before, 16 * 1024)
+
+		node.stop()
+
+	def test_bulk_load_disabled_emits_full_page_undo(self):
+		"""With the optimization disabled, the same workload emits the
+		expected page-level undo (sanity-check the GUC and the baseline)."""
+		node = self._setup_oriole()
+
+		node.safe_psql(
+		    "CREATE TABLE bulk_off (i bigint PRIMARY KEY, t text) USING orioledb;"
+		)
+		before = page_undo_loc(node)
+		node.safe_psql(f"""
+			SET orioledb.debug_force_page_undo = on;
+			INSERT INTO bulk_off SELECT g, repeat('a', 200)
+				FROM generate_series(1, {self.NROWS}) g;
+		""")
+		after = page_undo_loc(node)
+
+		# Each split emits ~8KB; 30k rows split many leaves.  Expect at
+		# least 100 KB.
+		self.assertGreater(after - before, 100 * 1024)
+
+		node.stop()
+
+	def test_bulk_load_with_concurrent_reader_keeps_page_undo(self):
+		"""A concurrent open scan on the same relation must force page
+		undo to be emitted, and the scanner must see only the pre-bulk
+		row set after each FETCH."""
+		node = self._setup_oriole()
+
+		node.safe_psql("""
+			CREATE TABLE r1 (i bigint PRIMARY KEY, t text) USING orioledb;
+			INSERT INTO r1 VALUES (0, 'pre');
+		""")
+
+		# Reader: REPEATABLE READ + open cursor pins the snapshot and
+		# bumps numSeqScans for the duration of FETCH iteration.  Omit
+		# ORDER BY: with ORDER BY on the PK, the planner picks a Custom
+		# Scan / index scan that does NOT bump numSeqScans, and the
+		# optimization would not see this reader.
+		with node.connect() as reader:
+			reader.begin('REPEATABLE READ')
+			reader.execute("DECLARE c CURSOR FOR SELECT i, t FROM r1;")
+			# Force the cursor to start streaming so a scan is registered.
+			first = reader.execute("FETCH FORWARD 1 FROM c;")
+			self.assertEqual(first, [(0, 'pre')])
+
+			with node.connect() as writer:
+				writer.execute("SET orioledb.debug_force_page_undo = off;")
+				before = page_undo_loc(node, writer)
+				writer.execute(f"""
+					INSERT INTO r1 SELECT g, repeat('a', 200)
+						FROM generate_series(1, {self.NROWS}) g;
+				""")
+				writer.commit()
+				after = page_undo_loc(node, writer)
+
+			# Concurrent reader must have prevented elision: expect
+			# substantial page undo emission.
+			self.assertGreater(after - before, 100 * 1024)
+
+			# Reader still sees only the pre-bulk row.
+			remaining = reader.execute("FETCH FORWARD 10 FROM c;")
+			self.assertEqual(remaining, [])
+			reader.execute("CLOSE c;")
+			reader.commit()
+
+		# Outside the reader's transaction the new rows are visible.
+		count = node.execute("SELECT count(*) FROM r1;")[0][0]
+		self.assertEqual(count, self.NROWS + 1)
+
+		node.stop()
+
+	def test_delete_then_bulk_insert_keeps_page_undo(self):
+		"""A delete by the same backend on a leaf forces page undo for
+		subsequent split/compact on that leaf, even with no concurrent
+		readers."""
+		node = self._setup_oriole()
+
+		# Seed enough rows to fill many leaves so deletes spread across them.
+		node.safe_psql(f"""
+			CREATE TABLE d1 (i bigint PRIMARY KEY, t text) USING orioledb;
+			INSERT INTO d1 SELECT g, repeat('a', 200)
+				FROM generate_series(1, {self.NROWS // 3}) g;
+		""")
+
+		# In a single transaction: delete scattered rows then bulk insert.
+		with node.connect() as con:
+			con.begin()
+			# mod() instead of '%' to avoid psycopg2 placeholder parsing.
+			con.execute("DELETE FROM d1 WHERE mod(i, 5) = 0;")
+			before = page_undo_loc(node, con)
+			con.execute(f"""
+				INSERT INTO d1 SELECT g, repeat('a', 200)
+					FROM generate_series({self.NROWS // 3 + 1}, {self.NROWS}) g;
+			""")
+			after = page_undo_loc(node, con)
+			con.commit()
+
+		# Pages with local deletes must take page-level undo on subsequent
+		# splits/compactions.  Only leaves where both a delete and a later
+		# split land emit undo, so we expect at least one page image
+		# (vs 0 in the fully optimized path).
+		self.assertGreater(after - before, 4 * 1024)
+
+		node.stop()
+
+	def test_abort_after_optimized_bulk_load(self):
+		"""When the optimization fired and the transaction aborts, the
+		original row set must remain visible."""
+		node = self._setup_oriole()
+
+		node.safe_psql("""
+			CREATE TABLE a1 (i bigint PRIMARY KEY, t text) USING orioledb;
+			INSERT INTO a1 SELECT g, 'orig'
+				FROM generate_series(1, 10) g;
+		""")
+
+		with node.connect() as con:
+			con.begin()
+			con.execute(f"""
+				INSERT INTO a1 SELECT g, repeat('a', 200)
+					FROM generate_series(100, {self.NROWS + 100}) g;
+			""")
+			con.rollback()
+
+		# Original ten rows must remain.
+		rows = node.execute("SELECT count(*), max(t) FROM a1;")
+		self.assertEqual(rows[0][0], 10)
+		self.assertEqual(rows[0][1], 'orig')
+
+		node.stop()
+
+	# ---- concurrent correctness ---------------------------------------
+
+	NWORKERS = 4
+
+	def _run_concurrent_inserts(self, node, table, ordered):
+		"""Spawn NWORKERS connections that each INSERT a disjoint slice of
+		[1..NROWS].  ordered=True: each worker's slice is a contiguous,
+		monotonic PK range.  ordered=False: each worker's slice is a hash-
+		shuffled set of PKs (disjoint via mod NWORKERS == worker id)."""
+		barrier = threading.Barrier(self.NWORKERS)
+		errors = []
+
+		def worker(wid, lo, hi):
+			try:
+				with node.connect() as con:
+					con.begin()
+					if ordered:
+						sql = (f"INSERT INTO {table} "
+						       f"SELECT g, 'w{wid}' "
+						       f"FROM generate_series({lo}, {hi}) g;")
+					else:
+						sql = (f"INSERT INTO {table} "
+						       f"SELECT (hashint8(g) & x'7fffffff'::bigint) "
+						       f"  * {self.NWORKERS} + {wid}, 'w{wid}' "
+						       f"FROM generate_series({lo}, {hi}) g "
+						       f"ON CONFLICT DO NOTHING;")
+					barrier.wait()
+					con.execute(sql)
+					con.commit()
+			except Exception as e:
+				errors.append((wid, repr(e)))
+
+		per = self.NROWS // self.NWORKERS
+		threads = [
+		    threading.Thread(target=worker,
+		                     args=(w, w * per + 1, (w + 1) * per))
+		    for w in range(self.NWORKERS)
+		]
+		for t in threads:
+			t.start()
+		for t in threads:
+			t.join()
+		self.assertFalse(errors, f"worker errors: {errors}")
+
+	def test_concurrent_ordered_inserts_correctness(self):
+		"""N workers insert disjoint monotonic PK ranges.  Final table must
+		contain every PK exactly once and per-worker row counts must match."""
+		node = self._setup_oriole()
+		node.safe_psql(
+		    "CREATE TABLE co_ord (i bigint PRIMARY KEY, t text) USING orioledb;"
+		)
+		self._run_concurrent_inserts(node, 'co_ord', ordered=True)
+
+		total = node.execute("SELECT count(*) FROM co_ord;")[0][0]
+		# Each worker writes NROWS//NWORKERS rows; total may be slightly
+		# below NROWS if NROWS isn't divisible by NWORKERS.
+		expected = (self.NROWS // self.NWORKERS) * self.NWORKERS
+		self.assertEqual(total, expected)
+
+		# No duplicates and every PK is in the expected interval.
+		dup = node.execute(
+		    "SELECT i FROM co_ord GROUP BY i HAVING count(*) > 1 LIMIT 1;")
+		self.assertEqual(dup, [])
+		out_of_range = node.execute(
+		    f"SELECT 1 FROM co_ord WHERE i < 1 OR i > {expected} LIMIT 1;")
+		self.assertEqual(out_of_range, [])
+
+		# Each worker's slice has the right count.
+		per = self.NROWS // self.NWORKERS
+		for w in range(self.NWORKERS):
+			lo, hi = w * per + 1, (w + 1) * per
+			cnt = node.execute(
+			    f"SELECT count(*) FROM co_ord WHERE i BETWEEN {lo} AND {hi};"
+			)[0][0]
+			self.assertEqual(cnt, per, f"worker {w} slice mismatch")
+
+		node.stop()
+
+	def test_concurrent_unordered_inserts_correctness(self):
+		"""N workers insert hash-shuffled PKs across the keyspace.  Final
+		table must satisfy: row count == sum of per-worker rows, PK
+		uniqueness, and each worker's tagged rows survive intact."""
+		node = self._setup_oriole()
+		node.safe_psql(
+		    "CREATE TABLE co_rand (i bigint PRIMARY KEY, t text) USING orioledb;"
+		)
+		self._run_concurrent_inserts(node, 'co_rand', ordered=False)
+
+		# Sum across workers (worker tag = 't' column) equals row count.
+		total = node.execute("SELECT count(*) FROM co_rand;")[0][0]
+		per_worker = node.execute(
+		    "SELECT t, count(*) FROM co_rand GROUP BY t ORDER BY t;")
+		self.assertEqual(sum(c for _, c in per_worker), total)
+		self.assertEqual(len(per_worker), self.NWORKERS)
+
+		# PK uniqueness is implicit (PRIMARY KEY) but double-check.
+		dup = node.execute(
+		    "SELECT i FROM co_rand GROUP BY i HAVING count(*) > 1 LIMIT 1;")
+		self.assertEqual(dup, [])
+
+		# Each worker's rows must carry that worker's tag and PK mod
+		# NWORKERS must match the worker id.
+		for w, cnt in per_worker:
+			wid = int(w[1:])
+			mismatched = node.execute(
+			    f"SELECT 1 FROM co_rand WHERE t = '{w}' "
+			    f"AND mod(i, {self.NWORKERS}) <> {wid} LIMIT 1;")
+			self.assertEqual(mismatched, [],
+			                 f"worker {w} has rows with wrong PK residue")
+
+		node.stop()
+
+	def test_reader_during_uncommitted_bulk_insert_sees_pre_state(self):
+		"""A reader that takes its snapshot AFTER an optimized bulk insert
+		has run (and triggered splits) but BEFORE the writing transaction
+		commits must see only the pre-insert state.  This exercises the
+		case where the skip optimization fires (no concurrent seq scan
+		during the writer's INSERT) yet MVCC visibility must still hide
+		uncommitted rows from a later snapshot."""
+		node = self._setup_oriole()
+		node.safe_psql("""
+			CREATE TABLE u1 (i bigint PRIMARY KEY, t text) USING orioledb;
+			INSERT INTO u1 SELECT g, 'pre' FROM generate_series(1, 50) g;
+		""")
+		pre_rows = node.execute("SELECT i, t FROM u1 ORDER BY i;")
+		self.assertEqual(len(pre_rows), 50)
+
+		with node.connect() as writer:
+			writer.begin()
+			# Bulk insert under the skip optimization (no concurrent scan).
+			writer.execute(f"""
+				INSERT INTO u1 SELECT g, 'new' FROM
+					generate_series(100, {self.NROWS + 100}) g;
+			""")
+			# Writer NOT yet committed.
+
+			with node.connect() as reader:
+				reader.begin('REPEATABLE READ')
+				# Pre-insert visibility under MVCC despite splits with no
+				# page-level undo.
+				cnt = reader.execute("SELECT count(*) FROM u1;")[0][0]
+				self.assertEqual(cnt, 50)
+				seen = reader.execute("SELECT i, t FROM u1 ORDER BY i;")
+				self.assertEqual(seen, pre_rows)
+				# 'new' rows must be entirely invisible.
+				new_seen = reader.execute(
+				    "SELECT count(*) FROM u1 WHERE t = 'new';")[0][0]
+				self.assertEqual(new_seen, 0)
+
+				writer.commit()
+
+				# Reader still in its RR snapshot: post-commit, still
+				# pre-state.
+				cnt = reader.execute("SELECT count(*) FROM u1;")[0][0]
+				self.assertEqual(cnt, 50)
+				reader.commit()
+
+		# A fresh connection now sees both pre and new.
+		total = node.execute("SELECT count(*) FROM u1;")[0][0]
+		self.assertEqual(total, 50 + self.NROWS + 1)
+
+		node.stop()


### PR DESCRIPTION
Page-level undo (pre-split/pre-compact page image) is needed only to
serve concurrent readers or rollback of in-flight changes on the same
page.  On bulk-insert workloads it dominates undo bandwidth and is
rarely consulted.