### PR TITLE
Zero the hikeys-to-first-chunk gap in null_unused_bytes()

### DIFF
--- a/include/btree/page_contents.h
+++ b/include/btree/page_contents.h
@@ -378,7 +378,6 @@ extern LocationIndex page_get_vacated_skip_item(BTreeDescr *desc,
 												LocationIndex skipOffset);
 extern LocationIndex page_get_vacated_space(BTreeDescr *desc, Page p,
 											CommitSeqNo csn);
-extern void null_unused_bytes(Page img);
 extern void put_page_image(OInMemoryBlkno blkno, Page img);
 extern void page_cut_first_key(Page node);
 

--- a/src/btree/check.c
+++ b/src/btree/check.c
@@ -24,6 +24,7 @@
 #include "recovery/recovery.h"
 #include "tableam/descr.h"
 #include "utils/compress.h"
+#include "utils/memdebug.h"
 #include "utils/page_pool.h"
 #include "utils/seq_buf.h"
 #include "utils/ucm.h"
@@ -752,7 +753,7 @@ btree_check_compression_recursive(BTreeDescr *desc, BTreeCompressStats *stats, O
 	}
 
 	memcpy(buf, p, ORIOLEDB_BLCKSZ);
-	null_unused_bytes(buf);
+	VALGRIND_MAKE_MEM_DEFINED(buf, ORIOLEDB_BLCKSZ);
 
 	PG_TRY();
 	{

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -193,8 +193,8 @@ partial_load_full_page(PartialPageState *partial, Page img)
 			return false;
 	}
 
-	/* btree_page_reorg() checks the free-space tail is zeroed under Valgrind. */
-	null_unused_bytes(img);
+	/* btree_page_reorg() checks the whole page is defined under Valgrind. */
+	VALGRIND_MAKE_MEM_DEFINED(img, ORIOLEDB_BLCKSZ);
 
 	partial->isPartial = false;
 	return true;

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -506,18 +506,6 @@ page_get_vacated_space(BTreeDescr *desc, Page p, CommitSeqNo csn)
 	return page_get_vacated_skip_item(desc, p, csn, -1);
 }
 
-/*
- * Sets to 0 unused space on the page.
- */
-void
-null_unused_bytes(Page img)
-{
-	BTreePageHeader *header = (BTreePageHeader *) img;
-
-	memset((Pointer) img + header->dataSize, 0,
-		   ORIOLEDB_BLCKSZ - header->dataSize);
-}
-
 void
 page_cut_first_key(Page node)
 {


### PR DESCRIPTION
btree_page_reorg() places the first chunk at
Max(BTREE_PAGE_HIKEYS_END, ...), which can exceed header->hikeysEnd. partial_load_full_page() loaded neither the trailing hikeys-area bytes nor the chunk data covering that gap, leaving palloc garbage there and tripping VALGRIND_CHECK_MEM_IS_DEFINED in the next reorg.