### PR TITLE
Don't wait on in-progress re-inserter of a concurrently-deleted key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  btree_scan \
 				  concurrent_update_delete \
 				  fkeys \
+				  forupdate_reinsert \
 				  included \
 				  insert_fails \
 				  ioc_deadlock \

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -208,6 +208,7 @@ extern UndoLocation make_merge_undo_image(BTreeDescr *desc, Pointer left,
 										  Pointer right, CommitSeqNo imageCsn);
 extern bool page_op_drops_tuple(BTreeDescr *desc, Pointer p,
 								CommitSeqNo imageCsn);
+extern bool tuple_is_deleted_for_csn(UndoLogType undoType, BTreeLeafTuphdr *pageTuphdr, CommitSeqNo my_csn);
 extern bool row_lock_conflicts(BTreeLeafTuphdr *pageTuphdr,
 							   BTreeLeafTuphdr *conflictTupHdr,
 							   UndoLogType undoType,

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -68,7 +68,8 @@ typedef enum ConflictResolution
 {
 	ConflictResolutionOK,
 	ConflictResolutionRetry,
-	ConflictResolutionFound
+	ConflictResolutionFound,
+	ConflictResolutionDeleted
 } ConflictResolution;
 
 BTreeModifyCallbackInfo nullCallbackInfo =
@@ -198,6 +199,11 @@ retry:
 			return OBTreeModifyResultFound;
 		else if (resolution == ConflictResolutionRetry)
 			goto retry;
+		else if (resolution == ConflictResolutionDeleted)
+		{
+			unlock_release(&context, true);
+			return OBTreeModifyResultDeleted;
+		}
 	}
 
 	Assert(page_is_locked(blkno) || O_PAGE_IS_LOCAL(blkno));
@@ -553,6 +559,16 @@ o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 				OFindPageResult result PG_USED_FOR_ASSERTS_ONLY;
 
 				Assert(COMMITSEQNO_IS_INPROGRESS(csn));
+
+				if (context->action == BTreeOperationLock &&
+					tuple_is_deleted_for_csn(desc->undoType, tuphdr, context->opCsn))
+				{
+					if (IsolationUsesXactSnapshot() && IsRelationTree(desc))
+						ereport(ERROR,
+								(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+								 errmsg("could not serialize access due to concurrent delete")));
+					return ConflictResolutionDeleted;
+				}
 
 				if (context->callbackInfo->waitCallback)
 				{

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1648,6 +1648,46 @@ clean_chain_has_locks_flag(UndoLogType undoType, UndoLocation location,
 
 
 /*
+ * Lock/Update at snapshot my_csn: return true if the row must be treated as
+ * deleted -- walking the version chain from the top down, the first committed
+ * version (skipping in-progress/aborted/lock-only) is a delete, or a committed
+ * delete is seen before reaching our visible committed version, or the undo
+ * chain breaks before reaching my_csn.  Avoids waiting on an in-progress
+ * re-inserter whose committed delete lies below it in the chain.
+ */
+bool
+tuple_is_deleted_for_csn(UndoLogType undoType, BTreeLeafTuphdr *pageTuphdr,
+						 CommitSeqNo my_csn)
+{
+	BTreeLeafTuphdr cur = *pageTuphdr;
+	UndoLocation retainedUndoLocation = get_snapshot_retained_undo_location(undoType);
+
+	while (true)
+	{
+		if (!XACT_INFO_IS_LOCK_ONLY(cur.xactInfo))
+		{
+			CommitSeqNo csn = oxid_get_csn(XACT_INFO_GET_OXID(cur.xactInfo), false);
+
+			if (!COMMITSEQNO_IS_INPROGRESS(csn) && !COMMITSEQNO_IS_ABORTED(csn))
+			{
+				/* committed version */
+				if (cur.deleted != BTreeLeafTupleNonDeleted)
+					return true;
+				if (csn < my_csn)
+					return false;
+				/* committed live but csn >= my_csn: keep walking */
+			}
+			/* in-progress or aborted: skip */
+		}
+		if (!UndoLocationIsValid(cur.undoLocation) ||
+			cur.undoLocation < retainedUndoLocation)
+			return true;
+		if (!get_prev_leaf_header_from_undo_if_exists(undoType, &cur))
+			return true;
+	}
+}
+
+/*
  * Check for row-level lock conflict
  *
  * Returns true if lock conflict.  On lock conflict places the conflicting undo

--- a/test/expected/forupdate_reinsert.out
+++ b/test/expected/forupdate_reinsert.out
@@ -1,0 +1,15 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1_snapshot s2_delete s3_reinsert s1_forupdate s3_commit s1_commit
+step s1_snapshot: SELECT count(*) FROM fu_reins;
+count
+-----
+    3
+(1 row)
+
+step s2_delete: DELETE FROM fu_reins WHERE id = 5;
+step s3_reinsert: INSERT INTO fu_reins VALUES (5, 200);
+step s1_forupdate: SELECT id FROM fu_reins ORDER BY id ASC LIMIT 1 FOR UPDATE;
+ERROR:  could not serialize access due to concurrent delete
+step s3_commit: COMMIT;
+step s1_commit: COMMIT;

--- a/test/specs/forupdate_reinsert.spec
+++ b/test/specs/forupdate_reinsert.spec
@@ -1,0 +1,37 @@
+# Regression test: SELECT ... FOR UPDATE must not wait on the in-progress
+# re-inserter of a key whose committed DELETE happened after our snapshot.
+# s1 fixes an RR snapshot while key 5 is alive; s2 deletes key 5 (commits);
+# s3 re-inserts key 5 (in-progress); s1's FOR UPDATE for the minimum key must
+# raise a serialization error immediately, NOT block on s3.
+
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+	CREATE TABLE fu_reins (
+		id int NOT NULL,
+		val int NOT NULL,
+		PRIMARY KEY (id)
+	) USING orioledb;
+	INSERT INTO fu_reins VALUES (5, 100), (10, 100), (20, 100);
+}
+
+teardown
+{
+	DROP TABLE fu_reins;
+}
+
+session "s1"
+setup { BEGIN ISOLATION LEVEL REPEATABLE READ; }
+step "s1_snapshot"  { SELECT count(*) FROM fu_reins; }
+step "s1_forupdate" { SELECT id FROM fu_reins ORDER BY id ASC LIMIT 1 FOR UPDATE; }
+step "s1_commit"    { COMMIT; }
+
+session "s2"
+step "s2_delete"    { DELETE FROM fu_reins WHERE id = 5; }
+
+session "s3"
+setup { BEGIN; }
+step "s3_reinsert"  { INSERT INTO fu_reins VALUES (5, 200); }
+step "s3_commit"    { COMMIT; }
+
+permutation "s1_snapshot" "s2_delete" "s3_reinsert" "s1_forupdate" "s3_commit" "s1_commit"


### PR DESCRIPTION
## Problem

`SELECT ... FOR UPDATE` could block on the **in-progress transaction that
re-inserted a tuple with the same primary key** whose `DELETE` had already
**committed after the waiter's snapshot**.

OrioleDB links a delete plus a later same-key re-insert into a single undo
chain. When resolving a lock conflict, the code walked up to the in-progress
top version and waited on it, instead of recognizing the committed delete
below it in the chain and treating the row as gone. Under `REPEATABLE READ` /
`SERIALIZABLE` this should be an immediate serialization error, not a wait on
a re-insert that is invisible to us.

Deterministic repro (3 sessions): s1 fixes an RR snapshot while key 5 is alive;
s2 deletes key 5 and commits; s3 re-inserts key 5 (in-progress); s1's
`... ORDER BY id LIMIT 1 FOR UPDATE` blocks on s3 until timeout. Expected:
immediate `could not serialize access due to concurrent delete`.

## Fix

In `o_btree_modify_handle_conflicts`, before `wait_for_tuple` and **only for
`BTreeOperationLock`**, walk the version chain via the new
`tuple_is_deleted_for_csn()`: if the first committed version is a delete, or
the undo chain breaks before reaching our snapshot's csn, raise a
serialization error (RR/SERIALIZABLE) or return `OBTreeModifyResultDeleted`
instead of blocking on the invisible re-inserter.

Uses `oxid_get_csn()` for per-version csn (not `XACT_INFO_MAP_CSN`, which
returns 0 for in-progress).

## Testing

- New isolation test `forupdate_reinsert` (fails before the fix — blocks;
  passes after — serialization error).
- `isolationcheck` 31/31 and `regresscheck` 46/46 pass locally.
- Validated on an optimized (`--disable-cassert`) build in **both** the FETCH
  and IMAGE iterator modes.

## Notes / open items (draft)

- Scope is limited to `BTreeOperationLock`. Extending to `Update` reintroduced
  `concurrent_update_delete` failures (update-over-deleted / pkey-change
  semantics) and a WAL assert, so it is left out for now.
- The chain walk fires on every in-progress `FOR UPDATE` lock conflict and adds
  ~13% overhead to the TPCC delivery convoy under the FETCH iterator (no cost
  under IMAGE). It could be gated to `IsolationUsesXactSnapshot()` (TPCC
  delivery is READ COMMITTED, where the spurious wait is a liveness rather than
  correctness issue) to remove that overhead — not done here pending review.
- This bug is not the cause of the FETCH-vs-IMAGE TPCC throughput difference
  (new_order never reuses a primary key, so same-key delete+reinsert does not
  occur there); it is a separate correctness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
