### PR TITLE
Differential page-level undo images for B-tree merge and split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  rll_deadlock \
 				  rll_mix \
 				  rll_subtrans \
+				  skipundo \
 				  table_lock_test \
 				  concurrent_truncate \
 				  uniq

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/reindex_test.py \
 						test/t/s3_test.py \
 						test/t/schema_test.py \
+						test/t/seq_scan_undo_test.py \
 						test/t/temp_local_pool_test.py \
 						test/t/toast_index_test.py \
 						test/t/trigger_test.py \

--- a/include/btree/page_chunks.h
+++ b/include/btree/page_chunks.h
@@ -31,6 +31,7 @@ typedef struct
 } BTreePageItem;
 
 extern bool partial_load_hikeys_chunk(PartialPageState *partial, Page img);
+extern bool partial_load_full_page(PartialPageState *partial, Page img);
 extern bool partial_load_chunk(PartialPageState *partial, Page img,
 							   OffsetNumber chunkOffset,
 							   BTreePageItemLocator *loc);

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -172,6 +172,19 @@ typedef struct
 /* maximum size of undo record */
 #define O_MAX_UNDO_RECORD_SIZE O_MERGE_UNDO_IMAGE_SIZE
 
+/*
+ * O_UNDO_GET_IMAGE_LOCATION() and get_page_from_undo() locate the page image
+ * at a fixed offset past the header, derived from UndoPageImageHeader, for
+ * every full-page image type: Compact and Merge use UndoPageImageHeader, while
+ * Split uses UndoPageImageSplitHeader.  That single offset is only correct if
+ * all full-image headers MAXALIGN to the same size.  Guard it so that, e.g.,
+ * adding a field to UndoPageImageSplitHeader cannot silently shift the split
+ * page image out from under those readers.
+ */
+StaticAssertDecl(MAXALIGN(sizeof(UndoPageImageHeader)) ==
+				 MAXALIGN(sizeof(UndoPageImageSplitHeader)),
+				 "full-page undo image headers must MAXALIGN to the same size");
+
 extern bool page_item_rollback(BTreeDescr *desc, Page p, BTreePageItemLocator *locator,
 							   bool loop, BTreeLeafTuphdr *non_lock_tuphdr_ptr,
 							   UndoLocation nonLockUndoLocation);

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -27,6 +27,29 @@ typedef enum
 	UndoPageImageSplit,
 	/* produced by pages merge */
 	UndoPageImageMerge,
+
+	/*
+	 * Differential merge image: produced by pages merge when the merge
+	 * dropped no tuple physically.  Stores only the boundary key and the
+	 * per-half undo chain continuation, not the page bytes.  The pre-merge
+	 * left/right page is reconstructed by trimming the (newer) merged page
+	 * already present in the caller's destination buffer at the boundary key.
+	 * See get_page_from_undo() and make_merge_undo_image().
+	 */
+	UndoPageImageMergeDiff,
+
+	/*
+	 * Differential split image: produced by a page split that dropped no
+	 * tuple physically.  Stores only the split key and the original
+	 * (pre-split) page's undo-chain continuation, not the page bytes.  Either
+	 * pre-split half is reconstructed by keeping the newer half already
+	 * present in the caller's destination buffer and rewiring its header to
+	 * continue into the original page's pre-split history; an older, wider
+	 * image further down the chain is clipped to the half's range by the
+	 * existing lokey/hikey machinery.  See get_page_from_undo() and
+	 * page_add_image_to_undo().
+	 */
+	UndoPageImageSplitDiff,
 	/* unknown value for default init */
 	UndoPageImageInvalid
 } UndoPageImageType;
@@ -40,6 +63,45 @@ typedef struct
 	uint8		splitKeyFlags;
 	LocationIndex splitKeyLen;
 } UndoPageImageHeader;
+
+/*
+ * Payload of a differential merge image (UndoPageImageMergeDiff), stored
+ * right after UndoPageImageHeader and followed by the boundary key bytes.
+ *
+ * The boundary key is the pre-merge hikey of the left page (== lokey of the
+ * right page).  leftCsn/leftUndoLoc and rightCsn/rightUndoLoc are the pre-merge
+ * (csn, undoLocation) of the left and right pages, used to synthesize the
+ * reconstructed half's header so the undo chain continues into that half's own
+ * pre-merge history.  rightRightmost records whether the right page (and hence
+ * the merged page) was RIGHTMOST.
+ */
+typedef struct
+{
+	CommitSeqNo leftCsn;
+	CommitSeqNo rightCsn;
+	UndoLocation leftUndoLoc;
+	UndoLocation rightUndoLoc;
+	uint8		boundaryFlags;
+	uint8		rightRightmost;
+	LocationIndex boundaryLen;
+} UndoMergeDiffData;
+
+/*
+ * Payload of a differential split image (UndoPageImageSplitDiff), stored right
+ * after UndoPageImageHeader and followed by the split key bytes (described by
+ * the header's splitKeyFlags/splitKeyLen).
+ *
+ * The split key is the boundary between the pre-split left half ([lo, splitKey))
+ * and right half ([splitKey, hi)).  origCsn/origUndoLoc are the original
+ * (pre-split) page's (csn, undoLocation); they are written into the
+ * reconstructed half's header so the undo chain continues into the original
+ * page's own pre-split history.
+ */
+typedef struct
+{
+	CommitSeqNo origCsn;
+	UndoLocation origUndoLoc;
+} UndoSplitDiffData;
 
 /*
  * Status of existing lock on the tuple made by the same transaction;
@@ -87,6 +149,12 @@ typedef struct
 #define O_MODIFY_UNDO_RESERVE_SIZE (2 * (O_MAX_SPLIT_UNDO_IMAGE_SIZE + O_UPDATE_MAX_UNDO_SIZE))
 /* size of image in undo log produced by pages merge */
 #define O_MERGE_UNDO_IMAGE_SIZE (MAXALIGN(sizeof(UndoPageImageHeader)) + ORIOLEDB_BLCKSZ * 2)
+/* size of differential merge image (no page bytes, just the boundary key) */
+#define O_MERGE_DIFF_UNDO_IMAGE_SIZE(boundaryLen) (MAXALIGN(sizeof(UndoPageImageHeader)) + \
+												   MAXALIGN(sizeof(UndoMergeDiffData)) + MAXALIGN(boundaryLen))
+/* size of differential split image (no page bytes, just the split key) */
+#define O_SPLIT_DIFF_UNDO_IMAGE_SIZE(splitKeyLen) (MAXALIGN(sizeof(UndoPageImageHeader)) + \
+												   MAXALIGN(sizeof(UndoSplitDiffData)) + MAXALIGN(splitKeyLen))
 /* undo location of a page image */
 #define O_UNDO_GET_IMAGE_LOCATION(undo_loc, left) ((undo_loc) + MAXALIGN(sizeof(UndoPageImageHeader)) + ((left) ? 0 : ORIOLEDB_BLCKSZ))
 /* maximum size of undo record */

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -72,8 +72,8 @@ typedef struct
  * right page).  leftCsn/leftUndoLoc and rightCsn/rightUndoLoc are the pre-merge
  * (csn, undoLocation) of the left and right pages, used to synthesize the
  * reconstructed half's header so the undo chain continues into that half's own
- * pre-merge history.  rightRightmost records whether the right page (and hence
- * the merged page) was RIGHTMOST.
+ * pre-merge history.  The merged page's RIGHTMOST flag (== the right page's
+ * pre-merge RIGHTMOST) is read directly from the live merged page on reconstruct.
  */
 typedef struct
 {
@@ -82,7 +82,6 @@ typedef struct
 	UndoLocation leftUndoLoc;
 	UndoLocation rightUndoLoc;
 	uint8		boundaryFlags;
-	uint8		rightRightmost;
 	LocationIndex boundaryLen;
 } UndoMergeDiffData;
 

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -55,18 +55,30 @@ typedef enum
 } UndoPageImageType;
 
 /*
- * B-Tree page images header in undo log.
+ * Each page-level undo image starts with `UndoPageImageType type` at offset 0
+ * so the reader can peek the type before reading the per-type header.
+ * UndoPageImageCompact and UndoPageImageMerge carry no extra metadata and
+ * use the peek header directly; the other types have their own headers below.
+ */
+typedef struct
+{
+	UndoPageImageType type;
+} UndoPageImageHeader;
+
+/*
+ * Full split image (UndoPageImageSplit) header, followed by the pre-split page
+ * and the split key.
  */
 typedef struct
 {
 	UndoPageImageType type;
 	uint8		splitKeyFlags;
 	LocationIndex splitKeyLen;
-} UndoPageImageHeader;
+} UndoPageImageSplitHeader;
 
 /*
- * Payload of a differential merge image (UndoPageImageMergeDiff), stored
- * right after UndoPageImageHeader and followed by the boundary key bytes.
+ * Differential merge image (UndoPageImageMergeDiff) header, followed by the
+ * boundary key bytes.
  *
  * The boundary key is the pre-merge hikey of the left page (== lokey of the
  * right page).  leftCsn/leftUndoLoc and rightCsn/rightUndoLoc are the pre-merge
@@ -77,18 +89,18 @@ typedef struct
  */
 typedef struct
 {
+	UndoPageImageType type;
+	uint8		boundaryFlags;
+	LocationIndex boundaryLen;
 	CommitSeqNo leftCsn;
 	CommitSeqNo rightCsn;
 	UndoLocation leftUndoLoc;
 	UndoLocation rightUndoLoc;
-	uint8		boundaryFlags;
-	LocationIndex boundaryLen;
-} UndoMergeDiffData;
+} UndoPageImageMergeDiffHeader;
 
 /*
- * Payload of a differential split image (UndoPageImageSplitDiff), stored right
- * after UndoPageImageHeader and followed by the split key bytes (described by
- * the header's splitKeyFlags/splitKeyLen).
+ * Differential split image (UndoPageImageSplitDiff) header, followed by the
+ * split key bytes.
  *
  * The split key is the boundary between the pre-split left half ([lo, splitKey))
  * and right half ([splitKey, hi)).  origCsn/origUndoLoc are the original
@@ -98,9 +110,12 @@ typedef struct
  */
 typedef struct
 {
+	UndoPageImageType type;
+	uint8		splitKeyFlags;
+	LocationIndex splitKeyLen;
 	CommitSeqNo origCsn;
 	UndoLocation origUndoLoc;
-} UndoSplitDiffData;
+} UndoPageImageSplitDiffHeader;
 
 /*
  * Status of existing lock on the tuple made by the same transaction;
@@ -139,9 +154,9 @@ typedef struct
 /* size of image in undo log produced by page compaction  */
 #define O_COMPACT_UNDO_IMAGE_SIZE (MAXALIGN(sizeof(UndoPageImageHeader)) + ORIOLEDB_BLCKSZ)
 /* max size of image in undo log produced by page split */
-#define O_MAX_SPLIT_UNDO_IMAGE_SIZE (MAXALIGN(sizeof(UndoPageImageHeader)) + ORIOLEDB_BLCKSZ + O_BTREE_MAX_KEY_SIZE)
+#define O_MAX_SPLIT_UNDO_IMAGE_SIZE (MAXALIGN(sizeof(UndoPageImageSplitHeader)) + ORIOLEDB_BLCKSZ + O_BTREE_MAX_KEY_SIZE)
 /* size of image in undo log produced by page split */
-#define O_SPLIT_UNDO_IMAGE_SIZE(splitKeySize) (MAXALIGN(sizeof(UndoPageImageHeader)) + ORIOLEDB_BLCKSZ + MAXALIGN(splitKeySize))
+#define O_SPLIT_UNDO_IMAGE_SIZE(splitKeySize) (MAXALIGN(sizeof(UndoPageImageSplitHeader)) + ORIOLEDB_BLCKSZ + MAXALIGN(splitKeySize))
 /* max size of update undo record */
 #define O_UPDATE_MAX_UNDO_SIZE (sizeof(BTreeModifyUndoStackItem) + O_BTREE_MAX_TUPLE_SIZE)
 /* on modification we should reserve size for split and update undo records */
@@ -149,11 +164,9 @@ typedef struct
 /* size of image in undo log produced by pages merge */
 #define O_MERGE_UNDO_IMAGE_SIZE (MAXALIGN(sizeof(UndoPageImageHeader)) + ORIOLEDB_BLCKSZ * 2)
 /* size of differential merge image (no page bytes, just the boundary key) */
-#define O_MERGE_DIFF_UNDO_IMAGE_SIZE(boundaryLen) (MAXALIGN(sizeof(UndoPageImageHeader)) + \
-												   MAXALIGN(sizeof(UndoMergeDiffData)) + MAXALIGN(boundaryLen))
+#define O_MERGE_DIFF_UNDO_IMAGE_SIZE(boundaryLen) (MAXALIGN(sizeof(UndoPageImageMergeDiffHeader)) + MAXALIGN(boundaryLen))
 /* size of differential split image (no page bytes, just the split key) */
-#define O_SPLIT_DIFF_UNDO_IMAGE_SIZE(splitKeyLen) (MAXALIGN(sizeof(UndoPageImageHeader)) + \
-												   MAXALIGN(sizeof(UndoSplitDiffData)) + MAXALIGN(splitKeyLen))
+#define O_SPLIT_DIFF_UNDO_IMAGE_SIZE(splitKeyLen) (MAXALIGN(sizeof(UndoPageImageSplitDiffHeader)) + MAXALIGN(splitKeyLen))
 /* undo location of a page image */
 #define O_UNDO_GET_IMAGE_LOCATION(undo_loc, left) ((undo_loc) + MAXALIGN(sizeof(UndoPageImageHeader)) + ((left) ? 0 : ORIOLEDB_BLCKSZ))
 /* maximum size of undo record */

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -206,6 +206,8 @@ extern UndoLocation page_add_image_to_undo(BTreeDescr *desc, Pointer p,
 										   OTuple *splitKey, LocationIndex splitKeyLen);
 extern UndoLocation make_merge_undo_image(BTreeDescr *desc, Pointer left,
 										  Pointer right, CommitSeqNo imageCsn);
+extern bool page_op_drops_tuple(BTreeDescr *desc, Pointer p,
+								CommitSeqNo imageCsn);
 extern bool row_lock_conflicts(BTreeLeafTuphdr *pageTuphdr,
 							   BTreeLeafTuphdr *conflictTupHdr,
 							   UndoLogType undoType,

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1597,13 +1597,29 @@ btree_find_context_lokey(OBTreeFindPageContext *context)
 		BTREE_PAGE_READ_INTERNAL_TUPLE(result, context->parentImg, &ploc);
 		return result;
 	}
+	else if (BTREE_PAGE_FIND_IS(context, LOKEY_EXISTS))
+	{
+		/*
+		 * Hikey of the left sibling of the parent, carried down the descent.
+		 */
+		return context->lokey.tuple;
+	}
 	else
 	{
 		/*
-		 * Hikey of the left sibling of the parent.
+		 * The descent established no lokey for this page.  This happens for a
+		 * frozen no-record split half (see o_btree_insert_split()) reached
+		 * live during a backward scan: its csn was not bumped, so the reader
+		 * never walked the undo chain that would have supplied a lokey.  Such
+		 * a page drops no tuple, so its smallest stored key is its lokey.
 		 */
-		Assert(context->flags & BTREE_PAGE_FIND_LOKEY_EXISTS);
-		return context->lokey.tuple;
+		OTuple		firstTuple;
+		BTreePageItemLocator loc;
+
+		BTREE_PAGE_LOCATOR_FIRST(context->img, &loc);
+		Assert(BTREE_PAGE_LOCATOR_IS_VALID(context->img, &loc));
+		BTREE_PAGE_READ_TUPLE(firstTuple, context->img, &loc);
+		return firstTuple;
 	}
 }
 

--- a/src/btree/insert.c
+++ b/src/btree/insert.c
@@ -20,6 +20,7 @@
 #include "btree/split.h"
 #include "btree/page_contents.h"
 #include "btree/page_chunks.h"
+#include "btree/scan.h"
 #include "btree/undo.h"
 #include "checkpoint/checkpoint.h"
 #include "recovery/recovery.h"
@@ -789,10 +790,54 @@ o_btree_insert_split(BTreeInsertStackItem *insert_item,
 											items,
 											&split_key, &split_key_len);
 
-	/* Make page-level undo item if needed */
+	/*
+	 * Make a page-level undo item if needed.
+	 *
+	 * A no-drop split is invisible to readers: it repartitions the same
+	 * tuples across two pages without removing any.  The only reason to keep
+	 * a page-level image is then to reconstruct the pre-split page structure
+	 * for a reader whose snapshot predates the split; when the page's own
+	 * pre-split undo location is already below the retain horizon (or
+	 * invalid), no such reader exists.  In that case we write no image at all
+	 * and mark both halves frozen with an invalid undo location: every reader
+	 * reads them live (a frozen csn precedes any snapshot, so the undo chain
+	 * is never walked) and per-tuple MVCC handles visibility, exactly as for
+	 * a freshly initialized page.
+	 *
+	 * If the split physically drops a tuple, we must keep a full image: a
+	 * tuple is droppable once it is finished for everybody (deleting xid <
+	 * runXmin), but that is xid-based -- an active snapshot whose csn
+	 * precedes the delete's commit still needs the tuple, and only the image
+	 * preserves it.
+	 *
+	 * A concurrent sequential scan is the other exception: it reconstructs
+	 * whole historical pages spanning the full pre-split key range through
+	 * the undo chain, so it needs a full image.  Fall back to one whenever a
+	 * seq scan is active on this tree.
+	 */
 	if (needsUndo)
-		undoLocation = page_add_image_to_undo(desc, p, csn,
-											  &split_key, split_key_len);
+	{
+		BTreePageHeader *php = (BTreePageHeader *) p;
+		UndoMeta   *undoMeta = get_undo_meta_by_type(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType));
+		UndoLocation retainLoc = pg_atomic_read_u64(enable_rewind ?
+													&undoMeta->minRewindRetainLocation :
+													&undoMeta->minProcRetainLocation);
+		bool		noRetainedReader = !UndoLocationIsValid(php->undoLocation) ||
+			php->undoLocation < retainLoc;
+
+		if (noRetainedReader &&
+			!page_op_drops_tuple(desc, p, csn) &&
+			meta_page_get_num_seq_scans(desc->rootInfo.metaPageBlkno) == 0)
+		{
+			csn = COMMITSEQNO_FROZEN;
+			undoLocation = InvalidUndoLocation;
+		}
+		else
+		{
+			undoLocation = page_add_image_to_undo(desc, p, csn,
+												  &split_key, split_key_len);
+		}
+	}
 	else
 		undoLocation = InvalidUndoLocation;
 

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -130,6 +130,7 @@ o_btree_find_tuple_by_key_cb(BTreeDescr *desc, void *key,
 	bool		combinedResult = false;
 	OTuple		result;
 	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
+	bool		forceFind = false;
 
 	/*
 	 * If we need to get the result from given snapshot in the past, and in
@@ -148,8 +149,10 @@ o_btree_find_tuple_by_key_cb(BTreeDescr *desc, void *key,
 						   combinedResult ? COMMITSEQNO_INPROGRESS : read_o_snapshot->csn,
 						   BTREE_PAGE_FIND_FETCH);
 
+retry:
+
 	/* Use page location hint if provided */
-	if (hint && OInMemoryBlknoIsValid(hint->blkno))
+	if (!forceFind && hint && OInMemoryBlknoIsValid(hint->blkno))
 		findResult = refind_page(&context, key, kind, 0, hint->blkno, hint->pageChangeCount);
 	else
 		findResult = find_page(&context, key, kind, 0);
@@ -231,7 +234,18 @@ o_btree_find_tuple_by_key_cb(BTreeDescr *desc, void *key,
 		 * There is no matching tuple modified by us.  So, we have to fetch
 		 * the page image from undo log as we didn't ask find_page() to do
 		 * this for us.
+		 *
+		 * The page was read partially (BTREE_PAGE_FIND_FETCH).  Differential
+		 * page-level undo images reconstruct the historical page in place
+		 * from the live page in img, so they need every chunk present; fully
+		 * materialize it first.  If the source page changed mid-load, the
+		 * find result is stale -- redo it with a fresh top-down search.
 		 */
+		if (!partial_load_full_page(&context.partial, img))
+		{
+			forceFind = true;
+			goto retry;
+		}
 		read_page_from_undo(desc, img, header->undoLocation, read_o_snapshot->csn,
 							key, kind, NULL);
 		btree_page_search(desc, img, key, kind, NULL, &loc);
@@ -1293,6 +1307,18 @@ undo_it_find_internal(UndoIterator *undoIt, void *key, BTreeKeyType kind)
 	undoLocation = undoIt->baseLoc;
 	undoIt->leftmost = true;
 	undoIt->rightmost = true;
+
+	/*
+	 * Seed the working image with the live data leaf before walking the
+	 * chain. Differential page-level undo images (UndoPageImage*Diff) do not
+	 * store page bytes; they reconstruct the historical page by transforming
+	 * the newer page in place.  Since each undo_it_find_internal() call
+	 * restarts the walk from baseLoc, it must restart from the live leaf --
+	 * mirroring the histImg re-seed in load_first_historical_page() /
+	 * load_next_historical_page(). For full images this memcpy is harmless:
+	 * they overwrite the image whole.
+	 */
+	memcpy(undoIt->image, undoIt->it->context.img, ORIOLEDB_BLCKSZ);
 
 	while (true)
 	{

--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -19,6 +19,7 @@
 #include "btree/io.h"
 #include "btree/merge.h"
 #include "btree/page_chunks.h"
+#include "btree/scan.h"
 #include "btree/undo.h"
 #include "checkpoint/checkpoint.h"
 #include "utils/page_pool.h"
@@ -64,6 +65,7 @@ btree_try_merge_pages(BTreeDescr *desc,
 	BTreePageHeader *left_header = (BTreePageHeader *) left;
 	FileExtent	right_extent;
 	CommitSeqNo csn;
+	CommitSeqNo headerCsn;
 	UndoLocation undo_loc;
 	uint32		checkpoint_number;
 	bool		copy_blkno;
@@ -130,17 +132,58 @@ btree_try_merge_pages(BTreeDescr *desc,
 		*merge_parent = false;
 	}
 
-	/* Make a page-level undo item if needed */
+	/*
+	 * Make a page-level undo item if needed.
+	 *
+	 * Like a no-drop split, a no-drop merge is invisible to readers: it only
+	 * moves the right page's tuples onto the left page without removing any.
+	 * The only reason to keep a page-level image is then to reconstruct the
+	 * pre-merge pages for a reader whose snapshot predates the merge; when
+	 * neither page's own undo location is still retained (or both are
+	 * invalid), no such reader exists.  In that case we write no image at all
+	 * and freeze the merged page with an invalid undo location: every reader
+	 * reads it live and per-tuple MVCC handles visibility (see
+	 * o_btree_insert_split()).
+	 *
+	 * If the merge physically drops a tuple, we must keep an image:
+	 * droppability is xid-based (deleting xid < runXmin), so an active
+	 * snapshot whose csn precedes the delete's commit still needs the tuple,
+	 * and only the image preserves it.  A concurrent sequential scan is the
+	 * other exception, as for a split.
+	 */
+	headerCsn = csn;
 	if (needsUndo)
 	{
-		undo_loc = make_merge_undo_image(desc, left, right, csn);
-		Assert(UndoLocationIsValid(undo_loc));
+		UndoMeta   *undoMeta = get_undo_meta_by_type(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType));
+		UndoLocation retainLoc = pg_atomic_read_u64(enable_rewind ?
+													&undoMeta->minRewindRetainLocation :
+													&undoMeta->minProcRetainLocation);
+		BTreePageHeader *right_header = (BTreePageHeader *) right;
+		bool		noRetainedReader =
+			(!UndoLocationIsValid(left_header->undoLocation) ||
+			 left_header->undoLocation < retainLoc) &&
+			(!UndoLocationIsValid(right_header->undoLocation) ||
+			 right_header->undoLocation < retainLoc);
 
-		/*
-		 * Memory barrier between making undo image and setting the undo
-		 * location.
-		 */
-		pg_write_barrier();
+		if (noRetainedReader &&
+			!page_op_drops_tuple(desc, left, csn) &&
+			!page_op_drops_tuple(desc, right, csn) &&
+			meta_page_get_num_seq_scans(desc->rootInfo.metaPageBlkno) == 0)
+		{
+			undo_loc = InvalidUndoLocation;
+			headerCsn = COMMITSEQNO_FROZEN;
+		}
+		else
+		{
+			undo_loc = make_merge_undo_image(desc, left, right, csn);
+			Assert(UndoLocationIsValid(undo_loc));
+
+			/*
+			 * Memory barrier between making undo image and setting the undo
+			 * location.
+			 */
+			pg_write_barrier();
+		}
 	}
 	else
 	{
@@ -166,7 +209,7 @@ btree_try_merge_pages(BTreeDescr *desc,
 	 * o_btree_read_page() for details.
 	 */
 	pg_write_barrier();
-	left_header->csn = csn;
+	left_header->csn = headerCsn;
 
 	Assert(checkpoint_state->stack[level].hikeyBlkno != left_blkno);
 	if (checkpoint_state->stack[level].hikeyBlkno == right_blkno)

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -193,14 +193,8 @@ partial_load_full_page(PartialPageState *partial, Page img)
 			return false;
 	}
 
-	/*
-	 * Zero the free-space tail after header->dataSize so whole page
-	 * doesn't contain undefined data. btree_page_reorg() checks this
-	 * under Valgrind.
-	 */
-	if (header->dataSize < ORIOLEDB_BLCKSZ)
-		memset((Pointer) img + header->dataSize, 0,
-			   ORIOLEDB_BLCKSZ - header->dataSize);
+	/* btree_page_reorg() checks the free-space tail is zeroed under Valgrind. */
+	null_unused_bytes(img);
 
 	partial->isPartial = false;
 	return true;

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -195,7 +195,7 @@ partial_load_full_page(PartialPageState *partial, Page img)
 
 	/*
 	 * Zero the free-space tail after header->dataSize so whole page
-	 * duesn't contain undefined data. btree_page_reorg() checks this
+	 * doesn't contain undefined data. btree_page_reorg() checks this
 	 * under Valgrind.
 	 */
 	if (header->dataSize < ORIOLEDB_BLCKSZ)

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -165,6 +165,38 @@ partial_load_chunk(PartialPageState *partial, Page img,
 	return true;
 }
 
+/*
+ * Fully materialize a partially-loaded page image: load the hikeys chunk and
+ * every data chunk from the source page, leaving `img` a complete copy.
+ *
+ * Differential page-level undo images (UndoPageImage*Diff) reconstruct the
+ * historical page in place from the live page carried in `img`, so they require
+ * every chunk present; the partial-read fast path (BTREE_PAGE_FIND_FETCH) only
+ * loads the chunks touched so far.  Returns false if the source page changed
+ * mid-load (consistency lost) -- the caller must retry the read.
+ */
+bool
+partial_load_full_page(PartialPageState *partial, Page img)
+{
+	BTreePageHeader *header = (BTreePageHeader *) img;
+	OffsetNumber i;
+
+	if (!partial->isPartial)
+		return true;
+
+	if (!partial_load_hikeys_chunk(partial, img))
+		return false;
+
+	for (i = 0; i < header->chunksCount; i++)
+	{
+		if (!partial_load_chunk(partial, img, i, NULL))
+			return false;
+	}
+
+	partial->isPartial = false;
+	return true;
+}
+
 BTreeItemPageFitType
 page_locator_fits_item(BTreeDescr *desc, Page p, BTreePageItemLocator *locator,
 					   LocationIndex size, bool replace, CommitSeqNo csn)

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -193,6 +193,15 @@ partial_load_full_page(PartialPageState *partial, Page img)
 			return false;
 	}
 
+	/*
+	 * Zero the free-space tail after header->dataSize so whole page
+	 * duesn't contain undefined data. btree_page_reorg() checks this
+	 * under Valgrind.
+	 */
+	if (header->dataSize < ORIOLEDB_BLCKSZ)
+		memset((Pointer) img + header->dataSize, 0,
+			   ORIOLEDB_BLCKSZ - header->dataSize);
+
 	partial->isPartial = false;
 	return true;
 }

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -220,13 +220,15 @@ o_btree_read_page(BTreeDescr *desc, OInMemoryBlkno blkno,
 	 *    location.  Note, that there is at least one memory barrier between
 	 *    increasing page change count and reusing the page during page unlock.
 	 */
+
 	/*
 	 * Always copy the live page into img first, then -- if it is too new for
 	 * our snapshot -- walk the page-level undo chain transforming img in
 	 * place.  Differential undo images (UndoPageImage*Diff) do not store page
-	 * bytes; they reconstruct the historical page from the newer image already
-	 * sitting in img.  So img must hold the live page before the chain walk,
-	 * which is why the former "read undo without copying" fast path is gone.
+	 * bytes; they reconstruct the historical page from the newer image
+	 * already sitting in img.  So img must hold the live page before the
+	 * chain walk, which is why the former "read undo without copying" fast
+	 * path is gone.
 	 */
 	if (!copy_page(blkno, pageChangeCount, img, partial,
 				   loadHikeysChunk, readCsn))
@@ -236,6 +238,17 @@ o_btree_read_page(BTreeDescr *desc, OInMemoryBlkno blkno,
 	if (read_undo && COMMITSEQNO_IS_NORMAL(csn) && header->csn >= csn)
 	{
 		UndoLocation pageUndoLoc;
+
+		/*
+		 * Differential page-level undo images reconstruct the historical page
+		 * in place from the live page in img, so they need every chunk
+		 * present. Fully materialize a partially-loaded page before walking
+		 * the chain; if the source page changed mid-load, report failure so
+		 * the caller refetches the downlink.
+		 */
+		if (partial && partial->isPartial &&
+			!partial_load_full_page(partial, img))
+			return false;
 
 		pageUndoLoc = read_page_from_undo(desc, img, header->undoLocation, csn,
 										  key, keyType, lokey);
@@ -302,6 +315,11 @@ o_btree_try_read_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeC
 	header = (BTreePageHeader *) img;
 	if (read_undo && COMMITSEQNO_IS_NORMAL(csn) && header->csn >= csn)
 	{
+		/* See o_btree_read_page(): differential undo images need a full page. */
+		if (partial && partial->isPartial &&
+			!partial_load_full_page(partial, img))
+			return ReadPageResultFailed;
+
 		read_page_from_undo(desc, img, header->undoLocation, csn,
 							key, keyType, NULL);
 		header = (BTreePageHeader *) img;

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -182,8 +182,6 @@ o_btree_read_page(BTreeDescr *desc, OInMemoryBlkno blkno,
 {
 	Page		p;
 	BTreePageHeader *header;
-	CommitSeqNo headerCsn;
-	UndoLocation headerUndoLocation;
 	bool		read_undo;
 
 	Assert(pageChangeCount != InvalidOPageChangeCount);
@@ -222,37 +220,19 @@ o_btree_read_page(BTreeDescr *desc, OInMemoryBlkno blkno,
 	 *    location.  Note, that there is at least one memory barrier between
 	 *    increasing page change count and reusing the page during page unlock.
 	 */
-	headerCsn = header->csn;
-
-	if (read_undo && COMMITSEQNO_IS_NORMAL(csn) && headerCsn >= csn)
-	{
-		UndoLocation pageUndoLoc;
-
-		pg_read_barrier();
-		headerUndoLocation = header->undoLocation;
-		pg_read_barrier();
-		if (header->o_header.pageChangeCount != pageChangeCount)
-			return false;
-
-		pageUndoLoc = read_page_from_undo(desc, img, headerUndoLocation, csn,
-										  key, keyType, lokey);
-		header = (BTreePageHeader *) img;
-		header->o_header.pageChangeCount = pageChangeCount;
-		if (partial)
-			partial->isPartial = false;
-		if (undoLocation)
-			*undoLocation = pageUndoLoc;
-		if (readCsn)
-			*readCsn = header->csn;
-		return true;
-	}
-
+	/*
+	 * Always copy the live page into img first, then -- if it is too new for
+	 * our snapshot -- walk the page-level undo chain transforming img in
+	 * place.  Differential undo images (UndoPageImage*Diff) do not store page
+	 * bytes; they reconstruct the historical page from the newer image already
+	 * sitting in img.  So img must hold the live page before the chain walk,
+	 * which is why the former "read undo without copying" fast path is gone.
+	 */
 	if (!copy_page(blkno, pageChangeCount, img, partial,
 				   loadHikeysChunk, readCsn))
 		return false;
 	header = (BTreePageHeader *) img;
 
-	/* Re-try reading page-level undo item due to concurrent changes */
 	if (read_undo && COMMITSEQNO_IS_NORMAL(csn) && header->csn >= csn)
 	{
 		UndoLocation pageUndoLoc;
@@ -308,33 +288,17 @@ o_btree_try_read_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeC
 
 	EA_READ_INC(blkno);
 
-	/* Check pointer to page-level undo item */
-	if (read_undo && COMMITSEQNO_IS_NORMAL(csn) && header->csn >= csn)
-	{
-		UndoLocation undoLoc;
-
-		pg_read_barrier();
-		undoLoc = header->undoLocation;
-		pg_read_barrier();
-
-		if (header->o_header.pageChangeCount != pageChangeCount)
-			return ReadPageResultWrongPageChangeCount;
-
-		read_page_from_undo(desc, img, undoLoc, csn,
-							key, keyType, NULL);
-		header = (BTreePageHeader *) img;
-		header->o_header.pageChangeCount = pageChangeCount;
-		if (readCsn)
-			*readCsn = header->csn;
-		return ReadPageResultOK;
-	}
-
+	/*
+	 * Copy the live page into img first; differential page-level undo images
+	 * reconstruct the historical page from the newer page already in img, so
+	 * the page must be present before walking the undo chain (see
+	 * o_btree_read_page()).
+	 */
 	result = try_copy_page(blkno, pageChangeCount, img, partial,
 						   loadHikeysChunk, readCsn);
 	if (result != ReadPageResultOK)
 		return result;
 
-	/* Re-try reading page-level undo item due to concurrent changes */
 	header = (BTreePageHeader *) img;
 	if (read_undo && COMMITSEQNO_IS_NORMAL(csn) && header->csn >= csn)
 	{

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -226,6 +226,14 @@ load_first_historical_page(BTreeSeqScan *scan)
 		O_TUPLE_SET_NULL(hikey.tuple);
 	O_TUPLE_SET_NULL(lokey.tuple);
 
+	/*
+	 * Seed histImg with the live page: differential page-level undo images
+	 * (UndoPageImage*Diff) reconstruct the historical page by transforming
+	 * the newer page in place, so the chain walk must start from the live
+	 * page.
+	 */
+	memcpy(scan->histImg, scan->leafImg, ORIOLEDB_BLCKSZ);
+
 	while (COMMITSEQNO_IS_NORMAL(header->csn) &&
 		   header->csn >= scan->oSnapshot.csn)
 	{
@@ -281,6 +289,15 @@ load_next_historical_page(BTreeSeqScan *scan)
 	OFixedKey	prevHikey;
 
 	copy_fixed_hikey(scan->desc, &prevHikey, scan->histImg);
+
+	/*
+	 * Re-seed histImg with the live page before reconstructing the next
+	 * historical sub-page.  Differential undo images transform the page in
+	 * place, so each reconstruction must restart from the live (merged) page
+	 * rather than the previous sub-page left in histImg.  prevHikey above was
+	 * captured from that previous sub-page first.
+	 */
+	memcpy(scan->histImg, scan->leafImg, ORIOLEDB_BLCKSZ);
 
 	while (COMMITSEQNO_IS_NORMAL(header->csn) &&
 		   header->csn >= scan->oSnapshot.csn)

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1598,7 +1598,6 @@ make_merge_undo_image(BTreeDescr *desc, Pointer left,
 		diff->leftUndoLoc = leftHeader->undoLocation;
 		diff->rightUndoLoc = rightHeader->undoLocation;
 		diff->boundaryFlags = boundary.formatFlags;
-		diff->rightRightmost = O_PAGE_IS(right, RIGHTMOST) ? 1 : 0;
 		diff->boundaryLen = boundaryLen;
 		memcpy(boundaryPtr, boundary.data, boundaryLen);
 	}

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -19,6 +19,7 @@
 #include "btree/io.h"
 #include "btree/merge.h"
 #include "btree/page_chunks.h"
+#include "btree/scan.h"
 #include "btree/undo.h"
 #include "catalog/o_sys_cache.h"
 #include "recovery/recovery.h"
@@ -48,6 +49,8 @@ static bool get_prev_leaf_header_from_undo_if_exists(UndoLogType undoType,
 static void update_leaf_header_in_undo(UndoLogType undoType,
 									   BTreeLeafTuphdr *tuphdr,
 									   UndoLocation location);
+static bool page_op_drops_tuple(BTreeDescr *desc, Pointer p,
+								CommitSeqNo imageCsn);
 
 /*
  * Add page image to the undo log.
@@ -59,10 +62,53 @@ page_add_image_to_undo(BTreeDescr *desc, Pointer p, CommitSeqNo imageCsn,
 	UndoPageImageHeader *header;
 	UndoLocation undoLocation;
 	Pointer		ptr;
+	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 
 	Assert(O_PAGE_IS(p, LEAF));
 
 	Assert(desc->undoType != UndoLogNone);
+
+	/*
+	 * Differential split: when the split drops no tuple physically, the two
+	 * post-split halves are an exact partition of the original page, so each
+	 * half can be reconstructed from the newer half carried forward in the
+	 * reader's buffer.  Store only the split key plus the original page's
+	 * undo continuation instead of a full page copy.  See
+	 * get_page_from_undo().
+	 *
+	 * A differential half only ever covers a single leaf's key range, which
+	 * is all a point lookup (MVCC) needs.  A sequential scan, however,
+	 * reconstructs whole historical pages and relies on the undo image
+	 * covering the full pre-split key range; across multi-level splits a half
+	 * cannot provide that.  So fall back to a full image whenever a
+	 * sequential scan is active on this tree -- it may read this image
+	 * through the undo chain.  (Index/range scans clip per-tuple to the
+	 * current leaf and are unaffected.)
+	 */
+	if (splitKey && !page_op_drops_tuple(desc, p, imageCsn) &&
+		meta_page_get_num_seq_scans(desc->rootInfo.metaPageBlkno) == 0)
+	{
+		BTreePageHeader *php = (BTreePageHeader *) p;
+		UndoSplitDiffData *diff;
+
+		ptr = get_undo_record(undoType, &undoLocation,
+							  O_SPLIT_DIFF_UNDO_IMAGE_SIZE(splitKeyLen));
+
+		header = (UndoPageImageHeader *) ptr;
+		header->type = UndoPageImageSplitDiff;
+		header->splitKeyFlags = splitKey->formatFlags;
+		header->splitKeyLen = splitKeyLen;
+
+		diff = (UndoSplitDiffData *) (ptr + MAXALIGN(sizeof(UndoPageImageHeader)));
+		diff->origCsn = php->csn;
+		diff->origUndoLoc = php->undoLocation;
+		memcpy((Pointer) diff + MAXALIGN(sizeof(UndoSplitDiffData)),
+			   splitKey->data, splitKeyLen);
+
+		release_reserved_undo_location(undoType);
+		return undoLocation;
+	}
+
 	if (splitKey)
 		ptr = get_undo_record(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType),
 							  &undoLocation,
@@ -1095,6 +1141,221 @@ read_hikey_from_undo(UndoLogType undoType, UndoLocation location,
 }
 
 /*
+ * Reconstruct a pre-merge half from a differential merge image.
+ *
+ * On entry `dest` holds the merged page (the newer page the undo chain walk
+ * carried forward); it is the exact union of the pre-merge left and right
+ * pages (the differential image is only written when the merge dropped no
+ * tuple).  We pick the half the caller needs (by `kind`/`key`, exactly like
+ * the full-merge case), trim `dest` to that half at the boundary key, and
+ * synthesize its header so the undo chain continues into that half's own
+ * pre-merge history.
+ */
+static void
+reconstruct_merge_diff_half(BTreeDescr *desc, UndoLocation undoLocation,
+							Pointer key, BTreeKeyType kind, Pointer dest,
+							bool *is_left, bool *is_right, OFixedKey *lokey)
+{
+	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
+	BTreePageHeader *header = (BTreePageHeader *) dest;
+	UndoMergeDiffData diff;
+	OFixedKey	boundary;
+	OFixedKey	rightHikey;
+	LocationIndex rightHikeySize = 0;
+	BTreePageItem items[BTREE_PAGE_MAX_CHUNK_ITEMS];
+	BTreePageItemLocator loc;
+	int			count = 0;
+	bool		wantRight;
+	OTuple		hikey;
+	LocationIndex hikeySize;
+
+	undo_read(undoType, undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)),
+			  sizeof(UndoMergeDiffData), (Pointer) &diff);
+	undo_read(undoType,
+			  undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)) +
+			  MAXALIGN(sizeof(UndoMergeDiffData)),
+			  diff.boundaryLen, boundary.fixedData);
+	boundary.tuple.formatFlags = diff.boundaryFlags;
+	boundary.tuple.data = boundary.fixedData;
+
+	/* Choose the half exactly as the full-merge path does. */
+	switch (kind)
+	{
+		case BTreeKeyNone:
+			wantRight = false;
+			break;
+		case BTreeKeyRightmost:
+			wantRight = true;
+			break;
+		default:
+			{
+				int			cmp_expected = (kind == BTreeKeyPageHiKey) ? 1 : 0;
+				BTreeKeyType realkind = (kind == BTreeKeyPageHiKey) ?
+					BTreeKeyNonLeafKey : kind;
+				int			cmp = o_btree_cmp(desc, key, realkind,
+											  &boundary.tuple, BTreeKeyNonLeafKey);
+
+				wantRight = (cmp >= cmp_expected);
+				break;
+			}
+	}
+
+	/*
+	 * Capture the merged page hikey before reorg overwrites it.  The right
+	 * half inherits it; the left half's hikey is the boundary key.
+	 */
+	if (!O_PAGE_IS(dest, RIGHTMOST))
+	{
+		OTuple		mhi;
+
+		BTREE_PAGE_GET_HIKEY(mhi, dest);
+		copy_fixed_key(desc, &rightHikey, mhi);
+		rightHikeySize = BTREE_PAGE_GET_HIKEY_SIZE(dest);
+	}
+	else
+		O_TUPLE_SET_NULL(rightHikey.tuple);
+
+	/* Collect the items of the requested half (M is sorted by key). */
+	BTREE_PAGE_FOREACH_ITEMS(dest, &loc)
+	{
+		OTuple		tup;
+		int			c;
+
+		BTREE_PAGE_READ_LEAF_TUPLE(tup, dest, &loc);
+		c = o_btree_cmp(desc, &tup, BTreeKeyLeafTuple,
+						&boundary.tuple, BTreeKeyNonLeafKey);
+		if ((wantRight && c >= 0) || (!wantRight && c < 0))
+		{
+			items[count].data = BTREE_PAGE_LOCATOR_GET_ITEM(dest, &loc);
+			items[count].flags = BTREE_PAGE_GET_ITEM_FLAGS(dest, &loc);
+			items[count].size = BTREE_PAGE_GET_ITEM_SIZE(dest, &loc);
+			count++;
+		}
+	}
+
+	if (wantRight)
+	{
+		header->flags &= ~O_BTREE_FLAG_LEFTMOST;
+		if (O_PAGE_IS(dest, RIGHTMOST))
+		{
+			hikeySize = 0;
+			O_TUPLE_SET_NULL(hikey);
+		}
+		else
+		{
+			hikey = rightHikey.tuple;
+			hikeySize = rightHikeySize;
+		}
+	}
+	else
+	{
+		header->flags &= ~O_BTREE_FLAG_RIGHTMOST;
+		hikey = boundary.tuple;
+		hikeySize = diff.boundaryLen;
+	}
+
+	btree_page_reorg(desc, dest, items, count, hikeySize, hikey);
+	o_btree_page_calculate_statistics(desc, dest);
+
+	header->csn = wantRight ? diff.rightCsn : diff.leftCsn;
+	header->undoLocation = wantRight ? diff.rightUndoLoc : diff.leftUndoLoc;
+
+	if (is_left)
+		*is_left = !wantRight;
+	if (is_right)
+		*is_right = wantRight;
+	if (wantRight && lokey)
+		copy_fixed_key(desc, lokey, boundary.tuple);
+}
+
+/*
+ * Reconstruct a pre-split half from a differential split image.
+ *
+ * On entry `dest` holds the post-split half the undo-chain walk carried forward
+ * (the left half [lo, splitKey) or the right half [splitKey, hi)); since the
+ * split dropped no tuple, that half is exactly the corresponding slice of the
+ * original page, so we keep `dest` as-is and only rewire its header to continue
+ * the chain into the original page's pre-split history.
+ *
+ * If that older history is a wider image (covering the original page's full
+ * range), the existing lokey/hikey machinery clips it back to this half: we set
+ * lokey to the split key on the right side (so a reader positions at splitKey),
+ * exactly as the full-image split path does, and the merge loop bounds the
+ * upper end by the leaf hikey.
+ *
+ * The two halves carry the same undo location, so is_left/is_right must
+ * distinguish them: the per-half image location O_UNDO_GET_IMAGE_LOCATION()
+ * is used by the iterator's step-left/right shortcut as an identity token to
+ * detect a single historical page spanning several current leaves.  Unlike a
+ * full split image (which returns the same wide page for both halves), each
+ * differential half is distinct, so they must yield distinct tokens or the
+ * iterator wrongly dedups one half against the other.
+ */
+static void
+reconstruct_split_diff(BTreeDescr *desc, UndoLocation undoLocation,
+					   Pointer dest, bool *is_left, bool *is_right,
+					   OFixedKey *lokey, OFixedKey *page_lokey)
+{
+	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
+	BTreePageHeader *header = (BTreePageHeader *) dest;
+	UndoPageImageHeader imgHeader;
+	UndoSplitDiffData diff;
+	OFixedKey	splitKey;
+	bool		rightHalf;
+
+	undo_read(undoType, undoLocation,
+			  sizeof(UndoPageImageHeader), (Pointer) &imgHeader);
+	undo_read(undoType, undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)),
+			  sizeof(UndoSplitDiffData), (Pointer) &diff);
+	undo_read(undoType,
+			  undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)) +
+			  MAXALIGN(sizeof(UndoSplitDiffData)),
+			  imgHeader.splitKeyLen, splitKey.fixedData);
+	splitKey.tuple.formatFlags = imgHeader.splitKeyFlags;
+	splitKey.tuple.data = splitKey.fixedData;
+
+	/*
+	 * Determine which half `dest` is from its own hikey: the left half's
+	 * hikey is exactly the split key; the right half's hikey is the original
+	 * page's (larger) hikey, or it is rightmost.
+	 */
+	if (O_PAGE_IS(dest, RIGHTMOST))
+		rightHalf = true;
+	else
+	{
+		OTuple		destHikey;
+
+		BTREE_PAGE_GET_HIKEY(destHikey, dest);
+		rightHalf = (o_btree_cmp(desc, &destHikey, BTreeKeyNonLeafKey,
+								 &splitKey.tuple, BTreeKeyNonLeafKey) != 0);
+	}
+
+	if (is_left != NULL)
+		*is_left = !rightHalf;
+	if (is_right != NULL)
+		*is_right = rightHalf;
+
+	/*
+	 * The right half's low boundary is the split key.  Report it through both
+	 * lokey (find / iterator path) and page_lokey (seq scan path) so a wider,
+	 * older image down the chain is clipped to this half.  The left half
+	 * starts at the original page's own low boundary, which the caller
+	 * already tracks.
+	 */
+	if (rightHalf)
+	{
+		if (lokey != NULL)
+			copy_fixed_key(desc, lokey, splitKey.tuple);
+		if (page_lokey != NULL)
+			copy_fixed_key(desc, page_lokey, splitKey.tuple);
+	}
+
+	/* Continue the chain into the original page's pre-split history. */
+	header->csn = diff.origCsn;
+	header->undoLocation = diff.origUndoLoc;
+}
+
+/*
  * Finds page image in undoLocation.
  */
 void
@@ -1115,6 +1376,20 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 	undo_read(undoType, undoLocation,
 			  sizeof(UndoPageImageHeader), (Pointer) &header);
 	left_loc = undoLocation + MAXALIGN(sizeof(UndoPageImageHeader));
+
+	if (header.type == UndoPageImageMergeDiff)
+	{
+		reconstruct_merge_diff_half(desc, undoLocation, key, kind, dest,
+									is_left, is_right, lokey);
+		return;
+	}
+
+	if (header.type == UndoPageImageSplitDiff)
+	{
+		reconstruct_split_diff(desc, undoLocation, dest,
+							   is_left, is_right, lokey, page_lokey);
+		return;
+	}
 
 	if (is_left != NULL)
 		*is_left = false;
@@ -1220,7 +1495,47 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 }
 
 /*
+ * Returns true if a merge or split would physically drop at least one tuple
+ * from the given page (a finished+deleted tuple whose deletion is visible to
+ * everybody as of imageCsn).  Mirrors the leaf drop condition in merge_pages()
+ * and make_split_items().
+ *
+ * When nothing is dropped, the post-op page(s) are an exact partition of the
+ * pre-op page(s), so a differential image (boundary/split key only) is
+ * sufficient: the pre-op page can be reconstructed from the newer page(s)
+ * carried forward.  When a tuple is dropped, an old snapshot may still need it,
+ * so we must fall back to a full page image.
+ */
+static bool
+page_op_drops_tuple(BTreeDescr *desc, Pointer p, CommitSeqNo imageCsn)
+{
+	BTreePageItemLocator loc;
+
+	Assert(O_PAGE_IS(p, LEAF));
+
+	BTREE_PAGE_FOREACH_ITEMS(p, &loc)
+	{
+		BTreeLeafTuphdr *tupHdr;
+
+		tupHdr = (BTreeLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
+		if (XACT_INFO_FINISHED_FOR_EVERYBODY(tupHdr->xactInfo) &&
+			tupHdr->deleted)
+		{
+			if (COMMITSEQNO_IS_INPROGRESS(imageCsn) ||
+				XACT_INFO_MAP_CSN(tupHdr->xactInfo) < imageCsn)
+				return true;
+		}
+	}
+	return false;
+}
+
+/*
  * Copy images of the left and the right pages into undo log.
+ *
+ * When the merge drops no tuple, write a compact differential image
+ * (UndoPageImageMergeDiff) holding just the boundary key and per-half undo
+ * continuation, instead of two full page copies.  get_page_from_undo()
+ * reconstructs the requested half by trimming the merged page.
  */
 UndoLocation
 make_merge_undo_image(BTreeDescr *desc, Pointer left,
@@ -1230,22 +1545,65 @@ make_merge_undo_image(BTreeDescr *desc, Pointer left,
 	UndoLocation undoLocation;
 	Pointer		undo_rec;
 	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
+	BTreePageHeader *leftHeader = (BTreePageHeader *) left;
+	BTreePageHeader *rightHeader = (BTreePageHeader *) right;
+	OTuple		boundary;
+	LocationIndex boundaryLen;
 
 	Assert(O_PAGE_IS(left, LEAF) && O_PAGE_IS(right, LEAF));
-
+	/* Left always has a right sibling here, so it is never rightmost. */
+	Assert(!O_PAGE_IS(left, RIGHTMOST));
 	Assert(undoType != UndoLogNone);
-	undo_rec = get_undo_record(GET_PAGE_LEVEL_UNDO_TYPE(undoType),
-							   &undoLocation, O_MERGE_UNDO_IMAGE_SIZE);
+
+	if (page_op_drops_tuple(desc, left, imageCsn) ||
+		page_op_drops_tuple(desc, right, imageCsn))
+	{
+		/*
+		 * Full two-page image required: an old snapshot may need a dropped
+		 * tuple.
+		 */
+		undo_rec = get_undo_record(undoType, &undoLocation,
+								   O_MERGE_UNDO_IMAGE_SIZE);
+
+		header = (UndoPageImageHeader *) undo_rec;
+		header->type = UndoPageImageMerge;
+		undo_rec = undo_rec + MAXALIGN(sizeof(UndoPageImageHeader));
+
+		memcpy(undo_rec, left, ORIOLEDB_BLCKSZ);
+		memcpy(undo_rec + ORIOLEDB_BLCKSZ, right, ORIOLEDB_BLCKSZ);
+
+		release_reserved_undo_location(undoType);
+		return undoLocation;
+	}
+
+	/* Differential image: boundary key is the left page's hikey. */
+	BTREE_PAGE_GET_HIKEY(boundary, left);
+	boundaryLen = BTREE_PAGE_GET_HIKEY_SIZE(left);
+
+	undo_rec = get_undo_record(undoType, &undoLocation,
+							   O_MERGE_DIFF_UNDO_IMAGE_SIZE(boundaryLen));
 
 	header = (UndoPageImageHeader *) undo_rec;
-	header->type = UndoPageImageMerge;
-	undo_rec = undo_rec + MAXALIGN(sizeof(UndoPageImageHeader));
+	header->type = UndoPageImageMergeDiff;
+	header->splitKeyFlags = 0;
+	header->splitKeyLen = 0;
 
-	memcpy(undo_rec, left, ORIOLEDB_BLCKSZ);
-	memcpy(undo_rec + ORIOLEDB_BLCKSZ, right, ORIOLEDB_BLCKSZ);
+	{
+		UndoMergeDiffData *diff = (UndoMergeDiffData *)
+			(undo_rec + MAXALIGN(sizeof(UndoPageImageHeader)));
+		Pointer		boundaryPtr = (Pointer) diff + MAXALIGN(sizeof(UndoMergeDiffData));
 
-	release_reserved_undo_location(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType));
+		diff->leftCsn = leftHeader->csn;
+		diff->rightCsn = rightHeader->csn;
+		diff->leftUndoLoc = leftHeader->undoLocation;
+		diff->rightUndoLoc = rightHeader->undoLocation;
+		diff->boundaryFlags = boundary.formatFlags;
+		diff->rightRightmost = O_PAGE_IS(right, RIGHTMOST) ? 1 : 0;
+		diff->boundaryLen = boundaryLen;
+		memcpy(boundaryPtr, boundary.data, boundaryLen);
+	}
 
+	release_reserved_undo_location(undoType);
 	return undoLocation;
 }
 

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1544,8 +1544,10 @@ make_merge_undo_image(BTreeDescr *desc, Pointer left,
 					  Pointer right, CommitSeqNo imageCsn)
 {
 	UndoPageImageHeader *header;
+	UndoMergeDiffData *diff;
 	UndoLocation undoLocation;
 	Pointer		undo_rec;
+	Pointer		boundaryPtr;
 	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 	BTreePageHeader *leftHeader = (BTreePageHeader *) left;
 	BTreePageHeader *rightHeader = (BTreePageHeader *) right;
@@ -1590,20 +1592,17 @@ make_merge_undo_image(BTreeDescr *desc, Pointer left,
 	header->splitKeyFlags = 0;
 	header->splitKeyLen = 0;
 
-	{
-		UndoMergeDiffData *diff = (UndoMergeDiffData *)
-			(undo_rec + MAXALIGN(sizeof(UndoPageImageHeader)));
-		Pointer		boundaryPtr = (Pointer) diff + MAXALIGN(sizeof(UndoMergeDiffData));
+	diff = (UndoMergeDiffData *) (undo_rec + MAXALIGN(sizeof(UndoPageImageHeader)));
+	boundaryPtr = (Pointer) diff + MAXALIGN(sizeof(UndoMergeDiffData));
 
-		memset(diff, 0, sizeof(*diff));
-		diff->leftCsn = leftHeader->csn;
-		diff->rightCsn = rightHeader->csn;
-		diff->leftUndoLoc = leftHeader->undoLocation;
-		diff->rightUndoLoc = rightHeader->undoLocation;
-		diff->boundaryFlags = boundary.formatFlags;
-		diff->boundaryLen = boundaryLen;
-		memcpy(boundaryPtr, boundary.data, boundaryLen);
-	}
+	memset(diff, 0, sizeof(*diff));
+	diff->leftCsn = leftHeader->csn;
+	diff->rightCsn = rightHeader->csn;
+	diff->leftUndoLoc = leftHeader->undoLocation;
+	diff->rightUndoLoc = rightHeader->undoLocation;
+	diff->boundaryFlags = boundary.formatFlags;
+	diff->boundaryLen = boundaryLen;
+	memcpy(boundaryPtr, boundary.data, boundaryLen);
 
 	release_reserved_undo_location(undoType);
 	return undoLocation;

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1171,6 +1171,7 @@ reconstruct_merge_diff_half(BTreeDescr *desc, UndoLocation undoLocation,
 
 	undo_read(undoType, undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)),
 			  sizeof(UndoMergeDiffData), (Pointer) &diff);
+	Assert(diff.boundaryLen <= O_BTREE_MAX_KEY_SIZE);
 	undo_read(undoType,
 			  undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)) +
 			  MAXALIGN(sizeof(UndoMergeDiffData)),
@@ -1305,6 +1306,7 @@ reconstruct_split_diff(BTreeDescr *desc, UndoLocation undoLocation,
 
 	undo_read(undoType, undoLocation,
 			  sizeof(UndoPageImageHeader), (Pointer) &imgHeader);
+	Assert(imgHeader.splitKeyLen <= O_BTREE_MAX_KEY_SIZE);
 	undo_read(undoType, undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)),
 			  sizeof(UndoSplitDiffData), (Pointer) &diff);
 	undo_read(undoType,

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1595,6 +1595,7 @@ make_merge_undo_image(BTreeDescr *desc, Pointer left,
 			(undo_rec + MAXALIGN(sizeof(UndoPageImageHeader)));
 		Pointer		boundaryPtr = (Pointer) diff + MAXALIGN(sizeof(UndoMergeDiffData));
 
+		memset(diff, 0, sizeof(*diff));
 		diff->leftCsn = leftHeader->csn;
 		diff->rightCsn = rightHeader->csn;
 		diff->leftUndoLoc = leftHeader->undoLocation;

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -49,8 +49,6 @@ static bool get_prev_leaf_header_from_undo_if_exists(UndoLogType undoType,
 static void update_leaf_header_in_undo(UndoLogType undoType,
 									   BTreeLeafTuphdr *tuphdr,
 									   UndoLocation location);
-static bool page_op_drops_tuple(BTreeDescr *desc, Pointer p,
-								CommitSeqNo imageCsn);
 
 /*
  * Add page image to the undo log.
@@ -1505,7 +1503,7 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
  * carried forward.  When a tuple is dropped, an old snapshot may still need it,
  * so we must fall back to a full page image.
  */
-static bool
+bool
 page_op_drops_tuple(BTreeDescr *desc, Pointer p, CommitSeqNo imageCsn)
 {
 	BTreePageItemLocator loc;

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -59,7 +59,6 @@ UndoLocation
 page_add_image_to_undo(BTreeDescr *desc, Pointer p, CommitSeqNo imageCsn,
 					   OTuple *splitKey, LocationIndex splitKeyLen)
 {
-	UndoPageImageHeader *header;
 	UndoLocation undoLocation;
 	Pointer		ptr;
 	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
@@ -89,55 +88,54 @@ page_add_image_to_undo(BTreeDescr *desc, Pointer p, CommitSeqNo imageCsn,
 		meta_page_get_num_seq_scans(desc->rootInfo.metaPageBlkno) == 0)
 	{
 		BTreePageHeader *php = (BTreePageHeader *) p;
-		UndoSplitDiffData *diff;
+		UndoPageImageSplitDiffHeader *sdHeader;
 
 		ptr = get_undo_record(undoType, &undoLocation,
 							  O_SPLIT_DIFF_UNDO_IMAGE_SIZE(splitKeyLen));
 
-		header = (UndoPageImageHeader *) ptr;
-		header->type = UndoPageImageSplitDiff;
-		header->splitKeyFlags = splitKey->formatFlags;
-		header->splitKeyLen = splitKeyLen;
-
-		diff = (UndoSplitDiffData *) (ptr + MAXALIGN(sizeof(UndoPageImageHeader)));
-		diff->origCsn = php->csn;
-		diff->origUndoLoc = php->undoLocation;
-		memcpy((Pointer) diff + MAXALIGN(sizeof(UndoSplitDiffData)),
-			   splitKey->data, splitKeyLen);
+		sdHeader = (UndoPageImageSplitDiffHeader *) ptr;
+		memset(sdHeader, 0, sizeof(*sdHeader));
+		sdHeader->type = UndoPageImageSplitDiff;
+		sdHeader->splitKeyFlags = splitKey->formatFlags;
+		sdHeader->splitKeyLen = splitKeyLen;
+		sdHeader->origCsn = php->csn;
+		sdHeader->origUndoLoc = php->undoLocation;
+		memcpy(ptr + MAXALIGN(sizeof(*sdHeader)), splitKey->data, splitKeyLen);
 
 		release_reserved_undo_location(undoType);
 		return undoLocation;
 	}
 
 	if (splitKey)
-		ptr = get_undo_record(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType),
-							  &undoLocation,
-							  O_SPLIT_UNDO_IMAGE_SIZE(splitKeyLen));
-	else
-		ptr = get_undo_record(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType),
-							  &undoLocation,
-							  O_COMPACT_UNDO_IMAGE_SIZE);
+	{
+		UndoPageImageSplitHeader *splitHeader;
 
-	header = (UndoPageImageHeader *) ptr;
-	if (splitKey)
-	{
-		header->type = UndoPageImageSplit;
-		header->splitKeyFlags = splitKey->formatFlags;
-		header->splitKeyLen = splitKeyLen;
-	}
-	else
-	{
-		header->type = UndoPageImageCompact;
-	}
-	ptr += MAXALIGN(sizeof(UndoPageImageHeader));
-	memcpy(ptr, p, ORIOLEDB_BLCKSZ);
-	if (splitKey)
-	{
+		ptr = get_undo_record(undoType, &undoLocation,
+							  O_SPLIT_UNDO_IMAGE_SIZE(splitKeyLen));
+
+		splitHeader = (UndoPageImageSplitHeader *) ptr;
+		splitHeader->type = UndoPageImageSplit;
+		splitHeader->splitKeyFlags = splitKey->formatFlags;
+		splitHeader->splitKeyLen = splitKeyLen;
+		ptr += MAXALIGN(sizeof(*splitHeader));
+		memcpy(ptr, p, ORIOLEDB_BLCKSZ);
 		ptr += ORIOLEDB_BLCKSZ;
 		memcpy(ptr, splitKey->data, splitKeyLen);
 	}
+	else
+	{
+		UndoPageImageHeader *header;
 
-	release_reserved_undo_location(GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType));
+		ptr = get_undo_record(undoType, &undoLocation,
+							  O_COMPACT_UNDO_IMAGE_SIZE);
+
+		header = (UndoPageImageHeader *) ptr;
+		header->type = UndoPageImageCompact;
+		ptr += MAXALIGN(sizeof(*header));
+		memcpy(ptr, p, ORIOLEDB_BLCKSZ);
+	}
+
+	release_reserved_undo_location(undoType);
 
 	return undoLocation;
 }
@@ -1158,7 +1156,7 @@ reconstruct_merge_diff_half(BTreeDescr *desc, UndoLocation undoLocation,
 {
 	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 	BTreePageHeader *header = (BTreePageHeader *) dest;
-	UndoMergeDiffData diff;
+	UndoPageImageMergeDiffHeader mdHeader;
 	OFixedKey	boundary;
 	OFixedKey	rightHikey;
 	LocationIndex rightHikeySize = 0;
@@ -1169,14 +1167,12 @@ reconstruct_merge_diff_half(BTreeDescr *desc, UndoLocation undoLocation,
 	OTuple		hikey;
 	LocationIndex hikeySize;
 
-	undo_read(undoType, undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)),
-			  sizeof(UndoMergeDiffData), (Pointer) &diff);
-	Assert(diff.boundaryLen <= O_BTREE_MAX_KEY_SIZE);
-	undo_read(undoType,
-			  undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)) +
-			  MAXALIGN(sizeof(UndoMergeDiffData)),
-			  diff.boundaryLen, boundary.fixedData);
-	boundary.tuple.formatFlags = diff.boundaryFlags;
+	undo_read(undoType, undoLocation,
+			  sizeof(mdHeader), (Pointer) &mdHeader);
+	Assert(mdHeader.boundaryLen <= O_BTREE_MAX_KEY_SIZE);
+	undo_read(undoType, undoLocation + MAXALIGN(sizeof(mdHeader)),
+			  mdHeader.boundaryLen, boundary.fixedData);
+	boundary.tuple.formatFlags = mdHeader.boundaryFlags;
 	boundary.tuple.data = boundary.fixedData;
 
 	/* Choose the half exactly as the full-merge path does. */
@@ -1252,14 +1248,14 @@ reconstruct_merge_diff_half(BTreeDescr *desc, UndoLocation undoLocation,
 	{
 		header->flags &= ~O_BTREE_FLAG_RIGHTMOST;
 		hikey = boundary.tuple;
-		hikeySize = diff.boundaryLen;
+		hikeySize = mdHeader.boundaryLen;
 	}
 
 	btree_page_reorg(desc, dest, items, count, hikeySize, hikey);
 	o_btree_page_calculate_statistics(desc, dest);
 
-	header->csn = wantRight ? diff.rightCsn : diff.leftCsn;
-	header->undoLocation = wantRight ? diff.rightUndoLoc : diff.leftUndoLoc;
+	header->csn = wantRight ? mdHeader.rightCsn : mdHeader.leftCsn;
+	header->undoLocation = wantRight ? mdHeader.rightUndoLoc : mdHeader.leftUndoLoc;
 
 	if (is_left)
 		*is_left = !wantRight;
@@ -1299,21 +1295,16 @@ reconstruct_split_diff(BTreeDescr *desc, UndoLocation undoLocation,
 {
 	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 	BTreePageHeader *header = (BTreePageHeader *) dest;
-	UndoPageImageHeader imgHeader;
-	UndoSplitDiffData diff;
+	UndoPageImageSplitDiffHeader sdHeader;
 	OFixedKey	splitKey;
 	bool		rightHalf;
 
 	undo_read(undoType, undoLocation,
-			  sizeof(UndoPageImageHeader), (Pointer) &imgHeader);
-	Assert(imgHeader.splitKeyLen <= O_BTREE_MAX_KEY_SIZE);
-	undo_read(undoType, undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)),
-			  sizeof(UndoSplitDiffData), (Pointer) &diff);
-	undo_read(undoType,
-			  undoLocation + MAXALIGN(sizeof(UndoPageImageHeader)) +
-			  MAXALIGN(sizeof(UndoSplitDiffData)),
-			  imgHeader.splitKeyLen, splitKey.fixedData);
-	splitKey.tuple.formatFlags = imgHeader.splitKeyFlags;
+			  sizeof(sdHeader), (Pointer) &sdHeader);
+	Assert(sdHeader.splitKeyLen <= O_BTREE_MAX_KEY_SIZE);
+	undo_read(undoType, undoLocation + MAXALIGN(sizeof(sdHeader)),
+			  sdHeader.splitKeyLen, splitKey.fixedData);
+	splitKey.tuple.formatFlags = sdHeader.splitKeyFlags;
 	splitKey.tuple.data = splitKey.fixedData;
 
 	/*
@@ -1353,8 +1344,8 @@ reconstruct_split_diff(BTreeDescr *desc, UndoLocation undoLocation,
 	}
 
 	/* Continue the chain into the original page's pre-split history. */
-	header->csn = diff.origCsn;
-	header->undoLocation = diff.origUndoLoc;
+	header->csn = sdHeader.origCsn;
+	header->undoLocation = sdHeader.origUndoLoc;
 }
 
 /*
@@ -1366,7 +1357,13 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 				   bool *is_left, bool *is_right, OFixedKey *lokey,
 				   OFixedKey *page_lokey, OTuple *page_hikey)
 {
-	UndoPageImageHeader header = {UndoPageImageInvalid, 0, 0};
+	/*
+	 * Read enough bytes to cover the peek header and (if this is a full Split)
+	 * its splitKeyFlags/splitKeyLen.  Compact/Merge/diff records are all at
+	 * least this long, so a single read works regardless of type; diff types
+	 * read their own larger headers in the reconstructor.
+	 */
+	UndoPageImageSplitHeader header = {UndoPageImageInvalid, 0, 0};
 	int			cmp,
 				cmp_expected;
 	OTuple		hikey;
@@ -1375,9 +1372,8 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 	LocationIndex loc = 0;
 	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 
-	undo_read(undoType, undoLocation,
-			  sizeof(UndoPageImageHeader), (Pointer) &header);
-	left_loc = undoLocation + MAXALIGN(sizeof(UndoPageImageHeader));
+	undo_read(undoType, undoLocation, sizeof(header), (Pointer) &header);
+	left_loc = undoLocation + MAXALIGN(sizeof(header));
 
 	if (header.type == UndoPageImageMergeDiff)
 	{
@@ -1543,11 +1539,9 @@ UndoLocation
 make_merge_undo_image(BTreeDescr *desc, Pointer left,
 					  Pointer right, CommitSeqNo imageCsn)
 {
-	UndoPageImageHeader *header;
-	UndoMergeDiffData *diff;
+	UndoPageImageMergeDiffHeader *mdHeader;
 	UndoLocation undoLocation;
 	Pointer		undo_rec;
-	Pointer		boundaryPtr;
 	UndoLogType undoType = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 	BTreePageHeader *leftHeader = (BTreePageHeader *) left;
 	BTreePageHeader *rightHeader = (BTreePageHeader *) right;
@@ -1566,12 +1560,14 @@ make_merge_undo_image(BTreeDescr *desc, Pointer left,
 		 * Full two-page image required: an old snapshot may need a dropped
 		 * tuple.
 		 */
+		UndoPageImageHeader *header;
+
 		undo_rec = get_undo_record(undoType, &undoLocation,
 								   O_MERGE_UNDO_IMAGE_SIZE);
 
 		header = (UndoPageImageHeader *) undo_rec;
 		header->type = UndoPageImageMerge;
-		undo_rec = undo_rec + MAXALIGN(sizeof(UndoPageImageHeader));
+		undo_rec = undo_rec + MAXALIGN(sizeof(*header));
 
 		memcpy(undo_rec, left, ORIOLEDB_BLCKSZ);
 		memcpy(undo_rec + ORIOLEDB_BLCKSZ, right, ORIOLEDB_BLCKSZ);
@@ -1587,22 +1583,16 @@ make_merge_undo_image(BTreeDescr *desc, Pointer left,
 	undo_rec = get_undo_record(undoType, &undoLocation,
 							   O_MERGE_DIFF_UNDO_IMAGE_SIZE(boundaryLen));
 
-	header = (UndoPageImageHeader *) undo_rec;
-	header->type = UndoPageImageMergeDiff;
-	header->splitKeyFlags = 0;
-	header->splitKeyLen = 0;
-
-	diff = (UndoMergeDiffData *) (undo_rec + MAXALIGN(sizeof(UndoPageImageHeader)));
-	boundaryPtr = (Pointer) diff + MAXALIGN(sizeof(UndoMergeDiffData));
-
-	memset(diff, 0, sizeof(*diff));
-	diff->leftCsn = leftHeader->csn;
-	diff->rightCsn = rightHeader->csn;
-	diff->leftUndoLoc = leftHeader->undoLocation;
-	diff->rightUndoLoc = rightHeader->undoLocation;
-	diff->boundaryFlags = boundary.formatFlags;
-	diff->boundaryLen = boundaryLen;
-	memcpy(boundaryPtr, boundary.data, boundaryLen);
+	mdHeader = (UndoPageImageMergeDiffHeader *) undo_rec;
+	memset(mdHeader, 0, sizeof(*mdHeader));
+	mdHeader->type = UndoPageImageMergeDiff;
+	mdHeader->boundaryFlags = boundary.formatFlags;
+	mdHeader->boundaryLen = boundaryLen;
+	mdHeader->leftCsn = leftHeader->csn;
+	mdHeader->rightCsn = rightHeader->csn;
+	mdHeader->leftUndoLoc = leftHeader->undoLocation;
+	mdHeader->rightUndoLoc = rightHeader->undoLocation;
+	memcpy(undo_rec + MAXALIGN(sizeof(*mdHeader)), boundary.data, boundaryLen);
 
 	release_reserved_undo_location(undoType);
 	return undoLocation;

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -114,6 +114,7 @@ page_add_image_to_undo(BTreeDescr *desc, Pointer p, CommitSeqNo imageCsn,
 							  O_SPLIT_UNDO_IMAGE_SIZE(splitKeyLen));
 
 		splitHeader = (UndoPageImageSplitHeader *) ptr;
+		memset(splitHeader, 0, sizeof(*splitHeader));
 		splitHeader->type = UndoPageImageSplit;
 		splitHeader->splitKeyFlags = splitKey->formatFlags;
 		splitHeader->splitKeyLen = splitKeyLen;
@@ -1358,10 +1359,10 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 				   OFixedKey *page_lokey, OTuple *page_hikey)
 {
 	/*
-	 * Read enough bytes to cover the peek header and (if this is a full Split)
-	 * its splitKeyFlags/splitKeyLen.  Compact/Merge/diff records are all at
-	 * least this long, so a single read works regardless of type; diff types
-	 * read their own larger headers in the reconstructor.
+	 * Read enough bytes to cover the peek header and (if this is a full
+	 * Split) its splitKeyFlags/splitKeyLen.  Compact/Merge/diff records are
+	 * all at least this long, so a single read works regardless of type; diff
+	 * types read their own larger headers in the reconstructor.
 	 */
 	UndoPageImageSplitHeader header = {UndoPageImageInvalid, 0, 0};
 	int			cmp,

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -1259,8 +1259,14 @@ o_sys_xid_undo_location_tuple_print(BTreeDescr *desc, StringInfo buf, OTuple tup
 {
 	ReplicationRetainUndoTuple *tuple = (ReplicationRetainUndoTuple *) tup.data;
 
-	appendStringInfo(buf, "(%u, " UINT64_FORMAT ")",
-					 tuple->xid, tuple->undoLocation);
+	/*
+	 * The undo location is an absolute offset into the undo log, which shifts
+	 * with any change to undo allocation (e.g. differential page-level undo
+	 * images consume less space).  Mask it so the structure dump stays stable
+	 * across such layout changes; the actual value is verified separately via
+	 * orioledb_read_sys_xid_undo_location().
+	 */
+	appendStringInfo(buf, "(%u, X)", tuple->xid);
 }
 
 static JsonbValue *

--- a/test/expected/btree_sys_check.out
+++ b/test/expected/btree_sys_check.out
@@ -728,24 +728,24 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 296, tuple = (730, 0)                         +
-     Item 1: offset = 328, tuple = (734, 96)                        +
-     Item 2: offset = 360, tuple = (735, 26944)                     +
-     Item 3: offset = 392, tuple = (736, 29344)                     +
-     Item 4: offset = 424, tuple = (737, 29800)                     +
-     Item 5: offset = 456, tuple = (739, 30368)                     +
-     Item 6: offset = 488, tuple = (740, 31360)                     +
-     Item 7: offset = 520, tuple = (743, 31520)                     +
-     Item 8: offset = 552, tuple = (744, 52240)                     +
-     Item 9: offset = 584, tuple = (745, 55144)                     +
-     Item 10: offset = 616, tuple = (746, 55592)                    +
-     Item 11: offset = 648, tuple = (747, 58328)                    +
-     Item 12: offset = 680, tuple = (1000, 2000)                    +
-     Item 13: offset = 712, tuple = (1001, 2001)                    +
-     Item 14: offset = 744, tuple = (1002, 2002)                    +
-     Item 15: offset = 776, tuple = (1003, 2003)                    +
-     Item 16: offset = 808, tuple = (1005, 2005)                    +
-     Item 17: offset = 840, tuple = (1006, 2006)                    +
+     Item 0: offset = 296, tuple = (730, X)                         +
+     Item 1: offset = 328, tuple = (734, X)                         +
+     Item 2: offset = 360, tuple = (735, X)                         +
+     Item 3: offset = 392, tuple = (736, X)                         +
+     Item 4: offset = 424, tuple = (737, X)                         +
+     Item 5: offset = 456, tuple = (739, X)                         +
+     Item 6: offset = 488, tuple = (740, X)                         +
+     Item 7: offset = 520, tuple = (743, X)                         +
+     Item 8: offset = 552, tuple = (744, X)                         +
+     Item 9: offset = 584, tuple = (745, X)                         +
+     Item 10: offset = 616, tuple = (746, X)                        +
+     Item 11: offset = 648, tuple = (747, X)                        +
+     Item 12: offset = 680, tuple = (1000, X)                       +
+     Item 13: offset = 712, tuple = (1001, X)                       +
+     Item 14: offset = 744, tuple = (1002, X)                       +
+     Item 15: offset = 776, tuple = (1003, X)                       +
+     Item 16: offset = 808, tuple = (1005, X)                       +
+     Item 17: offset = 840, tuple = (1006, X)                       +
                                                                     +
  
 (1 row)
@@ -764,8 +764,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
                                                                     +
  
 (1 row)
@@ -785,8 +785,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
                                                                     +
  
 (1 row)
@@ -805,9 +805,9 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
-     Item 2: offset = 328, tuple = (1009, 2009)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
+     Item 2: offset = 328, tuple = (1009, X)                        +
                                                                     +
  
 (1 row)
@@ -832,8 +832,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1008, 2008)                     +
-     Item 1: offset = 296, tuple = (1009, 2009)                     +
+     Item 0: offset = 264, tuple = (1008, X)                        +
+     Item 1: offset = 296, tuple = (1009, X)                        +
                                                                     +
  
 (1 row)

--- a/test/expected/btree_sys_check_1.out
+++ b/test/expected/btree_sys_check_1.out
@@ -727,24 +727,24 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 296, tuple = (738, 0)                         +
-     Item 1: offset = 328, tuple = (742, 96)                        +
-     Item 2: offset = 360, tuple = (743, 26944)                     +
-     Item 3: offset = 392, tuple = (744, 29344)                     +
-     Item 4: offset = 424, tuple = (745, 29800)                     +
-     Item 5: offset = 456, tuple = (747, 30368)                     +
-     Item 6: offset = 488, tuple = (748, 31360)                     +
-     Item 7: offset = 520, tuple = (751, 31520)                     +
-     Item 8: offset = 552, tuple = (752, 52240)                     +
-     Item 9: offset = 584, tuple = (753, 55144)                     +
-     Item 10: offset = 616, tuple = (754, 55592)                    +
-     Item 11: offset = 648, tuple = (755, 58328)                    +
-     Item 12: offset = 680, tuple = (1000, 2000)                    +
-     Item 13: offset = 712, tuple = (1001, 2001)                    +
-     Item 14: offset = 744, tuple = (1002, 2002)                    +
-     Item 15: offset = 776, tuple = (1003, 2003)                    +
-     Item 16: offset = 808, tuple = (1005, 2005)                    +
-     Item 17: offset = 840, tuple = (1006, 2006)                    +
+     Item 0: offset = 296, tuple = (738, X)                         +
+     Item 1: offset = 328, tuple = (742, X)                         +
+     Item 2: offset = 360, tuple = (743, X)                         +
+     Item 3: offset = 392, tuple = (744, X)                         +
+     Item 4: offset = 424, tuple = (745, X)                         +
+     Item 5: offset = 456, tuple = (747, X)                         +
+     Item 6: offset = 488, tuple = (748, X)                         +
+     Item 7: offset = 520, tuple = (751, X)                         +
+     Item 8: offset = 552, tuple = (752, X)                         +
+     Item 9: offset = 584, tuple = (753, X)                         +
+     Item 10: offset = 616, tuple = (754, X)                        +
+     Item 11: offset = 648, tuple = (755, X)                        +
+     Item 12: offset = 680, tuple = (1000, X)                       +
+     Item 13: offset = 712, tuple = (1001, X)                       +
+     Item 14: offset = 744, tuple = (1002, X)                       +
+     Item 15: offset = 776, tuple = (1003, X)                       +
+     Item 16: offset = 808, tuple = (1005, X)                       +
+     Item 17: offset = 840, tuple = (1006, X)                       +
                                                                     +
  
 (1 row)
@@ -763,8 +763,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
                                                                     +
  
 (1 row)
@@ -784,8 +784,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
                                                                     +
  
 (1 row)
@@ -804,9 +804,9 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
-     Item 2: offset = 328, tuple = (1009, 2009)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
+     Item 2: offset = 328, tuple = (1009, X)                        +
                                                                     +
  
 (1 row)
@@ -831,8 +831,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1008, 2008)                     +
-     Item 1: offset = 296, tuple = (1009, 2009)                     +
+     Item 0: offset = 264, tuple = (1008, X)                        +
+     Item 1: offset = 296, tuple = (1009, X)                        +
                                                                     +
  
 (1 row)

--- a/test/expected/btree_sys_check_2.out
+++ b/test/expected/btree_sys_check_2.out
@@ -723,24 +723,24 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 296, tuple = (752, 0)                         +
-     Item 1: offset = 328, tuple = (756, 96)                        +
-     Item 2: offset = 360, tuple = (757, 35184)                     +
-     Item 3: offset = 392, tuple = (758, 37584)                     +
-     Item 4: offset = 424, tuple = (759, 38040)                     +
-     Item 5: offset = 456, tuple = (761, 38608)                     +
-     Item 6: offset = 488, tuple = (762, 39600)                     +
-     Item 7: offset = 520, tuple = (765, 39760)                     +
-     Item 8: offset = 552, tuple = (766, 60576)                     +
-     Item 9: offset = 584, tuple = (767, 65104)                     +
-     Item 10: offset = 616, tuple = (768, 65552)                    +
-     Item 11: offset = 648, tuple = (769, 68288)                    +
-     Item 12: offset = 680, tuple = (1000, 2000)                    +
-     Item 13: offset = 712, tuple = (1001, 2001)                    +
-     Item 14: offset = 744, tuple = (1002, 2002)                    +
-     Item 15: offset = 776, tuple = (1003, 2003)                    +
-     Item 16: offset = 808, tuple = (1005, 2005)                    +
-     Item 17: offset = 840, tuple = (1006, 2006)                    +
+     Item 0: offset = 296, tuple = (752, X)                         +
+     Item 1: offset = 328, tuple = (756, X)                         +
+     Item 2: offset = 360, tuple = (757, X)                         +
+     Item 3: offset = 392, tuple = (758, X)                         +
+     Item 4: offset = 424, tuple = (759, X)                         +
+     Item 5: offset = 456, tuple = (761, X)                         +
+     Item 6: offset = 488, tuple = (762, X)                         +
+     Item 7: offset = 520, tuple = (765, X)                         +
+     Item 8: offset = 552, tuple = (766, X)                         +
+     Item 9: offset = 584, tuple = (767, X)                         +
+     Item 10: offset = 616, tuple = (768, X)                        +
+     Item 11: offset = 648, tuple = (769, X)                        +
+     Item 12: offset = 680, tuple = (1000, X)                       +
+     Item 13: offset = 712, tuple = (1001, X)                       +
+     Item 14: offset = 744, tuple = (1002, X)                       +
+     Item 15: offset = 776, tuple = (1003, X)                       +
+     Item 16: offset = 808, tuple = (1005, X)                       +
+     Item 17: offset = 840, tuple = (1006, X)                       +
                                                                     +
  
 (1 row)
@@ -759,8 +759,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
                                                                     +
  
 (1 row)
@@ -780,8 +780,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
                                                                     +
  
 (1 row)
@@ -800,9 +800,9 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1005, 2005)                     +
-     Item 1: offset = 296, tuple = (1006, 2006)                     +
-     Item 2: offset = 328, tuple = (1009, 2009)                     +
+     Item 0: offset = 264, tuple = (1005, X)                        +
+     Item 1: offset = 296, tuple = (1006, X)                        +
+     Item 2: offset = 328, tuple = (1009, X)                        +
                                                                     +
  
 (1 row)
@@ -827,8 +827,8 @@ SELECT orioledb_sys_tree_structure(23, 'ne');
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 264, tuple = (1008, 2008)                     +
-     Item 1: offset = 296, tuple = (1009, 2009)                     +
+     Item 0: offset = 264, tuple = (1008, X)                        +
+     Item 1: offset = 296, tuple = (1009, X)                        +
                                                                     +
  
 (1 row)

--- a/test/expected/skipundo.out
+++ b/test/expected/skipundo.out
@@ -1,0 +1,99 @@
+Parsed test spec with 2 sessions
+
+starting permutation: bs_s1_setup bs_s2_setup bs_s1_seed bs_s1_evict bs_s1_arm_refind bs_s2_bscan bs_s1_insert_low1 bs_s1_insert_low2 bs_s1_continue
+step bs_s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET application_name = 's1';
+
+step bs_s2_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET application_name = 's2';
+	SET enable_seqscan = off;
+
+step bs_s1_seed: 
+	INSERT INTO o_skipfb
+		(SELECT id || repeat('x', 2600)
+		 FROM generate_series(18, 21, 1) id);
+
+step bs_s1_evict: 
+	SELECT orioledb_evict_pages('o_skipfb'::regclass, 1);
+
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step bs_s1_arm_refind: 
+	SELECT pg_stopevent_set('load_page_refind',
+		'$.level == 0 && $applicationName == "s2"');
+
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step bs_s2_bscan: 
+	SELECT substr(id, 1, 2) FROM o_skipfb ORDER BY id DESC;
+ <waiting ...>
+step bs_s1_insert_low1: 
+	INSERT INTO o_skipfb
+		(SELECT id || repeat('x', 2600)
+		 FROM generate_series(10, 13, 1) id);
+
+step bs_s1_insert_low2: 
+	INSERT INTO o_skipfb
+		(SELECT id || repeat('x', 2600)
+		 FROM generate_series(14, 17, 1) id);
+
+step bs_s1_continue: 
+	SELECT pg_stopevent_reset('load_page_refind');
+
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step bs_s2_bscan: <... completed>
+substr
+------
+    21
+    20
+    19
+    18
+(4 rows)
+
+
+starting permutation: sr_s1_seed sr_s1_begin sr_s1_take_snap sr_s2_split_inserts sr_s2_deletes sr_s1_seqscan sr_s1_commit
+step sr_s1_seed: 
+	INSERT INTO o_skipss
+		(SELECT i, repeat('p', 1000)
+		 FROM generate_series(1, 200, 1) id(i));
+
+step sr_s1_begin: BEGIN ISOLATION LEVEL REPEATABLE READ;
+step sr_s1_take_snap: 
+	SELECT count(*) FROM o_skipss WHERE id <= 0;
+
+count
+-----
+    0
+(1 row)
+
+step sr_s2_split_inserts: 
+	INSERT INTO o_skipss
+		(SELECT i, repeat('p', 1000)
+		 FROM generate_series(201, 400, 1) id(i));
+
+step sr_s2_deletes: 
+	DELETE FROM o_skipss WHERE id BETWEEN 50 AND 60;
+
+step sr_s1_seqscan: 
+	SET enable_indexscan = off;
+	SET enable_bitmapscan = off;
+	SELECT count(*), min(id), max(id), sum(id::bigint) FROM o_skipss;
+
+count|min|max|  sum
+-----+---+---+-----
+  200|  1|200|20100
+(1 row)
+
+step sr_s1_commit: COMMIT;

--- a/test/specs/skipundo.spec
+++ b/test/specs/skipundo.spec
@@ -1,0 +1,175 @@
+# Regression tests for the skip-undo split / merge path in
+# o_btree_insert_split() and btree_try_merge_pages(), and for the
+# associated first-key lokey fallback in btree_find_context_lokey().
+#
+# Two permutations:
+#
+#  bscan_lokey  -- Drives a backward scan over pages that were produced
+#                  by the skip-undo split path, hitting the fallback
+#                  (load_page_refind temporarily unsets KEEP_LOKEY) on
+#                  non-LEFTMOST leaves at parent offset 0.  Verifies
+#                  the scan still returns the exact pre-split key set
+#                  in descending order, i.e. the split-key invariant
+#                  the fallback relies on holds.  Companion test for
+#                  load_refind_page.spec, which already trips the
+#                  fallback but with dense sequential keys where any
+#                  returned lokey value would happen to work.
+#
+#  seqscan_race -- Covers the lazy numSeqScans registration window:
+#                  init_btree_seq_scan() (which bumps the counter) is
+#                  called on the first btree_seq_scan_getnext(), not at
+#                  scan creation.  The skip-undo writer's retain-horizon
+#                  test already covers any seq scan with an active
+#                  snapshot (orioledb_snapshot_hook() publishes the
+#                  page-level retain before the executor can fetch),
+#                  but this permutation is the explicit guard: a seq
+#                  scan that starts before concurrent skip-undo splits
+#                  still sees every snapshot-visible row exactly once.
+
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+
+	CREATE TABLE IF NOT EXISTS o_skipfb (
+		id text NOT NULL,
+		PRIMARY KEY (id)
+	) USING orioledb;
+	TRUNCATE o_skipfb;
+
+	CREATE TABLE IF NOT EXISTS o_skipss (
+		id int NOT NULL,
+		pad text NOT NULL,
+		PRIMARY KEY (id)
+	) USING orioledb;
+	TRUNCATE o_skipss;
+}
+
+teardown
+{
+	DROP TABLE o_skipfb;
+	DROP TABLE o_skipss;
+}
+
+session "s1"
+
+# --- bscan_lokey steps ---------------------------------------------------
+
+step "bs_s1_setup" {
+	SET orioledb.enable_stopevents = true;
+	SET application_name = 's1';
+}
+
+step "bs_s1_seed" {
+	INSERT INTO o_skipfb
+		(SELECT id || repeat('x', 2600)
+		 FROM generate_series(18, 21, 1) id);
+}
+
+step "bs_s1_evict" {
+	SELECT orioledb_evict_pages('o_skipfb'::regclass, 1);
+}
+
+step "bs_s1_arm_refind" {
+	SELECT pg_stopevent_set('load_page_refind',
+		'$.level == 0 && $applicationName == "s2"');
+}
+
+# Each of these inserts triggers a no-drop split.  The source leaf has
+# undoLocation = Invalid (no prior page-level undo) and no tuple is
+# dropped, so o_btree_insert_split() takes the skip-undo branch: both
+# halves get csn = COMMITSEQNO_FROZEN and undoLocation = Invalid.
+step "bs_s1_insert_low1" {
+	INSERT INTO o_skipfb
+		(SELECT id || repeat('x', 2600)
+		 FROM generate_series(10, 13, 1) id);
+}
+
+step "bs_s1_insert_low2" {
+	INSERT INTO o_skipfb
+		(SELECT id || repeat('x', 2600)
+		 FROM generate_series(14, 17, 1) id);
+}
+
+step "bs_s1_continue" {
+	SELECT pg_stopevent_reset('load_page_refind');
+}
+
+# --- seqscan_race steps --------------------------------------------------
+
+step "sr_s1_seed" {
+	INSERT INTO o_skipss
+		(SELECT i, repeat('p', 1000)
+		 FROM generate_series(1, 200, 1) id(i));
+}
+
+step "sr_s1_begin" { BEGIN ISOLATION LEVEL REPEATABLE READ; }
+
+# Materialise the snapshot at statement start; subsequent reads in this
+# transaction see only rows visible at this point.  This count(*) does
+# NOT use a seq scan over the orioledb btree (it's a planner-level
+# count), so it does not register the scan via init_btree_seq_scan().
+step "sr_s1_take_snap" {
+	SELECT count(*) FROM o_skipss WHERE id <= 0;
+}
+
+# Force a seq scan in this transaction.  The point is to register the
+# scan AFTER concurrent splits, then verify it still sees every
+# snapshot-visible row exactly once.
+step "sr_s1_seqscan" {
+	SET enable_indexscan = off;
+	SET enable_bitmapscan = off;
+	SELECT count(*), min(id), max(id), sum(id::bigint) FROM o_skipss;
+}
+
+step "sr_s1_commit" { COMMIT; }
+
+session "s2"
+
+# --- bscan_lokey steps ---------------------------------------------------
+
+step "bs_s2_setup" {
+	SET orioledb.enable_stopevents = true;
+	SET application_name = 's2';
+	SET enable_seqscan = off;
+}
+
+# Backward scan over the surviving rows.  s2 is READ COMMITTED, so its
+# snapshot is taken at statement start -- s1's later 10..17 inserts are
+# invisible.  The scan parks at the level-0 refind, then resumes after
+# bs_s1_continue and walks left through pages that are now frozen split
+# halves.  Each backward step invokes btree_find_context_lokey() with
+# LOKEY_EXISTS unset (load_page_refind dropped it during the parent
+# re-find) and parent_off = 0, falling into the first-key fallback.
+#
+# Expected: 21, 20, 19, 18 in descending order.  If the fallback ever
+# misreports a lokey (split-key invariant broken), one or more of these
+# rows will be missing or returned out of order.
+step "bs_s2_bscan" {
+	SELECT substr(id, 1, 2) FROM o_skipfb ORDER BY id DESC;
+}
+
+# --- seqscan_race steps --------------------------------------------------
+
+# Inserts above the existing range.  All sources have undoLocation =
+# Invalid (no prior page-level undo), drop no tuple, and run while
+# numSeqScans = 0 (s1 hasn't called getnext() yet), so they take the
+# skip-undo branch and freeze their resulting halves.
+step "sr_s2_split_inserts" {
+	INSERT INTO o_skipss
+		(SELECT i, repeat('p', 1000)
+		 FROM generate_series(201, 400, 1) id(i));
+}
+
+# Counterpart deletes -- these don't change the seq scan's snapshot
+# but stress the per-tuple MVCC path the scan now has to rely on.
+step "sr_s2_deletes" {
+	DELETE FROM o_skipss WHERE id BETWEEN 50 AND 60;
+}
+
+permutation "bs_s1_setup" "bs_s2_setup" "bs_s1_seed" "bs_s1_evict"
+            "bs_s1_arm_refind" "bs_s2_bscan" "bs_s1_insert_low1"
+            "bs_s1_insert_low2" "bs_s1_continue"
+
+permutation "sr_s1_seed" "sr_s1_begin" "sr_s1_take_snap"
+            "sr_s2_split_inserts" "sr_s2_deletes" "sr_s1_seqscan"
+            "sr_s1_commit"

--- a/test/t/functions_test.py
+++ b/test/t/functions_test.py
@@ -24,8 +24,28 @@ class FunctionTest(BaseTest):
 		node.safe_psql("""
 			INSERT INTO oriole_table(t) select repeat('a', 270) FROM  generate_series(1, 40000) as i;
 		""")
+
+		# Hold an old snapshot so the undo produced below cannot be freed and is
+		# forced out to the on-disk undo files that orioledb_undo_size() reads
+		# (with sparse undo files, unretained undo is reclaimed before it ever
+		# reaches disk).
+		con = node.connect()
+		con.begin()
+		con.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		con.execute("SELECT count(*) FROM oriole_table;")
+
+		# Delete two thirds of the rows (interleaved, so survivors share pages
+		# with the deleted tuples), then grow the survivors.  The growing update
+		# forces page compaction/splits that physically drop the committed-dead
+		# tuples, which take a full-page undo image.  (A split or merge that
+		# drops nothing now uses a tiny differential image; the old same-size
+		# UPDATE produced only such differential page undo, which no longer
+		# spills to disk.)
 		node.safe_psql("""
-			UPDATE oriole_table set t = repeat('c', 270) WHERE i > 5000;
+			DELETE FROM oriole_table WHERE MOD(i, 3) <> 0;
+		""")
+		node.safe_psql("""
+			UPDATE oriole_table set t = repeat('c', 1200) WHERE i > 5000;
 		""")
 
 		self.assertGreaterEqual(
@@ -37,6 +57,8 @@ class FunctionTest(BaseTest):
 		        "SELECT undo_size FROM orioledb_undo_size() WHERE undo_type = 'page';"
 		    )[0][0], 200000)
 
+		con.rollback()
+		con.close()
 		node.stop()
 
 	def test_undo_log_size_system(self):

--- a/test/t/functions_test.py
+++ b/test/t/functions_test.py
@@ -13,7 +13,9 @@ class FunctionTest(BaseTest):
 	def test_undo_log_size(self):
 
 		node = self.node
-		node.append_conf('postgresql.conf', "checkpoint_timeout = 86400\n")
+		node.append_conf(
+		    'postgresql.conf', "checkpoint_timeout = 86400\n"
+		    "orioledb.undo_buffers = 128\n")
 		node.start()
 
 		node.safe_psql("""
@@ -22,13 +24,15 @@ class FunctionTest(BaseTest):
             CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
 		""")
 		node.safe_psql("""
-			INSERT INTO oriole_table(t) select repeat('a', 270) FROM  generate_series(1, 40000) as i;
+			INSERT INTO oriole_table(t) select repeat('a', 270) FROM  generate_series(1, 80000) as i;
 		""")
 
 		# Hold an old snapshot so the undo produced below cannot be freed and is
 		# forced out to the on-disk undo files that orioledb_undo_size() reads
 		# (with sparse undo files, unretained undo is reclaimed before it ever
-		# reaches disk).
+		# reaches disk).  The workload below is sized so the retained row undo
+		# overruns the per-type circular buffer floor
+		# (max_procs * 2 * O_MAX_UNDO_RECORD_SIZE), forcing evict-on-overflow.
 		con = node.connect()
 		con.begin()
 		con.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")

--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -56,6 +56,285 @@ class MergeTest(BaseTest):
 		    node.execute("SELECT orioledb_tbl_check('o_merge'::regclass)")[0]
 		    [0])
 
+	def test_merge_diff_old_snapshot_read(self):
+		"""
+		Exercises the differential merge undo image and its read path.
+
+		A low-fillfactor table keeps leaf pages sparse without any deletes, so
+		CHECKPOINT's page-merge pass (checkpoint_try_merge_page ->
+		btree_try_merge_pages) merges adjacent resident siblings while dropping
+		no tuple -> the merge writes a differential image (boundary key only).
+		A REPEATABLE READ snapshot taken before the CHECKPOINT has a csn below
+		the merge csn, so its reads of the merged pages route through the
+		page-level undo chain and must reconstruct the pre-merge halves by
+		trimming the merged page at the boundary key -- returning the exact
+		original key set.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_merge_diff ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb WITH (fillfactor = 10);"
+		    "TRUNCATE o_merge_diff;")
+		node.execute(
+		    "INSERT INTO o_merge_diff "
+		    "(SELECT id, repeat('x', 100) FROM generate_series(1, 3000) id);")
+
+		con_snap = node.connect()
+		con_snap.begin()
+		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff;")[0][0], 3000)
+
+		# CHECKPOINT merges the sparse, co-resident leaves (no deletes -> the
+		# merge drops nothing -> differential images), with a fresh csn above
+		# the snapshot's.
+		node.execute("CHECKPOINT;")
+
+		# The old snapshot reads the merged pages through undo and must
+		# reconstruct the exact original key set.
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff;")[0][0], 3000)
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff "
+		                     "WHERE id BETWEEN 1000 AND 2000;")[0][0], 1001)
+		self.assertEqual(
+		    con_snap.execute(
+		        "SELECT min(id), max(id), sum(id::bigint) FROM o_merge_diff;")
+		    [0], (1, 3000, 4501500))
+		con_snap.rollback()
+		con_snap.close()
+
+		self.assertTrue(
+		    node.execute("SELECT orioledb_tbl_check('o_merge_diff'::regclass)")
+		    [0][0])
+
+	def test_merge_diff_old_snapshot_index_read(self):
+		"""
+		Like test_merge_diff_old_snapshot_read, but the old snapshot reads the
+		merged pages through an *index* (ordered) scan, which routes the
+		page-level undo walk through the iterator (undo_it_find_internal) rather
+		than the seq-scan path.  Confirms the iterator seeds its working image
+		from the live merged leaf before reconstructing differential halves.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_merge_diff_idx ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb WITH (fillfactor = 10);"
+		    "TRUNCATE o_merge_diff_idx;")
+		node.execute(
+		    "INSERT INTO o_merge_diff_idx "
+		    "(SELECT id, repeat('x', 100) FROM generate_series(1, 3000) id);")
+
+		con_snap = node.connect()
+		con_snap.begin()
+		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		con_snap.execute("SET enable_seqscan = off;")
+		con_snap.execute("SET enable_bitmapscan = off;")
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff_idx;")[0][0],
+		    3000)
+
+		node.execute("CHECKPOINT;")
+
+		# Ordered/range index reads route through the page-level undo iterator.
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff_idx "
+		                     "WHERE id BETWEEN 1000 AND 2000;")[0][0], 1001)
+		self.assertEqual(
+		    con_snap.execute("SELECT id FROM o_merge_diff_idx "
+		                     "WHERE id BETWEEN 500 AND 2500 ORDER BY id;"),
+		    [(i, ) for i in range(500, 2501)])
+		self.assertEqual(
+		    con_snap.execute(
+		        "SELECT id FROM o_merge_diff_idx "
+		        "WHERE id BETWEEN 500 AND 2500 ORDER BY id DESC;"),
+		    [(i, ) for i in range(2500, 499, -1)])
+		self.assertEqual(
+		    con_snap.execute("SELECT min(id), max(id), sum(id::bigint) "
+		                     "FROM o_merge_diff_idx;")[0], (1, 3000, 4501500))
+		con_snap.rollback()
+		con_snap.close()
+
+		self.assertTrue(
+		    node.execute(
+		        "SELECT orioledb_tbl_check('o_merge_diff_idx'::regclass)")[0]
+		    [0])
+
+	def test_merge_diff_old_snapshot_point_read(self):
+		"""
+		Like test_merge_diff_old_snapshot_read, but the old snapshot reads the
+		merged pages through *point* and *bitmap* lookups, which route through
+		o_btree_find_tuple_by_key_cb -> find_page -> o_btree_read_page with a
+		partially-loaded page (BTREE_PAGE_FIND_FETCH).  A differential image must
+		fully materialize that page before reconstructing in place; this test
+		guards the partial-page materialization fix.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_merge_diff_pt ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb WITH (fillfactor = 10);"
+		    "TRUNCATE o_merge_diff_pt;")
+		node.execute(
+		    "INSERT INTO o_merge_diff_pt "
+		    "(SELECT id, repeat('x', 100) FROM generate_series(1, 3000) id);")
+
+		con_snap = node.connect()
+		con_snap.begin()
+		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff_pt;")[0][0],
+		    3000)
+
+		node.execute("CHECKPOINT;")
+
+		# Point lookups (index scan) over merged pages through undo.
+		con_snap.execute("SET enable_seqscan = off;")
+		con_snap.execute("SET enable_bitmapscan = off;")
+		for pk in (1, 2, 1500, 1501, 2999, 3000):
+			self.assertEqual(
+			    con_snap.execute(
+			        "SELECT id, payload = repeat('x', 100) FROM o_merge_diff_pt "
+			        "WHERE id = %d;" % pk), [(pk, True)])
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff_pt "
+		                     "WHERE id IN (700, 1300, 2200, 2900);")[0][0], 4)
+
+		# Bitmap scan over merged pages through undo.
+		con_snap.execute("SET enable_seqscan = off;")
+		con_snap.execute("SET enable_bitmapscan = on;")
+		con_snap.execute("SET enable_indexscan = off;")
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_merge_diff_pt "
+		                     "WHERE id < 100 OR id > 2950;")[0][0], 99 + 50)
+		con_snap.rollback()
+		con_snap.close()
+
+		self.assertTrue(
+		    node.execute(
+		        "SELECT orioledb_tbl_check('o_merge_diff_pt'::regclass)")[0]
+		    [0])
+
+	def test_split_diff_old_snapshot_read(self):
+		"""
+		Exercises the differential split undo image and its read paths.
+
+		An old REPEATABLE READ snapshot is taken over a fully-populated table.
+		Then a second transaction inserts keys interleaved between the existing
+		ones, forcing the pre-existing (full) leaves to split.  Each split drops
+		no tuple -> it writes a differential split image (split key only), with a
+		csn above the snapshot's.  The old snapshot then reads the split leaves
+		through the page-level undo chain via seq, index, point and bitmap scans
+		-- each must reconstruct the exact original key set, with none of the
+		newly inserted interleaved keys visible.
+
+		Also covers UPDATE-driven splits (a single UPDATE that grows rows and
+		re-fetches them through undo), which routes the page-level undo walk
+		through the partially-loaded combined-fetch path.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_split_diff ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb;"
+		    "TRUNCATE o_split_diff;")
+		# Even keys 2..10000 fill the leaves.
+		node.execute("INSERT INTO o_split_diff "
+		             "(SELECT id * 2, repeat('x', 100) "
+		             "FROM generate_series(1, 5000) id);")
+
+		con_snap = node.connect()
+		con_snap.begin()
+		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_split_diff;")[0][0], 5000)
+
+		# Odd keys 1..9999 interleave between the existing even keys, forcing the
+		# pre-existing full leaves to split (no deletes -> differential images),
+		# with fresh csns above the snapshot's.
+		node.execute("INSERT INTO o_split_diff "
+		             "(SELECT id * 2 - 1, repeat('y', 100) "
+		             "FROM generate_series(1, 5000) id);")
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM o_split_diff;")[0][0], 10000)
+
+		# Seq scan through undo.
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_split_diff;")[0][0], 5000)
+		self.assertEqual(
+		    con_snap.execute(
+		        "SELECT min(id), max(id), sum(id::bigint), count(*) "
+		        "FROM o_split_diff WHERE MOD(id, 2) = 1;")[0],
+		    (None, None, None, 0))
+		self.assertEqual(
+		    con_snap.execute("SELECT min(id), max(id), sum(id::bigint) "
+		                     "FROM o_split_diff;")[0], (2, 10000, 25005000))
+
+		# Point + index reads through undo (partial-page combined-fetch path).
+		con_snap.execute("SET enable_seqscan = off;")
+		con_snap.execute("SET enable_bitmapscan = off;")
+		for pk in (2, 1000, 5000, 9998, 10000):
+			self.assertEqual(
+			    con_snap.execute("SELECT id FROM o_split_diff WHERE id = %d;" %
+			                     pk), [(pk, )])
+		for odd in (1, 4999, 9999):
+			self.assertEqual(
+			    con_snap.execute(
+			        "SELECT count(*) FROM o_split_diff WHERE id = %d;" %
+			        odd)[0][0], 0)
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_split_diff "
+		                     "WHERE id BETWEEN 1000 AND 2000;")[0][0], 501)
+
+		# Bitmap scan through undo.
+		con_snap.execute("SET enable_bitmapscan = on;")
+		con_snap.execute("SET enable_indexscan = off;")
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM o_split_diff "
+		                     "WHERE id < 200 OR id > 9800;")[0][0], 99 + 100)
+		con_snap.rollback()
+		con_snap.close()
+
+		self.assertTrue(
+		    node.execute("SELECT orioledb_tbl_check('o_split_diff'::regclass)")
+		    [0][0])
+
+	def test_split_diff_update_grow(self):
+		"""
+		A single UPDATE that grows every row, forcing in-statement page splits
+		and re-fetches of the rows being updated through the (partially-loaded)
+		combined-fetch undo path.  Regression guard for the differential split
+		image + partial-page materialization.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_split_upd ("
+		    "    key int PRIMARY KEY, val int, spacer text"
+		    ") USING orioledb;"
+		    "TRUNCATE o_split_upd;")
+		node.execute("INSERT INTO o_split_upd "
+		             "(SELECT i, i, '' FROM generate_series(1, 100) i);")
+		node.execute("UPDATE o_split_upd SET spacer = repeat('a', 96) "
+		             "WHERE key > 1;")
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM o_split_upd;")[0][0], 100)
+		self.assertEqual(
+		    node.execute("SELECT bool_and(spacer = repeat('a', 96)) "
+		                 "FROM o_split_upd WHERE key > 1;")[0][0], True)
+		self.assertTrue(
+		    node.execute("SELECT orioledb_tbl_check('o_split_upd'::regclass)")
+		    [0][0])
+
 	def test_non_concurrent_merge(self):
 		node = self.node
 		node.execute("INSERT INTO o_merge"

--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -56,6 +56,38 @@ class MergeTest(BaseTest):
 		    node.execute("SELECT orioledb_tbl_check('o_merge'::regclass)")[0]
 		    [0])
 
+	def _open_merge_diff_snapshot(self, table):
+		"""
+		Shared setup for the test_merge_diff_old_snapshot_* cases: populate a
+		low-fillfactor table, open a REPEATABLE READ snapshot, then CHECKPOINT
+		so its page-merge pass writes differential merge images above the
+		snapshot's csn.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS %s ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb WITH (fillfactor = 10);"
+		    "TRUNCATE %s;" % (table, table))
+		node.execute(
+		    "INSERT INTO %s "
+		    "(SELECT id, repeat('x', 100) FROM generate_series(1, 3000) id);" %
+		    table)
+
+		con_snap = node.connect()
+		con_snap.begin()
+		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		self.assertEqual(
+		    con_snap.execute("SELECT count(*) FROM %s;" % table)[0][0], 3000)
+
+		# CHECKPOINT merges the sparse, co-resident leaves (no deletes -> the
+		# merge drops nothing -> differential images), with a fresh csn above
+		# the snapshot's.
+		node.execute("CHECKPOINT;")
+		return con_snap
+
 	def test_merge_diff_old_snapshot_read(self):
 		"""
 		Exercises the differential merge undo image and its read path.
@@ -70,46 +102,27 @@ class MergeTest(BaseTest):
 		trimming the merged page at the boundary key -- returning the exact
 		original key set.
 		"""
-		node = self.node
-		node.safe_psql(
-		    'postgres', "CREATE TABLE IF NOT EXISTS o_merge_diff ("
-		    "    id int NOT NULL,"
-		    "    payload text NOT NULL,"
-		    "    PRIMARY KEY (id)"
-		    ") USING orioledb WITH (fillfactor = 10);"
-		    "TRUNCATE o_merge_diff;")
-		node.execute(
-		    "INSERT INTO o_merge_diff "
-		    "(SELECT id, repeat('x', 100) FROM generate_series(1, 3000) id);")
-
-		con_snap = node.connect()
-		con_snap.begin()
-		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
-		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff;")[0][0], 3000)
-
-		# CHECKPOINT merges the sparse, co-resident leaves (no deletes -> the
-		# merge drops nothing -> differential images), with a fresh csn above
-		# the snapshot's.
-		node.execute("CHECKPOINT;")
+		table = 'o_merge_diff'
+		con_snap = self._open_merge_diff_snapshot(table)
 
 		# The old snapshot reads the merged pages through undo and must
 		# reconstruct the exact original key set.
 		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff;")[0][0], 3000)
+		    con_snap.execute("SELECT count(*) FROM %s;" % table)[0][0], 3000)
 		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff "
-		                     "WHERE id BETWEEN 1000 AND 2000;")[0][0], 1001)
+		    con_snap.execute("SELECT count(*) FROM %s "
+		                     "WHERE id BETWEEN 1000 AND 2000;" % table)[0][0],
+		    1001)
 		self.assertEqual(
 		    con_snap.execute(
-		        "SELECT min(id), max(id), sum(id::bigint) FROM o_merge_diff;")
-		    [0], (1, 3000, 4501500))
+		        "SELECT min(id), max(id), sum(id::bigint) FROM %s;" %
+		        table)[0], (1, 3000, 4501500))
 		con_snap.rollback()
 		con_snap.close()
 
 		self.assertTrue(
-		    node.execute("SELECT orioledb_tbl_check('o_merge_diff'::regclass)")
-		    [0][0])
+		    self.node.execute("SELECT orioledb_tbl_check('%s'::regclass)" %
+		                      table)[0][0])
 
 	def test_merge_diff_old_snapshot_index_read(self):
 		"""
@@ -119,52 +132,35 @@ class MergeTest(BaseTest):
 		than the seq-scan path.  Confirms the iterator seeds its working image
 		from the live merged leaf before reconstructing differential halves.
 		"""
-		node = self.node
-		node.safe_psql(
-		    'postgres', "CREATE TABLE IF NOT EXISTS o_merge_diff_idx ("
-		    "    id int NOT NULL,"
-		    "    payload text NOT NULL,"
-		    "    PRIMARY KEY (id)"
-		    ") USING orioledb WITH (fillfactor = 10);"
-		    "TRUNCATE o_merge_diff_idx;")
-		node.execute(
-		    "INSERT INTO o_merge_diff_idx "
-		    "(SELECT id, repeat('x', 100) FROM generate_series(1, 3000) id);")
-
-		con_snap = node.connect()
-		con_snap.begin()
-		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		table = 'o_merge_diff_idx'
+		con_snap = self._open_merge_diff_snapshot(table)
 		con_snap.execute("SET enable_seqscan = off;")
 		con_snap.execute("SET enable_bitmapscan = off;")
-		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff_idx;")[0][0],
-		    3000)
-
-		node.execute("CHECKPOINT;")
 
 		# Ordered/range index reads route through the page-level undo iterator.
 		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff_idx "
-		                     "WHERE id BETWEEN 1000 AND 2000;")[0][0], 1001)
+		    con_snap.execute("SELECT count(*) FROM %s "
+		                     "WHERE id BETWEEN 1000 AND 2000;" % table)[0][0],
+		    1001)
 		self.assertEqual(
-		    con_snap.execute("SELECT id FROM o_merge_diff_idx "
-		                     "WHERE id BETWEEN 500 AND 2500 ORDER BY id;"),
-		    [(i, ) for i in range(500, 2501)])
+		    con_snap.execute("SELECT id FROM %s "
+		                     "WHERE id BETWEEN 500 AND 2500 ORDER BY id;" %
+		                     table), [(i, ) for i in range(500, 2501)])
 		self.assertEqual(
 		    con_snap.execute(
-		        "SELECT id FROM o_merge_diff_idx "
-		        "WHERE id BETWEEN 500 AND 2500 ORDER BY id DESC;"),
+		        "SELECT id FROM %s "
+		        "WHERE id BETWEEN 500 AND 2500 ORDER BY id DESC;" % table),
 		    [(i, ) for i in range(2500, 499, -1)])
 		self.assertEqual(
-		    con_snap.execute("SELECT min(id), max(id), sum(id::bigint) "
-		                     "FROM o_merge_diff_idx;")[0], (1, 3000, 4501500))
+		    con_snap.execute(
+		        "SELECT min(id), max(id), sum(id::bigint) FROM %s;" %
+		        table)[0], (1, 3000, 4501500))
 		con_snap.rollback()
 		con_snap.close()
 
 		self.assertTrue(
-		    node.execute(
-		        "SELECT orioledb_tbl_check('o_merge_diff_idx'::regclass)")[0]
-		    [0])
+		    self.node.execute("SELECT orioledb_tbl_check('%s'::regclass)" %
+		                      table)[0][0])
 
 	def test_merge_diff_old_snapshot_point_read(self):
 		"""
@@ -175,26 +171,8 @@ class MergeTest(BaseTest):
 		fully materialize that page before reconstructing in place; this test
 		guards the partial-page materialization fix.
 		"""
-		node = self.node
-		node.safe_psql(
-		    'postgres', "CREATE TABLE IF NOT EXISTS o_merge_diff_pt ("
-		    "    id int NOT NULL,"
-		    "    payload text NOT NULL,"
-		    "    PRIMARY KEY (id)"
-		    ") USING orioledb WITH (fillfactor = 10);"
-		    "TRUNCATE o_merge_diff_pt;")
-		node.execute(
-		    "INSERT INTO o_merge_diff_pt "
-		    "(SELECT id, repeat('x', 100) FROM generate_series(1, 3000) id);")
-
-		con_snap = node.connect()
-		con_snap.begin()
-		con_snap.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
-		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff_pt;")[0][0],
-		    3000)
-
-		node.execute("CHECKPOINT;")
+		table = 'o_merge_diff_pt'
+		con_snap = self._open_merge_diff_snapshot(table)
 
 		# Point lookups (index scan) over merged pages through undo.
 		con_snap.execute("SET enable_seqscan = off;")
@@ -202,26 +180,26 @@ class MergeTest(BaseTest):
 		for pk in (1, 2, 1500, 1501, 2999, 3000):
 			self.assertEqual(
 			    con_snap.execute(
-			        "SELECT id, payload = repeat('x', 100) FROM o_merge_diff_pt "
-			        "WHERE id = %d;" % pk), [(pk, True)])
+			        "SELECT id, payload = repeat('x', 100) FROM %s "
+			        "WHERE id = %d;" % (table, pk)), [(pk, True)])
 		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff_pt "
-		                     "WHERE id IN (700, 1300, 2200, 2900);")[0][0], 4)
+		    con_snap.execute("SELECT count(*) FROM %s "
+		                     "WHERE id IN (700, 1300, 2200, 2900);" %
+		                     table)[0][0], 4)
 
 		# Bitmap scan over merged pages through undo.
-		con_snap.execute("SET enable_seqscan = off;")
 		con_snap.execute("SET enable_bitmapscan = on;")
 		con_snap.execute("SET enable_indexscan = off;")
 		self.assertEqual(
-		    con_snap.execute("SELECT count(*) FROM o_merge_diff_pt "
-		                     "WHERE id < 100 OR id > 2950;")[0][0], 99 + 50)
+		    con_snap.execute("SELECT count(*) FROM %s "
+		                     "WHERE id < 100 OR id > 2950;" % table)[0][0],
+		    99 + 50)
 		con_snap.rollback()
 		con_snap.close()
 
 		self.assertTrue(
-		    node.execute(
-		        "SELECT orioledb_tbl_check('o_merge_diff_pt'::regclass)")[0]
-		    [0])
+		    self.node.execute("SELECT orioledb_tbl_check('%s'::regclass)" %
+		                      table)[0][0])
 
 	def test_split_diff_old_snapshot_read(self):
 		"""

--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -203,16 +203,18 @@ class MergeTest(BaseTest):
 
 	def test_split_diff_old_snapshot_read(self):
 		"""
-		Exercises the differential split undo image and its read paths.
+		Exercises a no-drop split's read paths under an old snapshot.
 
 		An old REPEATABLE READ snapshot is taken over a fully-populated table.
 		Then a second transaction inserts keys interleaved between the existing
 		ones, forcing the pre-existing (full) leaves to split.  Each split drops
-		no tuple -> it writes a differential split image (split key only), with a
-		csn above the snapshot's.  The old snapshot then reads the split leaves
-		through the page-level undo chain via seq, index, point and bitmap scans
-		-- each must reconstruct the exact original key set, with none of the
-		newly inserted interleaved keys visible.
+		no tuple and the leaves carry no retained pre-split history, so it writes
+		no page-level undo image at all: both halves are frozen with an invalid
+		undo location and read live.  The old snapshot then reads the split
+		leaves through seq, index, point and bitmap scans -- each must return the
+		exact original key set, with the newly inserted interleaved keys filtered
+		out by per-tuple MVCC (physically present on the live halves but
+		invisible to the old snapshot).
 
 		Also covers UPDATE-driven splits (a single UPDATE that grows rows and
 		re-fetches them through undo), which routes the page-level undo walk
@@ -238,8 +240,8 @@ class MergeTest(BaseTest):
 		    con_snap.execute("SELECT count(*) FROM o_split_diff;")[0][0], 5000)
 
 		# Odd keys 1..9999 interleave between the existing even keys, forcing the
-		# pre-existing full leaves to split (no deletes -> differential images),
-		# with fresh csns above the snapshot's.
+		# pre-existing full leaves to split (no deletes -> no page-level undo
+		# image; the halves are frozen with an invalid undo location).
 		node.execute("INSERT INTO o_split_diff "
 		             "(SELECT id * 2 - 1, repeat('y', 100) "
 		             "FROM generate_series(1, 5000) id);")

--- a/test/t/seq_scan_undo_test.py
+++ b/test/t/seq_scan_undo_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import unittest
+
+from .base_test import BaseTest
+
+
+class SeqScanUndoTest(BaseTest):
+
+	def test_full_image_for_split_after_downlink_collection(self):
+		"""
+		A sequential scan that has already collected its on-disk downlinks must
+		still see every pre-operation row when a split rewrites those extents
+		underneath it.
+
+		This is the shared-table (non-temp) counterpart of
+		TempLocalPoolTest.test_evict_pages_with_concurrent_seq_scan.  It guards
+		the rule that a page split or merge keeps a *full* page-level undo image
+		while a sequential scan is active on the tree
+		(meta_page_get_num_seq_scans() > 0), even when the page has no retained
+		pre-op undo of its own -- a freshly written leaf has an invalid
+		undoLocation, so the retain-horizon test alone would let the image be
+		skipped and the scan would lose the tuples the split moved to a new page
+		that is not in its collected downlink set.
+
+		Arrangement (single backend, mirroring the temp-table test):
+
+		  1. Fill a table so the primary-key btree has many leaves and push
+		     every leaf to disk.
+		  2. A PK point lookup on the max id brings just the rightmost leaf back
+		     into the main pool; its parent downlink flips to IN_MEMORY while the
+		     rest stay ON_DISK.
+		  3. A cursor opens a seq scan.  The first FETCH walks the internal page,
+		     queues an ON_DISK downlink for every other leaf and bumps
+		     numSeqScans, leaving diskDownlinks[] populated but unconsumed.
+		  4. A bulk UPDATE grows every row enough to split the leaves.  With a
+		     seq scan active these splits must keep a full pre-split image.
+		  5. orioledb_evict_pages() rewrites the dirty pages back over the same
+		     on-disk extents the cursor's diskDownlinks[] still points at.
+		  6. Draining the cursor reads the overwritten extents as of its
+		     snapshot, reconstructing each pre-split page from the page-level
+		     undo chain.  It must return the full original key set.
+		"""
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "shared_preload_libraries = orioledb\n"
+		    "orioledb.main_buffers = 8MB\n"
+		    "orioledb.debug_disable_pools_limit = true\n"
+		    "orioledb.debug_disable_bgwriter = true\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		con = node.connect()
+		con.execute("""
+			CREATE TABLE o_seqscan (
+				id int PRIMARY KEY,
+				val int NOT NULL,
+				payload text
+			) USING orioledb;
+		""")
+		con.commit()
+
+		n = 5000
+		con.execute("INSERT INTO o_seqscan SELECT g, g, repeat('x', 200) "
+		            "FROM generate_series(1, %d) g;" % n)
+		con.commit()
+
+		# Push every leaf to disk.
+		con.execute("SELECT orioledb_evict_pages('o_seqscan'::regclass, 0);")
+
+		# Bring only the rightmost leaf back into the main pool.
+		self.assertEqual(
+		    con.execute("SELECT id FROM o_seqscan WHERE id = %d;" % n),
+		    [(n, )])
+
+		con.begin()
+		con.execute("SET LOCAL enable_indexscan = off;")
+		con.execute("SET LOCAL enable_bitmapscan = off;")
+		con.execute(
+		    "DECLARE c1 NO SCROLL CURSOR FOR SELECT id FROM o_seqscan;")
+
+		# The first FETCH initializes the seq scan: iterate_internal_page walks
+		# the internal page, queues ON_DISK downlinks for every leaf except the
+		# rightmost (which is IN_MEMORY) and bumps numSeqScans, leaving
+		# diskDownlinks[] populated but unconsumed.
+		first_batch = con.execute("FETCH 10 FROM c1;")
+		self.assertEqual(len(first_batch), 10)
+
+		# Grow every row so the leaves split while the seq scan is active.  Each
+		# split moves tuples to a new page that is not in the cursor's collected
+		# downlink set; only a full pre-split undo image lets the cursor recover
+		# them.
+		con.execute("UPDATE o_seqscan SET val = val + 1000000, "
+		            "payload = repeat('y', 600) WHERE id < %d;" % n)
+
+		# Rewrite the dirty pages in place, overwriting the on-disk extents the
+		# cursor's diskDownlinks[] still points at.
+		con.execute("SELECT orioledb_evict_pages('o_seqscan'::regclass, 0);")
+
+		rest = con.execute("FETCH ALL FROM c1;")
+		con.execute("CLOSE c1;")
+		con.commit()
+
+		all_ids = sorted(row[0] for row in first_batch + rest)
+		self.assertEqual(all_ids, list(range(1, n + 1)))
+
+		self.assertTrue(
+		    con.execute("SELECT orioledb_tbl_check('o_seqscan'::regclass);")[0]
+		    [0])
+
+		con.close()
+		node.stop()


### PR DESCRIPTION
## What

A B-tree page merge or split writes a copy of the pre-operation page(s) into
the page-level undo log so older snapshots can still see the original page(s).
Originally that was always a full copy — **2×8 KB for a merge, 8 KB + split
key for a split** — even though the operation only redistributes tuples and
physically drops nothing in the common case.

This series makes that page-level image **as cheap as the situation allows**:

- **No image at all** in the common case — a no-drop split/merge that no
  active snapshot is old enough to need.  The result page(s) are frozen and
  read live; per-tuple MVCC does the rest.
- A **differential** image (tens of bytes instead of kilobytes) when nothing
  is dropped but a snapshot *is* held over the page.
- A **full** image only when a tuple is physically dropped, or when a
  concurrent sequential scan may reconstruct whole pre-op pages.

This is a big win for the page-level undo produced during bulk load, where
splits are frequent and almost never need any image.

## How it works

Each operation classifies itself at op time.

**Skip the image entirely** when all of:

- the op drops no tuple (`page_op_drops_tuple()`, mirroring the leaf drop
  condition of `merge_pages()` / `make_split_items()`);
- the page's own pre-op `undoLocation` is already below the retain horizon
  (`minProcRetainLocation` / `minRewindRetainLocation`) or invalid — i.e. no
  active snapshot is older than the page (a merge requires this of *both*
  pages);
- no sequential scan is active on the tree (`meta_page_get_num_seq_scans()`).

The result page(s) then get `csn = COMMITSEQNO_FROZEN` and an invalid undo
location, exactly like a freshly initialized page: every reader reads them
live (a frozen csn precedes any snapshot, so the undo chain is never walked)
and per-tuple MVCC handles tuple visibility.  A backward index scan that steps
onto such a frozen split half takes the page's lokey from its smallest stored
key (valid precisely because nothing was dropped).

**Otherwise** write a page-level image:

- **`UndoPageImageMergeDiff`** / **`UndoPageImageSplitDiff`** (differential)
  when nothing is dropped but a snapshot is held: store the boundary/split key
  + the relevant `(csn, undoLocation)` continuation, and reconstruct from the
  newer page already sitting in the reader's buffer.  A differential split
  half only covers one leaf's key range — fine for point lookups (MVCC) and
  index/range scans (which clip per-tuple to the current leaf).
- a **full** image when a tuple is dropped, or when a sequential scan is
  active (it reconstructs whole pre-op pages spanning the full key range,
  which a differential half cannot provide across multi-level operations).

Why a dropped tuple forces an image: droppability is xid-based (the deleting
xid is older than `runXmin`), but an active snapshot whose csn precedes the
delete's *commit* can still need the tuple — only the image preserves it.

## Commits

1. **always seed page image before walking page-level undo** — foundation:
   copy the live page into the destination before walking the undo chain
   (differential images reconstruct in place from it).
2. **materialize partial page before walking page-level undo** — the
   fetch/index/bitmap paths read leaves by chunk; differential reconstruction
   needs every chunk, so `partial_load_full_page()` fully materializes a
   partially-loaded page first.
3. **differential page-level undo images for merge and split** — the
   `UndoPageImageMergeDiff` / `UndoPageImageSplitDiff` records and their read
   paths.
4. **mask undo location in sys-tree structure dump** — absolute undo
   locations shift when undo allocation shrinks; mask them so the dump test is
   stable.
5. Review follow-ups (per-type undo image headers, asserts, zeroing,
   `null_unused_bytes` reuse, shared test setup, header-layout StaticAssert,
   PG18 undo-buffer-floor test sizing).
6. **skip the page-level undo image for invisible splits and merges** — the
   no-image fast path described above (frozen pages + smallest-key lokey for
   backward scans).

## Testing

- `regresscheck` 44/44, `isolationcheck` 30/30.
- `merge_test`: no-image **and** differential merge/split exercised through
  seq, index, point, bitmap and UPDATE-driven paths under old snapshots.
- `load_refind_page` / `rightlink` / `btree_iterate` / `temp_local_pool_test`:
  concurrent eviction + seq/range scans, including backward scans over frozen
  no-image split halves.

## Known limitation

The seq-scan guard checks `numSeqScans` at op time, but a transaction takes
its snapshot before the orioledb seq-scan node registers.  A no-drop op that
lands in that window while a snapshot is held writes a **differential** image,
which a later seq scan (with the older snapshot) cannot fully reconstruct
across multi-level operations.  The no-image (frozen) fast path is unaffected —
it is read live, so a seq scan over it never reconstructs.  Closing the
differential-image window fully (publishing a seq-scan snapshot horizon at
snapshot acquisition) is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)