### PR TITLE
Tolerate missing coverage artifacts in CI cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -209,3 +209,4 @@ jobs:
         uses: geekyeggo/delete-artifact@v6
         with:
           name: "*coverage.info"
+          failOnError: false


### PR DESCRIPTION
Cleanup job fails with 404 when a matrix job did not upload its coverage.info. Set failOnError: false so missing artifacts are ignored.

retention-days: 1 still handles eventual cleanup