### PR TITLE
Don't try to save extended hash proc if it not exist for type

### DIFF
--- a/src/catalog/o_sys_cache.c
+++ b/src/catalog/o_sys_cache.c
@@ -1377,6 +1377,7 @@ o_cache_type_opclasses(Oid datoid, Oid typoid,
 		Oid			sys_datoid;
 		Oid			hash_opf;
 		Oid			hash_opintype;
+		Oid			hash_extended_proc = InvalidOid;
 
 		hash_opf = get_opclass_family(hash_opclass);
 		hash_opintype = get_opclass_input_type(hash_opclass);
@@ -1391,9 +1392,14 @@ o_cache_type_opclasses(Oid datoid, Oid typoid,
 		o_amproc_cache_add_if_needed(datoid, hash_opf, hash_opintype,
 									 hash_opintype, HASHSTANDARD_PROC,
 									 insert_lsn, NULL);
-		o_amproc_cache_add_if_needed(datoid, hash_opf, hash_opintype,
-									 hash_opintype, HASHEXTENDED_PROC,
-									 insert_lsn, NULL);
+		hash_extended_proc = get_opfamily_proc(hash_opf,
+											   hash_opintype,
+											   hash_opintype,
+											   HASHEXTENDED_PROC);
+		if (OidIsValid(hash_extended_proc))
+			o_amproc_cache_add_if_needed(datoid, hash_opf, hash_opintype,
+										 hash_opintype, HASHEXTENDED_PROC,
+										 insert_lsn, NULL);
 
 		o_class_cache_add_if_needed(sys_datoid, AccessMethodOperatorRelationId,
 									sys_lsn, NULL);

--- a/test/expected/types.out
+++ b/test/expected/types.out
@@ -1015,8 +1015,43 @@ SELECT * FROM o_test_domain_rollback;
 (1 row)
 
 ROLLBACK;
+CREATE TYPE test_ulid;
+CREATE FUNCTION test_ulid_in(cstring) RETURNS test_ulid AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type test_ulid is only a shell
+CREATE FUNCTION test_ulid_out(test_ulid) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type test_ulid is only a shell
+CREATE TYPE test_ulid (
+    INTERNALLENGTH = variable,
+    INPUT = test_ulid_in,
+    OUTPUT = test_ulid_out,
+    STORAGE = extended
+);
+CREATE FUNCTION test_ulid_eq(test_ulid, test_ulid) RETURNS boolean AS 'texteq' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR = (
+    LEFTARG = test_ulid,
+    RIGHTARG = test_ulid,
+    FUNCTION = test_ulid_eq,
+    COMMUTATOR = =
+);
+CREATE FUNCTION test_ulid_hash(test_ulid) RETURNS integer AS 'hashtext' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR FAMILY test_ulid_hash_ops USING hash;
+CREATE OPERATOR CLASS test_ulid_hash_ops
+    DEFAULT FOR TYPE test_ulid USING hash
+	FAMILY test_ulid_hash_ops AS
+    OPERATOR 1  = ,
+    FUNCTION 1  test_ulid_hash(test_ulid);
+CREATE FUNCTION test_ulid_cmp(test_ulid, test_ulid) RETURNS integer AS 'bttextcmp' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR FAMILY test_ulid_btree_ops USING btree;
+CREATE OPERATOR CLASS test_ulid_btree_ops
+    DEFAULT FOR TYPE test_ulid USING btree
+	FAMILY test_ulid_btree_ops AS
+    OPERATOR 3  = ,
+    FUNCTION 1  test_ulid_cmp(test_ulid, test_ulid);
+CREATE TABLE o_test_ulid (
+    id test_ulid PRIMARY KEY
+) USING orioledb;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 11 other objects
+NOTICE:  drop cascades to 12 other objects
 DETAIL:  drop cascades to table o_test_record_type
 drop cascades to table o_test_range
 drop cascades to table o_test_custom_range
@@ -1028,8 +1063,9 @@ drop cascades to table o_test_domain_array_index
 drop cascades to table o_test_record_type_alter
 drop cascades to table o_test_record_type_alter2
 drop cascades to table o_test_domain_check
+drop cascades to table o_test_ulid
 DROP SCHEMA types CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 17 other objects
 DETAIL:  drop cascades to type coordinates
 drop cascades to type custom_range
 drop cascades to type pg_rec
@@ -1038,4 +1074,13 @@ drop cascades to type record_type_non_altered
 drop cascades to type record_type_renamed
 drop cascades to type o_test_domain_1
 drop cascades to type o_test_domain_2
+drop cascades to function test_ulid_out(test_ulid)
+drop cascades to type test_ulid
+drop cascades to function test_ulid_in(cstring)
+drop cascades to function test_ulid_eq(test_ulid,test_ulid)
+drop cascades to operator =(test_ulid,test_ulid)
+drop cascades to function test_ulid_hash(test_ulid)
+drop cascades to operator family test_ulid_hash_ops for access method hash
+drop cascades to function test_ulid_cmp(test_ulid,test_ulid)
+drop cascades to operator family test_ulid_btree_ops for access method btree
 RESET search_path;

--- a/test/expected/types_1.out
+++ b/test/expected/types_1.out
@@ -1015,8 +1015,45 @@ SELECT * FROM o_test_domain_rollback;
 (1 row)
 
 ROLLBACK;
+CREATE TYPE test_ulid;
+CREATE FUNCTION test_ulid_in(cstring) RETURNS test_ulid AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type test_ulid is only a shell
+CREATE FUNCTION test_ulid_out(test_ulid) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type test_ulid is only a shell
+LINE 1: CREATE FUNCTION test_ulid_out(test_ulid) RETURNS cstring AS ...
+                                      ^
+CREATE TYPE test_ulid (
+    INTERNALLENGTH = variable,
+    INPUT = test_ulid_in,
+    OUTPUT = test_ulid_out,
+    STORAGE = extended
+);
+CREATE FUNCTION test_ulid_eq(test_ulid, test_ulid) RETURNS boolean AS 'texteq' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR = (
+    LEFTARG = test_ulid,
+    RIGHTARG = test_ulid,
+    FUNCTION = test_ulid_eq,
+    COMMUTATOR = =
+);
+CREATE FUNCTION test_ulid_hash(test_ulid) RETURNS integer AS 'hashtext' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR FAMILY test_ulid_hash_ops USING hash;
+CREATE OPERATOR CLASS test_ulid_hash_ops
+    DEFAULT FOR TYPE test_ulid USING hash
+	FAMILY test_ulid_hash_ops AS
+    OPERATOR 1  = ,
+    FUNCTION 1  test_ulid_hash(test_ulid);
+CREATE FUNCTION test_ulid_cmp(test_ulid, test_ulid) RETURNS integer AS 'bttextcmp' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR FAMILY test_ulid_btree_ops USING btree;
+CREATE OPERATOR CLASS test_ulid_btree_ops
+    DEFAULT FOR TYPE test_ulid USING btree
+	FAMILY test_ulid_btree_ops AS
+    OPERATOR 3  = ,
+    FUNCTION 1  test_ulid_cmp(test_ulid, test_ulid);
+CREATE TABLE o_test_ulid (
+    id test_ulid PRIMARY KEY
+) USING orioledb;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 11 other objects
+NOTICE:  drop cascades to 12 other objects
 DETAIL:  drop cascades to table o_test_record_type
 drop cascades to table o_test_range
 drop cascades to table o_test_custom_range
@@ -1028,8 +1065,9 @@ drop cascades to table o_test_domain_array_index
 drop cascades to table o_test_record_type_alter
 drop cascades to table o_test_record_type_alter2
 drop cascades to table o_test_domain_check
+drop cascades to table o_test_ulid
 DROP SCHEMA types CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 17 other objects
 DETAIL:  drop cascades to type coordinates
 drop cascades to type custom_range
 drop cascades to type pg_rec
@@ -1038,4 +1076,13 @@ drop cascades to type record_type_non_altered
 drop cascades to type record_type_renamed
 drop cascades to type o_test_domain_1
 drop cascades to type o_test_domain_2
+drop cascades to function test_ulid_out(test_ulid)
+drop cascades to type test_ulid
+drop cascades to function test_ulid_in(cstring)
+drop cascades to function test_ulid_eq(test_ulid,test_ulid)
+drop cascades to operator =(test_ulid,test_ulid)
+drop cascades to function test_ulid_hash(test_ulid)
+drop cascades to operator family test_ulid_hash_ops for access method hash
+drop cascades to function test_ulid_cmp(test_ulid,test_ulid)
+drop cascades to operator family test_ulid_btree_ops for access method btree
 RESET search_path;

--- a/test/sql/types.sql
+++ b/test/sql/types.sql
@@ -367,6 +367,43 @@ INSERT INTO o_test_domain_rollback VALUES ('{10}', 10, '10.10.10.10');
 SELECT * FROM o_test_domain_rollback;
 ROLLBACK;
 
+CREATE TYPE test_ulid;
+
+CREATE FUNCTION test_ulid_in(cstring) RETURNS test_ulid AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+CREATE FUNCTION test_ulid_out(test_ulid) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+CREATE TYPE test_ulid (
+    INTERNALLENGTH = variable,
+    INPUT = test_ulid_in,
+    OUTPUT = test_ulid_out,
+    STORAGE = extended
+);
+CREATE FUNCTION test_ulid_eq(test_ulid, test_ulid) RETURNS boolean AS 'texteq' LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE OPERATOR = (
+    LEFTARG = test_ulid,
+    RIGHTARG = test_ulid,
+    FUNCTION = test_ulid_eq,
+    COMMUTATOR = =
+);
+CREATE FUNCTION test_ulid_hash(test_ulid) RETURNS integer AS 'hashtext' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR FAMILY test_ulid_hash_ops USING hash;
+CREATE OPERATOR CLASS test_ulid_hash_ops
+    DEFAULT FOR TYPE test_ulid USING hash
+	FAMILY test_ulid_hash_ops AS
+    OPERATOR 1  = ,
+    FUNCTION 1  test_ulid_hash(test_ulid);
+CREATE FUNCTION test_ulid_cmp(test_ulid, test_ulid) RETURNS integer AS 'bttextcmp' LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR FAMILY test_ulid_btree_ops USING btree;
+CREATE OPERATOR CLASS test_ulid_btree_ops
+    DEFAULT FOR TYPE test_ulid USING btree
+	FAMILY test_ulid_btree_ops AS
+    OPERATOR 3  = ,
+    FUNCTION 1  test_ulid_cmp(test_ulid, test_ulid);
+
+CREATE TABLE o_test_ulid (
+    id test_ulid PRIMARY KEY
+) USING orioledb;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA types CASCADE;
 RESET search_path;


### PR DESCRIPTION
Fixes #928

Also thought that I had wrong assumption and we don't need default hash function for types, but it is still needed for calling lookup_type_cache during recovery