### PR TITLE
FETCH-mode partial B-tree iterator (backward scans + fastpath downlink search)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -64,6 +64,7 @@ sql/orioledb--1.4--1.5.sql
 sql/orioledb--1.5--1.6.sql
 sql/orioledb--1.6--1.7.sql
 sql/orioledb--1.7--1.8.sql
+sql/orioledb--1.8--1.9.sql
 
 #######################################################
 # second part: extra .dockerignore contents

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ sql/orioledb--1.4--1.5.sql
 sql/orioledb--1.5--1.6.sql
 sql/orioledb--1.6--1.7.sql
 sql/orioledb--1.7--1.8.sql
-# XXX: ^ Sync with .dockerignore
+sql/orioledb--1.8--1.9.sql
 
 # Exclude the PostGIS Docker build directory
 /docker-postgis

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ REGRESSCHECKS = btree_sys_check \
 				ddl \
 				exclude \
 				explain \
+				fastpath_desc \
 				fillfactor \
 				foreign_keys \
 				generated \

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ REGRESSCHECKS = btree_sys_check \
 				indices_build \
 				inherits \
 				ioc \
+				iterator \
 				joins \
 				nulls \
 				opclass \

--- a/include/btree/fastpath.h
+++ b/include/btree/fastpath.h
@@ -19,11 +19,26 @@
 #include "btree/page_contents.h"
 
 #define FASTPATH_FIND_DOWNLINK_MAX_KEYS (4)
-#define FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF (1)
-#define FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF (2)
 
+/*
+ * Per-key flags directing the array narrowing.  Unlike a raw value, these name
+ * a *storage position* (the on-page slot order), so they are correct for both
+ * ASC and DESC key columns: FIRST collapses the search range to its lowest
+ * storage slot, LAST to its highest.  find_downlink_get_keys() resolves value
+ * infinities, unbounded columns, and NULLs (via the column's ASC/DESC and
+ * NULLS FIRST/LAST ordering) into these storage directions.
+ */
+#define FASTPATH_FIND_DOWNLINK_FLAG_FIRST (1)
+#define FASTPATH_FIND_DOWNLINK_FLAG_LAST (2)
+
+/*
+ * Array-search routine over a fixed-stride column.  "descending" selects the
+ * DESC-ordered variant (values stored high-to-low) so the same routines serve
+ * both index orderings.
+ */
 typedef void (*ArraySearchFunc) (Pointer p, int stride,
-								 int *lower, int *upper, Datum keyDatum);
+								 int *lower, int *upper, Datum keyDatum,
+								 bool descending);
 
 typedef struct
 {
@@ -36,6 +51,7 @@ typedef struct
 	ArraySearchFunc funcs[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
 	Datum		values[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
 	uint8		flags[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
+	bool		descending[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
 } FastpathFindDownlinkMeta;
 
 typedef enum

--- a/include/btree/fastpath.h
+++ b/include/btree/fastpath.h
@@ -32,13 +32,13 @@
 #define FASTPATH_FIND_DOWNLINK_FLAG_LAST (2)
 
 /*
- * Array-search routine over a fixed-stride column.  "descending" selects the
- * DESC-ordered variant (values stored high-to-low) so the same routines serve
- * both index orderings.
+ * Array-search routine over a fixed-stride column.  "ascending" mirrors
+ * OIndexField.ascending: false selects the DESC-ordered variant (values stored
+ * high-to-low) so the same routines serve both index orderings.
  */
 typedef void (*ArraySearchFunc) (Pointer p, int stride,
 								 int *lower, int *upper, Datum keyDatum,
-								 bool descending);
+								 bool ascending);
 
 typedef struct
 {
@@ -51,7 +51,7 @@ typedef struct
 	ArraySearchFunc funcs[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
 	Datum		values[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
 	uint8		flags[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
-	bool		descending[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
+	bool		ascending[FASTPATH_FIND_DOWNLINK_MAX_KEYS];
 } FastpathFindDownlinkMeta;
 
 typedef enum

--- a/include/btree/find.h
+++ b/include/btree/find.h
@@ -117,9 +117,10 @@ typedef struct
 #define BTREE_PAGE_FIND_READ_CSN		(0x0800)
 /*
  * The caller navigates to sibling pages with find_left_page()/find_right_page()
- * and therefore needs the parent materialized in context->parentImg.  This is
- * incompatible with the fastpath downlink search, which reads the downlink
- * straight from the shared page, so it disables that optimization.
+ * and therefore needs the parent materialized in context->parentImg.  Forward
+ * descents still take the fastpath downlink search; the parent's materialized
+ * image is then deferred until a sibling step actually needs it
+ * (convert_fastpath_parent_to_img() in find_right_page() / find_left_page()).
  */
 #define BTREE_PAGE_FIND_KEEP_PARENT		(0x1000)
 

--- a/include/btree/find.h
+++ b/include/btree/find.h
@@ -87,6 +87,18 @@ typedef struct
 	 * BTREE_PAGE_FIND_LOKEY_UNDO is set when present.
 	 */
 	OFixedKey	undoLokey;
+
+	/*
+	 * A forward (non-KEEP_LOKEY) iterator descent that locates the immediate
+	 * parent via the fastpath defers materializing it into parentImg until
+	 * find_right_page() actually steps to a sibling.  While this is set the
+	 * parent's locator still points into the shared page and
+	 * parentImg/parentPartial are not yet valid; find_right_page() calls
+	 * convert_fastpath_parent_to_img() on demand.  A backward (KEEP_LOKEY)
+	 * descent reads the parent's lokey during the descent and so materializes
+	 * the parent eagerly, leaving this false.
+	 */
+	bool		parentImgDeferred;
 	uint16		flags;
 } OBTreeFindPageContext;
 

--- a/include/btree/find.h
+++ b/include/btree/find.h
@@ -39,7 +39,21 @@ typedef struct
 	Pointer		parentImg;
 	char		imgData[ORIOLEDB_BLCKSZ];
 	char		parentImgData[ORIOLEDB_BLCKSZ];
+
+	/*
+	 * Partial read state of the target (leaf) page in context->img.  Used in
+	 * FETCH mode (the leaf is read partially); in IMAGE mode the leaf is read
+	 * in full and this is unused.
+	 */
 	PartialPageState partial;
+
+	/*
+	 * Partial read state of the immediate parent page in context->parentImg.
+	 * Used in both IMAGE and FETCH modes so
+	 * find_left_page()/find_right_page() can navigate to sibling pages
+	 * through the parent's downlinks.
+	 */
+	PartialPageState parentPartial;
 	CommitSeqNo csn;
 	CommitSeqNo imgReadCsn;
 	UndoLocation imgUndoLoc;
@@ -54,6 +68,17 @@ typedef struct
 	 * sibling.
 	 */
 	OFixedKey	lokey;
+
+	/*
+	 * Stable copy of the current page's own lokey (its downlink key in the
+	 * immediate parent), captured during find_page() descent and refreshed by
+	 * find_left_page() when stepping through parent downlinks.  Used instead
+	 * of re-reading the parent image, which is unreliable in FETCH mode where
+	 * parentImg is partial and may be reclaimed under page-pool pressure.
+	 * Only meaningful when the current page's downlink is not the parent's
+	 * first one (otherwise btree_find_context_lokey() falls back to lokey).
+	 */
+	OFixedKey	leafLokey;
 
 	/*
 	 * Helps to avoid overwriting of a hikey by non-consistency read of the
@@ -78,6 +103,13 @@ typedef struct
 #define BTREE_PAGE_FIND_IMAGE			(0x0200)
 #define BTREE_PAGE_FIND_DOWNLINK_LOCATION (0x0400)
 #define BTREE_PAGE_FIND_READ_CSN		(0x0800)
+/*
+ * The caller navigates to sibling pages with find_left_page()/find_right_page()
+ * and therefore needs the parent materialized in context->parentImg.  This is
+ * incompatible with the fastpath downlink search, which reads the downlink
+ * straight from the shared page, so it disables that optimization.
+ */
+#define BTREE_PAGE_FIND_KEEP_PARENT		(0x1000)
 
 #define BTREE_PAGE_FIND_SET(context, flag) ((context)->flags |= BTREE_PAGE_FIND_##flag)
 #define BTREE_PAGE_FIND_UNSET(context, flag) ((context)->flags &= ~(BTREE_PAGE_FIND_##flag))

--- a/include/btree/find.h
+++ b/include/btree/find.h
@@ -151,6 +151,7 @@ extern OFindPageResult refind_page(OBTreeFindPageContext *context, void *key,
 extern bool find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey);
 extern bool find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey);
 extern OTuple btree_find_context_lokey(OBTreeFindPageContext *context);
+extern bool btree_find_context_has_lokey(OBTreeFindPageContext *context);
 extern void btree_find_context_from_modify_to_read(OBTreeFindPageContext *context,
 												   Pointer key,
 												   BTreeKeyType keyType,

--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -219,8 +219,15 @@ OIndexKeyAttnumToTupleAttnum(BTreeKeyType keyType, OIndexDescr *idx, int attnum)
 	}
 	else
 	{
+		/*
+		 * A page hikey is stored in the non-leaf tuple format, so it maps the
+		 * same way as BTreeKeyNonLeafKey (e.g. the fastpath downlink search
+		 * decomposes a BTreeKeyPageHiKey when an iterator steps to a
+		 * sibling).
+		 */
 		Assert((keyType == BTreeKeyLeafTuple && attnum <= idx->leafTupdesc->natts) ||
-			   (keyType == BTreeKeyNonLeafKey && attnum <= idx->nFields));
+			   ((keyType == BTreeKeyNonLeafKey || keyType == BTreeKeyPageHiKey) &&
+				attnum <= idx->nFields));
 		return attnum;
 	}
 }

--- a/orioledb.control
+++ b/orioledb.control
@@ -1,5 +1,5 @@
 # orioledb extension
 comment = 'OrioleDB -- the next generation transactional engine'
-default_version = '1.8'
+default_version = '1.9'
 module_pathname = '$libdir/orioledb'
 relocatable = true

--- a/sql/orioledb--1.8--1.9_dev.sql
+++ b/sql/orioledb--1.8--1.9_dev.sql
@@ -1,0 +1,9 @@
+/* contrib/orioledb/sql/orioledb--1.8--1.9_dev.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.9'" to load this file. \quit
+
+CREATE FUNCTION orioledb_test_endkey_returned_skip(relid oid, start_at int4)
+RETURNS int4[]
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.8--1.9_dev.sql
+++ b/sql/orioledb--1.8--1.9_dev.sql
@@ -7,3 +7,8 @@ CREATE FUNCTION orioledb_test_endkey_returned_skip(relid oid, start_at int4)
 RETURNS int4[]
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_test_back_refind_skip_tail(relid oid, fake_curkey int4)
+RETURNS int4[]
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.8--1.9_prod.sql
+++ b/sql/orioledb--1.8--1.9_prod.sql
@@ -1,0 +1,4 @@
+/* contrib/orioledb/sql/orioledb--1.8--1.9_prod.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.9'" to load this file. \quit

--- a/src/btree/fastpath.c
+++ b/src/btree/fastpath.c
@@ -339,6 +339,7 @@ fastpath_find_downlink(Pointer pagePtr,
 	Pointer		base;
 	uint64		state;
 	uint64		imageChangeCount = pg_atomic_read_u64(&imgHdr->o_header.state) & PAGE_STATE_CHANGE_COUNT_MASK;
+	uint32		imagePageChangeCount = O_PAGE_GET_CHANGE_COUNT(imgHdr);
 	OBTreeFastPathFindResult result;
 	static BTreeNonLeafTuphdr tuphdr;
 
@@ -400,7 +401,8 @@ fastpath_find_downlink(Pointer pagePtr,
 
 	state = pg_atomic_read_u64(&hdr->o_header.state);
 	if (O_PAGE_STATE_READ_IS_BLOCKED(state) ||
-		(state & PAGE_STATE_CHANGE_COUNT_MASK) != imageChangeCount)
+		(state & PAGE_STATE_CHANGE_COUNT_MASK) != imageChangeCount ||
+		O_PAGE_GET_CHANGE_COUNT(hdr) != imagePageChangeCount)
 		return OBTreeFastPathFindRetry;
 
 	if (chunkIndex == 0)
@@ -484,7 +486,8 @@ fastpath_find_downlink(Pointer pagePtr,
 
 	state = pg_atomic_read_u64(&hdr->o_header.state);
 	if (O_PAGE_STATE_READ_IS_BLOCKED(state) ||
-		(state & PAGE_STATE_CHANGE_COUNT_MASK) != imageChangeCount)
+		(state & PAGE_STATE_CHANGE_COUNT_MASK) != imageChangeCount ||
+		O_PAGE_GET_CHANGE_COUNT(hdr) != imagePageChangeCount)
 		return OBTreeFastPathFindRetry;
 
 	return OBTreeFastPathFindOK;
@@ -505,6 +508,7 @@ fastpath_find_chunk(Pointer pagePtr,
 	int			offset;
 	Pointer		base;
 	uint64		imageChangeCount = pg_atomic_read_u64(&imgHdr->o_header.state) & PAGE_STATE_CHANGE_COUNT_MASK;
+	uint32		imagePageChangeCount = O_PAGE_GET_CHANGE_COUNT(imgHdr);
 	uint64		state;
 
 	if (!O_PAGE_IS(pagePtr, HIKEYS_FIXED))
@@ -544,7 +548,8 @@ fastpath_find_chunk(Pointer pagePtr,
 
 	state = pg_atomic_read_u64(&hdr->o_header.state);
 	if (O_PAGE_STATE_READ_IS_BLOCKED(state) ||
-		(state & PAGE_STATE_CHANGE_COUNT_MASK) != imageChangeCount)
+		(state & PAGE_STATE_CHANGE_COUNT_MASK) != imageChangeCount ||
+		O_PAGE_GET_CHANGE_COUNT(hdr) != imagePageChangeCount)
 		return OBTreeFastPathFindRetry;
 
 	return OBTreeFastPathFindOK;

--- a/src/btree/fastpath.c
+++ b/src/btree/fastpath.c
@@ -49,17 +49,17 @@ static bool find_downlink_get_keys(BTreeDescr *desc,
 								   Oid *types, Datum *values, uint8 *flags);
 
 static void oid_array_search(Pointer p, int stride, int *lower,
-							 int *upper, Datum keyDatum);
+							 int *upper, Datum keyDatum, bool descending);
 static void int4_array_search(Pointer p, int stride, int *lower,
-							  int *upper, Datum keyDatum);
+							  int *upper, Datum keyDatum, bool descending);
 static void int8_array_search(Pointer p, int stride, int *lower,
-							  int *upper, Datum keyDatum);
+							  int *upper, Datum keyDatum, bool descending);
 static void float4_array_search(Pointer p, int stride, int *lower,
-								int *upper, Datum keyDatum);
+								int *upper, Datum keyDatum, bool descending);
 static void float8_array_search(Pointer p, int stride, int *lower,
-								int *upper, Datum keyDatum);
+								int *upper, Datum keyDatum, bool descending);
 static void tid_array_search(Pointer p, int stride, int *lower,
-							 int *upper, Datum keyDatum);
+							 int *upper, Datum keyDatum, bool descending);
 
 static ArraySearchDesc arraySearchDescs[] = {
 	{OIDOID, OID_BTREE_OPS_OID, sizeof(Oid), ALIGNOF_INT, oid_array_search},
@@ -128,13 +128,14 @@ can_fastpath_find_downlink(OBTreeFindPageContext *context,
 		OIndexField *field = &id->fields[i];
 
 		/*
-		 * The array-search routines compare raw datums assuming an ascending
-		 * layout, so they cannot be used for a DESC-ordered key field (its
-		 * values are stored in descending order).  Fall back to the regular
-		 * binary search in that case.
+		 * The array-search routines compare raw datums, so they require the
+		 * field's btree opclass to match the default one they implement. DESC
+		 * ordering is supported: the routine gets a "descending" flag and
+		 * find_downlink_get_keys() expresses bounds as storage directions, so
+		 * a DESC field is handled by mirroring the comparison rather than
+		 * bailing.
 		 */
-		if (!searchDesc || searchDesc->opcid != field->opclass ||
-			!field->ascending)
+		if (!searchDesc || searchDesc->opcid != field->opclass)
 		{
 			meta->enabled = false;
 			return;
@@ -143,6 +144,7 @@ can_fastpath_find_downlink(OBTreeFindPageContext *context,
 		offset = TYPEALIGN(searchDesc->align, offset);
 		meta->funcs[i] = searchDesc->func;
 		meta->offsets[i] = offset;
+		meta->descending[i] = !field->ascending;
 		types[i] = searchDesc->typeid;
 
 		offset += searchDesc->typlen;
@@ -207,7 +209,12 @@ find_downlink_get_keys(BTreeDescr *desc, void *key, BTreeKeyType keyType,
 	{
 		for (i = 0; i < numValues; i++)
 		{
-			flags[i] = (keyType == BTreeKeyNone) ? FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF : FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
+			/*
+			 * "None" is the leftmost (first storage slot), "Rightmost" the
+			 * last one -- these are storage positions, independent of
+			 * ASC/DESC.
+			 */
+			flags[i] = (keyType == BTreeKeyNone) ? FASTPATH_FIND_DOWNLINK_FLAG_FIRST : FASTPATH_FIND_DOWNLINK_FLAG_LAST;
 			values[i] = (Datum) 0;
 		}
 		return true;
@@ -229,21 +236,31 @@ find_downlink_get_keys(BTreeDescr *desc, void *key, BTreeKeyType keyType,
 
 			if (f & O_VALUE_BOUND_UNBOUNDED)
 			{
-				flags[i] = (f & O_VALUE_BOUND_LOWER) ? FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF : FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
+				/*
+				 * An unbounded-below column is a -infinity value, unbounded-
+				 * above a +infinity value.  Map the value extreme to a
+				 * storage slot through the column's ASC/DESC ordering: -inf
+				 * sits at the first slot for ASC and the last for DESC, +inf
+				 * vice versa.
+				 */
+				bool		valueMinusInf = (f & O_VALUE_BOUND_LOWER) != 0;
+
+				flags[i] = (valueMinusInf == id->fields[i].ascending) ?
+					FASTPATH_FIND_DOWNLINK_FLAG_FIRST : FASTPATH_FIND_DOWNLINK_FLAG_LAST;
 				values[i] = (Datum) 0;
 			}
 			else if (f & O_VALUE_BOUND_NULL)
 			{
 				/*
-				 * A NULL bound sorts to one extreme of the value range
-				 * depending on the field's NULLS FIRST/LAST ordering, exactly
-				 * as o_idx_cmp_range_key_to_value() resolves it.  Without
-				 * this the bound would be searched as its (meaningless) raw
-				 * value, sending the descent to the wrong end of the tree --
-				 * e.g. a backward scan's "+infinity" upper bound (UPPER |
-				 * NULL) would otherwise land on the leftmost page.
+				 * A NULL bound sorts to one storage extreme according to the
+				 * field's NULLS FIRST/LAST ordering, exactly as
+				 * o_idx_cmp_range_key_to_value() resolves it.  NULLS FIRST
+				 * puts NULLs in the first storage slot, NULLS LAST in the
+				 * last -- independent of ASC/DESC.  Without this the bound
+				 * would be searched as its (meaningless) raw value, sending
+				 * the descent to the wrong end of the tree.
 				 */
-				flags[i] = id->fields[i].nullfirst ? FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF : FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
+				flags[i] = id->fields[i].nullfirst ? FASTPATH_FIND_DOWNLINK_FLAG_FIRST : FASTPATH_FIND_DOWNLINK_FLAG_LAST;
 				values[i] = (Datum) 0;
 			}
 			else
@@ -257,25 +274,28 @@ find_downlink_get_keys(BTreeDescr *desc, void *key, BTreeKeyType keyType,
 		 * The bound may specify fewer columns than the key (e.g. "i = v" on a
 		 * (i, pk) key).  Such a bound fences either just before or just after
 		 * the whole run of entries sharing its specified prefix; represent
-		 * that fence by pinning every unspecified trailing column to -inf or
-		 * +inf. A lower-inclusive or upper-exclusive bound fences before the
-		 * run (-inf), a lower-exclusive or upper-inclusive bound fences after
-		 * it (+inf).  Leaving these columns unset would compare against
-		 * garbage and could position the descent in the wrong child.
+		 * that fence by pinning every unspecified trailing column to the
+		 * run's first or last storage slot.  A lower-inclusive or
+		 * upper-exclusive bound fences before the run (first slot), a
+		 * lower-exclusive or upper-inclusive bound fences after it (last
+		 * slot).  These are storage positions of the prefix run as a whole,
+		 * so they do not depend on the trailing columns' ASC/DESC.  Leaving
+		 * these columns unset would compare against garbage and could
+		 * position the descent in the wrong child.
 		 */
 		if (num > 0 && num < numValues)
 		{
 			uint8		f = bound->keys[num - 1].flags;
-			uint8		inf;
+			uint8		fence;
 
 			if (((f & O_VALUE_BOUND_LOWER) != 0) == ((f & O_VALUE_BOUND_INCLUSIVE) != 0))
-				inf = FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF;
+				fence = FASTPATH_FIND_DOWNLINK_FLAG_FIRST;
 			else
-				inf = FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
+				fence = FASTPATH_FIND_DOWNLINK_FLAG_LAST;
 
 			for (i = num; i < numValues; i++)
 			{
-				flags[i] = inf;
+				flags[i] = fence;
 				values[i] = (Datum) 0;
 			}
 		}
@@ -311,7 +331,7 @@ find_downlink_get_keys(BTreeDescr *desc, void *key, BTreeKeyType keyType,
 		values[i] = o_fastgetattr(*tuple, attnum, tupdesc, spec, &isnull);
 
 		if (isnull)
-			flags[i] = (id->fields[i].nullfirst) ? FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF : FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
+			flags[i] = (id->fields[i].nullfirst) ? FASTPATH_FIND_DOWNLINK_FLAG_FIRST : FASTPATH_FIND_DOWNLINK_FLAG_LAST;
 		else
 			flags[i] = 0;
 	}
@@ -388,10 +408,10 @@ fastpath_find_downlink(Pointer pagePtr,
 		if (meta->flags[i] == 0)
 			meta->funcs[i] (base + MAXALIGN(sizeof(BTreeNonLeafTuphdr)) + meta->offsets[i],
 							MAXALIGN(sizeof(BTreeNonLeafTuphdr)) + meta->length,
-							&lower, &upper, meta->values[i]);
-		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF)
+							&lower, &upper, meta->values[i], meta->descending[i]);
+		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_FIRST)
 			upper = lower;
-		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF)
+		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_LAST)
 			lower = upper;
 	}
 
@@ -531,10 +551,10 @@ fastpath_find_chunk(Pointer pagePtr,
 		if (meta->flags[i] == 0)
 			meta->funcs[i] (base + meta->offsets[i],
 							meta->length, &lower, &upper,
-							meta->values[i]);
-		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF)
+							meta->values[i], meta->descending[i]);
+		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_FIRST)
 			upper = lower;
-		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF)
+		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_LAST)
 			lower = upper;
 	}
 
@@ -560,7 +580,8 @@ fastpath_find_chunk(Pointer pagePtr,
  * below do the same for other datatypes.
  */
 static void
-int4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
+int4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
+				  bool descending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -577,7 +598,7 @@ int4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (value > key)
+		else if (descending ? value < key : value > key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -592,7 +613,8 @@ int4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
 }
 
 static void
-int8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
+int8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
+				  bool descending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -609,7 +631,7 @@ int8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (value > key)
+		else if (descending ? value < key : value > key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -624,7 +646,8 @@ int8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
 }
 
 static void
-oid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
+oid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
+				 bool descending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -641,7 +664,7 @@ oid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (value > key)
+		else if (descending ? value < key : value > key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -656,7 +679,8 @@ oid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
 }
 
 static void
-float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
+float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
+					bool descending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -674,7 +698,7 @@ float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (value > key)
+		else if (descending ? value < key : value > key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -689,7 +713,8 @@ float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 }
 
 static void
-float8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
+float8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
+					bool descending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -707,7 +732,7 @@ float8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (value > key)
+		else if (descending ? value < key : value > key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -742,7 +767,8 @@ tid_cmp(ItemPointer arg1, ItemPointer arg2)
 }
 
 static void
-tid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
+tid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
+				 bool descending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -759,7 +785,7 @@ tid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum)
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (cmp > 0)
+		else if (descending ? cmp < 0 : cmp > 0)
 		{
 			if (!lowerSet)
 				*lower = i;

--- a/src/btree/fastpath.c
+++ b/src/btree/fastpath.c
@@ -108,7 +108,15 @@ can_fastpath_find_downlink(OBTreeFindPageContext *context,
 		keyType == BTreeKeyUniqueUpperBound)
 		meta->numKeys = id->nUniqueFields;
 	else if (id->desc.type != oIndexToast && id->desc.type != oIndexBridge)
-		meta->numKeys = id->nKeyFields;
+
+		/*
+		 * Compare the whole tuple-identifying key, not just the user key
+		 * fields.  A non-unique index appends the primary key to make every
+		 * downlink/leaf key unique; comparing only the leading nKeyFields
+		 * would treat duplicate user-key values as an ambiguous prefix and
+		 * could descend into the wrong child (skipping earlier duplicates).
+		 */
+		meta->numKeys = id->nUniqueFields;
 	else
 		meta->numKeys = id->nonLeafSpec.natts;
 
@@ -119,7 +127,14 @@ can_fastpath_find_downlink(OBTreeFindPageContext *context,
 																	   TupleDescAttr(id->nonLeafTupdesc, i)->atttypid);
 		OIndexField *field = &id->fields[i];
 
-		if (!searchDesc || searchDesc->opcid != field->opclass)
+		/*
+		 * The array-search routines compare raw datums assuming an ascending
+		 * layout, so they cannot be used for a DESC-ordered key field (its
+		 * values are stored in descending order).  Fall back to the regular
+		 * binary search in that case.
+		 */
+		if (!searchDesc || searchDesc->opcid != field->opclass ||
+			!field->ascending)
 		{
 			meta->enabled = false;
 			return;
@@ -217,10 +232,51 @@ find_downlink_get_keys(BTreeDescr *desc, void *key, BTreeKeyType keyType,
 				flags[i] = (f & O_VALUE_BOUND_LOWER) ? FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF : FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
 				values[i] = (Datum) 0;
 			}
+			else if (f & O_VALUE_BOUND_NULL)
+			{
+				/*
+				 * A NULL bound sorts to one extreme of the value range
+				 * depending on the field's NULLS FIRST/LAST ordering, exactly
+				 * as o_idx_cmp_range_key_to_value() resolves it.  Without
+				 * this the bound would be searched as its (meaningless) raw
+				 * value, sending the descent to the wrong end of the tree --
+				 * e.g. a backward scan's "+infinity" upper bound (UPPER |
+				 * NULL) would otherwise land on the leftmost page.
+				 */
+				flags[i] = id->fields[i].nullfirst ? FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF : FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
+				values[i] = (Datum) 0;
+			}
 			else
 			{
 				flags[i] = 0;
 				values[i] = bound->keys[i].value;
+			}
+		}
+
+		/*
+		 * The bound may specify fewer columns than the key (e.g. "i = v" on a
+		 * (i, pk) key).  Such a bound fences either just before or just after
+		 * the whole run of entries sharing its specified prefix; represent
+		 * that fence by pinning every unspecified trailing column to -inf or
+		 * +inf. A lower-inclusive or upper-exclusive bound fences before the
+		 * run (-inf), a lower-exclusive or upper-inclusive bound fences after
+		 * it (+inf).  Leaving these columns unset would compare against
+		 * garbage and could position the descent in the wrong child.
+		 */
+		if (num > 0 && num < numValues)
+		{
+			uint8		f = bound->keys[num - 1].flags;
+			uint8		inf;
+
+			if (((f & O_VALUE_BOUND_LOWER) != 0) == ((f & O_VALUE_BOUND_INCLUSIVE) != 0))
+				inf = FASTPATH_FIND_DOWNLINK_FLAG_MINUS_INF;
+			else
+				inf = FASTPATH_FIND_DOWNLINK_FLAG_PLUS_INF;
+
+			for (i = num; i < numValues; i++)
+			{
+				flags[i] = inf;
+				values[i] = (Datum) 0;
 			}
 		}
 		return true;

--- a/src/btree/fastpath.c
+++ b/src/btree/fastpath.c
@@ -49,17 +49,17 @@ static bool find_downlink_get_keys(BTreeDescr *desc,
 								   Oid *types, Datum *values, uint8 *flags);
 
 static void oid_array_search(Pointer p, int stride, int *lower,
-							 int *upper, Datum keyDatum, bool descending);
+							 int *upper, Datum keyDatum, bool ascending);
 static void int4_array_search(Pointer p, int stride, int *lower,
-							  int *upper, Datum keyDatum, bool descending);
+							  int *upper, Datum keyDatum, bool ascending);
 static void int8_array_search(Pointer p, int stride, int *lower,
-							  int *upper, Datum keyDatum, bool descending);
+							  int *upper, Datum keyDatum, bool ascending);
 static void float4_array_search(Pointer p, int stride, int *lower,
-								int *upper, Datum keyDatum, bool descending);
+								int *upper, Datum keyDatum, bool ascending);
 static void float8_array_search(Pointer p, int stride, int *lower,
-								int *upper, Datum keyDatum, bool descending);
+								int *upper, Datum keyDatum, bool ascending);
 static void tid_array_search(Pointer p, int stride, int *lower,
-							 int *upper, Datum keyDatum, bool descending);
+							 int *upper, Datum keyDatum, bool ascending);
 
 static ArraySearchDesc arraySearchDescs[] = {
 	{OIDOID, OID_BTREE_OPS_OID, sizeof(Oid), ALIGNOF_INT, oid_array_search},
@@ -130,7 +130,7 @@ can_fastpath_find_downlink(OBTreeFindPageContext *context,
 		/*
 		 * The array-search routines compare raw datums, so they require the
 		 * field's btree opclass to match the default one they implement. DESC
-		 * ordering is supported: the routine gets a "descending" flag and
+		 * ordering is supported: the routine gets an "ascending" flag and
 		 * find_downlink_get_keys() expresses bounds as storage directions, so
 		 * a DESC field is handled by mirroring the comparison rather than
 		 * bailing.
@@ -144,7 +144,7 @@ can_fastpath_find_downlink(OBTreeFindPageContext *context,
 		offset = TYPEALIGN(searchDesc->align, offset);
 		meta->funcs[i] = searchDesc->func;
 		meta->offsets[i] = offset;
-		meta->descending[i] = !field->ascending;
+		meta->ascending[i] = field->ascending;
 		types[i] = searchDesc->typeid;
 
 		offset += searchDesc->typlen;
@@ -408,7 +408,7 @@ fastpath_find_downlink(Pointer pagePtr,
 		if (meta->flags[i] == 0)
 			meta->funcs[i] (base + MAXALIGN(sizeof(BTreeNonLeafTuphdr)) + meta->offsets[i],
 							MAXALIGN(sizeof(BTreeNonLeafTuphdr)) + meta->length,
-							&lower, &upper, meta->values[i], meta->descending[i]);
+							&lower, &upper, meta->values[i], meta->ascending[i]);
 		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_FIRST)
 			upper = lower;
 		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_LAST)
@@ -551,7 +551,7 @@ fastpath_find_chunk(Pointer pagePtr,
 		if (meta->flags[i] == 0)
 			meta->funcs[i] (base + meta->offsets[i],
 							meta->length, &lower, &upper,
-							meta->values[i], meta->descending[i]);
+							meta->values[i], meta->ascending[i]);
 		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_FIRST)
 			upper = lower;
 		else if (meta->flags[i] & FASTPATH_FIND_DOWNLINK_FLAG_LAST)
@@ -581,7 +581,7 @@ fastpath_find_chunk(Pointer pagePtr,
  */
 static void
 int4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
-				  bool descending)
+				  bool ascending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -598,7 +598,7 @@ int4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (descending ? value < key : value > key)
+		else if (ascending ? value > key : value < key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -614,7 +614,7 @@ int4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
 
 static void
 int8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
-				  bool descending)
+				  bool ascending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -631,7 +631,7 @@ int8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (descending ? value < key : value > key)
+		else if (ascending ? value > key : value < key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -647,7 +647,7 @@ int8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
 
 static void
 oid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
-				 bool descending)
+				 bool ascending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -664,7 +664,7 @@ oid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (descending ? value < key : value > key)
+		else if (ascending ? value > key : value < key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -680,7 +680,7 @@ oid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
 
 static void
 float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
-					bool descending)
+					bool ascending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -698,7 +698,7 @@ float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (descending ? value < key : value > key)
+		else if (ascending ? value > key : value < key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -714,7 +714,7 @@ float4_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 
 static void
 float8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
-					bool descending)
+					bool ascending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -732,7 +732,7 @@ float8_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatu
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (descending ? value < key : value > key)
+		else if (ascending ? value > key : value < key)
 		{
 			if (!lowerSet)
 				*lower = i;
@@ -768,7 +768,7 @@ tid_cmp(ItemPointer arg1, ItemPointer arg2)
 
 static void
 tid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
-				 bool descending)
+				 bool ascending)
 {
 	int			i;
 	bool		lowerSet = false;
@@ -785,7 +785,7 @@ tid_array_search(Pointer p, int stride, int *lower, int *upper, Datum keyDatum,
 			*lower = i;
 			lowerSet = true;
 		}
-		else if (descending ? cmp < 0 : cmp > 0)
+		else if (ascending ? cmp > 0 : cmp < 0)
 		{
 			if (!lowerSet)
 				*lower = i;

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -734,12 +734,14 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 
 			/*
 			 * The fastpath skips loading the hikeys chunk.  That is fine for
-			 * a single-tuple search, but a sibling-navigating caller
-			 * (KEEP_PARENT) iterates the whole target leaf and needs the page
-			 * header / chunk descriptors to cross chunks, so always load the
-			 * hikeys chunk for the leaf in that case.
+			 * a single-tuple search; a sibling-navigating caller
+			 * (KEEP_PARENT, the iterator) loads the hikeys chunk on demand
+			 * only when it needs it -- when stepping to a sibling, or when
+			 * crossing a chunk boundary within a leaf (the chunk-descriptor
+			 * array lives in the hikeys chunk).  So it does not need the
+			 * hikeys chunk in the image here either.
 			 */
-			loadHikeys = !fastpath || (keepParentFlag && !useParentImg);
+			loadHikeys = !fastpath;
 
 			if (tryFlag)
 			{

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1791,30 +1791,47 @@ btree_find_context_lokey(OBTreeFindPageContext *context)
 		 */
 		return context->leafLokey.tuple;
 	}
-	else if (BTREE_PAGE_FIND_IS(context, LOKEY_EXISTS))
-	{
-		/*
-		 * Hikey of the left sibling of the parent, carried down the descent.
-		 */
-		return context->lokey.tuple;
-	}
 	else
 	{
 		/*
-		 * The descent established no lokey for this page.  This happens for a
-		 * frozen no-record split half (see o_btree_insert_split()) reached
-		 * live during a backward scan: its csn was not bumped, so the reader
-		 * never walked the undo chain that would have supplied a lokey.  Such
-		 * a page drops no tuple, so its smallest stored key is its lokey.
+		 * The current page is the leftmost child of its immediate parent, so
+		 * its lokey is the parent's lokey, carried down the descent in
+		 * context->lokey (LOKEY_EXISTS).
+		 *
+		 * A frozen no-record split half (see o_btree_insert_split()) reached
+		 * live during a backward FETCH scan can transiently arrive here with
+		 * the lokey unestablished -- it is the leftmost child of its parent,
+		 * has no carried lokey, and its frozen csn means no undo chain
+		 * supplies one.  The backward iterator detects that via
+		 * btree_find_context_has_lokey() and re-descends
+		 * (iterator_refind_partial_leaf, which also switches to whole-page
+		 * reads) before stepping left, so by the time we reach here
+		 * LOKEY_EXISTS always holds.
 		 */
-		OTuple		firstTuple;
-		BTreePageItemLocator loc;
-
-		BTREE_PAGE_LOCATOR_FIRST(context->img, &loc);
-		Assert(BTREE_PAGE_LOCATOR_IS_VALID(context->img, &loc));
-		BTREE_PAGE_READ_TUPLE(firstTuple, context->img, &loc);
-		return firstTuple;
+		Assert(BTREE_PAGE_FIND_IS(context, LOKEY_EXISTS));
+		return context->lokey.tuple;
 	}
+}
+
+/*
+ * Whether btree_find_context_lokey() can return the current page's real lokey,
+ * i.e. the descent established one of its reliable sources.  Returns false only
+ * in the transient state a frozen no-record split half leaves when reached live
+ * in FETCH mode (leftmost child of its parent, no carried lokey and no undo
+ * chain to recover it); the backward iterator recovers from that by
+ * re-descending instead of stepping left off a bogus lokey.
+ */
+bool
+btree_find_context_has_lokey(OBTreeFindPageContext *context)
+{
+	BTreePageItemLocator ploc = context->items[context->index - 1].locator;
+
+	Assert(BTREE_PAGE_FIND_IS(context, KEEP_LOKEY));
+
+	return BTREE_PAGE_FIND_IS(context, LOKEY_UNDO) ||
+		BTREE_PAGE_FIND_IS(context, LOKEY_SIBLING) ||
+		BTREE_PAGE_LOCATOR_GET_OFFSET(context->parentImg, &ploc) > 0 ||
+		BTREE_PAGE_FIND_IS(context, LOKEY_EXISTS);
 }
 
 static Pointer

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -61,7 +61,8 @@ static void btree_page_search_items(BTreeDescr *desc, Page p, Pointer key,
 									BTreeKeyType keyType,
 									BTreePageItemLocator *locator);
 static void refresh_parent_img_chunk(OBTreeFindPageInternalContext *intCxt);
-static bool convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt);
+static bool convert_fastpath_parent_to_img(OBTreeFindPageContext *context,
+										   BTreePageItemLocator *locator);
 
 /*
  * A parent locator that find_left_page()/find_right_page() will navigate must
@@ -410,85 +411,40 @@ refresh_parent_img_chunk(OBTreeFindPageInternalContext *intCxt)
 
 /*
  * The fastpath downlink search positions the locator straight onto the shared
- * page (it skips copying the page into parentImg).  Callers that step to
- * siblings (KEEP_PARENT) need the parent in context->parentImg, so convert the
- * locator from the shared page to a local one: copy the header (with hikeys)
- * and the referenced chunk into parentImg, set up parentPartial so other chunks
- * load on demand, and rebind the locator onto parentImg.
+ * page (it skips loading the hikeys chunk, so parentImg holds only the base
+ * header that the descent's partial read already copied there).  Callers that
+ * step to siblings (KEEP_PARENT) need the parent fully navigable in parentImg,
+ * so finish that partial read on top of the *existing* snapshot: load the
+ * hikeys chunk (the chunk-descriptor array) and the chunk holding the downlink
+ * into parentImg through the already-set-up context->parentPartial, then rebind
+ * the locator onto parentImg.
  *
- * The copy is made from the live shared page without a page lock, so it has to
- * be validated the same way try_copy_page() validates a partial read: bail out
- * if reads are blocked, if a header field used to size the copy is out of
- * range (a torn read), if the page-state change count moved across the copy, or
- * if the page is no longer the one we descended to (pageChangeCount changed).
- * Returns false in any of those cases; the caller must re-read the parent.
+ * We deliberately do NOT re-read the page from scratch (o_btree_read_page()):
+ * the base header was snapshotted during the descent, and re-snapshotting would
+ * capture a possibly newer page version, leaving parentImg inconsistent with
+ * the downlink the fastpath already chose off that snapshot.  Both loads
+ * validate against the snapshot's change count (state bits + pageChangeCount),
+ * so a parent that changed or was evicted/reused under us makes them fail and
+ * the caller re-finds.  partial_load_chunk() positions the locator at item 0,
+ * so the caller's real itemOffset is restored afterwards.
+ *
+ * Returns false if the parent changed under us; the caller must re-find.
  */
 static bool
-convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt)
+convert_fastpath_parent_to_img(OBTreeFindPageContext *context,
+							   BTreePageItemLocator *locator)
 {
-	OBTreeFindPageContext *context = intCxt->context;
-	OInMemoryBlkno blkno = intCxt->blkno;
-	Pointer		src = O_GET_IN_MEMORY_PAGE(blkno);
-	BTreePageItemLocator *locator = &context->items[context->index].locator;
-	BTreePageHeader *hdr = (BTreePageHeader *) src;
 	OffsetNumber chunkOffset = locator->chunkOffset;
-	LocationIndex chunkBegin;
-	LocationIndex chunkEnd;
-	LocationIndex hikeysEnd;
-	OffsetNumber chunksCount;
-	uint64		state1,
-				state2;
+	OffsetNumber itemOffset = locator->itemOffset;
 
-	state1 = pg_atomic_read_u64(&(O_PAGE_HEADER(src)->state));
-	if (O_PAGE_STATE_READ_IS_BLOCKED(state1))
+	if (!partial_load_hikeys_chunk(&context->parentPartial, context->parentImg))
 		return false;
 
-	pg_read_barrier();
-
-	hikeysEnd = hdr->hikeysEnd;
-	chunksCount = hdr->chunksCount;
-	if (hikeysEnd < MAXALIGN(sizeof(BTreePageHeader)) || hikeysEnd > ORIOLEDB_BLCKSZ ||
-		chunkOffset >= chunksCount)
+	if (!partial_load_chunk(&context->parentPartial, context->parentImg,
+							chunkOffset, locator))
 		return false;
 
-	chunkBegin = SHORT_GET_LOCATION(hdr->chunkDesc[chunkOffset].shortLocation);
-	if (chunkOffset + 1 < chunksCount)
-		chunkEnd = SHORT_GET_LOCATION(hdr->chunkDesc[chunkOffset + 1].shortLocation);
-	else
-		chunkEnd = hdr->dataSize;
-	if (chunkBegin > chunkEnd || chunkEnd > ORIOLEDB_BLCKSZ)
-		return false;
-
-	pg_read_barrier();
-
-	/* Header including the hikeys chunk. */
-	memcpy(context->parentImg, src, hikeysEnd);
-	/* The single chunk that `locator` references. */
-	memcpy(context->parentImg + chunkBegin,
-		   src + chunkBegin,
-		   chunkEnd - chunkBegin);
-
-	pg_read_barrier();
-	state2 = pg_atomic_read_u64(&(O_PAGE_HEADER(src)->state));
-
-	/* The page must not have changed or been blocked while we copied it. */
-	if ((state1 & PAGE_STATE_CHANGE_COUNT_MASK) != (state2 & PAGE_STATE_CHANGE_COUNT_MASK) ||
-		O_PAGE_STATE_READ_IS_BLOCKED(state2))
-		return false;
-
-	/* ... and it must still be the page we descended to. */
-	if (O_PAGE_GET_CHANGE_COUNT(src) != intCxt->pageChangeCount)
-		return false;
-
-	context->parentPartial.src = src;
-	context->parentPartial.isPartial = true;
-	context->parentPartial.hikeysChunkIsLoaded = true;
-	memset(context->parentPartial.chunkIsLoaded, 0,
-		   sizeof(context->parentPartial.chunkIsLoaded));
-	context->parentPartial.chunkIsLoaded[chunkOffset] = true;
-
-	locator->chunk =
-		(BTreePageChunk *) (context->parentImg + chunkBegin);
+	locator->itemOffset = itemOffset;
 	return true;
 }
 
@@ -545,6 +501,7 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 	intCxt.keyType = keyType;
 	intCxt.targetLevel = targetLevel;
 	intCxt.inserted = false;
+	context->parentImgDeferred = false;
 
 
 	ASAN_UNPOISON_MEMORY_REGION(&fastpathMeta, sizeof(fastpathMeta));
@@ -904,15 +861,30 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 		 * The immediate parent's downlink may have been located via the
 		 * fastpath, leaving the locator pointing into the shared page (and
 		 * parentImg not populated).  A sibling-navigating caller
-		 * (KEEP_PARENT, e.g. the iterator) needs the parent in parentImg, so
-		 * materialize it and rebind the locator before recording the page
-		 * change count from parentImg.  The copy is validated; if the parent
-		 * changed under us while copying, re-read it from the top of the loop
-		 * (a stale/evicted parent is then caught by the change-count checks).
+		 * (KEEP_PARENT, e.g. the iterator) needs the parent in parentImg.
+		 *
+		 * A backward scan (KEEP_LOKEY) reads the parent's lokey from
+		 * parentImg just below, so materialize it now; if the parent changed
+		 * under us, re-read it from the top of the loop.  A forward scan
+		 * touches the parent only when it steps right, so defer the copy to
+		 * find_right_page() -- a scan that never crosses a parent boundary
+		 * then pays nothing, and the on-demand copy is fresher than one
+		 * carried across many iterator steps.  (A slowpath parent read
+		 * already filled parentImg, so nothing to do there.)
 		 */
-		if (fastpath && keepParentFlag && level == targetLevel + 1 &&
-			!convert_fastpath_parent_to_img(&intCxt))
-			continue;
+		if (level == targetLevel + 1)
+		{
+			if (fastpath && keepParentFlag && !keepLokeyFlag)
+				context->parentImgDeferred = true;
+			else
+			{
+				context->parentImgDeferred = false;
+				if (fastpath && keepParentFlag &&
+					!convert_fastpath_parent_to_img(context,
+													&context->items[context->index].locator))
+					continue;
+			}
+		}
 
 		context->items[context->index].pageChangeCount = O_PAGE_GET_CHANGE_COUNT(intCxt.pagePtr);
 
@@ -1506,6 +1478,25 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 	parentItem = &context->items[context->index - 1];
 	item = &context->items[context->index];
 
+	/* copy hikey (also needed for the find_page() fallback below) */
+	copy_fixed_hikey(desc, hikey, context->img);
+
+	/*
+	 * A forward descent that located the parent via the fastpath deferred
+	 * copying it into parentImg (see find_page()).  Now that we actually need
+	 * the parent's downlinks, materialize it; on failure (the parent changed
+	 * or was evicted) fall back to a find_page() re-descent from the root.
+	 */
+	if (context->parentImgDeferred)
+	{
+		if (!convert_fastpath_parent_to_img(context, &parentItem->locator))
+		{
+			(void) find_page(context, hikey, BTreeKeyNonLeafKey, level);
+			return true;
+		}
+		context->parentImgDeferred = false;
+	}
+
 	/* Try to get next item from the parent page */
 	loc = context->items[context->index - 1].locator;
 
@@ -1515,9 +1506,6 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 
 	if (BTREE_PAGE_LOCATOR_IS_VALID(context->parentImg, &loc))
 		BTREE_PAGE_LOCATOR_NEXT(context->parentImg, &loc);
-
-	/* copy hikey */
-	copy_fixed_hikey(desc, hikey, context->img);
 
 	/* Try to load next page using next parent downlink */
 	if (BTREE_PAGE_LOCATOR_IS_VALID(context->parentImg, &loc))

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -61,6 +61,18 @@ static void btree_page_search_items(BTreeDescr *desc, Page p, Pointer key,
 									BTreeKeyType keyType,
 									BTreePageItemLocator *locator);
 static void refresh_parent_img_chunk(OBTreeFindPageInternalContext *intCxt);
+static void convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt);
+
+/*
+ * A parent locator that find_left_page()/find_right_page() will navigate must
+ * point into context->parentImg (or be NULL).  Assert that at every place we
+ * record or advance such a locator, so a stray shared-page/img pointer is
+ * caught at its producer rather than only when the sibling step consumes it.
+ */
+#define ASSERT_PARENT_LOCATOR_LOCAL(context, loc) \
+	Assert((loc).chunk == NULL || \
+		   ((Pointer) (loc).chunk >= (context)->parentImg && \
+			(Pointer) (loc).chunk < (context)->parentImg + ORIOLEDB_BLCKSZ))
 
 /*
  * Initialize B-tree page find context.
@@ -385,12 +397,55 @@ refresh_parent_img_chunk(OBTreeFindPageInternalContext *intCxt)
 		   src + chunkBegin,
 		   chunkEnd - chunkBegin);
 
-	context->partial.src = src;
-	context->partial.isPartial = true;
-	context->partial.hikeysChunkIsLoaded = true;
-	memset(context->partial.chunkIsLoaded, 0,
-		   sizeof(context->partial.chunkIsLoaded));
-	context->partial.chunkIsLoaded[chunkOffset] = true;
+	context->parentPartial.src = src;
+	context->parentPartial.isPartial = true;
+	context->parentPartial.hikeysChunkIsLoaded = true;
+	memset(context->parentPartial.chunkIsLoaded, 0,
+		   sizeof(context->parentPartial.chunkIsLoaded));
+	context->parentPartial.chunkIsLoaded[chunkOffset] = true;
+
+	locator->chunk =
+		(BTreePageChunk *) (context->parentImg + chunkBegin);
+}
+
+/*
+ * The fastpath downlink search positions the locator straight onto the shared
+ * page (it skips copying the page into parentImg).  Callers that step to
+ * siblings (KEEP_PARENT) need the parent in context->parentImg, so convert the
+ * locator from the shared page to a local one: copy the header (with hikeys)
+ * and the referenced chunk into parentImg, set up parentPartial so other chunks
+ * load on demand, and rebind the locator onto parentImg.
+ */
+static void
+convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt)
+{
+	OBTreeFindPageContext *context = intCxt->context;
+	Pointer		src = O_GET_IN_MEMORY_PAGE(intCxt->blkno);
+	BTreePageItemLocator *locator = &context->items[context->index].locator;
+	BTreePageHeader *hdr = (BTreePageHeader *) src;
+	OffsetNumber chunkOffset = locator->chunkOffset;
+	LocationIndex chunkBegin;
+	LocationIndex chunkEnd;
+
+	chunkBegin = SHORT_GET_LOCATION(hdr->chunkDesc[chunkOffset].shortLocation);
+	if (chunkOffset + 1 < hdr->chunksCount)
+		chunkEnd = SHORT_GET_LOCATION(hdr->chunkDesc[chunkOffset + 1].shortLocation);
+	else
+		chunkEnd = hdr->dataSize;
+
+	/* Header including the hikeys chunk. */
+	memcpy(context->parentImg, src, hdr->hikeysEnd);
+	/* The single chunk that `locator` references. */
+	memcpy(context->parentImg + chunkBegin,
+		   src + chunkBegin,
+		   chunkEnd - chunkBegin);
+
+	context->parentPartial.src = src;
+	context->parentPartial.isPartial = true;
+	context->parentPartial.hikeysChunkIsLoaded = true;
+	memset(context->parentPartial.chunkIsLoaded, 0,
+		   sizeof(context->parentPartial.chunkIsLoaded));
+	context->parentPartial.chunkIsLoaded[chunkOffset] = true;
 
 	locator->chunk =
 		(BTreePageChunk *) (context->parentImg + chunkBegin);
@@ -428,15 +483,17 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 	OBTreeFindPageInternalContext intCxt;
 	BTreePageItemLocator loc;
 	bool		needLock = false,
-				fetchFlag PG_USED_FOR_ASSERTS_ONLY = BTREE_PAGE_FIND_IS(context, FETCH),
+				fetchFlag = BTREE_PAGE_FIND_IS(context, FETCH),
 				modifyFlag = BTREE_PAGE_FIND_IS(context, MODIFY),
 				imageFlag = BTREE_PAGE_FIND_IS(context, IMAGE),
 				tryFlag = BTREE_PAGE_FIND_IS(context, TRY_LOCK),
 				fixLeafFlag = BTREE_PAGE_FIND_IS(context, FIX_LEAF_SPLIT),
 				noFixFlag PG_USED_FOR_ASSERTS_ONLY = BTREE_PAGE_FIND_IS(context, NO_FIX_SPLIT),
 				keepLokeyFlag = BTREE_PAGE_FIND_IS(context, KEEP_LOKEY),
+				keepParentFlag = BTREE_PAGE_FIND_IS(context, KEEP_PARENT),
 				downlinkLocationFlag = BTREE_PAGE_FIND_IS(context, DOWNLINK_LOCATION);
 	bool		shmemIsReloaded = false;
+	bool		loadHikeys;
 	FastpathFindDownlinkMeta fastpathMeta;
 	Jsonb	   *params = NULL;
 
@@ -460,7 +517,7 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 	 */
 	Assert((imageFlag && (targetLevel <= ORIOLEDB_MAX_DEPTH) && !fetchFlag && !modifyFlag)
 		   || (imageFlag && targetLevel == 0 && !fetchFlag && modifyFlag)
-		   || (!imageFlag && fetchFlag && !modifyFlag && !keepLokeyFlag)
+		   || (!imageFlag && fetchFlag && !modifyFlag)
 		   || (!imageFlag && !fetchFlag && modifyFlag && !keepLokeyFlag));
 	Assert(!(COMMITSEQNO_IS_NORMAL(context->csn) && modifyFlag));
 
@@ -473,6 +530,7 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 	}
 	context->imgUndoLoc = InvalidUndoLocation;
 	context->partial.isPartial = false;
+	context->parentPartial.isPartial = false;
 	context->index = 0;
 
 	if (!tryFlag)
@@ -525,13 +583,15 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 		fastpath = fastpath && (keyType != BTreeKeyPageHiKey || level > 0);
 
 		intCxt.partial = NULL;
-		if (!imageFlag || level > 0)
-			context->partial.isPartial = false;
 
 		/*
-		 * else saves isPartial flag for the parent of the leaf in imageFlag
-		 * case
+		 * The leaf's partial state is re-initialized by each page read, so it
+		 * is safe to reset here unconditionally.  The parent's partial state
+		 * lives in context->parentPartial and is preserved across the leaf
+		 * read so find_left_page()/find_right_page() can navigate siblings
+		 * via the parent.
 		 */
+		context->partial.isPartial = false;
 
 		if (needLock || (modifyFlag && level == targetLevel))
 		{
@@ -582,12 +642,19 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 		{
 			bool		useParentImg = false;
 
-			if (imageFlag)
+			if (imageFlag || fetchFlag)
 			{
 				/*
-				 * In BTREE_PAGE_FIND_IMAGE case we read a target targetLevel
-				 * to the context.img without partial and read upper non-leaf
-				 * pages to the context.parentImg partially.
+				 * In both BTREE_PAGE_FIND_IMAGE and BTREE_PAGE_FIND_FETCH we
+				 * read upper non-leaf (parent) pages partially to
+				 * context->parentImg using context->parentPartial, so
+				 * find_left_page()/find_right_page() can navigate to sibling
+				 * pages through the parent's downlinks.
+				 *
+				 * The target (leaf) page is read to context->img: in full for
+				 * IMAGE (cheaper to iterate the whole page in memory) and
+				 * partially for FETCH (cheaper when only part of the page is
+				 * actually read).
 				 *
 				 * We consider it's OK to return page of lower targetLevel
 				 * than required, if tree doesn't have enough height.  That's
@@ -596,25 +663,43 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 				if (level <= targetLevel)
 				{
 					useParentImg = false;
-					intCxt.partial = NULL;
-					Assert(!fastpath);
+					if (fetchFlag)
+					{
+						intCxt.partial = &context->partial;
+					}
+					else
+					{
+						intCxt.partial = NULL;
+						Assert(!fastpath);
+					}
 				}
 				else
 				{
 					useParentImg = true;
-					intCxt.partial = &context->partial;
+					intCxt.partial = &context->parentPartial;
 				}
 			}
 			else
 			{
 				/*
-				 * In other cases we can use the img to hold a partial data.
+				 * BTREE_PAGE_FIND_MODIFY: parent pages are read partially to
+				 * context->img; the target page is locked above.
 				 */
 				useParentImg = false;
 				intCxt.partial = &context->partial;
 			}
 
 			intCxt.haveLock = false;
+
+			/*
+			 * The fastpath skips loading the hikeys chunk.  That is fine for
+			 * a single-tuple search, but a sibling-navigating caller
+			 * (KEEP_PARENT) iterates the whole target leaf and needs the page
+			 * header / chunk descriptors to cross chunks, so always load the
+			 * hikeys chunk for the leaf in that case.
+			 */
+			loadHikeys = !fastpath || (keepParentFlag && !useParentImg);
+
 			if (tryFlag)
 			{
 				ReadPageResult result;
@@ -624,7 +709,7 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 												  useParentImg,
 												  key, keyType,
 												  intCxt.partial,
-												  !fastpath);
+												  loadHikeys);
 				intCxt.pagePtr = useParentImg ? context->parentImg : context->img;
 				if (result == ReadPageResultWrongPageChangeCount)
 				{
@@ -643,7 +728,7 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 											  intCxt.pageChangeCount,
 											  useParentImg, key, keyType,
 											  intCxt.partial,
-											  !fastpath);
+											  loadHikeys);
 				intCxt.pagePtr = useParentImg ? context->parentImg : context->img;
 				if (!result)
 				{
@@ -771,10 +856,46 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 
 		context->items[context->index].locator = loc;
 		context->items[context->index].blkno = intCxt.blkno;
+
+		/*
+		 * The immediate parent's downlink may have been located via the
+		 * fastpath, leaving the locator pointing into the shared page (and
+		 * parentImg not populated).  A sibling-navigating caller
+		 * (KEEP_PARENT, e.g. the iterator) needs the parent in parentImg, so
+		 * materialize it and rebind the locator before recording the page
+		 * change count from parentImg.
+		 */
+		if (fastpath && keepParentFlag && level == targetLevel + 1)
+			convert_fastpath_parent_to_img(&intCxt);
+
 		context->items[context->index].pageChangeCount = O_PAGE_GET_CHANGE_COUNT(intCxt.pagePtr);
 
-		/* Save the lokey if needed */
-		if (keepLokeyFlag && level > 1 &&
+		/*
+		 * Save the lokey if needed.
+		 *
+		 * For levels above the immediate parent the located downlink is the
+		 * propagated lokey of the leftmost descent below; keep it in
+		 * context->lokey (LOKEY_EXISTS), which btree_find_context_lokey()
+		 * returns when the target page's own downlink is the parent's first
+		 * one.
+		 *
+		 * For the immediate parent of a *leaf* target (level == 1, i.e. the
+		 * leaf iterator's targetLevel == 0) the located downlink is the leaf
+		 * page's own lokey; stash it in the dedicated, stable
+		 * context->leafLokey so btree_find_context_lokey() can return it
+		 * without re-reading the parent image -- which is unreliable in FETCH
+		 * mode, where parentImg is partial and may be reclaimed under
+		 * page-pool pressure during iteration.
+		 *
+		 * When targetLevel > 0 (e.g. the sequential scan descends to
+		 * targetLevel == 1 with KEEP_LOKEY and reads context->lokey
+		 * directly), the immediate parent's downlink is still the target
+		 * page's own lokey, but its consumer expects it in context->lokey,
+		 * exactly as the pre-FETCH-iterator code produced it.  So only divert
+		 * to leafLokey for the leaf case (targetLevel == 0); otherwise fall
+		 * through to context->lokey.
+		 */
+		if (keepLokeyFlag && level > targetLevel &&
 			BTREE_PAGE_LOCATOR_GET_OFFSET(intCxt.pagePtr, &loc) > 0)
 		{
 			OTuple		lokey;
@@ -782,10 +903,16 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 			Assert(nonLeafHdr);
 
 			BTREE_PAGE_READ_INTERNAL_TUPLE(lokey, intCxt.pagePtr, &loc);
-			copy_fixed_key(context->desc, &context->lokey, lokey);
-			BTREE_PAGE_FIND_SET(context, LOKEY_EXISTS);
-			BTREE_PAGE_FIND_UNSET(context, LOKEY_SIBLING);
-			BTREE_PAGE_FIND_UNSET(context, LOKEY_UNDO);
+
+			if (level == targetLevel + 1 && targetLevel == 0)
+				copy_fixed_key(context->desc, &context->leafLokey, lokey);
+			else
+			{
+				copy_fixed_key(context->desc, &context->lokey, lokey);
+				BTREE_PAGE_FIND_SET(context, LOKEY_EXISTS);
+				BTREE_PAGE_FIND_UNSET(context, LOKEY_SIBLING);
+				BTREE_PAGE_FIND_UNSET(context, LOKEY_UNDO);
+			}
 		}
 
 		if (level != targetLevel && (!imageFlag || level > targetLevel) && !nonLeafHdr)
@@ -872,14 +999,16 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 					continue;
 				}
 
-				if (imageFlag && level == targetLevel + 1)
+				if ((imageFlag || keepParentFlag) && level == targetLevel + 1)
 				{
 					/*
 					 * Just loaded the target's child into shared memory and
 					 * refound the parent under MODIFY lock; the parent's
 					 * downlinks differ from the pre-load partial read still
 					 * sitting in parentImg.  Refresh parentImg and rebind the
-					 * locator before stepping down.
+					 * locator before stepping down.  Needed for any caller
+					 * that later navigates siblings (IMAGE, or FETCH via
+					 * KEEP_PARENT).
 					 */
 					refresh_parent_img_chunk(&intCxt);
 				}
@@ -914,7 +1043,7 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 			 * locator onto parentImg so subsequent reads do not race against
 			 * concurrent writers on the unlocked shared page.
 			 */
-			if (imageFlag && level == targetLevel + 1 &&
+			if ((imageFlag || keepParentFlag) && level == targetLevel + 1 &&
 				intCxt.haveLock && intCxt.pagePtr != context->parentImg)
 				refresh_parent_img_chunk(&intCxt);
 		}
@@ -1351,7 +1480,7 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 		BTreeNonLeafTuphdr *tuphdr = NULL;
 		bool		tup_loaded = true;
 
-		tup_loaded = partial_load_chunk(&context->partial, context->parentImg,
+		tup_loaded = partial_load_chunk(&context->parentPartial, context->parentImg,
 										loc.chunkOffset, NULL);
 		if (tup_loaded)
 		{
@@ -1372,7 +1501,9 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 			item->pageChangeCount = DOWNLINK_GET_IN_MEMORY_CHANGECOUNT(tuphdr->downlink);
 
 			success = btree_find_read_page(context, item->blkno, item->pageChangeCount,
-										   false, &hikey->tuple, BTreeKeyNonLeafKey, NULL,
+										   false, &hikey->tuple, BTreeKeyNonLeafKey,
+										   BTREE_PAGE_FIND_IS(context, FETCH) ?
+										   &context->partial : NULL,
 										   true);
 			if (success &&
 				PAGE_GET_LEVEL(context->img) == level)
@@ -1391,6 +1522,25 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 	 */
 	(void) find_page(context, hikey, BTreeKeyNonLeafKey, level);
 	return true;
+}
+
+/*
+ * Refresh the stable copy of the current page's own lokey after find_left_page()
+ * steps to a sibling through the parent downlink at *loc.  When the downlink is
+ * the parent's first one the sibling inherits the parent's propagated lokey
+ * (kept in context->lokey), so there is nothing to capture here.
+ */
+static inline void
+refresh_context_leaf_lokey(OBTreeFindPageContext *context,
+						   BTreePageItemLocator *loc)
+{
+	if (BTREE_PAGE_LOCATOR_GET_OFFSET(context->parentImg, loc) > 0)
+	{
+		OTuple		lokey;
+
+		BTREE_PAGE_READ_INTERNAL_TUPLE(lokey, context->parentImg, loc);
+		copy_fixed_key(context->desc, &context->leafLokey, lokey);
+	}
 }
 
 /*
@@ -1464,7 +1614,7 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 			if (BTREE_PAGE_LOCATOR_IS_VALID(context->parentImg, &loc))
 			{
 				BTREE_PAGE_LOCATOR_PREV(context->parentImg, &loc);
-				next_lokey_loaded = partial_load_chunk(&context->partial,
+				next_lokey_loaded = partial_load_chunk(&context->parentPartial,
 													   context->parentImg,
 													   loc.chunkOffset,
 													   NULL);
@@ -1490,7 +1640,8 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 												   false,
 												   NULL,
 												   BTreeKeyRightmost,
-												   NULL,
+												   BTREE_PAGE_FIND_IS(context, FETCH) ?
+												   &context->partial : NULL,
 												   true);
 
 					if (success &&
@@ -1498,6 +1649,7 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 						prevLoc == context->imgUndoLoc)
 					{
 						parentItem->locator = loc;
+						refresh_context_leaf_lokey(context, &loc);
 						continue;
 					}
 
@@ -1513,6 +1665,7 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 						{
 							Assert(O_PAGE_GET_CHANGE_COUNT(context->img) == item->pageChangeCount);
 							parentItem->locator = loc;
+							refresh_context_leaf_lokey(context, &loc);
 							BTREE_PAGE_LOCATOR_LAST(context->img, &item->locator);
 							return true;
 						}
@@ -1590,12 +1743,14 @@ btree_find_context_lokey(OBTreeFindPageContext *context)
 	else if (BTREE_PAGE_LOCATOR_GET_OFFSET(context->parentImg, &ploc) > 0)
 	{
 		/*
-		 * Fetches lokey for the left sibling from the parent image.
+		 * The current page's own lokey is its downlink key in the parent.
+		 * find_page() descent and find_left_page() stepping keep it in the
+		 * stable context->leafLokey, so return that instead of re-reading the
+		 * parent image.  In FETCH mode parentImg is partial and may have been
+		 * reclaimed under page-pool pressure since it was last read, which
+		 * would make a re-read return garbage.
 		 */
-		OTuple		result;
-
-		BTREE_PAGE_READ_INTERNAL_TUPLE(result, context->parentImg, &ploc);
-		return result;
+		return context->leafLokey.tuple;
 	}
 	else if (BTREE_PAGE_FIND_IS(context, LOKEY_EXISTS))
 	{

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -61,7 +61,7 @@ static void btree_page_search_items(BTreeDescr *desc, Page p, Pointer key,
 									BTreeKeyType keyType,
 									BTreePageItemLocator *locator);
 static void refresh_parent_img_chunk(OBTreeFindPageInternalContext *intCxt);
-static void convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt);
+static bool convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt);
 
 /*
  * A parent locator that find_left_page()/find_right_page() will navigate must
@@ -415,30 +415,70 @@ refresh_parent_img_chunk(OBTreeFindPageInternalContext *intCxt)
  * locator from the shared page to a local one: copy the header (with hikeys)
  * and the referenced chunk into parentImg, set up parentPartial so other chunks
  * load on demand, and rebind the locator onto parentImg.
+ *
+ * The copy is made from the live shared page without a page lock, so it has to
+ * be validated the same way try_copy_page() validates a partial read: bail out
+ * if reads are blocked, if a header field used to size the copy is out of
+ * range (a torn read), if the page-state change count moved across the copy, or
+ * if the page is no longer the one we descended to (pageChangeCount changed).
+ * Returns false in any of those cases; the caller must re-read the parent.
  */
-static void
+static bool
 convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt)
 {
 	OBTreeFindPageContext *context = intCxt->context;
-	Pointer		src = O_GET_IN_MEMORY_PAGE(intCxt->blkno);
+	OInMemoryBlkno blkno = intCxt->blkno;
+	Pointer		src = O_GET_IN_MEMORY_PAGE(blkno);
 	BTreePageItemLocator *locator = &context->items[context->index].locator;
 	BTreePageHeader *hdr = (BTreePageHeader *) src;
 	OffsetNumber chunkOffset = locator->chunkOffset;
 	LocationIndex chunkBegin;
 	LocationIndex chunkEnd;
+	LocationIndex hikeysEnd;
+	OffsetNumber chunksCount;
+	uint64		state1,
+				state2;
+
+	state1 = pg_atomic_read_u64(&(O_PAGE_HEADER(src)->state));
+	if (O_PAGE_STATE_READ_IS_BLOCKED(state1))
+		return false;
+
+	pg_read_barrier();
+
+	hikeysEnd = hdr->hikeysEnd;
+	chunksCount = hdr->chunksCount;
+	if (hikeysEnd < MAXALIGN(sizeof(BTreePageHeader)) || hikeysEnd > ORIOLEDB_BLCKSZ ||
+		chunkOffset >= chunksCount)
+		return false;
 
 	chunkBegin = SHORT_GET_LOCATION(hdr->chunkDesc[chunkOffset].shortLocation);
-	if (chunkOffset + 1 < hdr->chunksCount)
+	if (chunkOffset + 1 < chunksCount)
 		chunkEnd = SHORT_GET_LOCATION(hdr->chunkDesc[chunkOffset + 1].shortLocation);
 	else
 		chunkEnd = hdr->dataSize;
+	if (chunkBegin > chunkEnd || chunkEnd > ORIOLEDB_BLCKSZ)
+		return false;
+
+	pg_read_barrier();
 
 	/* Header including the hikeys chunk. */
-	memcpy(context->parentImg, src, hdr->hikeysEnd);
+	memcpy(context->parentImg, src, hikeysEnd);
 	/* The single chunk that `locator` references. */
 	memcpy(context->parentImg + chunkBegin,
 		   src + chunkBegin,
 		   chunkEnd - chunkBegin);
+
+	pg_read_barrier();
+	state2 = pg_atomic_read_u64(&(O_PAGE_HEADER(src)->state));
+
+	/* The page must not have changed or been blocked while we copied it. */
+	if ((state1 & PAGE_STATE_CHANGE_COUNT_MASK) != (state2 & PAGE_STATE_CHANGE_COUNT_MASK) ||
+		O_PAGE_STATE_READ_IS_BLOCKED(state2))
+		return false;
+
+	/* ... and it must still be the page we descended to. */
+	if (O_PAGE_GET_CHANGE_COUNT(src) != intCxt->pageChangeCount)
+		return false;
 
 	context->parentPartial.src = src;
 	context->parentPartial.isPartial = true;
@@ -449,6 +489,7 @@ convert_fastpath_parent_to_img(OBTreeFindPageInternalContext *intCxt)
 
 	locator->chunk =
 		(BTreePageChunk *) (context->parentImg + chunkBegin);
+	return true;
 }
 
 /*--
@@ -863,10 +904,13 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 		 * parentImg not populated).  A sibling-navigating caller
 		 * (KEEP_PARENT, e.g. the iterator) needs the parent in parentImg, so
 		 * materialize it and rebind the locator before recording the page
-		 * change count from parentImg.
+		 * change count from parentImg.  The copy is validated; if the parent
+		 * changed under us while copying, re-read it from the top of the loop
+		 * (a stale/evicted parent is then caught by the change-count checks).
 		 */
-		if (fastpath && keepParentFlag && level == targetLevel + 1)
-			convert_fastpath_parent_to_img(&intCxt);
+		if (fastpath && keepParentFlag && level == targetLevel + 1 &&
+			!convert_fastpath_parent_to_img(&intCxt))
+			continue;
 
 		context->items[context->index].pageChangeCount = O_PAGE_GET_CHANGE_COUNT(intCxt.pagePtr);
 

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1453,6 +1453,7 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 			   *item;
 	int			level;
 	Jsonb	   *params;
+	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
 
 	/* Nothing to do with rightmost page */
 	if (O_PAGE_IS(context->img, RIGHTMOST))
@@ -1491,7 +1492,8 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 	{
 		if (!convert_fastpath_parent_to_img(context, &parentItem->locator))
 		{
-			(void) find_page(context, hikey, BTreeKeyNonLeafKey, level);
+			findResult = find_page(context, hikey, BTreeKeyNonLeafKey, level);
+			Assert(findResult == OFindPageResultSuccess);
 			return true;
 		}
 		context->parentImgDeferred = false;
@@ -1554,7 +1556,8 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 	 * Give up with parent downlink.  Find the page from the root in a usual
 	 * way.  Should happen rarely.
 	 */
-	(void) find_page(context, hikey, BTreeKeyNonLeafKey, level);
+	findResult = find_page(context, hikey, BTreeKeyNonLeafKey, level);
+	Assert(findResult == OFindPageResultSuccess);
 	return true;
 }
 
@@ -1596,6 +1599,7 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 	UndoLocation prevLoc;
 	Jsonb	   *params;
 	OTuple		imgHikey;
+	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
 
 	Assert(BTREE_PAGE_FIND_IS(context, KEEP_LOKEY));
 
@@ -1708,7 +1712,8 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 			}
 		}
 
-		(void) find_page(context, &hikey->tuple, BTreeKeyPageHiKey, level);
+		findResult = find_page(context, &hikey->tuple, BTreeKeyPageHiKey, level);
+		Assert(findResult == OFindPageResultSuccess);
 
 		/* context levels may be changed */
 		parentItem = &context->items[context->index - 1];

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -86,11 +86,10 @@ struct BTreeIterator
 	bool		curKeyReturned;
 
 	/*
-	 * The scan's original start key/kind.  Contract: the caller must keep
-	 * the key alive and unmodified for the iterator's lifetime; the
-	 * !curKeySet branch of iterator_refind_partial_leaf() reads it to re-find
-	 * the scan start when a partial read fails before any tuple has been
-	 * returned.
+	 * The scan's original start key/kind.  Contract: the caller must keep the
+	 * key alive and unmodified for the iterator's lifetime; the !curKeySet
+	 * branch of iterator_refind_partial_leaf() reads it to re-find the scan
+	 * start when a partial read fails before any tuple has been returned.
 	 */
 	void	   *startKey;
 	BTreeKeyType startKind;
@@ -934,8 +933,8 @@ iterator_refind_partial_leaf(BTreeIterator *it)
 	 * no tuple on the leaf is >= curKey -- e.g. curKey got deleted and the
 	 * leaf's max is now strictly less than curKey.  For forward we leave the
 	 * locator invalid so the caller's outer loop steps to the right sibling.
-	 * For backward the largest tuple <= curKey on this leaf is the last
-	 * item, so decrement to it; mirrors the seed and !curKeySet paths.
+	 * For backward the largest tuple <= curKey on this leaf is the last item,
+	 * so decrement to it; mirrors the seed and !curKeySet paths.
 	 */
 	if (!BTREE_PAGE_LOCATOR_IS_VALID(context->img, loc))
 	{
@@ -1199,6 +1198,21 @@ btree_iterator_check_load_next_page(BTreeIterator *it)
 			continue;
 		}
 
+		/*
+		 * Backward stepping needs the current page's lokey.  A frozen
+		 * no-record split half (o_btree_insert_split()) reached live in FETCH
+		 * mode can arrive here with no reliable lokey source -- it is the
+		 * leftmost child of its parent, carries no lokey, and its frozen csn
+		 * means the undo chain supplies none either.  Stepping left off that
+		 * bogus lokey would skip rows, so re-descend (switching to whole-page
+		 * reads) instead.
+		 */
+		if (IT_IS_BACKWARD(it) && !btree_find_context_has_lokey(context))
+		{
+			iterator_refind_partial_leaf(it);
+			continue;
+		}
+
 		if (IT_IS_FORWARD(it))
 			step_result = find_right_page(context, &key_buf);
 		else
@@ -1369,11 +1383,11 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 			BTREE_PAGE_READ_LEAF_ITEM(*tupHdr, result, context->img, loc);
 
 			/*
-			 * Apply the end-key bound before mutating any iterator state.
-			 * A rejected tuple must leave curKey/curKeyReturned and the
-			 * locator untouched: a later partial-read refind would
-			 * otherwise treat it as already handed out and step past it,
-			 * silently dropping the row on a resumed scan.
+			 * Apply the end-key bound before mutating any iterator state. A
+			 * rejected tuple must leave curKey/curKeyReturned and the locator
+			 * untouched: a later partial-read refind would otherwise treat it
+			 * as already handed out and step past it, silently dropping the
+			 * row on a resumed scan.
 			 */
 			if (end != NULL && endKind != BTreeKeyNone)
 			{
@@ -1908,8 +1922,8 @@ orioledb_test_back_refind_skip_tail(PG_FUNCTION_ARGS)
 								 BackwardScanDirection);
 
 	/*
-	 * Forge curKey: a leaf-format tuple whose PK is fake_curkey.  Once
-	 * copied into it->curKey, find_page() on refind will land past-end.
+	 * Forge curKey: a leaf-format tuple whose PK is fake_curkey.  Once copied
+	 * into it->curKey, find_page() on refind will land past-end.
 	 */
 	fakeValue = Int32GetDatum(fake_curkey);
 	fakeTup = o_form_tuple(primary->leafTupdesc, &primary->leafSpec, 0,

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -615,7 +615,8 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 		{
 			BTREE_PAGE_FIND_UNSET(&it->context, FETCH);
 			BTREE_PAGE_FIND_SET(&it->context, IMAGE);
-			(void) find_page(&it->context, key, kind, 0);
+			findResult = find_page(&it->context, key, kind, 0);
+			Assert(findResult == OFindPageResultSuccess);
 			loc = &it->context.items[it->context.index].locator;
 		}
 
@@ -864,6 +865,7 @@ iterator_refind_partial_leaf(BTreeIterator *it)
 	BTreePageItemLocator *loc;
 	OTuple		tup;
 	bool		match;
+	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
 
 	Assert(!it->combinedResult);
 
@@ -890,7 +892,8 @@ iterator_refind_partial_leaf(BTreeIterator *it)
 	 */
 	if (!it->curKeySet)
 	{
-		(void) find_page(context, it->startKey, it->startKind, 0);
+		findResult = find_page(context, it->startKey, it->startKind, 0);
+		Assert(findResult == OFindPageResultSuccess);
 
 		loc = &context->items[context->index].locator;
 		if (it->startKey != NULL && IT_IS_BACKWARD(it) &&
@@ -920,7 +923,8 @@ iterator_refind_partial_leaf(BTreeIterator *it)
 	 * own partial-read failures), so the located tuple is always safe to
 	 * read.
 	 */
-	(void) find_page(context, &it->curKey.tuple, BTreeKeyNonLeafKey, 0);
+	findResult = find_page(context, &it->curKey.tuple, BTreeKeyNonLeafKey, 0);
+	Assert(findResult == OFindPageResultSuccess);
 
 	loc = &context->items[context->index].locator;
 

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -1455,6 +1455,16 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 			continue;
 		}
 
+		/*
+		 * Backward stepping needs a reliable lokey; mirror the guard in
+		 * btree_iterator_check_load_next_page().
+		 */
+		if (IT_IS_BACKWARD(it) && !btree_find_context_has_lokey(context))
+		{
+			iterator_refind_partial_leaf(it);
+			continue;
+		}
+
 		if (IT_IS_FORWARD(it))
 		{
 			if (!find_right_page(context, &key_buf))

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -22,6 +22,7 @@
 #include "btree/undo.h"
 #include "catalog/sys_trees.h"
 #include "tableam/descr.h"
+#include "tableam/key_range.h"
 #include "transam/oxid.h"
 #include "transam/undo.h"
 #include "utils/page_pool.h"
@@ -1685,3 +1686,129 @@ undo_it_find_internal(UndoIterator *undoIt, void *key, BTreeKeyType kind)
 	/* if O_PAGE_IS(undoIt->image, LEFTMOST) then undoIt->leftmost == true */
 	Assert(!O_PAGE_IS(undoIt->image, LEFTMOST) || undoIt->leftmost);
 }
+
+#ifdef IS_DEV
+/* ------------------------------------------------------------------------
+ * C-side test helpers.  Compiled only when IS_DEV is defined (-DIS_DEV);
+ * the SQL bindings are registered in the 1.8->1.9 dev migration.  See
+ * test/sql/iterator.sql for the test driver.
+ * ------------------------------------------------------------------------ */
+
+#include "access/relation.h"
+#include "fmgr.h"
+#include "tuple/format.h"
+#include "utils/builtins.h"
+
+/*
+ * Whitebox test: prove that the premature it->curKeyReturned = true at
+ * iterator.c:1358 (set before the end-key bound check at :1372) can leak
+ * into a partial-read refind and silently drop a tuple from a resumed scan.
+ *
+ * 1. Open a forward iterator at start_at.
+ * 2. iterate_raw with end == start_at exclusive: reads the tuple at start_at,
+ *    sets curKey=start_at and curKeyReturned=true, then rejects it via the
+ *    end bound and returns NULL with scanEnd=true.  State now claims
+ *    start_at was handed out, even though only NULL went to the caller.
+ * 3. Force iterator_refind_partial_leaf(), the path partial-read failures
+ *    take when the backing page changes.  With the bug it steps past
+ *    curKey=start_at; with the fix (no spurious "returned") it stays at it.
+ * 4. Resume with a wide end and drain the iterator.  Return the PKs as an
+ *    int4 array so the caller can `unnest` them: row count tells the story.
+ *
+ * Expected (post-fix): N rows starting at start_at.
+ * Bug (current code):  N-1 rows starting at start_at + 1 -- start_at lost.
+ *
+ * Assumes the relation's primary index has a single int4 key column.
+ */
+PG_FUNCTION_INFO_V1(orioledb_test_endkey_returned_skip);
+Datum
+orioledb_test_endkey_returned_skip(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	int32		start_at = PG_GETARG_INT32(1);
+	Relation	rel;
+	OTableDescr *descr;
+	OIndexDescr *primary;
+	OBTreeKeyBound startBound,
+				narrowEnd,
+				wideEnd;
+	BTreeIterator *it;
+	OTuple		result;
+	bool		scanEnd = false;
+	bool		isnull;
+	Datum	   *elems;
+	int			nelems = 0;
+	int			alloc = 16;
+	int			dims[1],
+				lbs[1];
+
+	rel = relation_open(relid, AccessShareLock);
+	descr = relation_get_descr(rel);
+	if (!descr)
+		elog(ERROR, "relation is not an orioledb table");
+	primary = GET_PRIMARY(descr);
+	if (primary->nKeyFields < 1 || primary->fields[0].inputtype != INT4OID)
+		elog(ERROR, "test requires a single int4 primary key column");
+
+	startBound.nkeys = 1;
+	startBound.n_row_keys = 0;
+	startBound.row_keys = NULL;
+	startBound.keys[0].type = INT4OID;
+	startBound.keys[0].flags = O_VALUE_BOUND_PLAIN_VALUE;
+	startBound.keys[0].comparator = primary->fields[0].comparator;
+	startBound.keys[0].exclusion_fn = NULL;
+	startBound.keys[0].value = Int32GetDatum(start_at);
+
+	narrowEnd = startBound;
+	wideEnd = startBound;
+	wideEnd.keys[0].value = Int32GetDatum(PG_INT32_MAX);
+
+	it = o_btree_iterator_create(&primary->desc, (Pointer) &startBound,
+								 BTreeKeyBound, &o_in_progress_snapshot,
+								 ForwardScanDirection);
+
+	/* Drive the iterator into the buggy state. */
+	result = btree_iterate_raw(it, (Pointer) &narrowEnd, BTreeKeyBound,
+							   false, &scanEnd, NULL);
+	if (!O_TUPLE_IS_NULL(result) || !scanEnd)
+		elog(ERROR, "unexpected first iterate_raw: scanEnd=%d, tuple is %s",
+			 scanEnd, O_TUPLE_IS_NULL(result) ? "null" : "non-null");
+
+	/* Simulate the partial-read failure that forces a refind. */
+	iterator_refind_partial_leaf(it);
+
+	/* Resume with a wide end and collect every PK the iterator now emits. */
+	elems = (Datum *) palloc(alloc * sizeof(Datum));
+	for (;;)
+	{
+		scanEnd = false;
+		result = btree_iterate_raw(it, (Pointer) &wideEnd, BTreeKeyBound,
+								   true, &scanEnd, NULL);
+		if (O_TUPLE_IS_NULL(result))
+		{
+			if (!scanEnd)
+				elog(ERROR, "iterate_raw returned NULL without scanEnd");
+			break;
+		}
+		if (nelems == alloc)
+		{
+			alloc *= 2;
+			elems = (Datum *) repalloc(elems, alloc * sizeof(Datum));
+		}
+		elems[nelems++] = o_fastgetattr(result, 1, primary->leafTupdesc,
+										&primary->leafSpec, &isnull);
+		if (isnull)
+			elog(ERROR, "PK column unexpectedly NULL");
+	}
+
+	btree_iterator_free(it);
+	relation_close(rel, AccessShareLock);
+
+	dims[0] = nelems;
+	lbs[0] = 1;
+	PG_RETURN_ARRAYTYPE_P(construct_md_array(elems, NULL, 1, dims, lbs,
+											 INT4OID, sizeof(int32), true,
+											 TYPALIGN_INT));
+}
+
+#endif							/* IS_DEV */

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -1349,20 +1349,12 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 			BTREE_PAGE_READ_LEAF_ITEM(*tupHdr, result, context->img, loc);
 
 			/*
-			 * Remember this position in case the page changes later.  This
-			 * tuple is being consumed, so mark it returned: a later re-find
-			 * resumes after it.
+			 * Apply the end-key bound before mutating any iterator state.
+			 * A rejected tuple must leave curKey/curKeyReturned and the
+			 * locator untouched: a later partial-read refind would
+			 * otherwise treat it as already handed out and step past it,
+			 * silently dropping the row on a resumed scan.
 			 */
-			copy_fixed_key(context->desc, &it->curKey, result);
-			it->curKeySet = true;
-			it->curKeyReturned = true;
-
-			if (!iterator_advance_leaf(it, loc))
-			{
-				iterator_refind_partial_leaf(it);
-				loc = &context->items[context->index].locator;
-			}
-
 			if (end != NULL && endKind != BTreeKeyNone)
 			{
 				BTreeDescr *desc = it->context.desc;
@@ -1375,6 +1367,21 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 					O_TUPLE_SET_NULL(result);
 					return result;
 				}
+			}
+
+			/*
+			 * Remember this position in case the page changes later.  The
+			 * tuple is being consumed, so mark it returned: a later re-find
+			 * resumes after it.
+			 */
+			copy_fixed_key(context->desc, &it->curKey, result);
+			it->curKeySet = true;
+			it->curKeyReturned = true;
+
+			if (!iterator_advance_leaf(it, loc))
+			{
+				iterator_refind_partial_leaf(it);
+				loc = &context->items[context->index].locator;
 			}
 
 			if (!deleted_as_null ||

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -923,8 +923,23 @@ iterator_refind_partial_leaf(BTreeIterator *it)
 	(void) find_page(context, &it->curKey.tuple, BTreeKeyNonLeafKey, 0);
 
 	loc = &context->items[context->index].locator;
+
+	/*
+	 * find_page() can land the locator past-end (offset == items_count) when
+	 * no tuple on the leaf is >= curKey -- e.g. curKey got deleted and the
+	 * leaf's max is now strictly less than curKey.  For forward we leave the
+	 * locator invalid so the caller's outer loop steps to the right sibling.
+	 * For backward the largest tuple <= curKey on this leaf is the last
+	 * item, so decrement to it; mirrors the seed and !curKeySet paths.
+	 */
 	if (!BTREE_PAGE_LOCATOR_IS_VALID(context->img, loc))
+	{
+		if (IT_IS_BACKWARD(it) &&
+			BTREE_PAGE_LOCATOR_GET_OFFSET(context->img, loc) ==
+			BTREE_PAGE_ITEMS_COUNT(context->img))
+			BTREE_PAGE_LOCATOR_PREV(context->img, loc);
 		return;
+	}
 
 	/*
 	 * find_page() leaves the locator on the first tuple >= curKey (its chunk

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -63,11 +63,35 @@ struct BTreeIterator
 	bool		combinedResult;
 	/* do we need to combine results in the current page? */
 	bool		combinedPage;
+	/* number of leaf pages visited; drives the FETCH->IMAGE switch */
+	int			pageCount;
 	/* memory context for returned tuples */
 	MemoryContext tupleCxt;
 	/* callback for fetching tuple version */
 	TupleFetchCallback fetchCallback;
 	void	   *fetchCallbackArg;
+
+	/*
+	 * Key of the last tuple position read from the current (FETCH-mode) leaf.
+	 * If the partial leaf's backing page changes mid-scan and a chunk can no
+	 * longer be loaded, we re-find this position from the root rather than
+	 * read stale data.  curKey is seeded at creation with the first tuple to
+	 * read, so it is valid even before the first fetch.  curKeyReturned tells
+	 * whether curKey has already been handed out: if so the re-find resumes
+	 * after it, otherwise it resumes at it.
+	 */
+	OFixedKey	curKey;
+	bool		curKeySet;
+	bool		curKeyReturned;
+
+	/*
+	 * The scan's original start key/kind, used to re-find from the beginning
+	 * when a partial read fails before any tuple has been read (curKeySet is
+	 * still false).  The caller keeps the key alive for the iterator's
+	 * lifetime, so storing the pointer is enough.
+	 */
+	void	   *startKey;
+	BTreeKeyType startKind;
 #ifdef USE_ASSERT_CHECKING
 	/* additional check for iteration order */
 	OFixedTuple prevTuple;
@@ -514,7 +538,7 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 						OSnapshot *o_snapshot, ScanDirection scanDir)
 {
 	BTreeIterator *it;
-	uint16		findFlags = BTREE_PAGE_FIND_IMAGE;
+	uint16		findFlags;
 	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
 
 	it = (BTreeIterator *) palloc(sizeof(BTreeIterator));
@@ -533,12 +557,24 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 	it->tupleCxt = CurrentMemoryContext;
 	it->fetchCallback = NULL;
 	it->fetchCallbackArg = NULL;
+	it->curKeySet = false;
+	it->curKeyReturned = false;
+	it->startKey = NULL;
+	it->startKind = BTreeKeyNone;
 	BTREE_PAGE_LOCATOR_SET_INVALID(&it->undoLoc);
 #ifdef USE_ASSERT_CHECKING
 	O_TUPLE_SET_NULL(it->prevTuple.tuple);
 #endif
 
 	undo_it_create(&it->undoIt, it);
+
+	/*
+	 * Read leaf pages partially (FETCH) by default; undo-merging scans use
+	 * IMAGE.  The iterator steps to siblings, so keep the parent image.
+	 */
+	findFlags = it->combinedResult ? BTREE_PAGE_FIND_IMAGE : BTREE_PAGE_FIND_FETCH;
+	findFlags |= BTREE_PAGE_FIND_KEEP_PARENT;
+	it->pageCount = 1;
 
 	if (IT_IS_BACKWARD(it))
 		findFlags |= BTREE_PAGE_FIND_KEEP_LOKEY;
@@ -553,6 +589,9 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 		else
 			kind = BTreeKeyRightmost;
 	}
+
+	it->startKey = key;
+	it->startKind = kind;
 
 	findResult = find_page(&it->context, key, kind, 0);
 	Assert(findResult == OFindPageResultSuccess);
@@ -588,6 +627,30 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 
 	load_page_from_undo(it, key,
 						kind != BTreeKeyRightmost ? kind : BTreeKeyNone);
+
+	/*
+	 * Seed the re-find key with the first tuple to read.  This way a partial
+	 * read failure on the very first fetch (the backing page can change
+	 * between positioning here and the first fetch, e.g. on a hot standby
+	 * applying WAL) still has a valid key to re-find from, marked as not yet
+	 * returned so the re-find resumes at it rather than past it.
+	 */
+	if (!it->combinedResult && BTREE_PAGE_FIND_IS(&it->context, FETCH))
+	{
+		BTreePageItemLocator *loc = &it->context.items[it->context.index].locator;
+
+		if (BTREE_PAGE_LOCATOR_IS_VALID(it->context.img, loc) &&
+			partial_load_chunk(&it->context.partial, it->context.img,
+							   loc->chunkOffset, NULL))
+		{
+			OTuple		tup;
+
+			BTREE_PAGE_READ_LEAF_TUPLE(tup, it->context.img, loc);
+			copy_fixed_key(desc, &it->curKey, tup);
+			it->curKeySet = true;
+			it->curKeyReturned = false;
+		}
+	}
 
 	return it;
 }
@@ -770,6 +833,114 @@ get_next_combined_location(BTreeIterator *it)
 }
 
 /*
+ * Recover the scan position after a partial (FETCH) leaf read failed because
+ * its backing page changed.  We must never read from a partial page whose
+ * chunk could not be loaded, so re-find the last read position from the root
+ * and leave the locator on the next tuple to return.
+ */
+static void
+iterator_refind_partial_leaf(BTreeIterator *it)
+{
+	OBTreeFindPageContext *context = &it->context;
+	BTreeDescr *desc = context->desc;
+	BTreePageItemLocator *loc;
+	OTuple		tup;
+	bool		match;
+
+	Assert(!it->combinedResult);
+
+	/*
+	 * A partial (FETCH) read just failed because the backing page changed
+	 * under us.  Switch this scan to whole-page images (IMAGE) for the rest
+	 * of its life before re-finding: a full page read is a consistent
+	 * snapshot, so the re-find below and every subsequent fetch are immune to
+	 * concurrent page changes and never touch the partial-read or fastpath
+	 * descent paths again.  (This is the same FETCH->IMAGE transition the
+	 * page-count heuristic makes; doing it here just makes it
+	 * failure-driven.)
+	 */
+	BTREE_PAGE_FIND_UNSET(context, FETCH);
+	BTREE_PAGE_FIND_SET(context, IMAGE);
+
+	/*
+	 * If we have not handed out any tuple yet, there is no resume key:
+	 * re-find the scan start from the original key/kind, mirroring the
+	 * positioning in o_btree_iterator_create().  (This happens when the very
+	 * first partial read fails -- e.g. the start position landed past the end
+	 * of the first page and the backing page changed before the next page
+	 * could be read.)
+	 */
+	if (!it->curKeySet)
+	{
+		(void) find_page(context, it->startKey, it->startKind, 0);
+
+		loc = &context->items[context->index].locator;
+		if (it->startKey != NULL && IT_IS_BACKWARD(it) &&
+			BTREE_PAGE_LOCATOR_IS_VALID(context->img, loc))
+		{
+			bool		make_dec = false;
+
+			if (BTREE_PAGE_LOCATOR_GET_OFFSET(context->img, loc) ==
+				BTREE_PAGE_ITEMS_COUNT(context->img))
+				make_dec = true;
+			else
+			{
+				BTREE_PAGE_READ_LEAF_TUPLE(tup, context->img, loc);
+				if (o_btree_cmp(desc, it->startKey, it->startKind,
+								&tup, BTreeKeyLeafTuple) < 0)
+					make_dec = true;
+			}
+			if (make_dec)
+				BTREE_PAGE_LOCATOR_PREV(context->img, loc);
+		}
+		return;
+	}
+
+	/*
+	 * find_page() sets up a fresh partial read for the current page change
+	 * count and loads the target locator's chunk (retrying internally on its
+	 * own partial-read failures), so the located tuple is always safe to
+	 * read.
+	 */
+	(void) find_page(context, &it->curKey.tuple, BTreeKeyNonLeafKey, 0);
+
+	loc = &context->items[context->index].locator;
+	if (!BTREE_PAGE_LOCATOR_IS_VALID(context->img, loc))
+		return;
+
+	/*
+	 * find_page() leaves the locator on the first tuple >= curKey (its chunk
+	 * loaded), so it is safe to read here.
+	 */
+	BTREE_PAGE_READ_LEAF_TUPLE(tup, context->img, loc);
+	match = o_btree_cmp(desc, &tup, BTreeKeyLeafTuple,
+						&it->curKey.tuple, BTreeKeyNonLeafKey) == 0;
+
+	if (IT_IS_FORWARD(it))
+	{
+		/*
+		 * The locator already sits on the first tuple >= curKey.  When curKey
+		 * was already returned and is still present, step past it to its
+		 * successor; otherwise (curKey not yet returned, or gone) the locator
+		 * is already on the next tuple to read.
+		 */
+		if (match && it->curKeyReturned)
+			BTREE_PAGE_LOCATOR_NEXT(context->img, loc);
+	}
+	else
+	{
+		/*
+		 * Backward: the next tuple to read is the largest one <= curKey.  If
+		 * curKey is present and not yet returned, that is curKey itself
+		 * (stay); otherwise (already returned, or gone) step left of the
+		 * first tuple >= curKey to reach the largest one strictly below it.
+		 */
+		if (it->curKeyReturned || !match)
+			BTREE_PAGE_LOCATOR_PREV(context->img, loc);
+	}
+}
+
+/*
  * Fetch next tuple without checking for end condition.
  */
 static OTuple
@@ -846,6 +1017,31 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
 		}
 		else
 		{
+			OTuple		posTup;
+
+			/* In FETCH mode the leaf is partial; load this tuple's chunk. */
+			if (BTREE_PAGE_FIND_IS(context, FETCH) &&
+				!partial_load_chunk(&context->partial, context->img,
+									leaf_item->locator.chunkOffset, NULL))
+			{
+				/*
+				 * The backing page changed since we set up the partial read.
+				 * Never read from it; re-find our position and retry.
+				 */
+				iterator_refind_partial_leaf(it);
+				continue;
+			}
+
+			/*
+			 * Remember this position in case the page changes later.  We are
+			 * about to consume this tuple, so mark it as returned: a later
+			 * re-find resumes after it.
+			 */
+			BTREE_PAGE_READ_LEAF_TUPLE(posTup, context->img, &leaf_item->locator);
+			copy_fixed_key(desc, &it->curKey, posTup);
+			it->curKeySet = true;
+			it->curKeyReturned = true;
+
 			result = o_find_tuple_version(desc, context->img,
 										  &leaf_item->locator,
 										  &it->oSnapshot, tupleCsn,
@@ -862,6 +1058,20 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
 
 	O_TUPLE_SET_NULL(result);
 	return result;				/* unreachable */
+}
+
+/*
+ * Switch the iterator from partial reads (FETCH) to whole-page images (IMAGE)
+ * once it has visited enough pages.  No-op for combined scans (always IMAGE).
+ */
+static inline void
+iterator_maybe_switch_to_image(BTreeIterator *it)
+{
+	if (BTREE_PAGE_FIND_IS(&it->context, FETCH) && ++it->pageCount >= 3)
+	{
+		BTREE_PAGE_FIND_UNSET(&it->context, FETCH);
+		BTREE_PAGE_FIND_SET(&it->context, IMAGE);
+	}
 }
 
 /*
@@ -887,6 +1097,8 @@ btree_iterator_check_load_next_page(BTreeIterator *it)
 
 		if (IS_LAST_PAGE(img, it))
 			return false;
+
+		iterator_maybe_switch_to_image(it);
 
 		if (IT_IS_FORWARD(it))
 			step_result = find_right_page(context, &key_buf);
@@ -1043,7 +1255,29 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 
 		if (BTREE_PAGE_LOCATOR_IS_VALID(img, loc))
 		{
+			/* In FETCH mode the leaf is partial; load this tuple's chunk. */
+			if (BTREE_PAGE_FIND_IS(context, FETCH) &&
+				!partial_load_chunk(&context->partial, context->img,
+									loc->chunkOffset, NULL))
+			{
+				/*
+				 * The backing page changed since we set up the partial read.
+				 * Never read from it; re-find our position and retry.
+				 */
+				iterator_refind_partial_leaf(it);
+				continue;
+			}
 			BTREE_PAGE_READ_LEAF_ITEM(*tupHdr, result, context->img, loc);
+
+			/*
+			 * Remember this position in case the page changes later.  This
+			 * tuple is being consumed, so mark it returned: a later re-find
+			 * resumes after it.
+			 */
+			copy_fixed_key(context->desc, &it->curKey, result);
+			it->curKeySet = true;
+			it->curKeyReturned = true;
+
 			IT_NEXT_OFFSET(it, loc);
 
 			if (end != NULL && endKind != BTreeKeyNone)
@@ -1083,6 +1317,8 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 			O_TUPLE_SET_NULL(result);
 			return result;
 		}
+
+		iterator_maybe_switch_to_image(it);
 
 		if (IT_IS_FORWARD(it))
 		{

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -1818,4 +1818,122 @@ orioledb_test_endkey_returned_skip(PG_FUNCTION_ARGS)
 											 TYPALIGN_INT));
 }
 
+/*
+ * Whitebox test: prove that iterator_refind_partial_leaf()'s curKeySet
+ * branch bails out (iterator.c:911) without decrementing the locator when
+ * find_page() lands past-end on a backward scan.  The seed path and the
+ * !curKeySet path both decrement in this case; only this branch doesn't.
+ * If find_page legitimately lands on a leaf with no tuple >= curKey
+ * (e.g. curKey got deleted and the leaf's max < curKey), the backward
+ * scan silently drops the leaf's tail.
+ *
+ * 1. Open a backward iterator past the leaf's max.  The seed lands the
+ *    locator on the leaf's largest tuple and copies it into curKey.
+ * 2. Overwrite curKey with a forged tuple whose PK is fake_curkey (chosen
+ *    > all tuples in the table) so find_page() lands past-end on refind.
+ * 3. iterator_refind_partial_leaf() -- the partial-read-failure path.
+ *    With the bug, curKeySet branch returns early; the locator stays
+ *    invalid and the caller's next find_left_page from the leftmost leaf
+ *    ends the scan.  With the fix (mirror seed/!curKeySet behaviour) the
+ *    locator decrements to the leaf's tail and the drain reads it.
+ * 4. Drain backward and return the PKs as int4[].
+ *
+ * Expected (post-fix): every row in the table, descending.
+ * Bug (current code): empty array -- the leaf's tail is silently dropped.
+ *
+ * Assumes the relation's primary index has a single int4 key column.
+ */
+PG_FUNCTION_INFO_V1(orioledb_test_back_refind_skip_tail);
+Datum
+orioledb_test_back_refind_skip_tail(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	int32		fake_curkey = PG_GETARG_INT32(1);
+	Relation	rel;
+	OTableDescr *descr;
+	OIndexDescr *primary;
+	OBTreeKeyBound startBound;
+	BTreeIterator *it;
+	OTuple		result;
+	OTuple		fakeTup;
+	Datum		fakeValue;
+	bool		fakeNull = false;
+	bool		scanEnd = false;
+	bool		isnull;
+	Datum	   *elems;
+	int			nelems = 0;
+	int			alloc = 16;
+	int			dims[1],
+				lbs[1];
+
+	rel = relation_open(relid, AccessShareLock);
+	descr = relation_get_descr(rel);
+	if (!descr)
+		elog(ERROR, "relation is not an orioledb table");
+	primary = GET_PRIMARY(descr);
+	if (primary->nKeyFields < 1 || primary->fields[0].inputtype != INT4OID)
+		elog(ERROR, "test requires a single int4 primary key column");
+
+	startBound.nkeys = 1;
+	startBound.n_row_keys = 0;
+	startBound.row_keys = NULL;
+	startBound.keys[0].type = INT4OID;
+	startBound.keys[0].flags = O_VALUE_BOUND_PLAIN_VALUE;
+	startBound.keys[0].comparator = primary->fields[0].comparator;
+	startBound.keys[0].exclusion_fn = NULL;
+	startBound.keys[0].value = Int32GetDatum(fake_curkey);
+
+	it = o_btree_iterator_create(&primary->desc, (Pointer) &startBound,
+								 BTreeKeyBound, &o_in_progress_snapshot,
+								 BackwardScanDirection);
+
+	/*
+	 * Forge curKey: a leaf-format tuple whose PK is fake_curkey.  Once
+	 * copied into it->curKey, find_page() on refind will land past-end.
+	 */
+	fakeValue = Int32GetDatum(fake_curkey);
+	fakeTup = o_form_tuple(primary->leafTupdesc, &primary->leafSpec, 0,
+						   &fakeValue, &fakeNull, NULL);
+	copy_fixed_key(&primary->desc, &it->curKey, fakeTup);
+	pfree(fakeTup.data);
+	it->curKeySet = true;
+	it->curKeyReturned = false;
+
+	/* Force the partial-read-failure refind path. */
+	iterator_refind_partial_leaf(it);
+
+	/* Drain backward; collect every PK the iterator now emits. */
+	elems = (Datum *) palloc(alloc * sizeof(Datum));
+	for (;;)
+	{
+		scanEnd = false;
+		result = btree_iterate_raw(it, NULL, BTreeKeyNone, false,
+								   &scanEnd, NULL);
+		if (O_TUPLE_IS_NULL(result))
+		{
+			if (!scanEnd)
+				elog(ERROR, "iterate_raw returned NULL without scanEnd");
+			break;
+		}
+		if (nelems == alloc)
+		{
+			alloc *= 2;
+			elems = (Datum *) repalloc(elems, alloc * sizeof(Datum));
+		}
+		elems[nelems++] = o_fastgetattr(result, 1, primary->leafTupdesc,
+										&primary->leafSpec, &isnull);
+		if (isnull)
+			elog(ERROR, "PK column unexpectedly NULL");
+	}
+
+	btree_iterator_free(it);
+	relation_close(rel, AccessShareLock);
+
+	dims[0] = nelems;
+	lbs[0] = 1;
+	PG_RETURN_ARRAYTYPE_P(construct_md_array(elems, NULL, 1, dims, lbs,
+											 INT4OID, sizeof(int32), true,
+											 TYPALIGN_INT));
+}
+
 #endif							/* IS_DEV */

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -86,10 +86,11 @@ struct BTreeIterator
 	bool		curKeyReturned;
 
 	/*
-	 * The scan's original start key/kind, used to re-find from the beginning
-	 * when a partial read fails before any tuple has been read (curKeySet is
-	 * still false).  The caller keeps the key alive for the iterator's
-	 * lifetime, so storing the pointer is enough.
+	 * The scan's original start key/kind.  Contract: the caller must keep
+	 * the key alive and unmodified for the iterator's lifetime; the
+	 * !curKeySet branch of iterator_refind_partial_leaf() reads it to re-find
+	 * the scan start when a partial read fails before any tuple has been
+	 * returned.
 	 */
 	void	   *startKey;
 	BTreeKeyType startKind;

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -602,6 +602,23 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 		bool		make_dec = false;
 
 		/*
+		 * Positioning the backward start reads the leaf's chunk descriptor
+		 * array (BTREE_PAGE_LOCATOR_GET_OFFSET / _PREV), which a partial
+		 * (FETCH) image read through the fastpath does not contain
+		 * (loadHikeys = !fastpath).  Load the hikeys chunk so the descriptors
+		 * are present; if the backing page changed, fall back to a whole-page
+		 * image read and re-position there.
+		 */
+		if (BTREE_PAGE_FIND_IS(&it->context, FETCH) &&
+			!partial_load_hikeys_chunk(&it->context.partial, it->context.img))
+		{
+			BTREE_PAGE_FIND_UNSET(&it->context, FETCH);
+			BTREE_PAGE_FIND_SET(&it->context, IMAGE);
+			(void) find_page(&it->context, key, kind, 0);
+			loc = &it->context.items[it->context.index].locator;
+		}
+
+		/*
 		 * From btree_page_binary_search(): "When nextkey is false (this
 		 * case), we are looking for the first item >= scankey."
 		 *
@@ -941,6 +958,50 @@ iterator_refind_partial_leaf(BTreeIterator *it)
 }
 
 /*
+ * Advance the leaf locator by one item in the scan direction.
+ *
+ * In IMAGE mode the whole page (including the chunk-descriptor array) is in
+ * context->img, so the plain BTREE_PAGE_LOCATOR_NEXT/PREV macros can cross
+ * chunk boundaries by reading the descriptors from the image.
+ *
+ * In FETCH mode the leaf is partial and the descriptor array is NOT loaded
+ * eagerly (loadHikeys = !fastpath in find_page()).  Moving inside the current
+ * chunk needs only the locator's cached per-chunk counts.  But crossing a
+ * chunk boundary needs the descriptor array, so we load the hikeys chunk (which
+ * contains it) on demand first; that is a no-op once it is loaded, so a
+ * multi-chunk leaf pays for it only on the first crossing.  After that the
+ * regular BTREE_PAGE_LOCATOR_NEXT/PREV macros cross using the descriptors now
+ * present in the image, and the loop in the caller loads the destination
+ * chunk's data before reading from it.
+ *
+ * Returns false if the hikeys chunk could not be loaded because the backing
+ * page changed; the caller must re-find.  On end-of-page in the scan direction
+ * the locator is left invalid (BTREE_PAGE_LOCATOR_IS_VALID() == false).
+ */
+static inline bool
+iterator_advance_leaf(BTreeIterator *it, BTreePageItemLocator *loc)
+{
+	OBTreeFindPageContext *context = &it->context;
+
+	if (BTREE_PAGE_FIND_IS(context, FETCH))
+	{
+		bool		crossing;
+
+		if (IT_IS_FORWARD(it))
+			crossing = loc->itemOffset + 1 >= loc->chunkItemsCount;
+		else
+			crossing = loc->itemOffset == 0;
+
+		if (crossing &&
+			!partial_load_hikeys_chunk(&context->partial, context->img))
+			return false;
+	}
+
+	IT_NEXT_OFFSET(it, loc);
+	return true;
+}
+
+/*
  * Fetch next tuple without checking for end condition.
  */
 static OTuple
@@ -1049,7 +1110,8 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
 										  it->fetchCallback,
 										  it->fetchCallbackArg);
 
-			IT_NEXT_OFFSET(it, &leaf_item->locator);
+			if (!iterator_advance_leaf(it, &leaf_item->locator))
+				iterator_refind_partial_leaf(it);
 
 			if (!O_TUPLE_IS_NULL(result))
 				return result;
@@ -1099,6 +1161,22 @@ btree_iterator_check_load_next_page(BTreeIterator *it)
 			return false;
 
 		iterator_maybe_switch_to_image(it);
+
+		/*
+		 * find_right_page() reads the current leaf's hikey to locate its
+		 * right sibling.  With hikeys loaded on demand (loadHikeys =
+		 * !fastpath), a FETCH leaf reached via the fastpath has no hikeys
+		 * chunk yet -- load it now.  partial_load_hikeys_chunk() is a no-op
+		 * once the chunk (or the whole page, in IMAGE mode) is present; on a
+		 * backing-page change recover through the standard re-find.  Backward
+		 * stepping uses the lokey, never the current leaf's hikey.
+		 */
+		if (IT_IS_FORWARD(it) &&
+			!partial_load_hikeys_chunk(&context->partial, context->img))
+		{
+			iterator_refind_partial_leaf(it);
+			continue;
+		}
 
 		if (IT_IS_FORWARD(it))
 			step_result = find_right_page(context, &key_buf);
@@ -1278,7 +1356,11 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 			it->curKeySet = true;
 			it->curKeyReturned = true;
 
-			IT_NEXT_OFFSET(it, loc);
+			if (!iterator_advance_leaf(it, loc))
+			{
+				iterator_refind_partial_leaf(it);
+				loc = &context->items[context->index].locator;
+			}
 
 			if (end != NULL && endKind != BTreeKeyNone)
 			{
@@ -1319,6 +1401,17 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 		}
 
 		iterator_maybe_switch_to_image(it);
+
+		/*
+		 * Load the current leaf's hikeys on demand for find_right_page() (see
+		 * the matching comment in btree_iterator_check_load_next_page()).
+		 */
+		if (IT_IS_FORWARD(it) &&
+			!partial_load_hikeys_chunk(&context->partial, context->img))
+		{
+			iterator_refind_partial_leaf(it);
+			continue;
+		}
 
 		if (IT_IS_FORWARD(it))
 		{

--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -221,6 +221,19 @@ btree_try_merge_pages(BTreeDescr *desc,
 	right_extent = right_desc->fileExtent;
 
 	CLEAN_DIRTY(desc->ppool, right_blkno);
+
+	/*
+	 * Block reads on the right page before retiring it.  Throughout the merge
+	 * the right page is only locked, never read-blocked, so its unlock inside
+	 * ppool_free_page() would otherwise not bump the page-state change count
+	 * (unlock_page() bumps it only when reads were blocked).  Without that
+	 * bump, a concurrent lock-free reader that already holds an in-memory
+	 * downlink to the right page can't tell from the state bits that the page
+	 * is gone, and has to rely solely on pageChangeCount.  Setting NO_READ
+	 * here makes the change count advance as well -- symmetric with how the
+	 * parent and left pages are handled.
+	 */
+	page_block_reads(right_blkno);
 	O_PAGE_CHANGE_COUNT_INC(right);
 
 	ppool_free_page(desc->ppool, right_blkno, true);

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -1460,7 +1460,19 @@ page_locator_find_real_item(Page p, PartialPageState *partial,
 			return true;
 
 		offset = locator->itemOffset - locator->chunkItemsCount;
-		if (partial)
+
+		/*
+		 * Advance the locator into the next chunk.  partial_load_chunk() only
+		 * fills the locator (chunkItemsCount, chunk pointer) when the page is
+		 * actually read partially; for a whole-page image it returns early
+		 * without touching the locator, so we must use the plain fill there.
+		 * Check partial->isPartial, not just the pointer: the iterator passes
+		 * a non-NULL PartialPageState even for IMAGE reads (isPartial ==
+		 * false), and trusting the pointer would leave the locator stuck in
+		 * the current chunk -- collapsing a cross-chunk position to chunk 0,
+		 * offset 0.
+		 */
+		if (partial && partial->isPartial)
 		{
 			if (!partial_load_chunk(partial, p, locator->chunkOffset + 1, locator))
 				return false;

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -87,14 +87,17 @@ read_page_from_undo(BTreeDescr *desc, Page img, UndoLocation undo_loc,
  * Try to copy consistent image of page with page number = blkno to dest.
  */
 static inline ReadPageResult
-try_copy_page(OInMemoryBlkno blkno, uint32 pageChangeCount, Page dest,
-			  PartialPageState *partial, bool loadHikeysChunk,
+try_copy_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeCount,
+			  Page dest, PartialPageState *partial, bool loadHikeysChunk,
 			  CommitSeqNo *readCsn)
 {
 	Page		p = O_GET_IN_MEMORY_PAGE(blkno);
 	uint64		state1,
 				state2;
 	bool		hiKeysEndOK PG_USED_FOR_ASSERTS_ONLY = true;
+#ifdef USE_ASSERT_CHECKING
+	ORelOids	pageOids;
+#endif
 	PagePool   *ppool;
 
 	state1 = pg_atomic_read_u64(&(O_PAGE_HEADER(p)->state));
@@ -123,6 +126,20 @@ try_copy_page(OInMemoryBlkno blkno, uint32 pageChangeCount, Page dest,
 	else
 		memcpy(dest, p, ORIOLEDB_BLCKSZ);
 
+#ifdef USE_ASSERT_CHECKING
+
+	/*
+	 * Read the page's owning tree oids inside the same barrier-protected
+	 * window as the copy.  If the state checks below confirm the page did not
+	 * change under us, these oids describe the page we copied and its
+	 * physical identity must match the tree we descended -- otherwise we
+	 * followed a downlink onto a page that belongs to a different tree (a
+	 * reused/evicted page).  Validated by the Assert() after all the regular
+	 * checks pass.
+	 */
+	pageOids = O_GET_IN_MEMORY_PAGEDESC(blkno)->oids;
+#endif
+
 	if (readCsn)
 		*readCsn = pg_atomic_read_u64(&TRANSAM_VARIABLES->nextCommitSeqNo);
 
@@ -138,6 +155,22 @@ try_copy_page(OInMemoryBlkno blkno, uint32 pageChangeCount, Page dest,
 
 	Assert(hiKeysEndOK);
 
+	/*
+	 * A shared-pool page must physically belong to the tree we descended.
+	 * Compare only the physical identity (datoid + relnode): reloid is the
+	 * logical catalog OID stamped into the descriptor at page creation and
+	 * can legitimately drift from desc->oids.reloid after DDL that keeps the
+	 * same relfilenode (e.g. ALTER TYPE), so it is excluded.  Local-pool
+	 * (temp) pages are skipped: they use a private oid scheme and a
+	 * per-backend slot can be reused across the temp relation's own indexes,
+	 * so their descriptor oids need not match.  The cross-tree reuse this
+	 * guards against (a stale downlink onto an evicted-and-reused page, e.g.
+	 * on a hot standby) is a shared-pool concern.
+	 */
+	Assert(O_PAGE_IS_LOCAL(blkno) ||
+		   (pageOids.datoid == desc->oids.datoid &&
+			pageOids.relnode == desc->oids.relnode));
+
 	ppool = get_ppool_by_blkno(blkno);
 	ppool_ucm_inc_usage(ppool, blkno);
 
@@ -148,15 +181,15 @@ try_copy_page(OInMemoryBlkno blkno, uint32 pageChangeCount, Page dest,
  * Copy consistent image of page with page number = blkno to dest.
  */
 static inline bool
-copy_page(OInMemoryBlkno blkno, uint32 pageChangeCount, Page dest,
-		  PartialPageState *partial, bool loadHikeysChunk,
+copy_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeCount,
+		  Page dest, PartialPageState *partial, bool loadHikeysChunk,
 		  CommitSeqNo *readCsn)
 {
 	while (true)
 	{
 		ReadPageResult result;
 
-		result = try_copy_page(blkno, pageChangeCount, dest,
+		result = try_copy_page(desc, blkno, pageChangeCount, dest,
 							   partial, loadHikeysChunk, readCsn);
 
 		if (result == ReadPageResultOK)
@@ -230,7 +263,7 @@ o_btree_read_page(BTreeDescr *desc, OInMemoryBlkno blkno,
 	 * chain walk, which is why the former "read undo without copying" fast
 	 * path is gone.
 	 */
-	if (!copy_page(blkno, pageChangeCount, img, partial,
+	if (!copy_page(desc, blkno, pageChangeCount, img, partial,
 				   loadHikeysChunk, readCsn))
 		return false;
 	header = (BTreePageHeader *) img;
@@ -307,7 +340,7 @@ o_btree_try_read_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint32 pageChangeC
 	 * the page must be present before walking the undo chain (see
 	 * o_btree_read_page()).
 	 */
-	result = try_copy_page(blkno, pageChangeCount, img, partial,
+	result = try_copy_page(desc, blkno, pageChangeCount, img, partial,
 						   loadHikeysChunk, readCsn);
 	if (result != ReadPageResultOK)
 		return result;

--- a/test/expected/explain.out
+++ b/test/expected/explain.out
@@ -243,10 +243,9 @@ FROM query_to_text($$ EXPLAIN (ANALYZE TRUE, BUFFERS TRUE)
 --------------------------------------------------------------------------------------------------------------
  Index Scan using o_explain_sec_non_valx on o_explain  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
    Index Cond: ((valx > x) AND (valx < x))
-   Buffers: shared hit=x
  Planning Time: x ms
  Execution Time: x ms
-(5 rows)
+(4 rows)
 
 -- uses primary and secondary index
 SELECT regexp_replace(t, '[\d\.]+', 'x', 'g')

--- a/test/expected/explain_1.out
+++ b/test/expected/explain_1.out
@@ -243,10 +243,9 @@ FROM query_to_text($$ EXPLAIN (ANALYZE TRUE, BUFFERS TRUE)
 --------------------------------------------------------------------------------------------------------------
  Index Scan using o_explain_sec_non_valx on o_explain  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
    Index Cond: ((valx > x) AND (valx < x))
-   Buffers: shared hit=x
  Planning Time: x ms
  Execution Time: x ms
-(5 rows)
+(4 rows)
 
 -- uses primary and secondary index
 SELECT regexp_replace(t, '[\d\.]+', 'x', 'g')

--- a/test/expected/explain_2.out
+++ b/test/expected/explain_2.out
@@ -250,10 +250,9 @@ FROM query_to_text($$ EXPLAIN (ANALYZE TRUE, BUFFERS TRUE)
  Index Scan using o_explain_sec_non_valx on o_explain  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
    Index Cond: ((valx > x) AND (valx < x))
    Index Searches: x
-   Buffers: shared hit=x
  Planning Time: x ms
  Execution Time: x ms
-(6 rows)
+(5 rows)
 
 -- uses primary and secondary index
 SELECT regexp_replace(t, '[\d\.]+', 'x', 'g')

--- a/test/expected/fastpath_desc.out
+++ b/test/expected/fastpath_desc.out
@@ -1,0 +1,242 @@
+-- Exercises the intra-page "fast path" downlink search (fastpath.c) on
+-- DESC-ordered key columns, which used to fall back to the slow binary search.
+-- A multi-level tree plus forced index scans drive the fastpath during descent;
+-- every result is cross-checked against an identical heap table whose ordering
+-- comes from a Sort node, so a wrong downlink (wrong subtree) shows up as a
+-- non-zero symmetric difference.
+CREATE SCHEMA fastpath_desc;
+SET SESSION search_path = 'fastpath_desc';
+CREATE EXTENSION orioledb;
+CREATE FUNCTION pseudo_random(seed bigint, i bigint) RETURNS bigint AS
+$$
+	SELECT (substr(sha256(($1::text || ' ' || $2::text)::bytea)::text, 2, 16)::bit(52)::bigint % 20000);
+$$ LANGUAGE sql;
+-- orioledb table under test and an identical heap oracle.
+CREATE TABLE o (id int8 PRIMARY KEY, v int4, a int4, b int8) USING orioledb;
+CREATE TABLE h (id int8 PRIMARY KEY, v int4, a int4, b int8);
+INSERT INTO o
+	SELECT g,
+		   CASE WHEN g % 50 = 0 THEN NULL ELSE pseudo_random(1, g)::int4 END,
+		   (pseudo_random(2, g) % 100)::int4,
+		   pseudo_random(3, g)
+	FROM generate_series(1, 30000) g;
+INSERT INTO h SELECT * FROM o;
+-- DESC index (NULLS FIRST by default), a distinct DESC NULLS LAST index, and a
+-- mixed (ASC, DESC) composite key.  Keeping the two single-column indexes
+-- distinct lets each ORDER BY below map unambiguously to one of them.
+CREATE INDEX o_v_desc ON o (v DESC);
+CREATE INDEX o_v_desc_nl ON o (v DESC NULLS LAST);
+CREATE INDEX o_ab ON o (a, b DESC);
+CREATE INDEX h_v_desc ON h (v DESC);
+CREATE INDEX h_v_desc_nl ON h (v DESC NULLS LAST);
+CREATE INDEX h_ab ON h (a, b DESC);
+ANALYZE o;
+ANALYZE h;
+-- Force index access on the orioledb table so the multi-level DESC indexes are
+-- descended through the fast path.
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+-- Symmetric-difference helper: returns the number of rows that the orioledb
+-- index scan and the heap oracle disagree on for a predicate.  Expected 0.
+-- Equality, including a value that is absent.
+SELECT count(*) AS eq_mismatch FROM (
+	(SELECT v, id FROM o WHERE v = 12345 EXCEPT ALL SELECT v, id FROM h WHERE v = 12345)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v = 12345 EXCEPT ALL SELECT v, id FROM o WHERE v = 12345)
+) d;
+ eq_mismatch 
+-------------
+           0
+(1 row)
+
+-- Range scans (each end inclusive/exclusive) over the DESC key.
+SELECT count(*) AS lt_mismatch FROM (
+	(SELECT v, id FROM o WHERE v < 5000 EXCEPT ALL SELECT v, id FROM h WHERE v < 5000)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v < 5000 EXCEPT ALL SELECT v, id FROM o WHERE v < 5000)
+) d;
+ lt_mismatch 
+-------------
+           0
+(1 row)
+
+SELECT count(*) AS ge_mismatch FROM (
+	(SELECT v, id FROM o WHERE v >= 15000 EXCEPT ALL SELECT v, id FROM h WHERE v >= 15000)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v >= 15000 EXCEPT ALL SELECT v, id FROM o WHERE v >= 15000)
+) d;
+ ge_mismatch 
+-------------
+           0
+(1 row)
+
+SELECT count(*) AS between_mismatch FROM (
+	(SELECT v, id FROM o WHERE v BETWEEN 8000 AND 12000 EXCEPT ALL SELECT v, id FROM h WHERE v BETWEEN 8000 AND 12000)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v BETWEEN 8000 AND 12000 EXCEPT ALL SELECT v, id FROM o WHERE v BETWEEN 8000 AND 12000)
+) d;
+ between_mismatch 
+------------------
+                0
+(1 row)
+
+-- Full content (incl. NULLs) must match.
+SELECT count(*) AS all_mismatch FROM (
+	(SELECT v, id FROM o EXCEPT ALL SELECT v, id FROM h)
+	UNION ALL
+	(SELECT v, id FROM h EXCEPT ALL SELECT v, id FROM o)
+) d;
+ all_mismatch 
+--------------
+            0
+(1 row)
+
+-- Composite key: equality on the leading ASC column, range on the DESC column.
+SELECT count(*) AS comp_mismatch FROM (
+	(SELECT a, b, id FROM o WHERE a = 7 EXCEPT ALL SELECT a, b, id FROM h WHERE a = 7)
+	UNION ALL
+	(SELECT a, b, id FROM h WHERE a = 7 EXCEPT ALL SELECT a, b, id FROM o WHERE a = 7)
+) d;
+ comp_mismatch 
+---------------
+             0
+(1 row)
+
+SELECT count(*) AS comp_range_mismatch FROM (
+	(SELECT a, b, id FROM o WHERE a = 42 AND b >= 10000 EXCEPT ALL SELECT a, b, id FROM h WHERE a = 42 AND b >= 10000)
+	UNION ALL
+	(SELECT a, b, id FROM h WHERE a = 42 AND b >= 10000 EXCEPT ALL SELECT a, b, id FROM o WHERE a = 42 AND b >= 10000)
+) d;
+ comp_range_mismatch 
+---------------------
+                   0
+(1 row)
+
+-- Ordered samples.  The EXPLAIN before each query shows the scan is served by
+-- the expected DESC index (forward) or its backward scan, not a seqscan/sort
+-- of the heap -- i.e. the fastpath descent is actually exercised.  Each
+-- ORDER BY's (direction, NULLS placement) maps unambiguously to one index:
+--   v DESC NULLS FIRST -> o_v_desc            (forward)
+--   v ASC  NULLS LAST  -> o_v_desc            (backward)
+--   v DESC NULLS LAST  -> o_v_desc_nl         (forward)
+--   v ASC  NULLS FIRST -> o_v_desc_nl         (backward)
+--   a = c, b DESC      -> o_ab                (forward)
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v DESC NULLS FIRST, id LIMIT 5;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: v DESC, id
+         Presorted Key: v
+         ->  Index Only Scan using o_v_desc on o
+(5 rows)
+
+SELECT v, id FROM o ORDER BY v DESC NULLS FIRST, id LIMIT 5;
+ v | id  
+---+-----
+   |  50
+   | 100
+   | 150
+   | 200
+   | 250
+(5 rows)
+
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v ASC NULLS LAST, id LIMIT 5;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: v, id
+         Presorted Key: v
+         ->  Index Only Scan Backward using o_v_desc on o
+(5 rows)
+
+SELECT v, id FROM o ORDER BY v ASC NULLS LAST, id LIMIT 5;
+ v |  id   
+---+-------
+ 1 |  3585
+ 3 |  9329
+ 4 | 22745
+ 4 | 26429
+ 5 | 20899
+(5 rows)
+
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v DESC NULLS LAST, id LIMIT 5;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: v DESC NULLS LAST, id
+         Presorted Key: v
+         ->  Index Only Scan using o_v_desc_nl on o
+(5 rows)
+
+SELECT v, id FROM o ORDER BY v DESC NULLS LAST, id LIMIT 5;
+   v   |  id   
+-------+-------
+ 19997 |  8092
+ 19997 | 24646
+ 19997 | 29643
+ 19995 |  3584
+ 19995 | 26355
+(5 rows)
+
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v ASC NULLS FIRST, id LIMIT 5;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: v NULLS FIRST, id
+         Presorted Key: v
+         ->  Index Only Scan Backward using o_v_desc_nl on o
+(5 rows)
+
+SELECT v, id FROM o ORDER BY v ASC NULLS FIRST, id LIMIT 5;
+ v | id  
+---+-----
+   |  50
+   | 100
+   | 150
+   | 200
+   | 250
+(5 rows)
+
+EXPLAIN (COSTS OFF)
+	SELECT b, id FROM o WHERE a = 7 ORDER BY b DESC, id LIMIT 10;
+                 QUERY PLAN                  
+---------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: b DESC, id
+         Presorted Key: b
+         ->  Index Only Scan using o_ab on o
+               Index Cond: (a = 7)
+(6 rows)
+
+SELECT b, id FROM o WHERE a = 7 ORDER BY b DESC, id LIMIT 10;
+   b   |  id   
+-------+-------
+ 19996 | 24143
+ 19867 | 23208
+ 19810 |  2001
+ 19699 | 24345
+ 19689 | 20391
+ 19641 | 11976
+ 19584 | 22398
+ 19485 |  5327
+ 19368 |  8436
+ 19283 | 14006
+(10 rows)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP SCHEMA fastpath_desc CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to extension orioledb
+drop cascades to function pseudo_random(bigint,bigint)
+drop cascades to table o
+drop cascades to table h

--- a/test/expected/iterator.out
+++ b/test/expected/iterator.out
@@ -25,6 +25,30 @@ SELECT unnest(orioledb_test_endkey_returned_skip('o_endkey_skip'::regclass, 5)) 
 (6 rows)
 
 DROP TABLE o_endkey_skip;
+-- Backward refind: silent invalid locator at items_count in
+-- iterator_refind_partial_leaf().  orioledb_test_back_refind_skip_tail()
+-- opens a backward iterator, forges curKey to a value past the leaf's max,
+-- then forces a refind.  With the bug the locator stays invalid; with the
+-- fix it decrements to the leaf's tail (mirroring the seed path) and the
+-- backward drain sees every row, descending.
+CREATE TABLE o_back_refind (id int4 PRIMARY KEY) USING orioledb;
+INSERT INTO o_back_refind SELECT g FROM generate_series(1, 10) g;
+SELECT unnest(orioledb_test_back_refind_skip_tail('o_back_refind'::regclass, 1000)) AS id;
+ id 
+----
+ 10
+  9
+  8
+  7
+  6
+  5
+  4
+  3
+  2
+  1
+(10 rows)
+
+DROP TABLE o_back_refind;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA iterator CASCADE;
 RESET search_path;

--- a/test/expected/iterator.out
+++ b/test/expected/iterator.out
@@ -1,0 +1,30 @@
+-- Whitebox tests for the orioledb B-tree iterator.  The C helpers exercised
+-- here live at the bottom of src/btree/iterator.c and are registered in the
+-- 1.8->1.9 dev migration.
+CREATE SCHEMA iterator;
+SET SESSION search_path = 'iterator';
+CREATE EXTENSION orioledb;
+-- it->curKeyReturned set BEFORE the end-key bound check in
+-- btree_iterate_raw_internal().  orioledb_test_endkey_returned_skip()
+-- drives an iterator into the buggy state via an end-bound rejection,
+-- forces iterator_refind_partial_leaf() (the partial-read failure path),
+-- then drains the iterator with a wide end and returns the PKs as int4[].
+-- The bug drops the rejected row from the resumed scan, so the resulting
+-- query has one fewer row than expected.
+CREATE TABLE o_endkey_skip (id int4 PRIMARY KEY) USING orioledb;
+INSERT INTO o_endkey_skip SELECT g FROM generate_series(1, 10) g;
+SELECT unnest(orioledb_test_endkey_returned_skip('o_endkey_skip'::regclass, 5)) AS id;
+ id 
+----
+  5
+  6
+  7
+  8
+  9
+ 10
+(6 rows)
+
+DROP TABLE o_endkey_skip;
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA iterator CASCADE;
+RESET search_path;

--- a/test/sql/fastpath_desc.sql
+++ b/test/sql/fastpath_desc.sql
@@ -1,0 +1,124 @@
+-- Exercises the intra-page "fast path" downlink search (fastpath.c) on
+-- DESC-ordered key columns, which used to fall back to the slow binary search.
+-- A multi-level tree plus forced index scans drive the fastpath during descent;
+-- every result is cross-checked against an identical heap table whose ordering
+-- comes from a Sort node, so a wrong downlink (wrong subtree) shows up as a
+-- non-zero symmetric difference.
+CREATE SCHEMA fastpath_desc;
+SET SESSION search_path = 'fastpath_desc';
+CREATE EXTENSION orioledb;
+
+CREATE FUNCTION pseudo_random(seed bigint, i bigint) RETURNS bigint AS
+$$
+	SELECT (substr(sha256(($1::text || ' ' || $2::text)::bytea)::text, 2, 16)::bit(52)::bigint % 20000);
+$$ LANGUAGE sql;
+
+-- orioledb table under test and an identical heap oracle.
+CREATE TABLE o (id int8 PRIMARY KEY, v int4, a int4, b int8) USING orioledb;
+CREATE TABLE h (id int8 PRIMARY KEY, v int4, a int4, b int8);
+
+INSERT INTO o
+	SELECT g,
+		   CASE WHEN g % 50 = 0 THEN NULL ELSE pseudo_random(1, g)::int4 END,
+		   (pseudo_random(2, g) % 100)::int4,
+		   pseudo_random(3, g)
+	FROM generate_series(1, 30000) g;
+INSERT INTO h SELECT * FROM o;
+
+-- DESC index (NULLS FIRST by default), a distinct DESC NULLS LAST index, and a
+-- mixed (ASC, DESC) composite key.  Keeping the two single-column indexes
+-- distinct lets each ORDER BY below map unambiguously to one of them.
+CREATE INDEX o_v_desc ON o (v DESC);
+CREATE INDEX o_v_desc_nl ON o (v DESC NULLS LAST);
+CREATE INDEX o_ab ON o (a, b DESC);
+CREATE INDEX h_v_desc ON h (v DESC);
+CREATE INDEX h_v_desc_nl ON h (v DESC NULLS LAST);
+CREATE INDEX h_ab ON h (a, b DESC);
+ANALYZE o;
+ANALYZE h;
+
+-- Force index access on the orioledb table so the multi-level DESC indexes are
+-- descended through the fast path.
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+
+-- Symmetric-difference helper: returns the number of rows that the orioledb
+-- index scan and the heap oracle disagree on for a predicate.  Expected 0.
+-- Equality, including a value that is absent.
+SELECT count(*) AS eq_mismatch FROM (
+	(SELECT v, id FROM o WHERE v = 12345 EXCEPT ALL SELECT v, id FROM h WHERE v = 12345)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v = 12345 EXCEPT ALL SELECT v, id FROM o WHERE v = 12345)
+) d;
+
+-- Range scans (each end inclusive/exclusive) over the DESC key.
+SELECT count(*) AS lt_mismatch FROM (
+	(SELECT v, id FROM o WHERE v < 5000 EXCEPT ALL SELECT v, id FROM h WHERE v < 5000)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v < 5000 EXCEPT ALL SELECT v, id FROM o WHERE v < 5000)
+) d;
+
+SELECT count(*) AS ge_mismatch FROM (
+	(SELECT v, id FROM o WHERE v >= 15000 EXCEPT ALL SELECT v, id FROM h WHERE v >= 15000)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v >= 15000 EXCEPT ALL SELECT v, id FROM o WHERE v >= 15000)
+) d;
+
+SELECT count(*) AS between_mismatch FROM (
+	(SELECT v, id FROM o WHERE v BETWEEN 8000 AND 12000 EXCEPT ALL SELECT v, id FROM h WHERE v BETWEEN 8000 AND 12000)
+	UNION ALL
+	(SELECT v, id FROM h WHERE v BETWEEN 8000 AND 12000 EXCEPT ALL SELECT v, id FROM o WHERE v BETWEEN 8000 AND 12000)
+) d;
+
+-- Full content (incl. NULLs) must match.
+SELECT count(*) AS all_mismatch FROM (
+	(SELECT v, id FROM o EXCEPT ALL SELECT v, id FROM h)
+	UNION ALL
+	(SELECT v, id FROM h EXCEPT ALL SELECT v, id FROM o)
+) d;
+
+-- Composite key: equality on the leading ASC column, range on the DESC column.
+SELECT count(*) AS comp_mismatch FROM (
+	(SELECT a, b, id FROM o WHERE a = 7 EXCEPT ALL SELECT a, b, id FROM h WHERE a = 7)
+	UNION ALL
+	(SELECT a, b, id FROM h WHERE a = 7 EXCEPT ALL SELECT a, b, id FROM o WHERE a = 7)
+) d;
+
+SELECT count(*) AS comp_range_mismatch FROM (
+	(SELECT a, b, id FROM o WHERE a = 42 AND b >= 10000 EXCEPT ALL SELECT a, b, id FROM h WHERE a = 42 AND b >= 10000)
+	UNION ALL
+	(SELECT a, b, id FROM h WHERE a = 42 AND b >= 10000 EXCEPT ALL SELECT a, b, id FROM o WHERE a = 42 AND b >= 10000)
+) d;
+
+-- Ordered samples.  The EXPLAIN before each query shows the scan is served by
+-- the expected DESC index (forward) or its backward scan, not a seqscan/sort
+-- of the heap -- i.e. the fastpath descent is actually exercised.  Each
+-- ORDER BY's (direction, NULLS placement) maps unambiguously to one index:
+--   v DESC NULLS FIRST -> o_v_desc            (forward)
+--   v ASC  NULLS LAST  -> o_v_desc            (backward)
+--   v DESC NULLS LAST  -> o_v_desc_nl         (forward)
+--   v ASC  NULLS FIRST -> o_v_desc_nl         (backward)
+--   a = c, b DESC      -> o_ab                (forward)
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v DESC NULLS FIRST, id LIMIT 5;
+SELECT v, id FROM o ORDER BY v DESC NULLS FIRST, id LIMIT 5;
+
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v ASC NULLS LAST, id LIMIT 5;
+SELECT v, id FROM o ORDER BY v ASC NULLS LAST, id LIMIT 5;
+
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v DESC NULLS LAST, id LIMIT 5;
+SELECT v, id FROM o ORDER BY v DESC NULLS LAST, id LIMIT 5;
+
+EXPLAIN (COSTS OFF)
+	SELECT v, id FROM o ORDER BY v ASC NULLS FIRST, id LIMIT 5;
+SELECT v, id FROM o ORDER BY v ASC NULLS FIRST, id LIMIT 5;
+
+EXPLAIN (COSTS OFF)
+	SELECT b, id FROM o WHERE a = 7 ORDER BY b DESC, id LIMIT 10;
+SELECT b, id FROM o WHERE a = 7 ORDER BY b DESC, id LIMIT 10;
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP SCHEMA fastpath_desc CASCADE;

--- a/test/sql/iterator.sql
+++ b/test/sql/iterator.sql
@@ -1,0 +1,25 @@
+-- Whitebox tests for the orioledb B-tree iterator.  The C helpers exercised
+-- here live at the bottom of src/btree/iterator.c and are registered in the
+-- 1.8->1.9 dev migration.
+
+CREATE SCHEMA iterator;
+SET SESSION search_path = 'iterator';
+CREATE EXTENSION orioledb;
+
+-- it->curKeyReturned set BEFORE the end-key bound check in
+-- btree_iterate_raw_internal().  orioledb_test_endkey_returned_skip()
+-- drives an iterator into the buggy state via an end-bound rejection,
+-- forces iterator_refind_partial_leaf() (the partial-read failure path),
+-- then drains the iterator with a wide end and returns the PKs as int4[].
+-- The bug drops the rejected row from the resumed scan, so the resulting
+-- query has one fewer row than expected.
+CREATE TABLE o_endkey_skip (id int4 PRIMARY KEY) USING orioledb;
+INSERT INTO o_endkey_skip SELECT g FROM generate_series(1, 10) g;
+
+SELECT unnest(orioledb_test_endkey_returned_skip('o_endkey_skip'::regclass, 5)) AS id;
+
+DROP TABLE o_endkey_skip;
+
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA iterator CASCADE;
+RESET search_path;

--- a/test/sql/iterator.sql
+++ b/test/sql/iterator.sql
@@ -20,6 +20,19 @@ SELECT unnest(orioledb_test_endkey_returned_skip('o_endkey_skip'::regclass, 5)) 
 
 DROP TABLE o_endkey_skip;
 
+-- Backward refind: silent invalid locator at items_count in
+-- iterator_refind_partial_leaf().  orioledb_test_back_refind_skip_tail()
+-- opens a backward iterator, forges curKey to a value past the leaf's max,
+-- then forces a refind.  With the bug the locator stays invalid; with the
+-- fix it decrements to the leaf's tail (mirroring the seed path) and the
+-- backward drain sees every row, descending.
+CREATE TABLE o_back_refind (id int4 PRIMARY KEY) USING orioledb;
+INSERT INTO o_back_refind SELECT g FROM generate_series(1, 10) g;
+
+SELECT unnest(orioledb_test_back_refind_skip_tail('o_back_refind'::regclass, 1000)) AS id;
+
+DROP TABLE o_back_refind;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA iterator CASCADE;
 RESET search_path;


### PR DESCRIPTION
## Overview

Implements a **FETCH-mode partial B-tree iterator**: the iterator reads only the
parts of each page it actually needs (partial reads) instead of copying whole
page images, and switches to full IMAGE reads after a few pages. Backward scans
are supported via a separate parent-partial state, and intra-page navigation
uses a cache-friendly fastpath downlink search.

## What's in here

- **Iterator FETCH mode + backward scans.** Defaults to FETCH (partial leaf
  reads), switches to IMAGE after the 3rd page. Backward scans keep a stable
  per-page lokey (`leafLokey`) and a separate parent-partial image so
  `find_left_page`/`find_right_page` can navigate siblings.

- **Fastpath downlink search** (`fastpath.c`): walks a fixed-stride array that
  mirrors the page layout to resolve a downlink without copying chunks, with
  lock-free validation (state-bits change count **and** `pageChangeCount`, so a
  reused/evicted/merged page is detected). Now also supports **DESC-ordered key
  columns** — the array-search routines take a `descending` flag and bounds are
  expressed as storage directions, so DESC and `NULLS FIRST/LAST` resolve
  correctly.

- **Load the hikeys chunk on demand** (`loadHikeys = !fastpath`): the
  chunk-descriptor array is loaded only when the iterator actually crosses a
  chunk boundary / steps to a sibling, not eagerly on every leaf.

- **`convert_fastpath_parent_to_img()`**: when the fastpath located the parent's
  downlink, materialize the parent into `parentImg` by *finishing the partial
  read the descent already started* (`partial_load_hikeys_chunk` +
  `partial_load_chunk`) rather than re-reading the page — re-snapshotting could
  leave `parentImg` inconsistent with the downlink the fastpath already chose.
  Forward scans defer this until `find_right_page()` actually needs it.

- **Defensive assert** in `try_copy_page()` (assert builds only): a copied
  shared-pool page must physically belong to the descended tree (`datoid` +
  `relnode`).

## Testing

- `regresscheck` 45/45, `isolationcheck` 30/30.
- `test_replication_hot_read` (hot standby) green.
- 64× `valgrind_1` matrix green (temporary CI fan-out, since removed).
- New regression test `fastpath_desc` cross-checks DESC / DESC-NULLS-FIRST /
  mixed `(ASC, DESC)` composite index scans against a heap oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
