### PR TITLE
Reduce database size test string length to fix intermittent failures

### DIFF
--- a/test/expected/database.out
+++ b/test/expected/database.out
@@ -36,7 +36,7 @@ select round(pg_database_size('oriole_database'), -6);
 
 CREATE EXTENSION orioledb;
 CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
-INSERT INTO oriole_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+INSERT INTO oriole_table(t) select generate_string(i, 250) FROM  generate_series(1, 10000) as i;
 CHECKPOINT;
 select round(pg_database_size('oriole_database'), -6);
   round   
@@ -104,7 +104,7 @@ select round(pg_database_size('mixed_database'), -6);
 (1 row)
 
 CREATE TABLE heap_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING heap;
-INSERT INTO heap_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+INSERT INTO heap_table(t) select generate_string(i, 250) FROM  generate_series(1, 10000) as i;
 CHECKPOINT;
 select round(pg_database_size('mixed_database'), -6);
   round   

--- a/test/expected/database_1.out
+++ b/test/expected/database_1.out
@@ -36,7 +36,7 @@ select round(pg_database_size('oriole_database'), -6);
 
 CREATE EXTENSION orioledb;
 CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
-INSERT INTO oriole_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+INSERT INTO oriole_table(t) select generate_string(i, 250) FROM  generate_series(1, 10000) as i;
 CHECKPOINT;
 select round(pg_database_size('oriole_database'), -6);
   round   
@@ -108,7 +108,7 @@ select round(pg_database_size('mixed_database'), -6);
 (1 row)
 
 CREATE TABLE heap_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING heap;
-INSERT INTO heap_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+INSERT INTO heap_table(t) select generate_string(i, 250) FROM  generate_series(1, 10000) as i;
 CHECKPOINT;
 select round(pg_database_size('mixed_database'), -6);
   round   

--- a/test/sql/database.sql
+++ b/test/sql/database.sql
@@ -43,7 +43,7 @@ select round(pg_database_size('oriole_database'), -6);
 
 CREATE EXTENSION orioledb;
 CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
-INSERT INTO oriole_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+INSERT INTO oriole_table(t) select generate_string(i, 250) FROM  generate_series(1, 10000) as i;
 CHECKPOINT;
 select round(pg_database_size('oriole_database'), -6);
 
@@ -81,7 +81,7 @@ CHECKPOINT;
 select round(pg_database_size('mixed_database'), -6);
 
 CREATE TABLE heap_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING heap;
-INSERT INTO heap_table(t) select generate_string(i, 270) FROM  generate_series(1, 10000) as i;
+INSERT INTO heap_table(t) select generate_string(i, 250) FROM  generate_series(1, 10000) as i;
 CHECKPOINT;
 select round(pg_database_size('mixed_database'), -6);
 


### PR DESCRIPTION
The database regression test checks pg_database_size() rounded to the nearest million. With 270-byte strings, the result hovers near a million-byte boundary, causing intermittent failures across PG versions, compilers, and system configurations (e.g. PG18's slightly larger system catalogs can push the value past 11.5M). Reducing the generated string length from 270 to 250 bytes adds enough margin to keep the rounded result stable across all supported PostgreSQL versions and build environments.

Assisted-by: Crush:glm-5.2

Without this change, the test fails with the following diff on my system:

```diff
diff -U3 /home/user/git/oriole/orioledb/test/expected/database_1.out /home/user/git/oriole/orioledb/test/results/database.out
--- /home/user/git/oriole/orioledb/test/expected/database_1.out 2026-06-25 14:45:28.529646253 +0300
+++ /home/user/git/oriole/orioledb/test/results/database.out    2026-06-25 14:46:26.580850942 +0300
@@ -41,7 +41,7 @@
 select round(pg_database_size('oriole_database'), -6);
   round   
 ----------
- 11000000
+ 12000000
 (1 row)
 
 SET allow_in_place_tablespaces = true;
@@ -113,7 +113,7 @@
 select round(pg_database_size('mixed_database'), -6);
   round   
 ----------
- 11000000
+ 12000000
 (1 row)
 
 CREATE TABLE oriole_table (i SERIAL PRIMARY KEY, t text STORAGE PLAIN) USING orioledb;
```