### PR TITLE
Refactoring: squash o_buffers_write/o_buffers_read variants behind bool flags

### DIFF
--- a/include/utils/o_buffers.h
+++ b/include/utils/o_buffers.h
@@ -42,16 +42,12 @@ typedef struct
 
 extern Size o_buffers_shmem_needs(OBuffersDesc *desc);
 extern void o_buffers_shmem_init(OBuffersDesc *desc, void *buf, bool found);
-extern void o_buffers_read(OBuffersDesc *desc, Pointer buf,
-						   uint32 tag, int64 offset, int64 size);
-extern bool o_buffers_read_if_exists(OBuffersDesc *desc, Pointer buf,
-									 uint32 tag, int64 offset, int64 size);
-extern void o_buffers_write(OBuffersDesc *desc, Pointer buf,
-							uint32 tag, int64 offset, int64 size);
-extern void o_buffers_write_clean(OBuffersDesc *desc, Pointer buf,
-								  uint32 tag, int64 offset, int64 size);
-extern bool o_buffers_write_if_exists(OBuffersDesc *desc, Pointer buf,
-									  uint32 tag, int64 offset, int64 size);
+extern bool o_buffers_read(OBuffersDesc *desc, Pointer buf,
+						   uint32 tag, int64 offset, int64 size,
+						   bool if_exists);
+extern bool o_buffers_write(OBuffersDesc *desc, Pointer buf,
+							uint32 tag, int64 offset, int64 size,
+							bool if_exists, bool mark_clean);
 extern void o_buffers_write_page_direct(OBuffersDesc *desc, char *data,
 										uint32 tag, int64 offset);
 extern void o_buffers_sync(OBuffersDesc *desc, uint32 tag, int64 fromOffset,

--- a/src/rewind/rewind.c
+++ b/src/rewind/rewind.c
@@ -334,7 +334,7 @@ log_print_rewind_queue(void)
 		o_buffers_read(&rewindBuffersDesc,
 					   (Pointer) &buffer, REWIND_BUFFERS_TAG,
 					   pos * sizeof(RewindItem),
-					   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem));
+					   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem), false);
 
 		for (i = 0; i < REWIND_DISK_BUFFER_LENGTH; i++)
 		{
@@ -437,7 +437,8 @@ do_rewind(int rewind_mode, int rewind_time, TimestampTz rewindStartTimeStamp, OX
 				o_buffers_read(&rewindBuffersDesc,
 							   (Pointer) &tmpbuf, REWIND_BUFFERS_TAG,
 							   (pos - REWIND_DISK_BUFFER_LENGTH + 1) * sizeof(RewindItem),
-							   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem));
+							   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem),
+							   false);
 				k = REWIND_DISK_BUFFER_LENGTH;
 			}
 			k--;
@@ -1097,18 +1098,19 @@ try_restore_evicted_rewind_page(void)
 			o_buffers_read(&rewindBuffersDesc,
 						   (Pointer) &rewindCompleteBuffer[start], REWIND_BUFFERS_TAG,
 						   rewindMeta->restorePos * sizeof(RewindItem),
-						   length_to_end * sizeof(RewindItem));
+						   length_to_end * sizeof(RewindItem), false);
 			o_buffers_read(&rewindBuffersDesc,
 						   (Pointer) &rewindCompleteBuffer[0], REWIND_BUFFERS_TAG,
 						   (rewindMeta->restorePos + length_to_end) * sizeof(RewindItem),
-						   (REWIND_DISK_BUFFER_LENGTH - length_to_end) * sizeof(RewindItem));
+						   (REWIND_DISK_BUFFER_LENGTH - length_to_end) * sizeof(RewindItem),
+						   false);
 		}
 		else
 		{
 			o_buffers_read(&rewindBuffersDesc,
 						   (Pointer) &rewindCompleteBuffer[start], REWIND_BUFFERS_TAG,
 						   rewindMeta->restorePos * sizeof(RewindItem),
-						   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem));
+						   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem), false);
 		}
 
 #ifdef USE_ASSERT_CHECKING
@@ -1490,13 +1492,15 @@ evict_rewind_items(uint64 curAddPosFilled)
 								(Pointer) &rewindAddBuffer[start],
 								REWIND_BUFFERS_TAG,
 								pg_atomic_read_u64(&rewindMeta->evictPos) * sizeof(RewindItem),
-								length_to_end * sizeof(RewindItem));
+								length_to_end * sizeof(RewindItem),
+								false, false);
 
 				o_buffers_write(&rewindBuffersDesc,
 								(Pointer) &rewindAddBuffer[0],
 								REWIND_BUFFERS_TAG,
 								(pg_atomic_read_u64(&rewindMeta->evictPos) + length_to_end) * sizeof(RewindItem),
-								(REWIND_DISK_BUFFER_LENGTH - length_to_end) * sizeof(RewindItem));
+								(REWIND_DISK_BUFFER_LENGTH - length_to_end) * sizeof(RewindItem),
+								false, false);
 			}
 			else
 			{
@@ -1504,7 +1508,8 @@ evict_rewind_items(uint64 curAddPosFilled)
 								(Pointer) &rewindAddBuffer[start],
 								REWIND_BUFFERS_TAG,
 								pg_atomic_read_u64(&rewindMeta->evictPos) * sizeof(RewindItem),
-								REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem));
+								REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem),
+								false, false);
 			}
 
 			/* Clean written items from ring buffer */
@@ -1887,7 +1892,8 @@ checkpoint_write_rewind_xids(void)
 			o_buffers_read(&rewindBuffersDesc,
 						   (Pointer) &buffer, REWIND_BUFFERS_TAG,
 						   startbuf * sizeof(RewindItem),
-						   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem));
+						   REWIND_DISK_BUFFER_LENGTH * sizeof(RewindItem),
+						   false);
 			buffer_loaded = true;
 		}
 

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -725,7 +725,7 @@ set_oxid_csn(OXid oxid, CommitSeqNo csn)
 	Assert(oxid < pg_atomic_read_u64(&xid_meta->writtenXmin));
 	o_buffers_write(&buffersDesc, (Pointer) &csn, OXID_BUFFERS_TAG,
 					oxid * sizeof(OXidMapItem) + offsetof(OXidMapItem, csn),
-					sizeof(CommitSeqNo));
+					sizeof(CommitSeqNo), false, false);
 }
 
 /*
@@ -770,7 +770,7 @@ set_oxid_xlog_ptr_internal(OXid oxid, XLogRecPtr ptr)
 	Assert(oxid < pg_atomic_read_u64(&xid_meta->writtenXmin));
 	o_buffers_write(&buffersDesc, (Pointer) &ptr, OXID_BUFFERS_TAG,
 					oxid * sizeof(OXidMapItem) + offsetof(OXidMapItem, commitPtr),
-					sizeof(XLogRecPtr));
+					sizeof(XLogRecPtr), false, false);
 }
 
 void
@@ -827,7 +827,7 @@ map_oxid(OXid oxid, CommitSeqNo *outCsn, XLogRecPtr *outPtr, bool getRawCsn)
 	Assert(oxid < pg_atomic_read_u64(&xid_meta->writtenXmin));
 	o_buffers_read(&buffersDesc, (Pointer) &mapItem, OXID_BUFFERS_TAG,
 				   oxid * sizeof(OXidMapItem),
-				   sizeof(OXidMapItem));
+				   sizeof(OXidMapItem), false);
 
 	/* Recheck if globalXmin was advanced concurrently */
 	if (oxid < pg_atomic_read_u64(&xid_meta->globalXmin))
@@ -948,18 +948,12 @@ write_xidsmap(OXid targetXmax)
 		else
 			dirty = xid_buffer_page_dirty(page);
 
-		if (dirty)
-			o_buffers_write(&buffersDesc,
-							(Pointer) &buffer[writeStart % bufferLength],
-							OXID_BUFFERS_TAG,
-							writeStart * sizeof(OXidMapItem),
-							(writeEnd - writeStart) * sizeof(OXidMapItem));
-		else
-			o_buffers_write_clean(&buffersDesc,
-								  (Pointer) &buffer[writeStart % bufferLength],
-								  OXID_BUFFERS_TAG,
-								  writeStart * sizeof(OXidMapItem),
-								  (writeEnd - writeStart) * sizeof(OXidMapItem));
+		o_buffers_write(&buffersDesc,
+						(Pointer) &buffer[writeStart % bufferLength],
+						OXID_BUFFERS_TAG,
+						writeStart * sizeof(OXidMapItem),
+						(writeEnd - writeStart) * sizeof(OXidMapItem),
+						false, !dirty);
 
 		pageOxid = writeEnd;
 	}

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -1583,7 +1583,8 @@ write_undo_range(OBuffersDesc *desc, Pointer buf, UndoLogType undoType,
 				 UndoLocation minLoc, UndoLocation maxLoc)
 {
 	if (maxLoc > minLoc)
-		o_buffers_write(desc, buf, (uint32) undoType, minLoc, maxLoc - minLoc);
+		o_buffers_write(desc, buf, (uint32) undoType, minLoc, maxLoc - minLoc,
+						false, false);
 }
 
 /*
@@ -1599,8 +1600,8 @@ write_undo_range_clean(OBuffersDesc *desc, Pointer buf, UndoLogType undoType,
 					   UndoLocation minLoc, UndoLocation maxLoc)
 {
 	if (maxLoc > minLoc)
-		o_buffers_write_clean(desc, buf, (uint32) undoType, minLoc,
-							  maxLoc - minLoc);
+		o_buffers_write(desc, buf, (uint32) undoType, minLoc, maxLoc - minLoc,
+						false, true);
 }
 
 static void
@@ -1608,7 +1609,7 @@ read_undo_range(OBuffersDesc *desc, Pointer buf, UndoLogType undoType,
 				UndoLocation minLoc, UndoLocation maxLoc)
 {
 	Assert(maxLoc > minLoc);
-	o_buffers_read(desc, buf, (uint32) undoType, minLoc, maxLoc - minLoc);
+	o_buffers_read(desc, buf, (uint32) undoType, minLoc, maxLoc - minLoc, false);
 }
 
 static bool
@@ -1616,7 +1617,8 @@ write_undo_range_if_exists(OBuffersDesc *desc, Pointer buf, UndoLogType undoType
 						   UndoLocation minLoc, UndoLocation maxLoc)
 {
 	if (maxLoc > minLoc)
-		return o_buffers_write_if_exists(desc, buf, (uint32) undoType, minLoc, maxLoc - minLoc);
+		return o_buffers_write(desc, buf, (uint32) undoType, minLoc,
+							   maxLoc - minLoc, true, false);
 	return true;
 }
 
@@ -1625,7 +1627,8 @@ read_undo_range_if_exists(OBuffersDesc *desc, Pointer buf, UndoLogType undoType,
 						  UndoLocation minLoc, UndoLocation maxLoc)
 {
 	Assert(maxLoc > minLoc);
-	return o_buffers_read_if_exists(desc, buf, (uint32) undoType, minLoc, maxLoc - minLoc);
+	return o_buffers_read(desc, buf, (uint32) undoType, minLoc,
+						  maxLoc - minLoc, true);
 }
 
 /*

--- a/src/utils/o_buffers.c
+++ b/src/utils/o_buffers.c
@@ -327,19 +327,31 @@ get_buffer(OBuffersDesc *desc, uint32 tag, int64 blockNum, bool write,
 }
 
 /*
- * Read or write a range of data from/to buffers.  When missing_ok is true
- * and the underlying file does not exist (read path only), returns false
- * with buf zeroed.
+ * Read or write a range of data from/to buffers.
+ *
+ * missing_ok: a missing underlying file returns false instead of panicking
+ * (read path returns with buf zeroed).  Otherwise the call always returns
+ * true.
+ *
+ * mark_clean (write only): the data is already durable on disk (the caller
+ * is refreshing the cache copy of a page a checkpoint-time flush already
+ * pushed out).  The touched buffers are left clean -- no write-back is
+ * performed and none must clobber the on-disk image.  Used by the
+ * undo/xidmap eviction paths so a stale partial copy a prior eviction left
+ * in the cache does not get read back after the written-frontier advances
+ * past it.
  */
 static bool
 o_buffers_rw(OBuffersDesc *desc, Pointer buf,
 			 uint32 tag, int64 offset, int64 size,
-			 bool write, bool missing_ok, bool markClean)
+			 bool write, bool missing_ok, bool mark_clean)
 {
 	int64		firstBlockNum = offset / ORIOLEDB_BLCKSZ,
 				lastBlockNum = (offset + size - 1) / ORIOLEDB_BLCKSZ,
 				blockNum;
 	Pointer		ptr = buf;
+
+	Assert(OBuffersMaxTagIsValid(tag) && offset >= 0 && size > 0);
 
 	for (blockNum = firstBlockNum; blockNum <= lastBlockNum; blockNum++)
 	{
@@ -378,15 +390,7 @@ o_buffers_rw(OBuffersDesc *desc, Pointer buf,
 		if (write)
 		{
 			memcpy(&buffer->data[copyOffset], ptr, copySize);
-
-			/*
-			 * In markClean mode the data is already durable on disk (the
-			 * caller is refreshing the cache copy of a page a checkpoint-time
-			 * flush already pushed out), so leave the buffer clean -- no
-			 * write-back is needed and none must clobber the on-disk image.
-			 * Otherwise the cache copy now differs from disk: mark it dirty.
-			 */
-			buffer->dirty = !markClean;
+			buffer->dirty = !mark_clean;
 		}
 		else
 		{
@@ -398,50 +402,19 @@ o_buffers_rw(OBuffersDesc *desc, Pointer buf,
 	return true;
 }
 
-void
-o_buffers_read(OBuffersDesc *desc, Pointer buf, uint32 tag, int64 offset, int64 size)
+bool
+o_buffers_read(OBuffersDesc *desc, Pointer buf, uint32 tag,
+			   int64 offset, int64 size, bool if_exists)
 {
-	Assert(OBuffersMaxTagIsValid(tag) && offset >= 0 && size > 0);
-	o_buffers_rw(desc, buf, tag, offset, size, false, false, false);
+	return o_buffers_rw(desc, buf, tag, offset, size, false, if_exists, false);
 }
 
 bool
-o_buffers_read_if_exists(OBuffersDesc *desc, Pointer buf, uint32 tag,
-						 int64 offset, int64 size)
+o_buffers_write(OBuffersDesc *desc, Pointer buf, uint32 tag,
+				int64 offset, int64 size, bool if_exists, bool mark_clean)
 {
-	Assert(OBuffersMaxTagIsValid(tag) && offset >= 0 && size > 0);
-	return o_buffers_rw(desc, buf, tag, offset, size, false, true, false);
-}
-
-void
-o_buffers_write(OBuffersDesc *desc, Pointer buf, uint32 tag, int64 offset, int64 size)
-{
-	Assert(OBuffersMaxTagIsValid(tag) && offset >= 0 && size > 0);
-	o_buffers_rw(desc, buf, tag, offset, size, true, false, false);
-}
-
-/*
- * Like o_buffers_write(), but leaves the touched cache buffers clean instead
- * of dirty and performs no disk write.  The undo/xidmap eviction paths use
- * this for ring pages a checkpoint-time flush already pushed to disk: the data
- * is already durable, so this just refreshes the (possibly stale) cache copy
- * to match the ring without dirtying it -- a later read then never sees a
- * stale copy, and the buffer is never written back over the on-disk image.
- */
-void
-o_buffers_write_clean(OBuffersDesc *desc, Pointer buf, uint32 tag,
-					  int64 offset, int64 size)
-{
-	Assert(OBuffersMaxTagIsValid(tag) && offset >= 0 && size > 0);
-	o_buffers_rw(desc, buf, tag, offset, size, true, false, true);
-}
-
-bool
-o_buffers_write_if_exists(OBuffersDesc *desc, Pointer buf, uint32 tag,
-						  int64 offset, int64 size)
-{
-	Assert(OBuffersMaxTagIsValid(tag) && offset >= 0 && size > 0);
-	return o_buffers_rw(desc, buf, tag, offset, size, true, true, false);
+	return o_buffers_rw(desc, buf, tag, offset, size, true,
+						if_exists, mark_clean);
 }
 
 /*


### PR DESCRIPTION
+Move the tag/offset/size Assert down into o_buffers_rw so the wrappers stay one-liners.
No behavior change