### PR TITLE
Add missing Postgres 18 into docker Github Workflows

### DIFF
--- a/.github/workflows/_docker-build-publish.yml
+++ b/.github/workflows/_docker-build-publish.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         cpu: [amd64, arm64]
-        postgres: [16, 17]
+        postgres: [16, 17, 18]
         distr: [alpine, ubuntu]
 
         # Define runner and distr_version depending on cpu and distr


### PR DESCRIPTION
Postgres 18 wasn't added into the `docker` Github Workflow when working on #848 