### PR TITLE
Implementation of moving database files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,8 @@ TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
 						test/t/undo_ring_keep_checkpoint_test.py \
 						test/t/rewind_xid_test.py \
 						test/t/rewind_xid_evict_large_test.py \
-						test/t/page_fit_items_test.py
+						test/t/page_fit_items_test.py \
+						test/t/move_database_test.py
 TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/checkpoint_eviction_test.py \
 						test/t/checkpoint_same_trx_test.py \

--- a/include/btree/io.h
+++ b/include/btree/io.h
@@ -32,6 +32,7 @@ extern void btree_io_error_cleanup(void);
 extern void request_btree_io_lwlocks(void);
 extern int	assign_io_num(OInMemoryBlkno blkno, OffsetNumber offnum);
 extern OWalkPageResult walk_page(OInMemoryBlkno blkno, bool evict);
+extern void write_tree_pages(BTreeDescr *desc, int maxLevel, bool evict);
 extern void unlock_io(int ionum);
 extern void wait_for_io_completion(int ionum);
 extern bool cleanup_btree_files(OIndexKey key, bool fsync);

--- a/include/catalog/o_tables.h
+++ b/include/catalog/o_tables.h
@@ -182,6 +182,12 @@ extern OTable *o_tables_drop_by_oids(ORelOids oids, OXid oxid, CommitSeqNo csn);
 /* Drops all tables from o_tables list */
 extern void o_tables_drop_all(OXid oxid, CommitSeqNo csn, Oid database_id);
 
+/* Move all tables from o_tables list */
+extern void o_tables_move_all(OXid oxid, CommitSeqNo csn, Oid database_id, Oid old_tspcoid, Oid new_tspcoid);
+
+/* Evict all tables in database */
+extern void o_tables_evict(Oid datoid, List **evicted);
+
 /* Drops all columns of a specific type */
 extern void o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid type_oid);
 

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -189,6 +189,13 @@ typedef struct
 	uint8		origin_lsn[sizeof(XLogRecPtr)];
 } WALRecOriginInfo;
 
+typedef struct
+{
+	uint8		recType;
+	uint8		datid[sizeof(Oid)];
+	uint8		src_tblspc[sizeof(Oid)];
+	uint8		dst_tblspc[sizeof(Oid)];
+} WALRecDbCopy;
 
 #define LOCAL_WAL_BUFFER_SIZE	(8192)
 #define ORIOLEDB_WAL_PREFIX	"o_wal"
@@ -205,6 +212,7 @@ extern void add_switch_logical_xid_wal_record(TransactionId logicalXid_top, Tran
 extern void add_savepoint_wal_record(SubTransactionId parentSubid,
 									 TransactionId prentLogicalXid);
 extern void add_rollback_to_savepoint_wal_record(SubTransactionId parentSubid);
+extern void add_database_copy_wal_record(Oid dboid, Oid src_tblspc, Oid dst_tblspc);
 extern bool local_wal_is_empty(void);
 extern XLogRecPtr flush_local_wal(bool isCommit, bool withXactTime);
 extern XLogRecPtr wal_commit(OXid oxid, TransactionId logicalXid,

--- a/include/recovery/wal_reader.h
+++ b/include/recovery/wal_reader.h
@@ -99,6 +99,14 @@ typedef struct WalRecord
 
 			bool		read_two_tuples;
 		}			modify;
+
+		struct
+		{
+			Oid			datOid;
+			Oid			src_tblspc;
+			Oid			dst_tblspc;
+		}			dbcopy;
+
 	}			u;
 
 } WalRecord;

--- a/include/recovery/wal_record.h
+++ b/include/recovery/wal_record.h
@@ -57,7 +57,8 @@
 	X(WAL_REC_REINSERT,             15, "REINSERT",           wal_parse_rec_modify) \
 	X(WAL_REC_REPLAY_FEEDBACK,      16, "REPLAY_FEEDBACK",    wal_parse_empty) \
 	X(WAL_REC_SWITCH_LOGICAL_XID,   17, "SWITCH_LOGICAL_XID", wal_parse_rec_switch_logical_xid) \
-	X(WAL_REC_RELREPLIDENT,         18, "RELREPLIDENT",       wal_parse_rec_relreplident)
+	X(WAL_REC_RELREPLIDENT,         18, "RELREPLIDENT",       wal_parse_rec_relreplident) \
+	X(WAL_REC_DATABASE_COPY,        19, "DATABASE_COPY",      wal_parse_rec_dbcopy)
 
 typedef enum
 {

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -3104,6 +3104,10 @@ retry:
 	return evict ? OWalkPageEvicted : OWalkPageWritten;
 }
 
+/*
+ * Recursively write pages in the tree. Stop reqursion if we reach maxLevel,
+ * when it has non-negtive value. To write all pages, set maxLevel to -1.
+ */
 static bool
 write_tree_pages_recursive(UndoLogType undoType,
 						   OInMemoryBlkno blkno, uint32 loadId,
@@ -3164,7 +3168,7 @@ write_tree_pages_recursive(UndoLogType undoType,
 										  maxLevel,
 										  evict);
 
-	if (level <= maxLevel)
+	if (level <= maxLevel || maxLevel == -1)
 	{
 		while (true)
 		{
@@ -3179,7 +3183,7 @@ write_tree_pages_recursive(UndoLogType undoType,
 	return true;
 }
 
-static void
+void
 write_tree_pages(BTreeDescr *desc, int maxLevel, bool evict)
 {
 	o_btree_load_shmem(desc);

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -23,6 +23,7 @@
 #include "catalog/o_sys_cache.h"
 #include "storage/lockdefs.h"
 #include "tableam/descr.h"
+#include "storage/copydir.h"
 #include "tableam/operations.h"
 #include "catalog/pg_am.h"
 #include "tableam/toast.h"
@@ -110,6 +111,13 @@
 static IndexBuildResult o_pkey_result;
 static void o_drop_table(ORelOids oids);
 
+typedef struct
+{
+	Oid			dest_dboid;		/* DB we are trying to move */
+	Oid			src_tsoid;		/* tablespace we are trying to move from */
+	Oid			dest_tsoid;		/* tablespace we are trying to move to */
+} movedb_params;
+
 static ProcessUtility_hook_type next_ProcessUtility_hook = NULL;
 static object_access_hook_type old_objectaccess_hook = NULL;
 
@@ -129,6 +137,7 @@ static IndexBuildResult o_pkey_result = {0};
 bool		o_in_add_column = false;
 static CreateStmt *create_stmt = NULL;
 static List *o_added_columns = NIL;
+static movedb_params o_movedb_data = {InvalidOid, InvalidOid, InvalidOid};
 
 static void orioledb_utility_command(PlannedStmt *pstmt,
 									 const char *queryString,
@@ -155,6 +164,8 @@ static bool get_db_info(const char *name, LOCKMODE lockmode, Oid *dbIdP);
 static Oid	o_createdb(ParseState *pstate, const CreatedbStmt *stmt);
 static void o_validate_replica_identity(Relation rel, ReplicaIdentityStmt *stmt);
 static void o_process_added_column(AlterTableCmd *cmd);
+static void o_check_movedb(const AlterDatabaseStmt *stmt, movedb_params *movedb);
+static void o_movedb_failure_callback(int code, Datum arg);
 
 void
 orioledb_setup_ddl_hooks(void)
@@ -1401,6 +1412,11 @@ orioledb_utility_command(PlannedStmt *pstmt,
 	{
 		create_stmt = (CreateStmt *) pstmt->utilityStmt;
 	}
+	else if (IsA(pstmt->utilityStmt, AlterDatabaseStmt))
+	{
+		memset(&o_movedb_data, 0, sizeof(o_movedb_data));
+		o_check_movedb(castNode(AlterDatabaseStmt, pstmt->utilityStmt), &o_movedb_data);
+	}
 #if PG_VERSION_NUM >= 170000
 	else if (IsA(pstmt->utilityStmt, CreateTableAsStmt))
 	{
@@ -1618,6 +1634,10 @@ orioledb_utility_command(PlannedStmt *pstmt,
 			/* cppcheck-suppress unknownEvaluationOrder */
 									  list_make2(expression_planner((Expr *) nve), makeString(colname)));
 		}
+	}
+	else if (IsA(pstmt->utilityStmt, AlterDatabaseStmt))
+	{
+		memset(&o_movedb_data, 0, sizeof(o_movedb_data));
 	}
 
 	free_parsestate(pstate);
@@ -4335,6 +4355,107 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 							  "It is easier to use single one during checkpoint."));
 		ReleaseSysCache(dbTuple);
 	}
+	else if (access == OAT_POST_ALTER && classId == DatabaseRelationId)
+	{
+		/*
+		 * Move all the orioledb objects from the source tablespace to the
+		 * destination tablespace. At this point CHECKPOINT was done and there
+		 * is no new connection to the moved database because
+		 * LockSharedObjectForSession on database was done as well.
+		 */
+		if (OidIsValid(o_movedb_data.dest_dboid) &&
+			OidIsValid(o_movedb_data.src_tsoid) &&
+			OidIsValid(o_movedb_data.dest_tsoid) &&
+			o_tables_num(o_movedb_data.dest_dboid))
+		{
+			char	   *src_dbpath = NULL;
+			char	   *dst_dbpath = NULL;
+			char	   *dst_prefix = NULL;
+			DIR		   *dir;
+			struct dirent *xlde;
+			bool		skipMoving = true;
+
+			o_get_prefixes_for_tablespace(o_movedb_data.dest_dboid, o_movedb_data.src_tsoid, NULL, &src_dbpath);
+			o_get_prefixes_for_tablespace(o_movedb_data.dest_dboid, o_movedb_data.dest_tsoid, &dst_prefix, &dst_dbpath);
+
+			/*
+			 * Fast exit if there are no relations in the source tablespace.
+			 */
+			dir = AllocateDir(src_dbpath);
+			if (dir != NULL)
+			{
+				bool		hasFiles = false;
+
+				while ((xlde = ReadDir(dir, src_dbpath)) != NULL)
+				{
+					if (strcmp(xlde->d_name, ".") == 0 ||
+						strcmp(xlde->d_name, "..") == 0)
+						continue;
+					hasFiles = true;
+					break;
+				}
+
+				FreeDir(dir);
+				skipMoving = !hasFiles;
+			}
+
+			if (!skipMoving)
+			{
+				dir = AllocateDir(dst_dbpath);
+				if (dir != NULL)
+				{
+					while ((xlde = ReadDir(dir, dst_dbpath)) != NULL)
+					{
+						if (strcmp(xlde->d_name, ".") == 0 ||
+							strcmp(xlde->d_name, "..") == 0)
+							continue;
+
+						ereport(ERROR,
+								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+								 errmsg("some relations of database \"%d\" are already in tablespace \"%d\"",
+										o_movedb_data.dest_dboid, o_movedb_data.dest_tsoid),
+								 errhint("You must move them back to the database's default tablespace before using this command.")));
+					}
+
+					FreeDir(dir);
+
+					/*
+					 * The directory exists but is empty. We must remove it
+					 * before using the copydir function.
+					 */
+					if (rmdir(dst_dbpath) != 0)
+						elog(ERROR, "could not remove directory \"%s\": %m",
+							 dst_dbpath);
+				}
+
+				PG_ENSURE_ERROR_CLEANUP(o_movedb_failure_callback,
+										PointerGetDatum(&o_movedb_data));
+				{
+					OSnapshot	oSnapshot;
+					OXid		oxid;
+
+					fill_current_oxid_osnapshot(&oxid, &oSnapshot);
+
+					o_verify_dir_exists_or_create(dst_prefix, NULL, NULL);
+					copydir(src_dbpath, dst_dbpath, false);
+
+					o_tables_table_meta_lock(NULL);
+					o_tables_move_all(oxid, oSnapshot.csn, o_movedb_data.dest_dboid, o_movedb_data.src_tsoid, o_movedb_data.dest_tsoid);
+					o_tables_table_meta_unlock(NULL, InvalidOid);
+
+					if (!rmtree(src_dbpath, true))
+						ereport(WARNING,
+								(errmsg("some useless files may be left behind in old database directory \"%s\"",
+										src_dbpath)));
+				}
+				PG_END_ENSURE_ERROR_CLEANUP(o_movedb_failure_callback,
+											PointerGetDatum(&o_movedb_data));
+			}
+
+			pfree(src_dbpath);
+			pfree(dst_dbpath);
+		}
+	}
 	else if (access == OAT_POST_ALTER && classId == IndexRelationId)
 	{
 		bool		old_indisprimary;
@@ -4753,6 +4874,70 @@ o_createdb(ParseState *pstate, const CreatedbStmt *stmt)
 	return result;
 }
 
+static void
+o_check_movedb(const AlterDatabaseStmt *stmt, movedb_params *movedb)
+{
+	Oid			src_tblspcoid = InvalidOid;
+	Oid			db_id = InvalidOid;
+	ListCell   *option;
+	DefElem    *dtablespace = NULL;
+	HeapTuple	tuple = NULL;
+
+	if (!get_db_info(stmt->dbname, NoLock, &db_id))
+
+		/*
+		 * Lets standard processing of moving datatabase generates an error.
+		 */
+		return;
+
+
+	foreach(option, stmt->options)
+	{
+		DefElem    *defel = (DefElem *) lfirst(option);
+
+		if (strcmp(defel->defname, "tablespace") == 0)
+		{
+			/*
+			 * skip check options because it will done in core statement
+			 * handling before this hook was called.
+			 */
+			dtablespace = defel;
+		}
+	}
+
+	if (dtablespace == NULL)
+		return;
+
+	tuple = SearchSysCache1(DATABASEOID, ObjectIdGetDatum(db_id));
+	if (HeapTupleIsValid(tuple))
+	{
+		Form_pg_database dbform = (Form_pg_database) GETSTRUCT(tuple);
+
+		src_tblspcoid = dbform->dattablespace;
+		ReleaseSysCache(tuple);
+	}
+
+	movedb->dest_dboid = db_id;
+	movedb->src_tsoid = src_tblspcoid;
+	movedb->dest_tsoid = get_tablespace_oid(defGetString(dtablespace), false);
+}
+
+static void
+o_movedb_failure_callback(int code, Datum arg)
+{
+	movedb_params *fparms = (movedb_params *) DatumGetPointer(arg);
+	char	   *dstpath = NULL;
+
+	/* Get rid of anything we managed to copy to the target directory */
+	o_get_prefixes_for_tablespace(fparms->dest_dboid, fparms->dest_tsoid, NULL, &dstpath);
+
+	if (dstpath)
+	{
+		(void) rmtree(dstpath, true);
+		pfree(dstpath);
+	}
+}
+
 int16
 o_parse_compress(const char *value)
 {
@@ -4883,6 +5068,7 @@ o_ddl_cleanup(void)
 	o_added_columns = NIL;
 	o_in_add_column = false;
 	create_stmt = NULL;
+	memset(&o_movedb_data, 0, sizeof(o_movedb_data));
 }
 
 static Node *

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -665,6 +665,23 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 		}
 	}
 
+	/*
+	 * Verify or create tablespace directory for defined secondary index if it
+	 * have to be located in differen tablespace then the table, but table is
+	 * an empty yet.
+	 */
+	if (!is_build && table_index->type != oIndexPrimary && o_table->tablespace != tablespace)
+	{
+		char	   *prefix;
+		char	   *db_prefix;
+
+		o_get_prefixes_for_tablespace(MyDatabaseId, tablespace,
+									  &prefix, &db_prefix);
+		o_verify_dir_exists_or_create(prefix, NULL, NULL);
+		o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
+		pfree(db_prefix);
+	}
+
 	if (reindex)
 	{
 		o_invalidate_oids(table_index->oids);

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -16,6 +16,7 @@
 #include "orioledb.h"
 
 #include "btree/btree.h"
+#include "btree/io.h"
 #include "btree/undo.h"
 #include "checkpoint/checkpoint.h"
 #include "catalog/o_indices.h"
@@ -85,6 +86,21 @@ typedef struct
 	CommitSeqNo csn;
 	Oid			datoid;
 } OTablesDropAllArg;
+
+typedef struct
+{
+	OXid		oxid;
+	CommitSeqNo csn;
+	Oid			datoid;
+	Oid			old_tablespace;
+	Oid			new_tablespace;
+} OTablesMoveAllArg;
+
+typedef struct
+{
+	Oid			datoid;
+	List	   *evicted;
+} OTablesEvictDBArg;
 
 typedef struct
 {
@@ -1226,6 +1242,117 @@ o_tables_drop_all(OXid oxid, CommitSeqNo csn, Oid database_id)
 
 	o_tables_foreach_oids(o_tables_drop_all_callback,
 						  &o_non_deleted_snapshot, &arg);
+}
+
+static void
+o_tables_move_all_callback(OTable *o_table, void *arg)
+{
+	OTablesMoveAllArg *move_arg = (OTablesMoveAllArg *) arg;
+	int			ctid_idx_off = o_table->has_primary ? 0 : 1;
+	bool		table_moved = false;
+
+	Assert(o_table);
+
+	if (move_arg->datoid != o_table->oids.datoid)
+		return;
+
+	if (o_table->tablespace == move_arg->old_tablespace)
+	{
+		o_table->tablespace = move_arg->new_tablespace;
+		if (!o_table->has_primary)
+		{
+			o_indices_update(o_table, PrimaryIndexNumber, move_arg->oxid, move_arg->csn);
+			table_moved = true;
+		}
+		if (ORelOidsIsValid(o_table->toast_oids))
+		{
+			o_indices_update(o_table, TOASTIndexNumber, move_arg->oxid, move_arg->csn);
+			table_moved = true;
+		}
+		if (ORelOidsIsValid(o_table->bridge_oids))
+		{
+			o_indices_update(o_table, BridgeIndexNumber, move_arg->oxid, move_arg->csn);
+			table_moved = true;
+		}
+	}
+
+	for (int ixnum = 0; ixnum < o_table->nindices; ixnum++)
+	{
+		OTableIndex *ix_table;
+
+		ix_table = &o_table->indices[ixnum];
+		if (ix_table->tablespace != move_arg->old_tablespace)
+			continue;
+		ix_table->tablespace = move_arg->new_tablespace;
+		o_indices_update(o_table, ixnum + ctid_idx_off, move_arg->oxid, move_arg->csn);
+		o_invalidate_oids(ix_table->oids);
+		o_invalidate_descrs(ix_table->oids.datoid, ix_table->oids.reloid, ix_table->oids.relnode);
+	}
+	if (table_moved)
+	{
+		o_tables_update(o_table, move_arg->oxid, move_arg->csn);
+	}
+	o_tables_after_update(o_table, move_arg->oxid, move_arg->csn);
+}
+
+void
+o_tables_move_all(OXid oxid, CommitSeqNo csn, Oid database_id, Oid old_tspcoid, Oid new_tspcoid)
+{
+	OTablesMoveAllArg arg;
+
+	arg.oxid = oxid;
+	arg.csn = csn;
+	arg.datoid = database_id;
+	arg.old_tablespace = old_tspcoid;
+	arg.new_tablespace = new_tspcoid;
+
+	add_database_copy_wal_record(database_id, old_tspcoid, new_tspcoid);
+	o_tables_foreach(o_tables_move_all_callback,
+					 &o_non_deleted_snapshot, &arg);
+}
+
+static void
+o_tables_evict_callback(OTable *o_table, void *arg)
+{
+	OTablesEvictDBArg *args = (OTablesEvictDBArg *) arg;
+	OTableDescr *descr;
+	BTreeDescr *td;
+
+	if (args->datoid != o_table->oids.datoid)
+		return;
+
+	descr = o_fetch_table_descr(o_table->oids);
+
+	if (!descr)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation oid %u does not exists", o_table->oids.reloid)));
+
+	table_descr_inc_refcnt(descr);
+
+	for (int treen = 0; treen < descr->nIndices; treen++)
+	{
+		td = &descr->indices[treen]->desc;
+		write_tree_pages(td, -1, true);
+		args->evicted = lappend_oid(args->evicted, td->oids.relnode);
+	}
+	td = &descr->toast->desc;
+	write_tree_pages(td, -1, true);
+	args->evicted = lappend_oid(args->evicted, td->oids.relnode);
+
+	table_descr_dec_refcnt(descr);
+	o_invalidate_descrs(descr->oids.datoid, descr->oids.reloid, descr->oids.reloid);
+}
+
+void
+o_tables_evict(Oid datoid, List **evicted)
+{
+	OTablesEvictDBArg arg;
+
+	arg.datoid = datoid;
+	arg.evicted = NIL;
+	o_tables_foreach(o_tables_evict_callback, &o_non_deleted_snapshot, &arg);
+	*evicted = arg.evicted;
 }
 
 void

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -31,6 +31,7 @@
 #include "recovery/wal_reader.h"
 #include "replication/walreceiver.h"
 #include "storage/itemptr.h"
+#include "storage/copydir.h"
 #include "tableam/descr.h"
 #include "tableam/operations.h"
 #include "tableam/tree.h"
@@ -48,6 +49,7 @@
 #include "access/hash.h"
 #include "access/xlog_internal.h"
 #include "access/xlogrecovery.h"
+#include "access/xlogutils.h"
 #include "lib/ilist.h"
 #include "lib/pairingheap.h"
 #include "miscadmin.h"
@@ -58,9 +60,11 @@
 #include "storage/ipc.h"
 #include "storage/shm_mq.h"
 #include "storage/standby.h"
+#include "storage/lmgr.h"
 #include "utils/memdebug.h"
 #include "utils/memutils.h"
 #include "utils/typcache.h"
+#include "catalog/pg_database.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -3917,6 +3921,115 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 }
 
 static void
+handle_movedb(Oid dbOid, Oid src_tblspcoid, Oid dst_tblspcoid)
+{
+	char	   *src_dbpath = NULL;
+	char	   *dst_dbpath = NULL;
+	char	   *dst_prefix = NULL;
+	char	   *dst_prefix_copy = NULL;
+	DIR		   *dstdir;
+	struct dirent *xlde;
+	List	   *evicted = NIL;
+	ListCell   *lc;
+
+	/*
+	 * Prepare stage of moving: check destination directory.
+	 */
+	o_get_prefixes_for_tablespace(dbOid, src_tblspcoid, NULL, &src_dbpath);
+	o_get_prefixes_for_tablespace(dbOid, dst_tblspcoid, &dst_prefix, &dst_dbpath);
+
+	dstdir = AllocateDir(dst_dbpath);
+	if (dstdir != NULL)
+	{
+		while ((xlde = ReadDir(dstdir, dst_dbpath)) != NULL)
+		{
+			if (strcmp(xlde->d_name, ".") == 0 ||
+				strcmp(xlde->d_name, "..") == 0)
+				continue;
+
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("some relations of database \"%d\" are already in tablespace \"%d\"",
+							dbOid, dst_tblspcoid),
+					 errhint("You must move them back to the database's default tablespace before using this command.")));
+		}
+
+		FreeDir(dstdir);
+
+		/*
+		 * The directory exists but is empty. We must remove it before using
+		 * the copydir function.
+		 */
+		if (rmdir(dst_dbpath) != 0)
+			elog(ERROR, "could not remove directory \"%s\": %m",
+				 dst_dbpath);
+	}
+
+	if (InHotStandby)
+	{
+		/*
+		 * Lock database while we resolve conflicts to ensure that
+		 * InitPostgres() cannot fully re-execute concurrently. This avoids
+		 * backends re-connecting automatically to same database, which can
+		 * happen in some cases.
+		 *
+		 * This will lock out walsenders trying to connect to db-specific
+		 * slots for logical decoding too, so it's safe for us to drop slots.
+		 */
+		LockSharedObjectForSession(DatabaseRelationId, dbOid, 0, AccessExclusiveLock);
+		ResolveRecoveryConflictWithDatabase(dbOid);
+	}
+
+	/*
+	 * Evict all relation related to the moved database. As soon as all
+	 * backends are terminated and LockSharedObjectForSession is acquired, no
+	 * new pages will appear in page pool till the and of moving database.
+	 */
+	dst_prefix_copy = pstrdup(dst_prefix);
+	o_tables_evict(dbOid, &evicted);
+
+	o_verify_dir_exists_or_create(dst_prefix_copy, NULL, NULL);
+	copydir(src_dbpath, dst_dbpath, false);
+
+	/*
+	 * Change tablespace in evicted meta data as well.
+	 */
+	foreach(lc, evicted)
+	{
+		EvictedTreeData *evicted_data = NULL;
+		Oid			relnode = lfirst_oid(lc);
+
+		evicted_data = read_evicted_data(dbOid, relnode, true);
+
+		if (evicted_data != NULL)
+		{
+			evicted_data->freeBuf.tag.key.tablespace = dst_tblspcoid;
+			evicted_data->nextChkp.tag.key.tablespace = dst_tblspcoid;
+			evicted_data->tmpBuf.tag.key.tablespace = dst_tblspcoid;
+			insert_evicted_data(evicted_data);
+		}
+	}
+
+	list_free(evicted);
+	rmtree(src_dbpath, true);
+
+	if (InHotStandby)
+	{
+		/*
+		 * Release locks prior to commit. XXX There is a race condition here
+		 * that may allow backends to reconnect, but the window for this is
+		 * small because the gap between here and commit is mostly fairly
+		 * small and it is unlikely that people will be dropping databases
+		 * that we are trying to connect to anyway.
+		 */
+		UnlockSharedObjectForSession(DatabaseRelationId, dbOid, 0, AccessExclusiveLock);
+	}
+	pfree(dst_prefix_copy);
+	pfree(src_dbpath);
+	pfree(dst_dbpath);
+}
+
+static void
 invalidate_typcache(void)
 {
 	SharedInvalidationMessage msg;
@@ -4160,6 +4273,10 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 			cur_recovery_xid_state->o_tables_meta_locked = true;
 			elog(DEBUG3, "[%s] META_LOCK for [ %u %u %u ] ctx->sys_tree_num %d", __func__,
 				 rec->oids.datoid, rec->oids.reloid, rec->oids.relnode, ctx->sys_tree_num);
+			break;
+
+		case WAL_REC_DATABASE_COPY:
+			handle_movedb(rec->u.dbcopy.datOid, rec->u.dbcopy.src_tblspc, rec->u.dbcopy.dst_tblspc);
 			break;
 
 		case WAL_REC_O_TABLES_META_UNLOCK:

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -561,6 +561,27 @@ add_o_tables_meta_unlock_wal_record(ORelOids oids, Oid oldRelnode)
 }
 
 void
+add_database_copy_wal_record(Oid dboid, Oid src_tblspc, Oid dst_tblspc)
+{
+	WALRecDbCopy *rec;
+
+	Assert(!is_recovery_process());
+	flush_local_wal_if_needed(sizeof(*rec));
+	Assert(local_wal.buffer_offset + sizeof(*rec) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE);
+
+	add_xid_wal_record_if_needed();
+
+	rec = (WALRecDbCopy *) (&local_wal.buffer[local_wal.buffer_offset]);
+
+	rec->recType = WAL_REC_DATABASE_COPY;
+	memcpy(rec->datid, &dboid, sizeof(Oid));
+	memcpy(rec->src_tblspc, &src_tblspc, sizeof(Oid));
+	memcpy(rec->dst_tblspc, &dst_tblspc, sizeof(Oid));
+
+	local_wal.buffer_offset += sizeof(*rec);
+}
+
+void
 add_switch_logical_xid_wal_record(TransactionId logicalXid_top, TransactionId logicalXid_sub)
 {
 	WALRecSwitchLogicalXid *rec;

--- a/src/recovery/wal_reader.c
+++ b/src/recovery/wal_reader.c
@@ -41,6 +41,7 @@ static WalParseResult wal_parse_rec_bridge_erase(WalReaderState *r, WalRecord *r
 static WalParseResult wal_parse_rec_switch_logical_xid(WalReaderState *r, WalRecord *rec);
 static WalParseResult wal_parse_rec_relreplident(WalReaderState *r, WalRecord *rec);
 static WalParseResult wal_parse_rec_modify(WalReaderState *r, WalRecord *rec);
+static WalParseResult wal_parse_rec_dbcopy(WalReaderState *r, WalRecord *rec);
 
 const char *
 wal_type_name(WalRecordType type)
@@ -295,6 +296,20 @@ wal_parse_rec_modify(WalReaderState *r, WalRecord *rec)
 		rec->u.modify.t2.data = r->ptr;
 		WR_SKIP(r, rec->u.modify.len2);
 	}
+
+	return WALPARSE_OK;
+}
+
+/* Parser for WAL_REC_DATABASE_COPY */
+static WalParseResult
+wal_parse_rec_dbcopy(WalReaderState *r, WalRecord *rec)
+{
+	Assert(r);
+	Assert(rec);
+
+	WR_PARSE(r, &rec->u.dbcopy.datOid);
+	WR_PARSE(r, &rec->u.dbcopy.src_tblspc);
+	WR_PARSE(r, &rec->u.dbcopy.dst_tblspc);
 
 	return WALPARSE_OK;
 }

--- a/test/t/move_database_test.py
+++ b/test/t/move_database_test.py
@@ -1,0 +1,810 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+from testgres.exceptions import QueryException
+import os
+import shutil
+import subprocess
+import testgres
+import inspect
+import time
+from threading import Thread, Event
+import tempfile
+
+
+class ThreadLoopQueryExecutor(Thread):
+
+	def __init__(self, connection, sql_query):
+		super().__init__()
+		self._connection = connection
+		self._sql_query = sql_query
+		self._stop_event = Event()
+		self._result = None
+
+	def run(self):
+		try:
+			while not self._stop_event.is_set():
+				try:
+					res = self._connection.execute(self._sql_query)
+					self._result = res
+				except Exception as e:
+					self._result = e
+					break
+		finally:
+			pass
+
+	def join(self, timeout=None):
+		self._stop_event.set()
+		super().join(timeout=timeout)
+		if isinstance(self._return, Exception):
+			raise self._result
+		return self._result
+
+	def stop(self):
+		self._stop_event.set()
+
+
+def create_and_clear_directory(base_path, dir_name):
+	new_dir_path = os.path.join(base_path, dir_name)
+
+	if os.path.exists(new_dir_path):
+		shutil.rmtree(new_dir_path)
+
+	os.makedirs(new_dir_path)
+
+	return new_dir_path
+
+
+def get_files_in_directory(dir, files):
+	if dir is None:
+		return []
+	existed_files = []
+	for root, _, filenames in os.walk(dir):
+		for filename in filenames:
+			if filename in files:
+				existed_files.append(filename)
+	return sorted(existed_files)
+
+
+def get_catversion(data_dir):
+	result = subprocess.run(['pg_controldata', data_dir],
+	                        capture_output=True,
+	                        text=True)
+	for line in result.stdout.splitlines():
+		if 'Catalog version number' in line:
+			return line.split(':')[-1].strip()
+	raise RuntimeError("Catalog version not found")
+
+
+class TablespaceTest(BaseTest):
+
+	def setUp(self):
+		super().setUp()
+		self.ts_tmpdir = tempfile.mkdtemp()
+		user_ts1_path = create_and_clear_directory(self.ts_tmpdir, 'user_ts1')
+		user_ts2_path = create_and_clear_directory(self.ts_tmpdir, 'user_ts2')
+		self.node.start()
+		self.node.safe_psql(
+		    f"CREATE TABLESPACE user_ts1 LOCATION '{user_ts1_path}';")
+		self.node.safe_psql(
+		    f"CREATE TABLESPACE user_ts2 LOCATION '{user_ts2_path}';")
+		major_version = int(
+		    self.node.execute("SHOW server_version_num;")[0][0]) // 10000
+		cat_version = get_catversion(self.node.data_dir)
+		self.node.stop()
+		self.ts_cat_version = f"PG_{major_version}_{cat_version}"
+		self.user_ts1_path = os.path.join(user_ts1_path, self.ts_cat_version)
+		self.user_ts2_path = os.path.join(user_ts2_path, self.ts_cat_version)
+
+	def tearDown(self):
+		super().tearDown()
+		if os.path.exists(self.node.data_dir):
+			shutil.move(self.ts_tmpdir, self.node.data_dir)
+
+	def ensureDataAccess(self, node, dbname, plan_setup, data_query,
+	                     plan_expected, data_expected):
+		self.assertTrue(plan_expected in node.safe_psql(
+		    dbname, f"{plan_setup} EXPLAIN {data_query}").decode('utf-8'))
+		res = node.safe_psql(dbname, f"{plan_setup} {data_query}")
+		res = [
+		    tuple([int(x)]) for x in res.decode('utf-8').strip().splitlines()
+		    if x.strip()
+		]
+		self.assertEqual(data_expected, res)
+
+	def ensureDataAccessReplication(self, master, replica, table,
+	                                seq_scan_expected, index_scan_expected):
+		check_seq_scan_query = f"SELECT i FROM {table} WHERE mod(i,10) = 0;"
+		set_prefix_for_index_scan = "set enable_seqscan = off; set enable_bitmapscan = off;"
+		check_index_scan_query = f"SELECT i FROM {table} WHERE t like 'test%9' ORDER BY i;"
+
+		self.ensureDataAccess(master, "testdb", "", check_seq_scan_query,
+		                      "Seq Scan", seq_scan_expected)
+		self.ensureDataAccess(replica, "testdb", "", check_seq_scan_query,
+		                      "Seq Scan", seq_scan_expected)
+		self.ensureDataAccess(master, "testdb", set_prefix_for_index_scan,
+		                      check_index_scan_query, "Index Scan",
+		                      index_scan_expected)
+		self.ensureDataAccess(replica, "testdb", set_prefix_for_index_scan,
+		                      check_index_scan_query, "Index Scan",
+		                      index_scan_expected)
+
+	def get_relfilenode(self, dbname, relname):
+		node = self.node
+		return str(
+		    node.execute(
+		        dbname,
+		        f"select relfilenode from pg_class where relname='{relname}';")
+		    [0][0])
+
+	def move_database_test(self, ddl_query, created_ts, moved_ts, stay_ts,
+	                       moved_relations, stay_relations):
+		node = self.node
+		node.start()
+
+		ts_suffix = f"TABLESPACE {created_ts[0]}" if created_ts[
+		    0] is not None else ""
+		node.safe_psql(f"CREATE DATABASE testdb {ts_suffix};")
+
+		dbOid = node.execute(
+		    f"SELECT oid FROM pg_database WHERE datname='testdb';")[0][0]
+		created_db_dir = os.path.join(created_ts[1], str(dbOid))
+		moved_db_dir = os.path.join(moved_ts[1], str(dbOid))
+		stay_db_dir = os.path.join(stay_ts[1],
+		                           str(dbOid)) if stay_ts is not None else None
+
+		node.safe_psql("testdb", """CREATE EXTENSION orioledb;""")
+		node.safe_psql("testdb", ddl_query)
+		node.safe_psql(
+		    "testdb",
+		    """INSERT INTO test_tbl_ctid SELECT i, i * 2, 'test'||i FROM generate_series(1, 1000) i;
+                                    INSERT INTO test_tbl_pkey SELECT i, i * 2, 'test'||i FROM generate_series(1, 1000) i;
+                                 """)
+
+		node.safe_psql("CHECKPOINT;")
+
+		moved_files = [
+		    self.get_relfilenode("testdb", x) for x in moved_relations
+		]
+		moved_files.sort()
+
+		stay_files = [
+		    self.get_relfilenode("testdb", x) for x in stay_relations
+		]
+		stay_files.sort()
+
+		self.assertEqual(moved_files,
+		                 get_files_in_directory(created_db_dir, moved_files))
+		self.assertEqual(stay_files,
+		                 get_files_in_directory(stay_db_dir, stay_files))
+
+		node.safe_psql(f"ALTER DATABASE testdb SET TABLESPACE {moved_ts[0]};")
+
+		self.assertEqual([], get_files_in_directory(created_db_dir,
+		                                            moved_files))
+		self.assertEqual(moved_files,
+		                 get_files_in_directory(moved_db_dir, moved_files))
+		self.assertEqual(stay_files,
+		                 get_files_in_directory(stay_db_dir, stay_files))
+		self.assertEqual([], get_files_in_directory(moved_db_dir, stay_files))
+
+		# Check after move
+		node.safe_psql(
+		    "testdb",
+		    """INSERT INTO test_tbl_ctid SELECT i, i * 2, 'test'||i FROM generate_series(1001, 2000) i;
+                                    INSERT INTO test_tbl_pkey SELECT i, i * 2, 'test'||i FROM generate_series(1001, 2000) i;"""
+		)
+
+		self.assertEqual([], get_files_in_directory(created_db_dir,
+		                                            moved_files))
+		self.assertEqual(moved_files,
+		                 get_files_in_directory(moved_db_dir, moved_files))
+		self.assertEqual(stay_files,
+		                 get_files_in_directory(stay_db_dir, stay_files))
+		self.assertEqual([], get_files_in_directory(moved_db_dir, stay_files))
+
+		self.ensureDataAccess(
+		    node, "testdb", "set enable_seqscan = off;",
+		    "SELECT count(*) FROM test_tbl_ctid WHERE mod(j, 3) = 0;",
+		    "Index Scan", [(666, )])
+		self.ensureDataAccess(
+		    node, "testdb", "set enable_seqscan = off;",
+		    "SELECT count(*) FROM test_tbl_ctid WHERE t like 'test11%';",
+		    "Index Scan", [(111, )])
+		self.ensureDataAccess(
+		    node, "testdb", "",
+		    "SELECT count(*) FROM test_tbl_ctid WHERE mod(i, 10) = 0;",
+		    "Seq Scan", [(200, )])
+		self.ensureDataAccess(
+		    node, "testdb", "set enable_seqscan = off;",
+		    "SELECT count(*) FROM test_tbl_pkey WHERE mod(j, 3) = 0;",
+		    "Index Scan", [(666, )])
+		self.ensureDataAccess(
+		    node, "testdb", "set enable_seqscan = off;",
+		    "SELECT count(*) FROM test_tbl_pkey WHERE t like 'test11%';",
+		    "Index Scan", [(111, )])
+		self.ensureDataAccess(
+		    node, "testdb", "",
+		    "SELECT count(*) FROM test_tbl_pkey WHERE mod(i, 10) = 0;",
+		    "Seq Scan", [(200, )])
+
+		node.stop()
+		self.assertEqual([], get_files_in_directory(created_db_dir,
+		                                            moved_files))
+		self.assertEqual(moved_files,
+		                 get_files_in_directory(moved_db_dir, moved_files))
+		self.assertEqual(stay_files,
+		                 get_files_in_directory(stay_db_dir, stay_files))
+		self.assertEqual([], get_files_in_directory(moved_db_dir, stay_files))
+
+	def test_move_from_user_ts_full_database(self):
+		ddl_query = """ CREATE TABLE test_tbl_ctid(i int, j int, t text) USING orioledb;
+                        CREATE TABLE test_tbl_pkey(i int PRIMARY KEY, j int, t text) USING orioledb;
+                        CREATE INDEX secondary_idx_ctid1 ON test_tbl_ctid (t);
+                        CREATE INDEX secondary_idx_ctid2 ON test_tbl_ctid (j);
+                        CREATE INDEX secondary_idx_pkey1 ON test_tbl_pkey (t);
+                        CREATE INDEX secondary_idx_pkey2 ON test_tbl_pkey (j);"""
+		moved_relations = [
+		    'test_tbl_ctid', 'secondary_idx_ctid1', 'secondary_idx_ctid2',
+		    'test_tbl_pkey_pkey', 'secondary_idx_pkey1', 'secondary_idx_pkey2'
+		]
+		created_ts = ("user_ts1",
+		              os.path.join(self.user_ts1_path, 'orioledb_data'))
+		moved_ts = ("user_ts2",
+		            os.path.join(self.user_ts2_path, 'orioledb_data'))
+		self.move_database_test(ddl_query, created_ts, moved_ts, None,
+		                        moved_relations, [])
+
+	def test_move_from_default_ts_full_database(self):
+		ddl_query = """ CREATE TABLE test_tbl_ctid(i int, j int, t text) USING orioledb;
+                        CREATE TABLE test_tbl_pkey(i int PRIMARY KEY, j int, t text) USING orioledb;
+                        CREATE INDEX secondary_idx_ctid1 ON test_tbl_ctid (t);
+                        CREATE INDEX secondary_idx_ctid2 ON test_tbl_ctid (j);
+                        CREATE INDEX secondary_idx_pkey1 ON test_tbl_pkey (t);
+                        CREATE INDEX secondary_idx_pkey2 ON test_tbl_pkey (j);"""
+		moved_relations = [
+		    'test_tbl_ctid', 'secondary_idx_ctid1', 'secondary_idx_ctid2',
+		    'test_tbl_pkey_pkey', 'secondary_idx_pkey1', 'secondary_idx_pkey2'
+		]
+		created_ts = (None,
+		              os.path.join(self.node.base_dir, 'data',
+		                           'orioledb_data'))
+		moved_ts = ("user_ts2",
+		            os.path.join(self.user_ts2_path, 'orioledb_data'))
+		self.move_database_test(ddl_query, created_ts, moved_ts, None,
+		                        moved_relations, [])
+
+	def test_move_from_default_ts_only_indexes(self):
+		ddl_query = """ CREATE TABLE test_tbl_pkey(i int PRIMARY KEY, j int, t text) USING orioledb TABLESPACE user_ts1;
+                        CREATE INDEX secondary_idx_pkey1 ON test_tbl_pkey (t);
+                        CREATE INDEX secondary_idx_pkey2 ON test_tbl_pkey (j);
+                        CREATE TABLE test_tbl_ctid(i int, j int, t text) USING orioledb TABLESPACE user_ts1;
+                        CREATE INDEX secondary_idx_ctid1 ON test_tbl_ctid (t);
+                        CREATE INDEX secondary_idx_ctid2 ON test_tbl_ctid (j);"""
+		# Primary key relation always create in database default tablespace.
+		# So it moved with database.
+		moved_relations = [
+		    'secondary_idx_ctid1', 'secondary_idx_ctid2', 'test_tbl_pkey_pkey',
+		    'secondary_idx_pkey1', 'secondary_idx_pkey2'
+		]
+		stay_relations = ['test_tbl_ctid']
+		created_ts = (None,
+		              os.path.join(self.node.base_dir, 'data',
+		                           'orioledb_data'))
+		moved_ts = ("user_ts2",
+		            os.path.join(self.user_ts2_path, 'orioledb_data'))
+		stay_ts = ("user_ts1", os.path.join(self.user_ts1_path,
+		                                    'orioledb_data'))
+		self.move_database_test(ddl_query, created_ts, moved_ts, stay_ts,
+		                        moved_relations, stay_relations)
+
+	def test_move_from_default_ts_only_tables(self):
+		ddl_query = """ CREATE TABLE test_tbl_pkey(i int PRIMARY KEY, j int, t text) USING orioledb;
+                        CREATE INDEX secondary_idx_pkey1 ON test_tbl_pkey (t) TABLESPACE user_ts1;
+                        CREATE INDEX secondary_idx_pkey2 ON test_tbl_pkey (j)TABLESPACE user_ts1;
+                        CREATE TABLE test_tbl_ctid(i int, j int, t text) USING orioledb;
+                        CREATE INDEX secondary_idx_ctid1 ON test_tbl_ctid (t) TABLESPACE user_ts1;
+                        CREATE INDEX secondary_idx_ctid2 ON test_tbl_ctid (j) TABLESPACE user_ts1;"""
+		# Primary key relation always create in database default tablespace.
+		# So it moved with database.
+		moved_relations = ['test_tbl_ctid', 'test_tbl_pkey_pkey']
+		stay_relations = [
+		    'secondary_idx_ctid1', 'secondary_idx_ctid2',
+		    'secondary_idx_pkey1', 'secondary_idx_pkey2'
+		]
+		created_ts = (None,
+		              os.path.join(self.node.base_dir, 'data',
+		                           'orioledb_data'))
+		moved_ts = ("user_ts2",
+		            os.path.join(self.user_ts2_path, 'orioledb_data'))
+		stay_ts = ("user_ts1", os.path.join(self.user_ts1_path,
+		                                    'orioledb_data'))
+		self.move_database_test(ddl_query, created_ts, moved_ts, stay_ts,
+		                        moved_relations, stay_relations)
+
+	def test_move_from_default_ts_some_relations(self):
+		ddl_query = """ CREATE TABLE test_tbl_pkey(i int PRIMARY KEY, j int, t text) USING orioledb ;
+                        CREATE INDEX secondary_idx_pkey1 ON test_tbl_pkey (t);
+                        CREATE INDEX secondary_idx_pkey2 ON test_tbl_pkey (j)TABLESPACE user_ts1;
+                        CREATE TABLE test_tbl_ctid(i int, j int, t text) USING orioledb TABLESPACE user_ts1;
+                        CREATE INDEX secondary_idx_ctid1 ON test_tbl_ctid (t) TABLESPACE user_ts1;
+                        CREATE INDEX secondary_idx_ctid2 ON test_tbl_ctid (j);"""
+
+		moved_relations = [
+		    'test_tbl_pkey_pkey', 'secondary_idx_pkey1', 'secondary_idx_ctid2'
+		]
+		stay_relations = [
+		    'secondary_idx_pkey2', 'test_tbl_ctid', 'secondary_idx_ctid1'
+		]
+		created_ts = (None,
+		              os.path.join(self.node.base_dir, 'data',
+		                           'orioledb_data'))
+		moved_ts = ("user_ts2",
+		            os.path.join(self.user_ts2_path, 'orioledb_data'))
+		stay_ts = ("user_ts1", os.path.join(self.user_ts1_path,
+		                                    'orioledb_data'))
+		self.move_database_test(ddl_query, created_ts, moved_ts, stay_ts,
+		                        moved_relations, stay_relations)
+
+	def getReplica_TS(self,
+	                  options,
+	                  has_restoring: bool = False) -> testgres.PostgresNode:
+		if self.replica is None:
+			(test_path, t) = os.path.split(
+			    os.path.dirname(inspect.getfile(self.__class__)))
+			baseDir = os.path.join(test_path, 'tmp_check_t',
+			                       self.myName + '_tgsb')
+			if os.path.exists(baseDir):
+				shutil.rmtree(baseDir)
+			replica = self.node.backup(
+			    base_dir=baseDir, options=options).spawn_replica('replica')
+			replica.append_conf(port=replica.port)
+
+			self.replica = replica
+
+			if has_restoring:
+				self.enableRestoring(
+				    self.replica, os.path.join(self.node.base_dir, "archives"))
+
+		return self.replica
+
+	def test_replication_database_move(self):
+		master = self.node
+		master_ts1_path = os.path.dirname(self.user_ts1_path)
+		master_ts2_path = os.path.dirname(self.user_ts2_path)
+		replica_ts1_path = create_and_clear_directory(self.ts_tmpdir,
+		                                              'replica_user_ts1')
+		replica_ts2_path = create_and_clear_directory(self.ts_tmpdir,
+		                                              'replica_user_ts2')
+		ts_mapping = [
+		    '-T', f"{master_ts1_path}={replica_ts1_path}", '-T',
+		    f"{master_ts2_path}={replica_ts2_path}"
+		]
+
+		replica_ts1_path = os.path.join(replica_ts1_path, self.ts_cat_version)
+		replica_ts2_path = os.path.join(replica_ts2_path, self.ts_cat_version)
+
+		master.start()
+		with self.getReplica_TS(ts_mapping).start() as replica:
+			self.catchup_orioledb(replica)
+			master.safe_psql("CREATE DATABASE testdb TABLESPACE user_ts1;")
+			dbOid = master.execute(
+			    f"SELECT oid FROM pg_database WHERE datname='testdb';")[0][0]
+
+			master_ts1_path = os.path.join(self.user_ts1_path, 'orioledb_data',
+			                               str(dbOid))
+			master_ts2_path = os.path.join(self.user_ts2_path, 'orioledb_data',
+			                               str(dbOid))
+			replica_ts1_path = os.path.join(replica_ts1_path, 'orioledb_data',
+			                                str(dbOid))
+			replica_ts2_path = os.path.join(replica_ts2_path, 'orioledb_data',
+			                                str(dbOid))
+
+			master.safe_psql(
+			    "testdb", """CREATE EXTENSION orioledb;
+                                          CREATE TABLE test_tbl (i int, j int, t text) USING orioledb;
+                                          CREATE INDEX test_tbl_t_idx ON test_tbl(t);
+                                          CREATE TABLE test_tbl2 (i int, j int PRIMARY KEY, t text) USING orioledb;
+                                          CREATE INDEX test_tbl2_t_idx ON test_tbl2(t);"""
+			)
+
+			files_to_check = [
+			    self.get_relfilenode("testdb", "test_tbl"),
+			    self.get_relfilenode("testdb", "test_tbl_t_idx"),
+			    self.get_relfilenode("testdb", "test_tbl2_pkey"),
+			    self.get_relfilenode("testdb", "test_tbl2_t_idx")
+			]
+
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(1, 10) i;
+			       INSERT INTO test_tbl2 SELECT i, i * 2, 'test'||i FROM generate_series(1, 10) i;"""
+			)
+			self.catchup_orioledb(replica)
+
+			con1 = replica.connect("testdb")
+			t1 = ThreadLoopQueryExecutor(con1,
+			                             "SELECT count(*) FROM test_tbl;")
+			t1.start()
+			master.safe_psql("ALTER DATABASE testdb SET TABLESPACE user_ts2;")
+			self.catchup_orioledb(replica)
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(11, 20) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(21, 30) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(31, 40) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			self.catchup_orioledb(replica)
+
+			try:
+				t1.stop()
+				t1.join()
+				self.assertTrue(False)
+			except:
+				self.assertTrue(True)
+
+			seq_scan_expected1 = [(10, ), (20, ), (30, ), (40, )]
+			index_scan_expected1 = [(9, ), (19, ), (29, ), (39, )]
+			self.ensureDataAccessReplication(master, replica, 'test_tbl',
+			                                 seq_scan_expected1,
+			                                 index_scan_expected1)
+
+			seq_scan_expected2 = [(10, )]
+			index_scan_expected2 = [(9, )]
+			self.ensureDataAccessReplication(master, replica, 'test_tbl2',
+			                                 seq_scan_expected2,
+			                                 index_scan_expected2)
+
+			master.stop()
+			replica.stop()
+
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+			master.start()
+			replica.start()
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(41, 50) i;"""
+			)
+			self.catchup_orioledb(replica)
+			seq_scan_expected1.append((50, ))
+			index_scan_expected1.append((49, ))
+			self.ensureDataAccessReplication(master, replica, 'test_tbl',
+			                                 seq_scan_expected1,
+			                                 index_scan_expected1)
+			self.ensureDataAccessReplication(master, replica, 'test_tbl2',
+			                                 seq_scan_expected2,
+			                                 index_scan_expected2)
+			master.stop()
+			replica.stop()
+
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+	def test_replication_of_moving_database_after_restart(self):
+		master = self.node
+		master_ts1_path = os.path.dirname(self.user_ts1_path)
+		master_ts2_path = os.path.dirname(self.user_ts2_path)
+		replica_ts1_path = create_and_clear_directory(self.ts_tmpdir,
+		                                              'replica_user_ts1')
+		replica_ts2_path = create_and_clear_directory(self.ts_tmpdir,
+		                                              'replica_user_ts2')
+		ts_mapping = [
+		    '-T', f"{master_ts1_path}={replica_ts1_path}", '-T',
+		    f"{master_ts2_path}={replica_ts2_path}"
+		]
+
+		replica_ts1_path = os.path.join(replica_ts1_path, self.ts_cat_version)
+		replica_ts2_path = os.path.join(replica_ts2_path, self.ts_cat_version)
+
+		master.start()
+		with self.getReplica_TS(ts_mapping).start() as replica:
+			self.catchup_orioledb(replica)
+			master.safe_psql("CREATE DATABASE testdb TABLESPACE user_ts1;")
+			dbOid = master.execute(
+			    f"SELECT oid FROM pg_database WHERE datname='testdb';")[0][0]
+
+			master_ts1_path = os.path.join(self.user_ts1_path, 'orioledb_data',
+			                               str(dbOid))
+			master_ts2_path = os.path.join(self.user_ts2_path, 'orioledb_data',
+			                               str(dbOid))
+			replica_ts1_path = os.path.join(replica_ts1_path, 'orioledb_data',
+			                                str(dbOid))
+			replica_ts2_path = os.path.join(replica_ts2_path, 'orioledb_data',
+			                                str(dbOid))
+
+			master.safe_psql(
+			    "testdb", """CREATE EXTENSION orioledb;
+                                          CREATE TABLE test_tbl (i int, j int, t text) USING orioledb;
+                                          CREATE INDEX test_tbl_t_idx ON test_tbl(t);
+                                          CREATE TABLE test_tbl2 (i int, j int PRIMARY KEY, t text) USING orioledb;
+                                          CREATE INDEX test_tbl2_t_idx ON test_tbl2(t);"""
+			)
+
+			files_to_check = [
+			    self.get_relfilenode("testdb", "test_tbl"),
+			    self.get_relfilenode("testdb", "test_tbl_t_idx")
+			]
+
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(1, 10) i;
+			       INSERT INTO test_tbl2 SELECT i, i * 2, 'test'||i FROM generate_series(1, 10) i;"""
+			)
+			self.catchup_orioledb(replica)
+			master.stop()
+			replica.stop()
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts1_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts1_path, files_to_check))
+
+			master.start()
+			replica.start()
+
+			master.safe_psql("ALTER DATABASE testdb SET TABLESPACE user_ts2;")
+			self.catchup_orioledb(replica)
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(11, 20) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(21, 30) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(31, 40) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			self.catchup_orioledb(replica)
+
+			seq_scan_expected1 = [(10, ), (20, ), (30, ), (40, )]
+			index_scan_expected1 = [(9, ), (19, ), (29, ), (39, )]
+			self.ensureDataAccessReplication(master, replica, 'test_tbl',
+			                                 seq_scan_expected1,
+			                                 index_scan_expected1)
+
+			seq_scan_expected2 = [(10, )]
+			index_scan_expected2 = [(9, )]
+			self.ensureDataAccessReplication(master, replica, 'test_tbl2',
+			                                 seq_scan_expected2,
+			                                 index_scan_expected2)
+
+			master.stop()
+			replica.stop()
+
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+			master.start()
+			replica.start()
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(41, 50) i;"""
+			)
+			self.catchup_orioledb(replica)
+			seq_scan_expected1.append((50, ))
+			index_scan_expected1.append((49, ))
+			self.ensureDataAccessReplication(master, replica, 'test_tbl',
+			                                 seq_scan_expected1,
+			                                 index_scan_expected1)
+			self.ensureDataAccessReplication(master, replica, 'test_tbl2',
+			                                 seq_scan_expected2,
+			                                 index_scan_expected2)
+			master.stop()
+			replica.stop()
+
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+	def test_replication_of_moving_database_evicted_relation(self):
+		master = self.node
+		master_ts1_path = os.path.dirname(self.user_ts1_path)
+		master_ts2_path = os.path.dirname(self.user_ts2_path)
+		replica_ts1_path = create_and_clear_directory(self.ts_tmpdir,
+		                                              'replica_user_ts1')
+		replica_ts2_path = create_and_clear_directory(self.ts_tmpdir,
+		                                              'replica_user_ts2')
+		ts_mapping = [
+		    '-T', f"{master_ts1_path}={replica_ts1_path}", '-T',
+		    f"{master_ts2_path}={replica_ts2_path}"
+		]
+
+		replica_ts1_path = os.path.join(replica_ts1_path, self.ts_cat_version)
+		replica_ts2_path = os.path.join(replica_ts2_path, self.ts_cat_version)
+
+		master.start()
+		with self.getReplica_TS(ts_mapping).start() as replica:
+			self.catchup_orioledb(replica)
+			master.safe_psql("CREATE DATABASE testdb TABLESPACE user_ts1;")
+			dbOid = master.execute(
+			    f"SELECT oid FROM pg_database WHERE datname='testdb';")[0][0]
+
+			master_ts1_path = os.path.join(self.user_ts1_path, 'orioledb_data',
+			                               str(dbOid))
+			master_ts2_path = os.path.join(self.user_ts2_path, 'orioledb_data',
+			                               str(dbOid))
+			replica_ts1_path = os.path.join(replica_ts1_path, 'orioledb_data',
+			                                str(dbOid))
+			replica_ts2_path = os.path.join(replica_ts2_path, 'orioledb_data',
+			                                str(dbOid))
+
+			master.safe_psql(
+			    "testdb", """CREATE EXTENSION orioledb;
+                                          CREATE TABLE test_tbl (i int, j int, t text) USING orioledb;
+                                          CREATE INDEX test_tbl_t_idx ON test_tbl(t);
+                                          CREATE TABLE test_tbl2 (i int, j int PRIMARY KEY, t text) USING orioledb;
+                                          CREATE INDEX test_tbl2_t_idx ON test_tbl2(t);"""
+			)
+
+			files_to_check = [
+			    self.get_relfilenode("testdb", "test_tbl"),
+			    self.get_relfilenode("testdb", "test_tbl_t_idx")
+			]
+
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(1, 10) i;
+				   INSERT INTO test_tbl2 SELECT i, i * 2, 'test'||i FROM generate_series(1, 10) i;"""
+			)
+			self.catchup_orioledb(replica)
+
+			replica.safe_psql(
+			    "testdb",
+			    "SELECT orioledb_evict_pages('test_tbl'::regclass, -1);")
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts1_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts1_path, files_to_check))
+
+			master.safe_psql("ALTER DATABASE testdb SET TABLESPACE user_ts2;")
+			self.catchup_orioledb(replica)
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(11, 20) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(21, 30) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(31, 40) i;"""
+			)
+			master.safe_psql("CHECKPOINT;")
+			self.catchup_orioledb(replica)
+
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			seq_scan_expected1 = [(10, ), (20, ), (30, ), (40, )]
+			index_scan_expected1 = [(9, ), (19, ), (29, ), (39, )]
+			self.ensureDataAccessReplication(master, replica, 'test_tbl',
+			                                 seq_scan_expected1,
+			                                 index_scan_expected1)
+
+			seq_scan_expected2 = [(10, )]
+			index_scan_expected2 = [(9, )]
+			self.ensureDataAccessReplication(master, replica, 'test_tbl2',
+			                                 seq_scan_expected2,
+			                                 index_scan_expected2)
+
+			master.stop()
+			replica.stop()
+
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))
+
+			master.start()
+			replica.start()
+			master.safe_psql(
+			    "testdb",
+			    """INSERT INTO test_tbl SELECT i, i * 2, 'test'||i FROM generate_series(41, 50) i;"""
+			)
+			self.catchup_orioledb(replica)
+			seq_scan_expected1.append((50, ))
+			index_scan_expected1.append((49, ))
+			self.ensureDataAccessReplication(master, replica, 'test_tbl',
+			                                 seq_scan_expected1,
+			                                 index_scan_expected1)
+			self.ensureDataAccessReplication(master, replica, 'test_tbl2',
+			                                 seq_scan_expected2,
+			                                 index_scan_expected2)
+			master.stop()
+			replica.stop()
+
+			self.assertFalse(os.path.exists(master_ts1_path))
+			self.assertFalse(os.path.exists(replica_ts1_path))
+
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(master_ts2_path, files_to_check))
+			self.assertEqual(
+			    files_to_check,
+			    get_files_in_directory(replica_ts2_path, files_to_check))


### PR DESCRIPTION
Implement moving database files via ALTER DATABASE ... SET TABLESPACE command.
For moving using file system directory copy. In order to support replication this DDL command new WAL record introduced.