### PR TITLE
Adjust logic of CI tests to allow manual dispatch and reduce extra runs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,6 @@
 name: check
 
-on:
-  push:
-  pull_request:
+on: [workflow_dispatch, pull_request]
 
 jobs:
   matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,10 @@
 name: check
 
-on: [workflow_dispatch, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   matrix:

--- a/.github/workflows/pgindent.yml
+++ b/.github/workflows/pgindent.yml
@@ -1,7 +1,8 @@
 name: pgindent
 
 on:
-  push: ["main"]
+  push:
+    branches: ["main"]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/pgindent.yml
+++ b/.github/workflows/pgindent.yml
@@ -1,8 +1,6 @@
 name: pgindent
 
-on:
-  push:
-  pull_request:
+on: [workflow_dispatch, pull_request]
 
 jobs:
   pgindent:

--- a/.github/workflows/pgindent.yml
+++ b/.github/workflows/pgindent.yml
@@ -1,6 +1,9 @@
 name: pgindent
 
-on: [workflow_dispatch, pull_request]
+on:
+  push: ["main"]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   pgindent:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,6 +1,10 @@
 name: static
 
-on: [workflow_dispatch, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   static:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,8 +1,6 @@
 name: static
 
-on:
-  push:
-  pull_request:
+on: [workflow_dispatch, pull_request]
 
 jobs:
   static:


### PR DESCRIPTION
Currently CI runs trigger on a PR and on a Push to any branch. This duplicates the runs when PR is created wasting resources and complicating run result analysis.

Remove CI runs for `Push` events on `test`, `pgindent` and `static` for non-`main` branches and instead only run on PRs and allow manual dispatch.

This way developers can manually run CI on dev branches without needing a PR.