### PR TITLE
check: include next-checkpoint .tmp + in-memory seq_buf tail in orioledb_tbl_check

### DIFF
--- a/include/utils/seq_buf.h
+++ b/include/utils/seq_buf.h
@@ -84,6 +84,9 @@ extern bool seq_buf_write_file_extent(SeqBufDescPrivate *seqBufPrivate, FileExte
 extern bool seq_buf_read_file_extent(SeqBufDescPrivate *seqBufPrivate, FileExtent *extent);
 
 extern uint64 seq_buf_finalize(SeqBufDescPrivate *seqBufPrivate);
+extern Size seq_buf_snapshot_pending_data(SeqBufDescPrivate *seqBufPrivate,
+										  char *buf);
+extern Size seq_buf_max_pending_data_size(void);
 extern char *get_seq_buf_filename(SeqBufTag *tag);
 extern uint64 seq_buf_get_offset(SeqBufDescPrivate *seqBufPrivate);
 extern SeqBufReplaceResult seq_buf_try_replace(SeqBufDescPrivate *seqBufPrivate,

--- a/src/btree/check.c
+++ b/src/btree/check.c
@@ -63,6 +63,12 @@ static void get_free_extents(BTreeDescr *desc, ExtentsArray *free_extents,
 static void get_free_extents_from_file(SeqBufTag *tag, off_t offset,
 									   ExtentsArray *free_extents,
 									   bool compressed, bool should_exists);
+static void get_free_extents_from_seqbuf_pending(SeqBufDescPrivate *seqBuf,
+												 SeqBufTag *expected_tag,
+												 ExtentsArray *free_extents,
+												 bool compressed);
+static void decode_free_extent_buf(const char *buf, Size len,
+								   ExtentsArray *free_extents, bool compressed);
 static bool is_sorted_by_off(ExtentsArray *array);
 static bool is_sorted_by_len_off(ExtentsArray *array);
 
@@ -267,11 +273,31 @@ get_free_extents(BTreeDescr *desc, ExtentsArray *free_extents,
 		freebuf_offset = seq_buf_get_offset(&desc->freeBuf);
 
 		get_free_extents_from_file(&chkp_tag, freebuf_offset, free_extents, false, false);
-		for (num = chkp_tag.num; num < chkp_num; num++)
+
+		/*
+		 * Read every .tmp file whose data could still feed the free-extent
+		 * stream: anything written for the previous checkpoint (already
+		 * flushed) up to chkp_num + 1 (the "next" checkpoint accepting fresh
+		 * frees from in-flight merges and from copy-blkno page rewrites).
+		 * Mirrors the compressed branch below, which already extends the
+		 * range to chkp_num + 1.  Stopping at chkp_num leaves out frees that
+		 * are sitting in chkp.{chkp_num+1}.tmp and produces a phantom "Extent
+		 * ... is neither free or busy" report.
+		 *
+		 * For each .tmp file we also drain the matching desc->tmpBuf[] in
+		 * shared memory.  free_extent_for_checkpoint() buffers small writes
+		 * in an 8 KB seq_buf page; until the chunk fills or the checkpoint
+		 * finalises, the bytes are not visible via the on-disk file read.
+		 * Appending them here closes that read-side race.
+		 */
+		for (num = chkp_tag.num; num <= chkp_num; num++)
 		{
 			chkp_tag.num = num + 1;
 			chkp_tag.type = 't';
 			get_free_extents_from_file(&chkp_tag, 0, free_extents, false, false);
+			get_free_extents_from_seqbuf_pending(&desc->tmpBuf[(num + 1) % 2],
+												 &chkp_tag, free_extents,
+												 false);
 		}
 	}
 	else
@@ -292,7 +318,42 @@ get_free_extents(BTreeDescr *desc, ExtentsArray *free_extents,
 			chkp_tag.num = num;
 			chkp_tag.type = 't';
 			get_free_extents_from_file(&chkp_tag, 0, free_extents, true, false);
+			/* Mirror the uncompressed-path append (see comment above). */
+			get_free_extents_from_seqbuf_pending(&desc->tmpBuf[num % 2],
+												 &chkp_tag, free_extents,
+												 true);
 		}
+	}
+}
+
+/*
+ * Decode a buffer of contiguous extent records into the free_extents array.
+ * `len` is the number of bytes in `buf` to decode and must be a multiple of
+ * the on-disk record size for this index.
+ */
+static void
+decode_free_extent_buf(const char *buf, Size len, ExtentsArray *free_extents,
+					   bool compressed)
+{
+	FileExtent	extent;
+	uint32		off;
+	Size		i = 0;
+
+	while (i < len)
+	{
+		if (compressed || use_device)
+		{
+			memcpy(&extent, buf + i, sizeof(FileExtent));
+			i += sizeof(FileExtent);
+		}
+		else
+		{
+			memcpy(&off, buf + i, sizeof(uint32));
+			i += sizeof(uint32);
+			extent.off = off;
+			extent.len = 1;
+		}
+		add_extent(free_extents, extent);
 	}
 }
 
@@ -307,10 +368,7 @@ get_free_extents_from_file(SeqBufTag *tag, off_t offset,
 	char		buf[ORIOLEDB_BLCKSZ],
 			   *filename;
 	File		file;
-	FileExtent	extent;
 	off_t		bytes_read;
-	uint32		off;
-	int			i;
 
 	filename = get_seq_buf_filename(tag);
 	file = PathNameOpenFile(filename, O_RDONLY | PG_BINARY);
@@ -328,28 +386,38 @@ get_free_extents_from_file(SeqBufTag *tag, off_t offset,
 		bytes_read = OFileRead(file, buf, ORIOLEDB_BLCKSZ, offset,
 							   WAIT_EVENT_DATA_FILE_READ);
 		offset += bytes_read;
-
-		i = 0;
-		while (i < bytes_read)
-		{
-			if (compressed || use_device)
-			{
-				memcpy(&extent, buf + i, sizeof(FileExtent));
-				i += sizeof(FileExtent);
-			}
-			else
-			{
-				memcpy(&off, buf + i, sizeof(uint32));
-				i += sizeof(uint32);
-				extent.off = off;
-				extent.len = 1;
-			}
-			add_extent(free_extents, extent);
-		}
+		decode_free_extent_buf(buf, bytes_read, free_extents, compressed);
 	} while (bytes_read == ORIOLEDB_BLCKSZ);
 
 	FileClose(file);
 	pfree(filename);
+}
+
+/*
+ * Appends in-memory free-extent records that have been written to the given
+ * write-mode seq_buf but are not yet flushed to its on-disk file.  Pair with
+ * get_free_extents_from_file() to cover both halves of the stream when the
+ * caller wants a snapshot that includes mid-checkpoint writes.
+ */
+static void
+get_free_extents_from_seqbuf_pending(SeqBufDescPrivate *seqBuf,
+									 SeqBufTag *expected_tag,
+									 ExtentsArray *free_extents,
+									 bool compressed)
+{
+	char	   *buf;
+	Size		len;
+
+	if (!SEQ_BUF_SHARED_EXIST(seqBuf->shared))
+		return;
+	if (!SeqBufTagEqual(&seqBuf->shared->tag, expected_tag))
+		return;
+
+	buf = palloc(seq_buf_max_pending_data_size());
+	len = seq_buf_snapshot_pending_data(seqBuf, buf);
+	if (len > 0)
+		decode_free_extent_buf(buf, len, free_extents, compressed);
+	pfree(buf);
 }
 
 /*

--- a/src/utils/seq_buf.c
+++ b/src/utils/seq_buf.c
@@ -543,6 +543,65 @@ seq_buf_finalize(SeqBufDescPrivate *seqBufPrivate)
 }
 
 /*
+ * Snapshot data that has been written to this seq_buf but is not yet visible
+ * via the on-disk file -- i.e., bytes still buffered in the in-memory current
+ * page.  After this call, a reader can `OFileRead` the file path to get every
+ * byte committed to disk and then concatenate the returned tail bytes to see
+ * the full stream of data written so far.
+ *
+ * Behaviour mirrors seq_buf_finalize() for the previous-page state: any
+ * in-flight write is waited for, and a SeqBufPrevPageError is retried in
+ * place; on a second failure we PANIC.
+ *
+ * `buf` must be SEQBUF_CHUNK_SIZE bytes.  Returns the number of bytes copied
+ * (0 if the seq_buf is empty/uninitialised, at most SEQBUF_CHUNK_SIZE).  Only
+ * valid on write-mode seq_bufs.
+ */
+Size
+seq_buf_max_pending_data_size(void)
+{
+	return SEQBUF_CHUNK_SIZE;
+}
+
+Size
+seq_buf_snapshot_pending_data(SeqBufDescPrivate *seqBufPrivate, char *buf)
+{
+	SeqBufDescShared *shared = seqBufPrivate->shared;
+	Page		page;
+	Size		len;
+
+	Assert(seqBufPrivate->write);
+
+	if (!SEQ_BUF_SHARED_EXIST(shared))
+		return 0;
+
+	SpinLockAcquire(&shared->lock);
+	seq_buf_wait_prev_page(shared);
+	if (shared->prevPageState == SeqBufPrevPageError)
+	{
+		if (!seq_buf_finish_prev_page(seqBufPrivate))
+		{
+			SpinLockRelease(&shared->lock);
+			ereport(PANIC, (errcode_for_file_access(),
+							errmsg("could not finalize previous sequence buffer page to file %s: %m",
+								   get_seq_buf_filename(&seqBufPrivate->tag))));
+		}
+		shared->prevPageState = SeqBufPrevPageDone;
+	}
+
+	Assert(shared->location >= SEQBUF_DATA_OFF);
+	len = shared->location - SEQBUF_DATA_OFF;
+	if (len > 0)
+	{
+		page = O_GET_IN_MEMORY_PAGE(shared->pages[shared->curPageNum]);
+		memcpy(buf, page + SEQBUF_DATA_OFF, len);
+	}
+	SpinLockRelease(&shared->lock);
+
+	return len;
+}
+
+/*
  * Get current offset in the file.
  */
 uint64

--- a/test/t/checkpoint_split3_test.py
+++ b/test/t/checkpoint_split3_test.py
@@ -288,8 +288,12 @@ class CheckpointSplit3Test(CheckpointSplitBaseTest):
 
 		self.assertEqual(
 		    node.execute("SELECT COUNT(*) FROM o_checkpoint;")[0][0], 28)
-		# autonomous checkpoint write happens
-		self.assertFalse(
+		# autonomous checkpoint write happens; the extents freed by
+		# the autonomous rewrites land in the next checkpoint's tmpBuf
+		# (chkp.{N+1}.tmp + seq_buf in-memory chunk).
+		# orioledb_tbl_check() now reads both so it reports the table
+		# as consistent at this mid-checkpoint snapshot.
+		self.assertTrue(
 		    node.execute("SELECT orioledb_tbl_check('o_checkpoint'::regclass)")
 		    [0][0])
 
@@ -343,8 +347,12 @@ class CheckpointSplit3Test(CheckpointSplitBaseTest):
 
 		self.assertEqual(
 		    node.execute("SELECT COUNT(*) FROM o_checkpoint;")[0][0], 29)
-		# autonomous checkpoint page write happens
-		self.assertFalse(
+		# autonomous checkpoint page write happens; the extents freed
+		# by the autonomous rewrites land in the next checkpoint's
+		# tmpBuf (chkp.{N+1}.tmp + seq_buf in-memory chunk).
+		# orioledb_tbl_check() now reads both so it reports the table
+		# as consistent at this mid-checkpoint snapshot.
+		self.assertTrue(
 		    node.execute("SELECT orioledb_tbl_check('o_checkpoint'::regclass)")
 		    [0][0])
 

--- a/test/t/incomplete_split_test.py
+++ b/test/t/incomplete_split_test.py
@@ -90,9 +90,12 @@ class SplitTest(BaseTest):
 
 		con2.execute("SELECT pg_stopevent_reset('split_fail');")
 		con2.execute("CHECKPOINT;")
-		# checkpoint fixes split and has autonomous page writes
-		# btree_check() will fail
-		self.checkSplitTable(100, False)
+		# checkpoint fixes split and has autonomous page writes; the
+		# extents freed by those autonomous writes live in the
+		# in-progress next checkpoint's tmpBuf (.tmp file + seq_buf
+		# in-memory chunk), and orioledb_tbl_check() now consults both
+		# so the check accepts the table as consistent.
+		self.checkSplitTable(100, True)
 		con2.execute("CHECKPOINT;")
 
 		# After second checkpoint there is no incomplete split pages and lost blocks in BTree
@@ -121,9 +124,12 @@ class SplitTest(BaseTest):
 
 		con2.execute("SELECT pg_stopevent_reset('split_fail');")
 		con2.execute("CHECKPOINT;")
-		# checkpoint fixes split and has autonomous page writes
-		# btree_check() will fail
-		self.checkSplitTable(58, False)
+		# checkpoint fixes split and has autonomous page writes; the
+		# extents freed by those autonomous writes live in the
+		# in-progress next checkpoint's tmpBuf (.tmp file + seq_buf
+		# in-memory chunk), and orioledb_tbl_check() now consults both
+		# so the check accepts the table as consistent.
+		self.checkSplitTable(58, True)
 		con2.execute("CHECKPOINT;")
 
 		# After second checkpoint there is no incomplete split pages and lost blocks in BTree
@@ -156,9 +162,12 @@ class SplitTest(BaseTest):
 		con2.execute("CHECKPOINT;")
 		con2.commit()
 
-		# checkpoint fixes split and has autonomous page writes
-		# btree_check() will fail
-		self.checkSplitTable(11, False)
+		# checkpoint fixes split and has autonomous page writes; the
+		# extents freed by those autonomous writes live in the
+		# in-progress next checkpoint's tmpBuf (.tmp file + seq_buf
+		# in-memory chunk), and orioledb_tbl_check() now consults both
+		# so the check accepts the table as consistent.
+		self.checkSplitTable(11, True)
 		con2.execute("CHECKPOINT;")
 		# After second checkpoint there is no incomplete split pages and lost blocks
 		self.checkSplitTable(11, True)
@@ -430,3 +439,66 @@ class SplitTest(BaseTest):
 			raise
 		except Exception:
 			self.assertTrue(True)
+
+	def test_tbl_check_sees_pending_tmpbuf_freelist(self):
+		"""
+		orioledb_tbl_check() rebuilds the free-extent set by reading both
+		the on-disk .map/.tmp files and the in-memory seq_buf chunks
+		that free_extent_for_checkpoint() writes to before the next
+		CHECKPOINT finalises them.  This test deterministically forces
+		the read-side path that used to produce phantom "Extent N M is
+		neither free or busy" reports.
+
+		Setup mirrors test_incomplete_leaf_checkpoint_fix but the
+		assertion order is named after the read-side property: right
+		after the CHECKPOINT that triggers autonomous in-place page
+		rewrites, the freed extents live in tmpBuf for the in-progress
+		next checkpoint -- not yet flushed to disk -- and the check
+		must consult that tmpBuf to avoid mis-reporting a hole.
+
+		Pre-fix this would return False (uncompressed loop bound was
+		`num < chkp_num`, so chkp.{chkp_num+1}.tmp was skipped, and
+		the in-memory seq_buf chunk was never read).  Post-fix it
+		returns True.
+		"""
+		node = self.node
+		self.insertToSplitTable(node, 10, 50, 4)
+
+		con1 = self.createConnection()
+		con1.execute("SET orioledb.enable_stopevents = true;")
+		con2 = self.createConnection()
+		con2.execute("SELECT pg_stopevent_set('split_fail', 'true');")
+
+		self.assertEqual(
+		    node.execute("SELECT COUNT(*) FROM o_split;")[0][0], 11)
+
+		# Force a phase-1-only split: the new right leaf is allocated
+		# but the parent's downlink isn't installed, so the tree has a
+		# BROKEN_SPLIT page reachable only via rightlink.
+		self.failedInsertToSplitTable(con1, 51, 90, 4)
+		self.checkSplitTable(11, False)
+		con2.execute("SELECT pg_stopevent_reset('split_fail');")
+
+		# CHECKPOINT runs autonomous in-place rewrites to finish the
+		# BROKEN_SPLIT.  The freed locations of the rewritten leaves go
+		# through free_extent_for_checkpoint() into tmpBuf for the
+		# *next* checkpoint -- specifically into the seq_buf in-memory
+		# chunk because the freed count is far below 8 KB.
+		con2.begin()
+		con2.execute("CHECKPOINT;")
+		con2.commit()
+
+		# Without a second CHECKPOINT to flush tmpBuf, the freed
+		# extents are visible only via:
+		#   (a) chkp.{chkp_num + 1}.tmp on disk
+		#   (b) the seq_buf in-memory chunk of desc->tmpBuf[]
+		# orioledb_tbl_check() must read both to report consistency.
+		# Pre-fix returned False here; post-fix returns True.
+		self.checkSplitTable(11, True)
+
+		# Sanity: the second CHECKPOINT finalises tmpBuf and the
+		# state must remain consistent.
+		con2.execute("CHECKPOINT;")
+		self.checkSplitTable(11, True)
+
+		self.stopAll()


### PR DESCRIPTION
## Summary

`orioledb_tbl_check()` failed sporadically on a busy primary with the message:

```
NOTICE:  Extent N M is neither free or busy
NOTICE:  Corrupted index name = <index>
```

Despite the message, no real extent leak was present — the freed extent existed but was buffered in shared memory or in a `.tmp` file the checker did not consult.

The free list comes from two sources:

1. `desc->freeBuf` — previous checkpoint's map file, starting at the unread offset.
2. `.tmp` files for the in-progress checkpoint range.

Two gaps fed the false report:

- The uncompressed branch of `get_free_extents()` looped `num < chkp_num`, so it stopped one short and silently skipped `chkp.{chkp_num + 1}.tmp` — which is exactly where merges and `copy_blkno` rewrites that happen *during the current checkpoint* are recorded.  The compressed branch already iterates to `chkp_num + 1`; this commit makes the uncompressed branch match.

- `free_extent_for_checkpoint()` writes through `desc->tmpBuf[chkp_num % 2]`, whose underlying `seq_buf` only flushes a chunk to disk when the 8 KB page fills or the checkpoint finalises.  For low-churn indexes (e.g. a small unique index that sees only a handful of merges per cycle) the chunk never fills, so the freed extent sits in shared memory until the surrounding checkpoint completes.  Reading the on-disk `.tmp` file by path could not see it.

This PR closes the gap on the read side:

- Adds `seq_buf_snapshot_pending_data(SeqBufDescPrivate *, char *buf)` to `seq_buf.{h,c}`.  Acquires the seq_buf spinlock, waits for any in-flight page flush to settle (matching `seq_buf_finalize`'s semantics on `SeqBufPrevPageError`), and copies the unflushed current-page bytes into the caller-provided buffer.  Companion `seq_buf_max_pending_data_size()` exposes the required buffer size without leaking `SEQBUF_CHUNK_SIZE` through the public header.

- In `check.c::get_free_extents()`, extends the uncompressed loop bound to `num <= chkp_num` and, after each `.tmp` file read, also drains the matching `desc->tmpBuf[]` via the new helper.  This unions on-disk + pending into the free-list view the checker uses.

## Test plan

- [x] `make regresscheck REGRESSCHECKS="btree_sys_check createas indices"` — all pass.
- [x] 25 iterations of the rr_stress `test_bank_account_invariant` test (20 writers, streaming-replication crash + periodic postmaster SIGKILL chaos) — pre-fix: ~50% PASS, all failures `Extent N M is neither free or busy`; post-fix: **25/25 PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)