### PR TITLE
Size max_procs by autovacuum_worker_slots on PG18

### DIFF
--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -477,7 +477,10 @@ _PG_init(void)
 	o_verify_dir_exists_or_create(psprintf("%s/1", ORIOLEDB_DATA_DIR), NULL, NULL);
 
 	/* See InitializeMaxBackends(), InitProcGlobal() */
-#if PG_VERSION_NUM >= 170000
+#if PG_VERSION_NUM >= 180000
+	max_procs = MaxConnections + autovacuum_worker_slots + 1 +
+		max_worker_processes + max_wal_senders + NUM_SPECIAL_WORKER_PROCS + NUM_AUXILIARY_PROCS;
+#elif PG_VERSION_NUM >= 170000
 	max_procs = MaxConnections + autovacuum_max_workers + 1 +
 		max_worker_processes + max_wal_senders + NUM_SPECIAL_WORKER_PROCS + NUM_AUXILIARY_PROCS;
 #else


### PR DESCRIPTION
Since c758119e5bfb PG18 InitializeMaxBackends() uses autovacuum_worker_slots (default 16), not
autovacuum_max_workers (default 3) to size
the proc array.

We must mirror this logic calculating max_procs,
otherwise we can have out-of-array-bound access past that boundary and memory corruption.