### PR TITLE
Implement multi-insert optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ REGRESSCHECKS = btree_sys_check \
 				ioc \
 				iterator \
 				joins \
+				multi_insert \
 				nulls \
 				opclass \
 				parallel_scan \
@@ -212,6 +213,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/logical_test.py \
 						test/t/logical_xid_subxacts_test.py \
 						test/t/merge_into_test.py \
+						test/t/multi_insert_test.py \
 						test/t/not_supported_yet_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \

--- a/include/btree/insert.h
+++ b/include/btree/insert.h
@@ -16,6 +16,7 @@
 
 #include "btree.h"
 #include "btree/find.h"
+#include "btree/modify.h"
 
 extern void o_btree_split_fix_and_unlock(BTreeDescr *descr,
 										 OInMemoryBlkno left_blkno);
@@ -29,5 +30,41 @@ extern void o_btree_insert_tuple_to_leaf(OBTreeFindPageContext *context,
 extern bool o_btree_split_is_incomplete(OInMemoryBlkno left_blkno,
 										uint32 pageChangeCount,
 										bool *relocked);
+
+/*
+ * Result of probing a leaf slot for a new-item insert:
+ * Fits means the located position can receive the item AsIs.
+ * HikeyCrossed -> the key belongs to a later leaf;
+ * NoFit -> page is out of slack at this locator;
+ * Duplicate -> the key already exists at the locator.
+ *
+ * The probe only detects "key past this leaf's hikey", not "key before
+ * this leaf's lokey" -- detecting the latter would need parent context
+ * (a leaf's downlink key is held by its parent, not the leaf itself).
+ * The helper assumes keys[] are sorted ascending.
+ *
+ * For the batch driver Fits at the end of the loop means "no bail
+ * happened, all items inserted"; caller need to inspect result only
+ * when count < nitems.
+ */
+typedef enum BTreeLeafProbeResult
+{
+	BTreeLeafProbeFits,
+	BTreeLeafProbeHikeyCrossed,
+	BTreeLeafProbeNoFit,
+	BTreeLeafProbeDuplicate
+} BTreeLeafProbeResult;
+
+extern int	o_btree_multi_insert_item(OBTreeFindPageContext *ctx,
+									  OTuple *tuples,
+									  LocationIndex *tuplens,
+									  Pointer *keys,
+									  BTreeKeyType keyType,
+									  int nitems,
+									  OXid opOxid,
+									  RowLockMode lockMode,
+									  BTreeModifyCallbackInfo *cb,
+									  void **cb_args,
+									  BTreeLeafProbeResult *result);
 
 #endif							/* __BTREE_INSERT_H__ */

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -447,6 +447,7 @@ extern Page *local_ppool_pages;
 extern OrioleDBPageDesc *page_descs;
 extern OrioleDBPageDesc *local_ppool_page_descs;
 extern bool remove_old_checkpoint_files;
+extern bool orioledb_debug_disable_multi_insert;
 extern bool skip_unmodified_trees;
 extern bool debug_disable_bgwriter;
 extern MemoryContext btree_insert_context;

--- a/include/tableam/operations.h
+++ b/include/tableam/operations.h
@@ -94,6 +94,9 @@ typedef struct
 extern TupleTableSlot *o_tbl_insert(OTableDescr *descr, Relation relation,
 									TupleTableSlot *slot, OXid oxid,
 									CommitSeqNo csn);
+extern void o_tbl_multi_insert(OTableDescr *descr, Relation relation,
+							   TupleTableSlot **slots, int ntuples,
+							   OXid oxid, CommitSeqNo csn);
 extern TupleTableSlot *o_tbl_insert_with_arbiter(Relation rel,
 												 OTableDescr *descr,
 												 TupleTableSlot *slot,

--- a/src/btree/insert.c
+++ b/src/btree/insert.c
@@ -960,6 +960,211 @@ o_btree_insert_needs_page_undo(BTreeDescr *desc, Page p)
 	return needsUndo;
 }
 
+/*
+ * Per-item pre-check shared by o_btree_insert_item_with_waiters()
+ * branch and o_btree_multi_insert_item(): hikey gate, btree_page_search,
+ * raw fit check, duplicate-at-locator probe.  Positions *loc on success
+ * and on Duplicate (so the caller can read the conflicting tuple if it
+ * wants); leaves it indeterminate on HikeyCrossed (no search was done)
+ * and may leave it positioned-but-unfit on NoFit.
+ *
+ * key/keyType match how the caller addresses the new item: waiters pass
+ * the leaf tuple itself with BTreeKeyLeafTuple, the multi-insert driver
+ * passes the precomputed OBTreeKeyBound with BTreeKeyBound.
+ */
+static BTreeLeafProbeResult
+btree_leaf_probe_insert_slot(BTreeDescr *desc, Page p, bool rightmost,
+							 OTuple *hikey,
+							 Pointer key, BTreeKeyType keyType,
+							 LocationIndex newItemSize,
+							 BTreePageItemLocator *loc)
+{
+	if (!rightmost &&
+		o_btree_cmp(desc, hikey, BTreeKeyNonLeafKey, key, keyType) <= 0)
+		return BTreeLeafProbeHikeyCrossed;
+
+	btree_page_search(desc, p, key, keyType, NULL, loc);
+
+	if (!page_locator_fits_new_item(p, loc, newItemSize))
+		return BTreeLeafProbeNoFit;
+
+	if (BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
+	{
+		OTuple		existing;
+
+		BTREE_PAGE_READ_LEAF_TUPLE(existing, p, loc);
+		if (o_btree_cmp(desc, key, keyType,
+						&existing, BTreeKeyLeafTuple) == 0)
+			return BTreeLeafProbeDuplicate;
+	}
+
+	return BTreeLeafProbeFits;
+}
+
+/*
+ * Write one new leaf item at *loc.  Shared page-write body for
+ * o_btree_insert_item_with_waiters() and o_btree_multi_insert_item().
+ * Caller has positioned loc, made any undo record, decided that the
+ * item fits, and entered the critical section.  Caller follows
+ * with optional page_split_chunk_if_needed() + MARK_DIRTY.
+ */
+static inline void
+btree_leaf_write_new_item(BTreeDescr *desc, Page p,
+						  BTreePageItemLocator *loc,
+						  const BTreeLeafTuphdr *tuphdr,
+						  OTuple tuple, LocationIndex tuplen)
+{
+	BTreePageHeader *header = (BTreePageHeader *) p;
+	LocationIndex newItemSize = MAXALIGN(tuplen) + BTreeLeafTuphdrSize;
+	LocationIndex keyLen;
+	Pointer		ptr;
+
+	page_locator_insert_item(p, loc, newItemSize);
+	header->prevInsertOffset = BTREE_PAGE_LOCATOR_GET_OFFSET(p, loc);
+	keyLen = MAXALIGN(o_btree_len(desc, tuple, OTupleKeyLengthNoVersion));
+	header->maxKeyLen = Max(header->maxKeyLen, keyLen);
+
+	ptr = BTREE_PAGE_LOCATOR_GET_ITEM(p, loc);
+	memcpy(ptr, tuphdr, BTreeLeafTuphdrSize);
+	ptr += BTreeLeafTuphdrSize;
+	memcpy(ptr, tuple.data, tuplen);
+	BTREE_PAGE_SET_ITEM_FLAGS(p, loc, tuple.formatFlags);
+
+	if (!(tuple.formatFlags & O_TUPLE_FLAGS_FIXED_FORMAT))
+		header->chunkDesc[loc->chunkOffset].chunkKeysFixed = 0;
+}
+
+/*
+ * Insert a strict prefix of items[0..nitems-1] into the leaf ctx is parked
+ * on, in one lock cycle.  Returns N, the count inserted:
+ *   items[0..N-1]        inserted, in order.
+ *   items[N]             the item that bailed; *result says why
+ *                        (HikeyCrossed / NoFit / Duplicate).
+ *   items[N+1..nitems-1] untouched.
+ * N == nitems means the whole batch fit; *result is left at Fits.
+ *
+ * The leaf is always unlocked before return.
+ *
+ * Caller is responsible for:
+ *  - ctx points at a LEAF, locked exclusive, no incomplete split
+ *  - desc->ppool->numPagesReserved[PPOOL_RESERVE_INSERT] >= 2
+ *  - keys[] ascending, tuples[] are the matching leaf tuples
+ *  - Reserving enough row-undo for every per-row make_undo_record
+ *    plus one extra row of slack for get_undo_record's buffer-wrap retry,
+ *    so no eviction happens with the leaf locked
+ */
+int
+o_btree_multi_insert_item(OBTreeFindPageContext *ctx,
+						  OTuple *tuples, LocationIndex *tuplens,
+						  Pointer *keys, BTreeKeyType keyType,
+						  int nitems,
+						  OXid opOxid, RowLockMode lockMode,
+						  BTreeModifyCallbackInfo *cb,
+						  void **cb_args,
+						  BTreeLeafProbeResult *result)
+{
+	BTreeDescr *desc = ctx->desc;
+	OInMemoryBlkno blkno;
+	Page		p;
+	BTreePageItemLocator loc;
+	OTupleXactInfo xactInfo;
+	OTuple		hikey;
+	bool		rightmost;
+	bool		needsUndo;
+	int			inserted = 0;
+	int			k;
+
+	Assert(ctx->index >= 0 && ctx->index < ORIOLEDB_MAX_DEPTH);
+	blkno = ctx->items[ctx->index].blkno;
+	p = O_GET_IN_MEMORY_PAGE(blkno);
+	Assert(O_PAGE_IS(p, LEAF));
+	Assert(desc->ppool->numPagesReserved[PPOOL_RESERVE_INSERT] >= 2);
+
+	rightmost = O_PAGE_IS(p, RIGHTMOST);
+	if (!rightmost)
+		BTREE_PAGE_GET_HIKEY(hikey, p);
+
+	xactInfo = OXID_GET_XACT_INFO(OXidIsValid(opOxid) ? opOxid : BootstrapTransactionId,
+								  lockMode, false);
+
+	/*
+	 * Mirrors the needsUndo logic in o_btree_modify_internal (self-created
+	 * shortcut).
+	 */
+	needsUndo = desc->undoType != UndoLogNone;
+	if (!(cb && cb->needsUndoForSelfCreated) &&
+		OXidIsValid(desc->createOxid) &&
+		desc->createOxid == opOxid &&
+		!UndoLocationIsValid(get_subxact_undo_location(desc->undoType)))
+		needsUndo = false;
+
+	page_block_reads(blkno);
+
+	*result = BTreeLeafProbeFits;
+
+	for (k = 0; k < nitems; k++)
+	{
+		OTuple		tuple = tuples[k];
+		LocationIndex tuplen = tuplens[k];
+		LocationIndex newItemSize = MAXALIGN(tuplen) + BTreeLeafTuphdrSize;
+		BTreeLeafTuphdr tuphdr;
+		UndoLocation undoLocation = InvalidUndoLocation;
+
+		*result = btree_leaf_probe_insert_slot(desc, p, rightmost, &hikey,
+											   keys[k], keyType, newItemSize, &loc);
+		if (*result != BTreeLeafProbeFits)
+		{
+			/*
+			 * Items are sorted: HikeyCrossed means every remaining key is
+			 * also past, so the outer driver re-finds the next leaf.  NoFit
+			 * and Duplicate are bailed-to-slow-path conditions.
+			 */
+			break;
+		}
+
+		/*
+		 * Build per-row undo record + tuphdr.  Matches the non-replace branch
+		 * of o_btree_modify_add_undo_record: real undo record goes on the
+		 * undo stack via make_undo_record(), tuphdr.undoLocation in the page
+		 * only carries the command-tag for UndoLogRegular.
+		 */
+		if (needsUndo)
+			undoLocation = make_undo_record(desc, tuple, true,
+											BTreeOperationInsert, blkno,
+											O_PAGE_GET_CHANGE_COUNT(p), NULL);
+
+		tuphdr.xactInfo = xactInfo;
+		tuphdr.deleted = BTreeLeafTupleNonDeleted;
+		tuphdr.chainHasLocks = false;
+		tuphdr.formatFlags = 0;
+		tuphdr.undoLocation = InvalidUndoLocation;
+		if (desc->undoType == UndoLogRegular && !is_recovery_process())
+			tuphdr.undoLocation |= current_command_get_undo_location();
+
+		START_CRIT_SECTION();
+
+		btree_leaf_write_new_item(desc, p, &loc, &tuphdr, tuple, tuplen);
+		page_split_chunk_if_needed(desc, p, &loc);
+		MARK_DIRTY(desc, blkno);
+
+		/*
+		 * Fire the post-undo hook under the page lock so the pendingSkUndoLoc
+		 * marker is installed before the next iteration advances the page --
+		 * matches the ordering in o_btree_modify_insert_update().
+		 */
+		if (cb && cb->postUndoRecorded)
+			cb->postUndoRecorded(needsUndo ? undoLocation : WaitingSkUndoLoc,
+								 cb_args ? cb_args[k] : cb->arg);
+
+		END_CRIT_SECTION();
+
+		inserted++;
+	}
+
+	unlock_page(blkno);
+	return inserted;
+}
+
 static bool
 o_btree_insert_item_with_waiters(BTreeInsertStackItem *insert_item,
 								 int reserve_kind,
@@ -996,17 +1201,19 @@ o_btree_insert_item_with_waiters(BTreeInsertStackItem *insert_item,
 		totalSize + MAXALIGN(sizeof(LocationIndex)) * (tupleWaitersCount + 1) <=
 		BTREE_PAGE_FREE_SPACE(p))
 	{
+		bool		rightmost = O_PAGE_IS(p, RIGHTMOST);
+		OTuple		hikey;
+
+		if (!rightmost)
+			hikey = page_get_hikey(p);
 
 		page_block_reads(blkno);
 
 		for (i = 0; i <= tupleWaitersCount; i++)
 		{
 			LocationIndex tuplen;
-			LocationIndex keyLen;
-			BTreePageHeader *header = (BTreePageHeader *) p;
 			BTreeLeafTuphdr tuphdr;
 			OTuple		tuple;
-			Pointer		ptr;
 
 			if (i == 0)
 			{
@@ -1020,37 +1227,28 @@ o_btree_insert_item_with_waiters(BTreeInsertStackItem *insert_item,
 			{
 				TupleWaiterInfo *waiterInfo = &tupleWaiterInfos[i - 1];
 				OPageWaiterShmemState *lockerState = &lockerStates[waiterInfo->pgprocno];
+				BTreeLeafProbeResult result;
 
 				tuple.formatFlags = waiterInfo->item.flags;
 				tuple.data = waiterInfo->item.data + BTreeLeafTuphdrSize;
 				tuphdr = *((BTreeLeafTuphdr *) waiterInfo->item.data);
 				tuplen = waiterInfo->item.size - BTreeLeafTuphdrSize;
 
-				if (!O_PAGE_IS(p, RIGHTMOST))
-				{
-					OTuple		hikey;
+				result = btree_leaf_probe_insert_slot(desc, p, rightmost, &hikey,
+													  (Pointer) &tuple, BTreeKeyLeafTuple,
+													  waiterInfo->item.size, &loc);
 
-					hikey = page_get_hikey(p);
-					if (o_btree_cmp(desc, &tuple, BTreeKeyLeafTuple, &hikey, BTreeKeyNonLeafKey) >= 0)
-						continue;
-
-				}
-
-				btree_page_search(desc, p, (Pointer) &tuple,
-								  BTreeKeyLeafTuple, NULL, &loc);
-
-				if (!page_locator_fits_new_item(p, &loc, waiterInfo->item.size))
+				/*
+				 * Waiters arrive in arrival order, not sorted: a stray past
+				 * the hikey or a duplicate doesn't imply later waiters fail
+				 * too, so skip and keep trying.  A non-fit means the page is
+				 * out of slack for the remaining items -- abandon them.
+				 */
+				if (result == BTreeLeafProbeHikeyCrossed ||
+					result == BTreeLeafProbeDuplicate)
+					continue;
+				if (result == BTreeLeafProbeNoFit)
 					break;
-
-				if (BTREE_PAGE_LOCATOR_IS_VALID(p, &loc))
-				{
-					OTuple		existingTup;
-
-					BTREE_PAGE_READ_LEAF_TUPLE(existingTup, p, &loc);
-
-					if (o_btree_cmp(desc, &tuple, BTreeKeyLeafTuple, &existingTup, BTreeKeyLeafTuple) == 0)
-						continue;
-				}
 
 				START_CRIT_SECTION();
 				if (desc->undoType != UndoLogNone)
@@ -1065,27 +1263,12 @@ o_btree_insert_item_with_waiters(BTreeInsertStackItem *insert_item,
 				lockerState->inserted = true;
 			}
 
-			page_locator_insert_item(p, &loc, MAXALIGN(tuplen) + BTreeLeafTuphdrSize);
-			header->prevInsertOffset = BTREE_PAGE_LOCATOR_GET_OFFSET(p, &loc);
-			keyLen = MAXALIGN(o_btree_len(desc, tuple, OTupleKeyLengthNoVersion));
-			header->maxKeyLen = Max(header->maxKeyLen, keyLen);
-
-			/* Copy new tuple and header */
-			ptr = BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
-			memcpy(ptr, &tuphdr, BTreeLeafTuphdrSize);
-			ptr += BTreeLeafTuphdrSize;
-			memcpy(ptr, tuple.data, tuplen);
-			BTREE_PAGE_SET_ITEM_FLAGS(p, &loc, tuple.formatFlags);
-
-			if (!(tuple.formatFlags & O_TUPLE_FLAGS_FIXED_FORMAT))
-				header->chunkDesc[loc.chunkOffset].chunkKeysFixed = 0;
+			btree_leaf_write_new_item(desc, p, &loc, &tuphdr, tuple, tuplen);
 			MARK_DIRTY(desc, blkno);
 			END_CRIT_SECTION();
 		}
 
 		unlock_page(blkno);
-
-
 		return true;
 	}
 

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -101,6 +101,7 @@ OrioleDBPageDesc *local_ppool_page_descs = NULL;
 
 /* Custom GUC variables */
 int			orioledb_serializable_mode = O_SERIALIZABLE_TABLE_LOCK;
+bool		orioledb_debug_disable_multi_insert = false;
 
 static const struct config_enum_entry serializable_mode_options[] = {
 	{"table_lock", O_SERIALIZABLE_TABLE_LOCK, false},
@@ -509,6 +510,20 @@ _PG_init(void)
 							 &orioledb_serializable_mode,
 							 O_SERIALIZABLE_TABLE_LOCK,
 							 serializable_mode_options,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("orioledb.debug_disable_multi_insert",
+							 "Disable the batched same-leaf primary insert path.",
+							 "Debug switch.  When on, orioledb_multi_insert falls "
+							 "back to per-row o_tbl_insert instead of draining "
+							 "adjacent ordered keys into the same primary leaf "
+							 "under one lwlock.",
+							 &orioledb_debug_disable_multi_insert,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -1868,10 +1868,32 @@ static void
 orioledb_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 					  CommandId cid, int options, BulkInsertState bistate)
 {
+	OTableDescr *descr;
+	OSnapshot	oSnapshot;
+	OXid		oxid;
 	int			i;
 
+	if (OidIsValid(relation->rd_rel->relrewrite))
+		return;
+
+	o_serializable_lock_relation(RelationGetRelid(relation));
+	o_set_current_command(cid);
+	descr = relation_get_descr(relation);
+	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
+
+	/*
+	 * Batched path drains adjacent ordered keys into the same primary leaf
+	 * under a single lwlock (see o_tbl_multi_insert).  Single-row or GUC-off
+	 * falls back to per-row.
+	 */
+	if (!orioledb_debug_disable_multi_insert && ntuples > 1)
+	{
+		o_tbl_multi_insert(descr, relation, slots, ntuples, oxid, oSnapshot.csn);
+		return;
+	}
+
 	for (i = 0; i < ntuples; i++)
-		orioledb_tuple_insert(relation, slots[i], cid, options, bistate);
+		o_tbl_insert(descr, relation, slots[i], oxid, oSnapshot.csn);
 }
 
 static void

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -16,9 +16,12 @@
 #include "orioledb.h"
 
 #include "btree/btree.h"
+#include "btree/find.h"
+#include "btree/insert.h"
 #include "btree/iterator.h"
 #include "btree/modify.h"
 #include "btree/undo.h"
+#include "utils/page_pool.h"
 #include "indexam/handler.h"
 #include "recovery/recovery.h"
 #include "recovery/wal.h"
@@ -350,7 +353,8 @@ o_apply_new_bridge_index_ctid(OTableDescr *descr, Relation relation,
 		fill_current_oxid_osnapshot(&oxid, &o_snapshot);
 
 		success = (o_tbl_index_insert(descr, descr->bridge, &tuple, bridge_slot,
-									  oxid, o_snapshot.csn, &callbackInfo, UNIQUE_CHECK_YES) == OBTreeModifyResultInserted);
+									  oxid, o_snapshot.csn, &callbackInfo,
+									  UNIQUE_CHECK_YES) == OBTreeModifyResultInserted);
 
 		if (!success && !overflow)
 			o_report_duplicate(relation, descr->bridge, bridge_slot);
@@ -464,7 +468,8 @@ o_tbl_insert(OTableDescr *descr, Relation relation,
 								false);
 
 	mres.success = (o_tbl_index_insert(descr, descr->indices[0], NULL, slot,
-									   oxid, csn, &callbackInfo, UNIQUE_CHECK_YES) == OBTreeModifyResultInserted);
+									   oxid, csn, &callbackInfo,
+									   UNIQUE_CHECK_YES) == OBTreeModifyResultInserted);
 
 	/*
 	 * The marker (if any) was already installed under page lock by the
@@ -496,6 +501,333 @@ o_tbl_insert(OTableDescr *descr, Relation relation,
 		o_wal_insert(&primary->desc, tup, relation->rd_rel->relreplident, descr->version);
 
 	return slot;
+}
+
+/*
+ * Comparator for qsort_arg'ing the permutation array idx[] used by
+ * o_tbl_multi_insert when input keys are not monotone.  Sorts indices
+ * by the key bound they refer to.
+ */
+typedef struct MultiInsertSortCtx
+{
+	BTreeDescr *desc;
+	OBTreeKeyBound *keys;
+} MultiInsertSortCtx;
+
+static int
+multi_insert_sort_cmp(const void *a, const void *b, void *arg)
+{
+	MultiInsertSortCtx *cx = (MultiInsertSortCtx *) arg;
+	int			ia = *(const int *) a;
+	int			ib = *(const int *) b;
+
+	return o_btree_cmp(cx->desc,
+					   (Pointer) &cx->keys[ia], BTreeKeyBound,
+					   (Pointer) &cx->keys[ib], BTreeKeyBound);
+}
+
+/*
+ * Multi-row insert with same-leaf batching for the primary index.
+ *
+ * Phase 1: per-slot primary tuple, key bound, ctid + bridge ctid, in-row
+ *          TOAST.
+ *
+ * Phase 2: optimistically assume keys[] are monotone and just verify with
+ *          an O(n) scan; the common cases (CTID-PK by construction,
+ *          ordered explicit-PK COPY) hit this fast path and reuse the
+ *          original arrays in place.  Only if the check fails do we fall
+ *          back to building an idx[] permutation, qsort_arg-ing by key,
+ *          and materializing sorted views of tuples / tuplens / keyptrs /
+ *          cb_args.  The caller's slots[] stays in arrival order so
+ *          copyfrom.c's linenos[] indexing remains valid.  Sorting is
+ *          required because the leaf probe detects "key past this leaf's
+ *          hikey" but not "key before this leaf's lokey", so non-monotone
+ *          input could corrupt downlinks.
+ *
+ * Phase 3: stream sorted keys through primary leaves, holding each leaf's
+ *          lwlock for as many adjacent keys as fit
+ *          (o_btree_multi_insert_item).  Each iteration tops up row-undo
+ *          for the upcoming batch, capped at 2 * O_MAX_UNDO_RECORD_SIZE
+ *          so max_procs concurrent multi_inserts can't outrun the row
+ *          buffer; larger inputs split across iterations.  HikeyCrossed
+ *          re-finds the next leaf; NoFit / Duplicate slow-paths one row
+ *          via o_tbl_index_insert and resumes.
+ *
+ * Phase 4: per-slot TOAST values insert + WAL.
+ *
+ * Slots that aren't already orioledb-typed share a single descr->newTuple
+ * scratch slot and can't be batched -- in that case fall back to per-row
+ * o_tbl_insert before doing any work.
+ */
+void
+o_tbl_multi_insert(OTableDescr *descr, Relation relation,
+				   TupleTableSlot **slots, int ntuples,
+				   OXid oxid, CommitSeqNo csn)
+{
+	OIndexDescr *primary = GET_PRIMARY(descr);
+	BTreeDescr *pdesc = &primary->desc;
+	bool		was_saving;
+	OTuple	   *tuples;
+	LocationIndex *tuplens;
+	OBTreeKeyBound *keys;
+	Pointer    *keyptrs;
+	OBTreeFindPageContext ctx;
+	BTreeModifyCallbackInfo callbackInfo =
+	{
+		.waitCallback = NULL,
+		.modifyDeletedCallback = o_insert_callback,
+		.modifyCallback = NULL,
+		.needsUndoForSelfCreated = false,
+		.postUndoRecorded = set_pending_sk_marker_from_slot
+	};
+	int			i;
+
+	was_saving = o_start_saving_inval_messages();
+	CheckCmdReplicaIdentity(relation, CMD_INSERT);
+	o_stop_saving_inval_messages(was_saving);
+
+	o_btree_load_shmem(pdesc);
+
+	/*
+	 * Non-orioledb slots share descr->newTuple; can't hold N independent
+	 * pre-formed tuples across Phase 3.  Fall back to per-row.
+	 */
+	for (i = 0; i < ntuples; i++)
+	{
+		TupleTableSlot *slot = slots[i];
+
+		if (slot->tts_ops != descr->newTuple->tts_ops ||
+			(((OTableSlot *) slot)->descr != NULL &&
+			 ((OTableSlot *) slot)->descr != descr))
+		{
+			for (i = 0; i < ntuples; i++)
+				o_tbl_insert(descr, relation, slots[i], oxid, csn);
+			return;
+		}
+	}
+
+	tuples = (OTuple *) palloc(sizeof(OTuple) * ntuples);
+	tuplens = (LocationIndex *) palloc(sizeof(LocationIndex) * ntuples);
+	keys = (OBTreeKeyBound *) palloc(sizeof(OBTreeKeyBound) * ntuples);
+	keyptrs = (Pointer *) palloc(sizeof(Pointer) * ntuples);
+
+	/* Phase 1: per-slot prep (ctid, bridge, toast, form, key bound). */
+	for (i = 0; i < ntuples; i++)
+	{
+		TupleTableSlot *slot = slots[i];
+
+		if (primary->primaryIsCtid)
+		{
+			ItemPointerData iptr = btree_ctid_get_and_inc(pdesc);
+
+			tts_orioledb_set_ctid(slot, &iptr);
+		}
+
+		if (descr->bridge)
+			o_apply_new_bridge_index_ctid(descr, relation, slot, csn, true);
+
+		tts_orioledb_toast(slot, descr);
+
+		tuples[i] = tts_orioledb_form_tuple(slot, descr);
+		tuplens[i] = o_tuple_size(tuples[i], &primary->leafSpec);
+		o_btree_check_size_of_tuple(tuplens[i],
+									RelationGetRelationName(relation), false);
+
+		tts_orioledb_fill_key_bound(slot, primary, &keys[i]);
+		keyptrs[i] = (Pointer) &keys[i];
+	}
+
+	/*
+	 * Phase 2: the batch helper assumes keys[] ascend (its probe detects
+	 * "past hikey" but not "before lokey" -- lokey lives in the parent, not
+	 * the leaf, so a key < lokey would silently corrupt the downlink
+	 * invariant).  CTID-PK input is monotone by construction (Phase 1's
+	 * btree_ctid_get_and_inc); explicit-PK COPY may arrive unsorted.
+	 *
+	 * Optimistically assume monotone and just verify with an O(n) scan; the
+	 * common cases pass and Phase 3 consumes the original arrays in place. On
+	 * the first out-of-order pair fall back to sorting: build an idx[]
+	 * permutation, qsort it by key, and materialise sorted views of the
+	 * parallel arrays.  slots[] itself stays in arrival order so the caller's
+	 * linenos[] indexing (copyfrom.c) remains correct; the sorted view's
+	 * cb_args[] and the post-insert bookkeeping resolve back to the original
+	 * slot via idx[].
+	 */
+	{
+		OTuple	   *use_tuples = tuples;
+		LocationIndex *use_tuplens = tuplens;
+		Pointer    *use_keyptrs = keyptrs;
+		void	  **use_cb_args = (void **) slots;
+		int		   *idx = NULL;
+		bool		sorted = true;
+
+		for (i = 1; i < ntuples; i++)
+		{
+			if (o_btree_cmp(pdesc, keyptrs[i - 1], BTreeKeyBound,
+							keyptrs[i], BTreeKeyBound) > 0)
+			{
+				sorted = false;
+				break;
+			}
+		}
+
+		if (!sorted)
+		{
+			MultiInsertSortCtx sortcx = {pdesc, keys};
+			OTuple	   *sorted_tuples;
+			LocationIndex *sorted_tuplens;
+			Pointer    *sorted_keyptrs;
+			void	  **sorted_cb_args;
+
+			idx = (int *) palloc(sizeof(int) * ntuples);
+			for (i = 0; i < ntuples; i++)
+				idx[i] = i;
+			qsort_arg(idx, ntuples, sizeof(int),
+					  multi_insert_sort_cmp, &sortcx);
+
+			sorted_tuples = (OTuple *) palloc(sizeof(OTuple) * ntuples);
+			sorted_tuplens = (LocationIndex *) palloc(sizeof(LocationIndex) * ntuples);
+			sorted_keyptrs = (Pointer *) palloc(sizeof(Pointer) * ntuples);
+			sorted_cb_args = (void **) palloc(sizeof(void *) * ntuples);
+			for (i = 0; i < ntuples; i++)
+			{
+				sorted_tuples[i] = tuples[idx[i]];
+				sorted_tuplens[i] = tuplens[idx[i]];
+				sorted_keyptrs[i] = (Pointer) &keys[idx[i]];
+				sorted_cb_args[i] = slots[idx[i]];
+			}
+			use_tuples = sorted_tuples;
+			use_tuplens = sorted_tuplens;
+			use_keyptrs = sorted_keyptrs;
+			use_cb_args = sorted_cb_args;
+		}
+
+		/* Phase 3: drain into primary leaves. */
+		init_page_find_context(&ctx, pdesc, COMMITSEQNO_INPROGRESS,
+							   BTREE_PAGE_FIND_MODIFY | BTREE_PAGE_FIND_FIX_LEAF_SPLIT);
+
+		i = 0;
+		while (i < ntuples)
+		{
+			OFindPageResult fr PG_USED_FOR_ASSERTS_ONLY;
+			BTreeLeafProbeResult result;
+			int			n;
+			int			remaining = ntuples - i;
+			int			batch = remaining;
+			int			k;
+			int			orig;
+
+			if (pdesc->undoType != UndoLogNone)
+			{
+				Size		need = MAXIMUM_ALIGNOF;
+				Size		maxrow = 0;
+
+				/*
+				 * Bound the batch by the per-backend row-undo share the
+				 * circular buffer is sized for (see undo_shmem_needs); larger
+				 * inputs are processed in successive chunks.  The trailing
+				 * maxrow slot absorbs the one extra `size` that
+				 * get_undo_record may consume on a buffer-wrap retry.
+				 */
+				for (k = 0; k < remaining; k++)
+				{
+					Size		one = MAXALIGN(sizeof(BTreeModifyUndoStackItem) + use_tuplens[i + k]);
+
+					if (k > 0 && need + one + Max(maxrow, one) > 2 * O_MAX_UNDO_RECORD_SIZE)
+						break;
+					need += one;
+					if (one > maxrow)
+						maxrow = one;
+				}
+				batch = k;
+				need += maxrow;
+				reserve_undo_size(pdesc->undoType, need);
+			}
+			ppool_reserve_pages(pdesc->ppool, PPOOL_RESERVE_INSERT, 2);
+
+			fr = find_page(&ctx, use_keyptrs[i], BTreeKeyBound, 0);
+			Assert(fr == OFindPageResultSuccess);
+
+			n = o_btree_multi_insert_item(&ctx,
+										  use_tuples + i, use_tuplens + i,
+										  use_keyptrs + i, BTreeKeyBound,
+										  batch,
+										  oxid, RowLockUpdate,
+										  &callbackInfo,
+										  use_cb_args + i,
+										  &result);
+
+			for (k = 0; k < n; k++)
+			{
+				orig = idx ? idx[i + k] : i + k;
+				((OTableSlot *) slots[orig])->version = o_tuple_get_version(use_tuples[i + k]);
+				pgstat_count_heap_insert(relation, 1);
+				fire_sk_modify_pending_stopevent(descr);
+			}
+			i += n;
+
+			if (i >= ntuples)
+				break;
+
+			/*
+			 * HikeyCrossed -> re-find the next leaf; Fits with i < ntuples
+			 * means the helper exited because the per-batch undo cap was
+			 * reached, not because of a bail condition -- just re-reserve and
+			 * continue.  Slow path runs only on NoFit / Duplicate.
+			 */
+			if (result == BTreeLeafProbeHikeyCrossed ||
+				result == BTreeLeafProbeFits)
+				continue;
+
+			/*
+			 * Slow path for one item.  Resolve back to the original slot so
+			 * o_report_duplicate and the post-undo callback see the row the
+			 * caller submitted, not the sorted-position alias.
+			 */
+			orig = idx ? idx[i] : i;
+			callbackInfo.arg = slots[orig];
+			if (o_tbl_index_insert(descr, primary, &tuples[orig], slots[orig],
+								   oxid, csn, &callbackInfo,
+								   UNIQUE_CHECK_YES) != OBTreeModifyResultInserted)
+			{
+				o_report_apply_conflict(CT_INSERT_EXISTS);
+				o_report_duplicate(relation, primary, slots[orig]);
+			}
+			else
+			{
+				pgstat_count_heap_insert(relation, 1);
+			}
+			fire_sk_modify_pending_stopevent(descr);
+			i++;
+		}
+	}
+
+	/*
+	 * Release any reservation still held (idempotent if the last iteration
+	 * slow-pathed and the modify already released).
+	 */
+	if (pdesc->undoType != UndoLogNone)
+		release_undo_size(pdesc->undoType);
+	ppool_release_reserved(pdesc->ppool, PPOOL_RESERVE_INSERT_MASK);
+
+	/* Phase 4: per-slot TOAST values + WAL. */
+	for (i = 0; i < ntuples; i++)
+	{
+		TupleTableSlot *slot = slots[i];
+		OTuple		tup;
+
+		o_toast_insert_values(relation, descr, slot, oxid, csn);
+		tup = tts_orioledb_form_tuple(slot, descr);
+
+		if (pdesc->storageType == BTreeStoragePersistence)
+			o_wal_insert(pdesc, tup, relation->rd_rel->relreplident,
+						 descr->version);
+	}
+
+	pfree(tuples);
+	pfree(tuplens);
+	pfree(keys);
+	pfree(keyptrs);
 }
 
 static RowLockMode
@@ -1079,7 +1411,8 @@ o_tbl_insert_with_arbiter(Relation rel,
 
 			ioc_arg.conflictIxNum = InvalidIndexNumber;
 			result = o_tbl_index_insert(descr, descr->indices[i], NULL, slot,
-										oxid, csn, &callbackInfo, UNIQUE_CHECK_YES);
+										oxid, csn, &callbackInfo,
+										UNIQUE_CHECK_YES);
 
 			if (result != OBTreeModifyResultInserted)
 			{

--- a/test/expected/multi_insert.out
+++ b/test/expected/multi_insert.out
@@ -1,0 +1,255 @@
+CREATE SCHEMA multi_insert;
+SET SESSION search_path = 'multi_insert';
+CREATE EXTENSION IF NOT EXISTS orioledb;
+-- The batched same-leaf primary insert path must not change visible
+-- results regardless of the debug GUC.  Each scenario runs both with
+-- the batched path enabled and disabled so a mishap in either branch
+-- would show up as a row-count or ordering diff.
+CREATE TABLE t_ord (
+    id   bigint PRIMARY KEY,
+    val  int,
+    grp  int
+) USING orioledb;
+CREATE INDEX t_ord_val_idx ON t_ord(val);
+CREATE INDEX t_ord_grp_idx ON t_ord(grp);
+-- A) Ordered insert: the hot path.  Run with batched on then off.
+SET orioledb.debug_disable_multi_insert = off;
+INSERT INTO t_ord SELECT i, i * 7, i % 50 FROM generate_series(1, 2000) i;
+SET orioledb.debug_disable_multi_insert = on;
+INSERT INTO t_ord SELECT i, i * 7, i % 50 FROM generate_series(2001, 4000) i;
+SELECT count(*), min(id), max(id), sum(val) FROM t_ord;
+ count | min | max  |   sum    
+-------+-----+------+----------
+  4000 |   1 | 4000 | 56014000
+(1 row)
+
+SELECT count(*) FROM t_ord WHERE val BETWEEN 700 AND 1400;
+ count 
+-------
+   101
+(1 row)
+
+SELECT count(*) FROM t_ord WHERE grp = 7;
+ count 
+-------
+    80
+(1 row)
+
+-- B) Out-of-order insertion: hikey checks must fall back cleanly.
+TRUNCATE t_ord;
+SET orioledb.debug_disable_multi_insert = off;
+INSERT INTO t_ord
+SELECT i, i * 3, i % 13
+FROM   generate_series(1, 1000) i
+ORDER BY md5(i::text);
+SELECT count(*) FROM t_ord;
+ count 
+-------
+  1000
+(1 row)
+
+SELECT count(*) FROM t_ord WHERE val < 1500;
+ count 
+-------
+   499
+(1 row)
+
+-- C) Unique violation still fires under the optimisation.
+SET orioledb.debug_disable_multi_insert = off;
+DO $$
+BEGIN
+    INSERT INTO t_ord VALUES (1, 99, 99);
+    RAISE EXCEPTION 'duplicate accepted';
+EXCEPTION WHEN unique_violation THEN
+    NULL;
+END$$;
+-- D) Reverse-order insert: every row crosses the leaf hikey so the
+-- batched helper must bail and refind_page each time.
+CREATE TABLE t_rev (id bigint PRIMARY KEY, val int) USING orioledb;
+INSERT INTO t_rev
+SELECT i, i FROM generate_series(500, 1, -1) i;
+SELECT count(*), min(id), max(id) FROM t_rev;
+ count | min | max 
+-------+-----+-----
+   500 |   1 | 500
+(1 row)
+
+-- E) Unsorted COPY into explicit-PK table spanning multiple leaves.
+-- This is the regression-tested case: probe must detect BeforeLeaf and
+-- bail to re-find for the out-of-order key, otherwise a row would be
+-- inserted onto a leaf whose lokey is greater than the row's key,
+-- breaking the B-tree downlink invariant.
+CREATE TABLE t_copy_unsorted (id integer PRIMARY KEY, val int) USING orioledb;
+-- Build a multi-leaf tree (about ~80 rows per leaf with the default settings).
+INSERT INTO t_copy_unsorted SELECT i * 10, i FROM generate_series(1, 2000) i;
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_copy_unsorted FROM stdin;
+SELECT count(*) FROM t_copy_unsorted;
+ count 
+-------
+  2006
+(1 row)
+
+-- Each freshly-COPYed row must be reachable via the PK index.
+SELECT id FROM t_copy_unsorted WHERE id IN (1, 3, 7, 9999, 12345, 15555)
+  ORDER BY id;
+  id   
+-------
+     1
+     3
+     7
+  9999
+ 12345
+ 15555
+(6 rows)
+
+-- B-tree integrity: a corrupted downlink would make this fail.
+SELECT orioledb_tbl_check('t_copy_unsorted'::regclass);
+ orioledb_tbl_check 
+--------------------
+ t
+(1 row)
+
+-- F) Larger unsorted COPY through psql's \copy with COPY FROM PROGRAM.
+-- Builds a multi-leaf tree first, then COPYs an interleaving set of
+-- keys in reverse order to keep the monotonicity-fallback path exercised
+-- across multiple leaves.
+CREATE TABLE t_copy_reverse (id integer PRIMARY KEY, val int) USING orioledb;
+INSERT INTO t_copy_reverse SELECT i * 10, i FROM generate_series(1, 5000) i;
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_copy_reverse FROM PROGRAM
+  'for i in $(seq 999 -2 1); do echo "$((50001 + i))\t$i"; done';
+SELECT count(*) FROM t_copy_reverse;
+ count 
+-------
+  5500
+(1 row)
+
+SELECT orioledb_tbl_check('t_copy_reverse'::regclass);
+ orioledb_tbl_check 
+--------------------
+ t
+(1 row)
+
+-- G) In-batch duplicate against existing row: must still surface a
+-- unique violation when the conflict is the first probed.
+CREATE TABLE t_dup_existing (id int PRIMARY KEY, v int) USING orioledb;
+INSERT INTO t_dup_existing VALUES (5, 100);
+SET orioledb.debug_disable_multi_insert = off;
+DO $$
+BEGIN
+    INSERT INTO t_dup_existing VALUES (5, 200), (6, 300);
+    RAISE EXCEPTION 'duplicate accepted';
+EXCEPTION WHEN unique_violation THEN
+    NULL;
+END$$;
+SELECT count(*) FROM t_dup_existing;
+ count 
+-------
+     1
+(1 row)
+
+SELECT orioledb_tbl_check('t_dup_existing'::regclass);
+ orioledb_tbl_check 
+--------------------
+ t
+(1 row)
+
+-- H) Self-created table COPYed in the same transaction.  desc->createOxid
+-- equals the inserting oxid so o_btree_modify_internal's "needsUndo = false"
+-- shortcut fires.  The multi-insert helper mirrors that and the post-undo
+-- callback receives WaitingSkUndoLoc instead of a real undo loc.
+BEGIN;
+CREATE TABLE t_selfcreated (id integer PRIMARY KEY, val int) USING orioledb;
+CREATE INDEX ON t_selfcreated (val);
+SET LOCAL orioledb.debug_disable_multi_insert = off;
+COPY t_selfcreated FROM PROGRAM
+  'for i in $(seq 1 500); do echo "$i\t$((i*3))"; done';
+SELECT count(*) FROM t_selfcreated;
+ count 
+-------
+   500
+(1 row)
+
+SELECT count(*) FROM t_selfcreated WHERE val BETWEEN 100 AND 300;
+ count 
+-------
+    67
+(1 row)
+
+COMMIT;
+SELECT orioledb_tbl_check('t_selfcreated'::regclass);
+ orioledb_tbl_check 
+--------------------
+ t
+(1 row)
+
+-- I) COPY of TOAST-eligible long values.  Phase 1 calls tts_orioledb_toast
+-- to decide what to toast; Phase 3 calls o_toast_insert_values to write
+-- the toast btree entries.  Verify both ends survive a multi-row COPY.
+CREATE TABLE t_toast (id integer PRIMARY KEY, body text) USING orioledb;
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_toast FROM PROGRAM
+  'for i in $(seq 1 200); do
+     printf "%d\t" "$i"
+     printf "X%.0s" $(seq 1 6000)
+     printf "\n"
+   done';
+SELECT count(*), min(length(body)), max(length(body)) FROM t_toast;
+ count | min  | max  
+-------+------+------
+   200 | 6000 | 6000
+(1 row)
+
+-- Verify TOASTed values round-trip intact for a sample of rows.
+SELECT id, length(body) FROM t_toast WHERE id IN (1, 100, 200) ORDER BY id;
+ id  | length 
+-----+--------
+   1 |   6000
+ 100 |   6000
+ 200 |   6000
+(3 rows)
+
+SELECT orioledb_tbl_check('t_toast'::regclass);
+ orioledb_tbl_check 
+--------------------
+ t
+(1 row)
+
+-- J) CTID-PK (no explicit PK) multi-leaf COPY.  Exercises the prefix
+-- contract on monotone CTID keys at scale: Phase 1's btree_ctid_get_and_inc
+-- assigns each row a monotone TID; the helper should drain runs cleanly,
+-- crossing leaf hikeys via HikeyCrossed -> refind.
+CREATE TABLE t_ctid_pk (val int, grp int) USING orioledb;
+CREATE INDEX ON t_ctid_pk (val);
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_ctid_pk FROM PROGRAM
+  'for i in $(seq 1 5000); do echo "$i\t$((i % 47))"; done';
+SELECT count(*), min(val), max(val) FROM t_ctid_pk;
+ count | min | max  
+-------+-----+------
+  5000 |   1 | 5000
+(1 row)
+
+SELECT count(*) FROM t_ctid_pk WHERE val BETWEEN 1000 AND 2000;
+ count 
+-------
+  1001
+(1 row)
+
+SELECT orioledb_tbl_check('t_ctid_pk'::regclass);
+ orioledb_tbl_check 
+--------------------
+ t
+(1 row)
+
+DROP TABLE t_ord;
+DROP TABLE t_rev;
+DROP TABLE t_copy_unsorted;
+DROP TABLE t_copy_reverse;
+DROP TABLE t_dup_existing;
+DROP TABLE t_selfcreated;
+DROP TABLE t_toast;
+DROP TABLE t_ctid_pk;
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA multi_insert CASCADE;

--- a/test/sql/multi_insert.sql
+++ b/test/sql/multi_insert.sql
@@ -1,0 +1,161 @@
+CREATE SCHEMA multi_insert;
+SET SESSION search_path = 'multi_insert';
+CREATE EXTENSION IF NOT EXISTS orioledb;
+
+-- The batched same-leaf primary insert path must not change visible
+-- results regardless of the debug GUC.  Each scenario runs both with
+-- the batched path enabled and disabled so a mishap in either branch
+-- would show up as a row-count or ordering diff.
+
+CREATE TABLE t_ord (
+    id   bigint PRIMARY KEY,
+    val  int,
+    grp  int
+) USING orioledb;
+CREATE INDEX t_ord_val_idx ON t_ord(val);
+CREATE INDEX t_ord_grp_idx ON t_ord(grp);
+
+-- A) Ordered insert: the hot path.  Run with batched on then off.
+SET orioledb.debug_disable_multi_insert = off;
+INSERT INTO t_ord SELECT i, i * 7, i % 50 FROM generate_series(1, 2000) i;
+
+SET orioledb.debug_disable_multi_insert = on;
+INSERT INTO t_ord SELECT i, i * 7, i % 50 FROM generate_series(2001, 4000) i;
+
+SELECT count(*), min(id), max(id), sum(val) FROM t_ord;
+SELECT count(*) FROM t_ord WHERE val BETWEEN 700 AND 1400;
+SELECT count(*) FROM t_ord WHERE grp = 7;
+
+-- B) Out-of-order insertion: hikey checks must fall back cleanly.
+TRUNCATE t_ord;
+SET orioledb.debug_disable_multi_insert = off;
+INSERT INTO t_ord
+SELECT i, i * 3, i % 13
+FROM   generate_series(1, 1000) i
+ORDER BY md5(i::text);
+
+SELECT count(*) FROM t_ord;
+SELECT count(*) FROM t_ord WHERE val < 1500;
+
+-- C) Unique violation still fires under the optimisation.
+SET orioledb.debug_disable_multi_insert = off;
+DO $$
+BEGIN
+    INSERT INTO t_ord VALUES (1, 99, 99);
+    RAISE EXCEPTION 'duplicate accepted';
+EXCEPTION WHEN unique_violation THEN
+    NULL;
+END$$;
+
+-- D) Reverse-order insert: every row crosses the leaf hikey so the
+-- batched helper must bail and refind_page each time.
+CREATE TABLE t_rev (id bigint PRIMARY KEY, val int) USING orioledb;
+INSERT INTO t_rev
+SELECT i, i FROM generate_series(500, 1, -1) i;
+SELECT count(*), min(id), max(id) FROM t_rev;
+
+-- E) Unsorted COPY into explicit-PK table spanning multiple leaves.
+-- This is the regression-tested case: probe must detect BeforeLeaf and
+-- bail to re-find for the out-of-order key, otherwise a row would be
+-- inserted onto a leaf whose lokey is greater than the row's key,
+-- breaking the B-tree downlink invariant.
+CREATE TABLE t_copy_unsorted (id integer PRIMARY KEY, val int) USING orioledb;
+-- Build a multi-leaf tree (about ~80 rows per leaf with the default settings).
+INSERT INTO t_copy_unsorted SELECT i * 10, i FROM generate_series(1, 2000) i;
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_copy_unsorted FROM stdin;
+9999	1
+1	2
+15555	3
+3	4
+12345	5
+7	6
+\.
+SELECT count(*) FROM t_copy_unsorted;
+-- Each freshly-COPYed row must be reachable via the PK index.
+SELECT id FROM t_copy_unsorted WHERE id IN (1, 3, 7, 9999, 12345, 15555)
+  ORDER BY id;
+-- B-tree integrity: a corrupted downlink would make this fail.
+SELECT orioledb_tbl_check('t_copy_unsorted'::regclass);
+
+-- F) Larger unsorted COPY through psql's \copy with COPY FROM PROGRAM.
+-- Builds a multi-leaf tree first, then COPYs an interleaving set of
+-- keys in reverse order to keep the monotonicity-fallback path exercised
+-- across multiple leaves.
+CREATE TABLE t_copy_reverse (id integer PRIMARY KEY, val int) USING orioledb;
+INSERT INTO t_copy_reverse SELECT i * 10, i FROM generate_series(1, 5000) i;
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_copy_reverse FROM PROGRAM
+  'for i in $(seq 999 -2 1); do echo "$((50001 + i))\t$i"; done';
+SELECT count(*) FROM t_copy_reverse;
+SELECT orioledb_tbl_check('t_copy_reverse'::regclass);
+
+-- G) In-batch duplicate against existing row: must still surface a
+-- unique violation when the conflict is the first probed.
+CREATE TABLE t_dup_existing (id int PRIMARY KEY, v int) USING orioledb;
+INSERT INTO t_dup_existing VALUES (5, 100);
+SET orioledb.debug_disable_multi_insert = off;
+DO $$
+BEGIN
+    INSERT INTO t_dup_existing VALUES (5, 200), (6, 300);
+    RAISE EXCEPTION 'duplicate accepted';
+EXCEPTION WHEN unique_violation THEN
+    NULL;
+END$$;
+SELECT count(*) FROM t_dup_existing;
+SELECT orioledb_tbl_check('t_dup_existing'::regclass);
+
+-- H) Self-created table COPYed in the same transaction.  desc->createOxid
+-- equals the inserting oxid so o_btree_modify_internal's "needsUndo = false"
+-- shortcut fires.  The multi-insert helper mirrors that and the post-undo
+-- callback receives WaitingSkUndoLoc instead of a real undo loc.
+BEGIN;
+CREATE TABLE t_selfcreated (id integer PRIMARY KEY, val int) USING orioledb;
+CREATE INDEX ON t_selfcreated (val);
+SET LOCAL orioledb.debug_disable_multi_insert = off;
+COPY t_selfcreated FROM PROGRAM
+  'for i in $(seq 1 500); do echo "$i\t$((i*3))"; done';
+SELECT count(*) FROM t_selfcreated;
+SELECT count(*) FROM t_selfcreated WHERE val BETWEEN 100 AND 300;
+COMMIT;
+SELECT orioledb_tbl_check('t_selfcreated'::regclass);
+
+-- I) COPY of TOAST-eligible long values.  Phase 1 calls tts_orioledb_toast
+-- to decide what to toast; Phase 3 calls o_toast_insert_values to write
+-- the toast btree entries.  Verify both ends survive a multi-row COPY.
+CREATE TABLE t_toast (id integer PRIMARY KEY, body text) USING orioledb;
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_toast FROM PROGRAM
+  'for i in $(seq 1 200); do
+     printf "%d\t" "$i"
+     printf "X%.0s" $(seq 1 6000)
+     printf "\n"
+   done';
+SELECT count(*), min(length(body)), max(length(body)) FROM t_toast;
+-- Verify TOASTed values round-trip intact for a sample of rows.
+SELECT id, length(body) FROM t_toast WHERE id IN (1, 100, 200) ORDER BY id;
+SELECT orioledb_tbl_check('t_toast'::regclass);
+
+-- J) CTID-PK (no explicit PK) multi-leaf COPY.  Exercises the prefix
+-- contract on monotone CTID keys at scale: Phase 1's btree_ctid_get_and_inc
+-- assigns each row a monotone TID; the helper should drain runs cleanly,
+-- crossing leaf hikeys via HikeyCrossed -> refind.
+CREATE TABLE t_ctid_pk (val int, grp int) USING orioledb;
+CREATE INDEX ON t_ctid_pk (val);
+SET orioledb.debug_disable_multi_insert = off;
+COPY t_ctid_pk FROM PROGRAM
+  'for i in $(seq 1 5000); do echo "$i\t$((i % 47))"; done';
+SELECT count(*), min(val), max(val) FROM t_ctid_pk;
+SELECT count(*) FROM t_ctid_pk WHERE val BETWEEN 1000 AND 2000;
+SELECT orioledb_tbl_check('t_ctid_pk'::regclass);
+
+DROP TABLE t_ord;
+DROP TABLE t_rev;
+DROP TABLE t_copy_unsorted;
+DROP TABLE t_copy_reverse;
+DROP TABLE t_dup_existing;
+DROP TABLE t_selfcreated;
+DROP TABLE t_toast;
+DROP TABLE t_ctid_pk;
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA multi_insert CASCADE;

--- a/test/t/multi_insert_test.py
+++ b/test/t/multi_insert_test.py
@@ -12,7 +12,7 @@ correct conflict semantics under concurrency.
 test_ab_ordered_copy A/B-benchmarks orioledb.debug_disable_multi_insert
 to catch regressions in the batched same-leaf primary insert path
 (o_tbl_multi_insert), which orioledb_multi_insert dispatches to for
-COPY-driven bulk loads.  Gated behind RUN_ORIOLEDB_PERF_TESTS=1.
+COPY-driven bulk loads.  Gated behind ORIOLEDB_RUN_PERF=1.
 """
 
 import io
@@ -36,9 +36,9 @@ VALGRIND = os.environ.get('USE_VALGRIND', '') == '1'
 
 # Perf tests cost minutes (valgrind: 5+ minutes for the 1.4M-row benchmark)
 # and add nothing to correctness coverage already in the concurrency cases
-# and test/sql/multi_insert.sql.  Opt in via RUN_ORIOLEDB_PERF_TESTS=1 from
+# and test/sql/multi_insert.sql.  Opt in via ORIOLEDB_RUN_PERF=1 from
 # a dedicated perf CI job or a manual pre-release run.
-PERF_TESTS = os.environ.get('RUN_ORIOLEDB_PERF_TESTS', '') == '1'
+PERF_TESTS = os.environ.get('ORIOLEDB_RUN_PERF', '') == '1'
 
 
 def _build_csv(n: int) -> str:
@@ -201,7 +201,7 @@ class MultiInsertTest(BaseTest):
 		return time.perf_counter() - start
 
 	@unittest.skipUnless(PERF_TESTS,
-	                     "perf test; set RUN_ORIOLEDB_PERF_TESTS=1 to enable")
+	                     "perf test; set ORIOLEDB_RUN_PERF=1 to enable")
 	def test_ab_ordered_copy(self):
 		node = self.node
 		node.start()

--- a/test/t/multi_insert_test.py
+++ b/test/t/multi_insert_test.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""multi_insert tests.
+
+test_concurrent_* exercise the per-leaf lwlock serialization between
+two parallel COPY sessions.  orioledb_multi_insert acquires each
+primary leaf's lwlock via plain lock_page (the helper does not set
+insertTuple, so it does not queue as a waiter on a contended leaf --
+it just blocks).  These tests verify no corruption, no deadlock, and
+correct conflict semantics under concurrency.
+
+test_ab_ordered_copy A/B-benchmarks orioledb.debug_disable_multi_insert
+to catch regressions in the batched same-leaf primary insert path
+(o_tbl_multi_insert), which orioledb_multi_insert dispatches to for
+COPY-driven bulk loads.  Gated behind RUN_ORIOLEDB_PERF_TESTS=1.
+"""
+
+import io
+import os
+import threading
+import time
+import unittest
+
+from .base_test import BaseTest
+
+# Conservative threshold: ON may not be slower than this multiple of OFF.
+# We mainly want to catch a regression, not enforce a guaranteed speedup
+# (which varies by host).
+MAX_ALLOWED_SLOWDOWN = 1.20
+
+RUNS_PER_MODE = 3
+ROWS_PER_RUN = 200_000
+ROWS_PER_SESSION = 5000
+
+VALGRIND = os.environ.get('USE_VALGRIND', '') == '1'
+
+# Perf tests cost minutes (valgrind: 5+ minutes for the 1.4M-row benchmark)
+# and add nothing to correctness coverage already in the concurrency cases
+# and test/sql/multi_insert.sql.  Opt in via RUN_ORIOLEDB_PERF_TESTS=1 from
+# a dedicated perf CI job or a manual pre-release run.
+PERF_TESTS = os.environ.get('RUN_ORIOLEDB_PERF_TESTS', '') == '1'
+
+
+def _build_csv(n: int) -> str:
+	"""Generate an ordered TSV payload (id, val, grp)."""
+	buf = io.StringIO()
+	for i in range(1, n + 1):
+		buf.write(f"{i}\t{i * 7}\t{i % 113}\n")
+	return buf.getvalue()
+
+
+def _csv(payload):
+	"""Wrap a list of (id, val) tuples into a TSV StringIO."""
+	buf = io.StringIO()
+	for row in payload:
+		buf.write(f"{row[0]}\t{row[1]}\n")
+	buf.seek(0)
+	return buf
+
+
+def _run_copy(node, payload, errors):
+	"""Open a connection, run a single COPY, record any exception."""
+	con = node.connect()
+	try:
+		c = con.cursor
+		c.execute("SET orioledb.debug_disable_multi_insert = off")
+		try:
+			c.copy_expert("COPY t (id, val) FROM STDIN", _csv(payload))
+			con.connection.commit()
+		except Exception as e:
+			errors.append(e)
+			try:
+				con.connection.rollback()
+			except Exception:
+				pass
+	finally:
+		con.close()
+
+
+class MultiInsertTest(BaseTest):
+
+	def _prepare_t(self):
+		"""Spin up a fresh table 't' used by the concurrency cases."""
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql("""
+			CREATE TABLE t (
+				id  bigint PRIMARY KEY,
+				val int
+			) USING orioledb;
+			CREATE INDEX t_val_idx ON t(val);
+		""")
+		return node
+
+	def _check_t(self, node, expected_count):
+		con = node.connect()
+		try:
+			c = con.cursor
+			c.execute("SELECT count(*) FROM t")
+			(n, ) = c.fetchone()
+			self.assertEqual(n, expected_count)
+			c.execute("SELECT orioledb_tbl_check('t'::regclass)")
+			(ok, ) = c.fetchone()
+			self.assertTrue(ok, "orioledb_tbl_check returned false")
+		finally:
+			con.close()
+
+	def test_concurrent_disjoint(self):
+		"""Two sessions, disjoint key ranges, same table.
+
+		Both must succeed; no contention loss, tree intact.
+		"""
+		node = self._prepare_t()
+		try:
+			a = [(i, i) for i in range(1, ROWS_PER_SESSION + 1)]
+			b = [(i, i)
+			     for i in range(ROWS_PER_SESSION + 1, 2 * ROWS_PER_SESSION + 1)
+			     ]
+			errors = []
+			ta = threading.Thread(target=_run_copy, args=(node, a, errors))
+			tb = threading.Thread(target=_run_copy, args=(node, b, errors))
+			ta.start()
+			tb.start()
+			ta.join()
+			tb.join()
+			self.assertEqual(errors, [],
+			                 f"unexpected errors: {[str(e) for e in errors]}")
+			self._check_t(node, 2 * ROWS_PER_SESSION)
+		finally:
+			node.stop()
+
+	def test_concurrent_overlapping(self):
+		"""Two sessions, interleaved keys on the same table.
+
+		Session A writes even ids, B writes odd ids.  Both share the same
+		primary leaves so they contend on each leaf's lwlock; the
+		serialization path must produce a consistent tree.
+		"""
+		node = self._prepare_t()
+		try:
+			even = [(i, i) for i in range(2, 2 * ROWS_PER_SESSION + 1, 2)]
+			odd = [(i, i) for i in range(1, 2 * ROWS_PER_SESSION + 1, 2)]
+			errors = []
+			ta = threading.Thread(target=_run_copy, args=(node, even, errors))
+			tb = threading.Thread(target=_run_copy, args=(node, odd, errors))
+			ta.start()
+			tb.start()
+			ta.join()
+			tb.join()
+			self.assertEqual(errors, [],
+			                 f"unexpected errors: {[str(e) for e in errors]}")
+			self._check_t(node, 2 * ROWS_PER_SESSION)
+		finally:
+			node.stop()
+
+	def test_concurrent_same_key_conflict(self):
+		"""Two sessions racing on overlapping PK values.
+
+		Each thread COPYs 1..ROWS_PER_SESSION.  Exactly one row per id
+		should land; the loser raises unique_violation (the entire COPY
+		aborts on first conflict).  Tree must still be consistent.
+		"""
+		node = self._prepare_t()
+		try:
+			payload = [(i, i) for i in range(1, ROWS_PER_SESSION + 1)]
+			errors = []
+			ta = threading.Thread(target=_run_copy,
+			                      args=(node, payload, errors))
+			tb = threading.Thread(target=_run_copy,
+			                      args=(node, payload, errors))
+			ta.start()
+			tb.start()
+			ta.join()
+			tb.join()
+			# Both COPYs ran concurrently.  Either both raced fully and one
+			# saw a unique_violation, or one finished before the other
+			# started and the second saw the conflict.  Either way, exactly
+			# one failure expected.
+			self.assertEqual(
+			    len(errors), 1, f"expected exactly one unique_violation, "
+			    f"got {len(errors)}: {[str(e) for e in errors]}")
+			self.assertIn(
+			    "duplicate key",
+			    str(errors[0]).lower() +
+			    " ".join(str(arg) for arg in errors[0].args).lower())
+			self._check_t(node, ROWS_PER_SESSION)
+		finally:
+			node.stop()
+
+	def _copy_once(self, nodecon, payload: str, mode_on: bool) -> float:
+		c = nodecon.cursor
+		c.execute("SET orioledb.debug_disable_multi_insert = " +
+		          ("off" if mode_on else "on"))
+		c.execute("TRUNCATE t_perf")
+		nodecon.connection.commit()
+		start = time.perf_counter()
+		c.copy_expert("COPY t_perf (id, val, grp) FROM STDIN",
+		              io.StringIO(payload))
+		nodecon.connection.commit()
+		return time.perf_counter() - start
+
+	@unittest.skipUnless(PERF_TESTS,
+	                     "perf test; set RUN_ORIOLEDB_PERF_TESTS=1 to enable")
+	def test_ab_ordered_copy(self):
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql("""
+			CREATE TABLE t_perf (
+				id  bigint PRIMARY KEY,
+				val int,
+				grp int
+			) USING orioledb;
+			CREATE INDEX t_perf_val_idx ON t_perf(val);
+		""")
+
+		payload = _build_csv(ROWS_PER_RUN)
+		nodecon = node.connect()
+		try:
+			# Warm-up so JIT/syscache costs don't taint the first measurement.
+			self._copy_once(nodecon, payload, mode_on=False)
+
+			off_times = [
+			    self._copy_once(nodecon, payload, mode_on=False)
+			    for _ in range(RUNS_PER_MODE)
+			]
+			on_times = [
+			    self._copy_once(nodecon, payload, mode_on=True)
+			    for _ in range(RUNS_PER_MODE)
+			]
+
+			off = min(off_times)
+			on = min(on_times)
+			ratio = on / off if off > 0 else float('inf')
+			speedup_pct = (1.0 - ratio) * 100.0
+
+			print(
+			    f"\n[multi_insert] rows={ROWS_PER_RUN} "
+			    f"off={off:.3f}s on={on:.3f}s "
+			    f"ratio={ratio:.3f} speedup={speedup_pct:+.1f}%",
+			    flush=True)
+
+			nodecon.cursor.execute("SELECT count(*) FROM t_perf")
+			(rowcount, ) = nodecon.cursor.fetchone()
+			self.assertEqual(rowcount, ROWS_PER_RUN)
+
+			if not VALGRIND:
+				self.assertLess(
+				    ratio, MAX_ALLOWED_SLOWDOWN,
+				    f"batched multi_insert should not slow inserts "
+				    f"(off={off:.3f}s, on={on:.3f}s, ratio={ratio:.3f})")
+		finally:
+			nodecon.close()
+		node.stop()
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Drain ordered rows into one locked primary leaf

orioledb_multi_insert previously did one find_page + lwlock cycle per row. For ordered bulk loads (COPY into a CTID-PK table, or any sorted explicit-PK COPY) most rows share a primary leaf with their neighbors, so the per-row descent and lock acquisition are pure overhead.

Now o_tbl_multi_insert() is the four-phase:

  Phase 1  per-slot ctid + bridge ctid + in-row TOAST + form primary tuple
           + key bound.

  Phase 2  optimistically assume keys[] are monotone and just verify with
           an O(n) scan; the common cases (CTID-PK by construction,
           ordered explicit-PK COPY) hit this fast path.  Only on the first
           out-of-order pair do we fall back to qsort_arg-ing by key,
	   and materializing sorted views of tuples / tuplens / keyptrs / cb_args.
           Sorting is required because the leaf probe detects "key past hikey"
	   but not "key before lokey" (lokey lives in the parent, not the leaf),
	   so non-monotone input could corrupt downlinks.

  Phase 3  stream sorted keys through primary leaves, holding each
           leaf's lwlock for as many adjacent keys as fit.  Two safety
           bounds on the per-batch row-undo reservation:

           - Tail slack of one max-row size.  get_undo_record() deducts
             size again on its circular-buffer boundary-cross retry, so
             an exact nitems * per_row reservation underflows on the last
             call when one allocation straddles the wrap.

           - Cap at 2 * O_MAX_UNDO_RECORD_SIZE -- the per-backend share
             the buffer is sized for (see undo_shmem_needs).  Without it,
             max_procs concurrent multi_insert backends could collectively
             reserve more than the buffer holds.  Larger inputs are split
             across successive iterations; a Fits-with-i<ntuples exit
             branch covers the cap path, since it isn't a bail to
             slow-path.

           NoFit / Duplicate -> slow-path one row via o_tbl_index_insert
           and resume; HikeyCrossed -> re-find the next leaf.  Non-orioledb
           input slots fall back to per-row o_tbl_insert.

  Phase 4  per-slot TOAST values + WAL (order-independent).

orioledb_multi_insert() routes to the batched path when orioledb.debug_disable_multi_insert is off (default) and ntuples > 1