### PR TITLE
Execute row-array IN() lists pointwise instead of whole-warehouse scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ REGRESSCHECKS = btree_sys_check \
 				partial \
 				partition \
 				primary_key \
+				row_array_in \
 				row_level_locks \
 				row_security \
 				sanitizers \

--- a/include/tableam/index_scan.h
+++ b/include/tableam/index_scan.h
@@ -36,6 +36,31 @@ typedef struct OScanState
 	OBTreeKeyRange curKeyRange;
 	BTreeIterator *iterator;
 	List	   *indexQuals;
+
+	/*
+	 * Row-array-IN pointwise mode.  When a qual of the form "(c1,...,ck) IN
+	 * ((v11,...,v1k), ...)" pins a set of full multi-column index keys, we
+	 * iterate the N tuples as N exact point lookups instead of one
+	 * prefix-bounded whole-index scan.  rowArrayNKeys is the number of key
+	 * columns each arm pins (== index nUniqueFields); rowArrayNTuples the
+	 * number of arms; rowArrayKeyExprs is a flat array of ExprState* of
+	 * length rowArrayNTuples * rowArrayNKeys (arm-major order) evaluated at
+	 * rescan; rowArrayCurTuple is the current arm index during iteration.
+	 * When rowArrayNTuples == 0 this mode is inactive and the scan behaves as
+	 * before.
+	 */
+	int			rowArrayNKeys;
+	int			rowArrayNTuples;
+	int			rowArrayCurTuple;
+	struct ExprState **rowArrayKeyExprs;
+	/* evaluated per-arm key values, valid after rescan; length as above */
+	Datum	   *rowArrayValues;
+	bool	   *rowArrayNulls;
+	/* per key column: index field type, for building bounds */
+	Oid		   *rowArrayKeyTypes;
+	/* arm indices in key order (asc), skipping NULL-bearing arms */
+	int		   *rowArrayOrder;
+	int			rowArrayNValid;
 	/* used only by direct modify functions */
 	CmdType		cmd;
 	OSnapshot	oSnapshot;
@@ -54,6 +79,17 @@ typedef struct OIndexPlanState
 	int			iss_NumRuntimeKeys;
 	bool		iss_RuntimeKeysReady;
 	ExprContext *iss_RuntimeContext;
+
+	/*
+	 * Row-array-IN pointwise mode metadata carried from the plan.  The value
+	 * expressions (arm-major, key-position order; length ntuples*nkeys) are
+	 * initialized into ExprState in o_begin_custom_scan and evaluated at
+	 * rescan.  rowArrayNTuples == 0 means the mode is inactive.
+	 */
+	List	   *rowArrayKeyExprList;
+	int			rowArrayNTuples;
+	int			rowArrayNKeys;
+	Oid		   *rowArrayKeyTypes;
 
 	/*
 	 * Keep the index relation open for the lifetime of the scan so that

--- a/include/tableam/key_range.h
+++ b/include/tableam/key_range.h
@@ -73,4 +73,11 @@ extern bool o_key_data_to_key_range(OBTreeKeyRange *res,
 									int resultNKeys,
 									OIndexField *fields);
 
+extern bool o_exact_key_range_from_values(OBTreeKeyRange *res,
+										  Datum *values,
+										  const Oid *types,
+										  int nPinned,
+										  int resultNKeys,
+										  OIndexField *fields);
+
 #endif

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -324,6 +324,72 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	if (!so->qual_ok)
 		return false;
 
+	/*
+	 * Row-array-IN mode: iterate the list of per-tuple ranges.  Each range
+	 * pins the same contiguous leading prefix (rowArrayNKeys columns).  When
+	 * the prefix covers the whole key it is a point lookup (exact); otherwise
+	 * it is a prefix range served by an iterator.  rowArrayOrder holds the
+	 * arm indices in key order (ascending); we walk it forward or backward
+	 * according to the scan direction so the output matches the index order
+	 * the plan promised.
+	 */
+	if (ostate->rowArrayNTuples > 0)
+	{
+		int			ord;
+		int			totalNKeys = indexDescr->nonLeafTupdesc->natts;
+
+		if (!ostate->curKeyRangeIsLoaded)
+			ostate->rowArrayCurTuple = 0;
+		else
+			ostate->rowArrayCurTuple++;
+		ostate->curKeyRangeIsLoaded = true;
+
+		if (ostate->rowArrayCurTuple >= ostate->rowArrayNValid)
+		{
+			ostate->exact = false;
+			return false;
+		}
+
+		if (ostate->iterator != NULL)
+		{
+			btree_iterator_free(ostate->iterator);
+			ostate->iterator = NULL;
+		}
+
+		/* forward walks ascending, backward walks descending */
+		if (ostate->scanDir == BackwardScanDirection)
+			ord = ostate->rowArrayOrder[ostate->rowArrayNValid - 1 -
+										ostate->rowArrayCurTuple];
+		else
+			ord = ostate->rowArrayOrder[ostate->rowArrayCurTuple];
+
+		oldcontext = MemoryContextSwitchTo(ostate->cxt);
+		ostate->exact =
+			o_exact_key_range_from_values(&ostate->curKeyRange,
+										  &ostate->rowArrayValues[ord * ostate->rowArrayNKeys],
+										  ostate->rowArrayKeyTypes,
+										  ostate->rowArrayNKeys,
+										  totalNKeys,
+										  indexDescr->fields);
+
+		if (!ostate->exact)
+		{
+			bound = (ostate->scanDir == ForwardScanDirection
+					 ? &ostate->curKeyRange.low
+					 : &ostate->curKeyRange.high);
+			ostate->iterator = o_btree_iterator_create(&indexDescr->desc,
+													   (Pointer) bound,
+													   BTreeKeyBound,
+													   &ostate->oSnapshot,
+													   ostate->scanDir);
+			o_btree_iterator_set_tuple_ctx(ostate->iterator, tupleCxt);
+		}
+
+		MemoryContextSwitchTo(oldcontext);
+
+		return true;
+	}
+
 #if PG_VERSION_NUM >= 170000
 
 	if (so->numArrayKeys)

--- a/src/tableam/key_range.c
+++ b/src/tableam/key_range.c
@@ -353,6 +353,58 @@ o_key_data_to_key_range(OBTreeKeyRange *res, ScanKeyData *keyData,
 	return exact;
 }
 
+/*
+ * Build a per-tuple key range that pins a contiguous leading prefix.
+ *
+ * Used by the row-array-IN scan mode: each OR arm of a "(c1..cj) IN (...)"
+ * qual pins the first nPinned key columns to exact equality values, leaving
+ * the remaining (resultNKeys - nPinned) columns unbounded.  The pinned columns
+ * are set inclusive with low == high; the rest get -inf/+inf.  The value types
+ * are given per pinned column in types[]; NULLs are not accepted here (callers
+ * must skip NULL-bearing arms, since equality never matches NULL).
+ *
+ * Returns true if the resulting range is exact (nPinned == resultNKeys, i.e. a
+ * point lookup), false if it is a prefix range (nPinned < resultNKeys).
+ */
+bool
+o_exact_key_range_from_values(OBTreeKeyRange *res, Datum *values,
+							  const Oid *types, int nPinned,
+							  int resultNKeys, OIndexField *fields)
+{
+	int			i;
+
+	res->empty = false;
+	res->low.nkeys = resultNKeys;
+	res->high.nkeys = resultNKeys;
+	res->low.n_row_keys = 0;
+	res->high.n_row_keys = 0;
+
+	for (i = 0; i < resultNKeys; i++)
+	{
+		OIndexField *field = &fields[i];
+		OBTreeValueBound low = {0, 0, O_VALUE_BOUND_MINUS_INFINITY, NULL, NULL};
+		OBTreeValueBound high = {0, 0, O_VALUE_BOUND_PLUS_INFINITY, NULL, NULL};
+
+		if (i < nPinned)
+		{
+			Oid			type = types[i];
+
+			low.flags = O_VALUE_BOUND_LOWER | O_VALUE_BOUND_INCLUSIVE;
+			high.flags = O_VALUE_BOUND_UPPER | O_VALUE_BOUND_INCLUSIVE;
+
+			if (!OidIsValid(type))
+				type = field->inputtype;
+
+			o_fill_key_bounds(values[i], type, &low, &high, field);
+		}
+
+		res->low.keys[i] = low;
+		res->high.keys[i] = high;
+	}
+
+	return nPinned == resultNKeys;
+}
+
 static void
 o_fill_key_bounds(Datum v, Oid type,
 				  OBTreeValueBound *low, OBTreeValueBound *high,

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -45,8 +45,10 @@
 #include "optimizer/restrictinfo.h"
 #include "optimizer/plancat.h"
 #include "optimizer/planmain.h"
+#include "parser/parse_coerce.h"
 #include "parser/parsetree.h"
 #include "utils/json.h"
+#include "utils/datum.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
@@ -91,6 +93,14 @@ static void o_rescan_custom_scan(CustomScanState *node);
 static void o_explain_custom_scan(CustomScanState *node, List *ancestors,
 								  ExplainState *es);
 static Node *o_create_custom_scan_state(CustomScan *cscan);
+static bool o_extract_row_array_keys(OIndexDescr *primary, Index scanrelid,
+									 bool prefixUsesIndexVars,
+									 bool qpqualUsesIndexVars,
+									 List *indexqual, List *qpqual,
+									 List **out_key_exprs, int *out_ntuples,
+									 int *out_nkeys, List **out_key_types);
+static void o_maybe_inject_row_array_path(PlannerInfo *root, RelOptInfo *rel,
+										  OTableDescr *descr);
 
 static CustomPathMethods o_path_methods =
 {
@@ -195,6 +205,123 @@ transform_path(Path *src_path, OTableDescr *descr)
 		result->custom_private = list_make1(new_path);
 	}
 	return &result->path;
+}
+
+/*
+ * If the rel has a row-array-IN on a contiguous prefix of the primary key but
+ * no primary index path was generated to serve it pointwise (e.g. a covering
+ * secondary index whose leading column matches only the common prefix wins, or
+ * a parameterized/generic plan where no common leading value is known), inject
+ * a full primary index scan path.  The row-array-IN OR (and any planner-derived
+ * leading equality) stays in baserestrictinfo and becomes the scan's qpqual,
+ * which o_plan_custom_path turns into N per-tuple probes.
+ *
+ * This works for SELECT and for UPDATE/DELETE: the primary index scan is
+ * transformed into an o_scan that already emits the row identity (rowid) the
+ * ModifyTable node needs, exactly like a planner-generated primary index
+ * UPDATE/DELETE scan.
+ */
+static bool
+o_rel_is_rowmarked(PlannerInfo *root, Index relid)
+{
+	ListCell   *lc;
+
+	foreach(lc, root->rowMarks)
+	{
+		PlanRowMark *rc = lfirst_node(PlanRowMark, lc);
+
+		if (rc->rti == relid)
+			return true;
+	}
+	return false;
+}
+
+static void
+o_maybe_inject_row_array_path(PlannerInfo *root, RelOptInfo *rel,
+							  OTableDescr *descr)
+{
+	OIndexDescr *primary = GET_PRIMARY(descr);
+	IndexOptInfo *primaryIndex = NULL;
+	ListCell   *lc;
+	bool		matched = false;
+	List	   *dummyExprs;
+	int			dummyNTuples,
+				dummyNKeys;
+	List	   *dummyTypes;
+
+	if (o_rel_is_rowmarked(root, rel->relid))
+		return;
+
+	if (primary->primaryIsCtid || primary->nUniqueFields <= 1)
+		return;
+
+	foreach(lc, rel->indexlist)
+	{
+		IndexOptInfo *index = (IndexOptInfo *) lfirst(lc);
+
+		if (index->indexoid == primary->oids.reloid)
+		{
+			primaryIndex = index;
+			break;
+		}
+	}
+	if (primaryIndex == NULL)
+		return;
+
+	/*
+	 * Split the base restrict clauses into the row-array-IN OR and the plain
+	 * equalities the planner may have derived alongside it (e.g. a common
+	 * "o_w_id = const" pulled out of the OR).  Those equalities pin the
+	 * shared leading prefix, so pass them as the "prefix"
+	 * (indexqual-equivalent) with table-var resolution; the OR is the qpqual.
+	 */
+	{
+		List	   *orClauses = NIL;
+		List	   *eqClauses = NIL;
+
+		foreach(lc, rel->baserestrictinfo)
+		{
+			RestrictInfo *rinfo = (RestrictInfo *) lfirst(lc);
+			Node	   *clause = (Node *) rinfo->clause;
+
+			if (IsA(clause, BoolExpr) &&
+				((BoolExpr *) clause)->boolop == OR_EXPR)
+				orClauses = lappend(orClauses, clause);
+			else if (IsA(clause, OpExpr))
+				eqClauses = lappend(eqClauses, clause);
+		}
+
+		if (list_length(orClauses) == 1 &&
+			!o_rel_is_rowmarked(root, rel->relid) &&
+			o_extract_row_array_keys(primary, rel->relid, false, false,
+									 eqClauses, orClauses,
+									 &dummyExprs, &dummyNTuples,
+									 &dummyNKeys, &dummyTypes))
+			matched = true;
+	}
+	if (!matched)
+		return;
+
+	{
+		IndexPath  *ipath;
+		double		nprobes = (double) dummyNTuples;
+		Cost		per_probe = 2.0 * cpu_operator_cost * primary->nUniqueFields
+			+ random_page_cost;
+
+		ipath = create_index_path(root, primaryIndex,
+								  NIL, NIL, NIL, NIL,
+								  ForwardScanDirection,
+								  false,
+								  rel->lateral_relids, 1.0, false);
+
+		if (ipath != NULL)
+		{
+			ipath->path.startup_cost = 0.0;
+			ipath->path.total_cost = nprobes * per_probe +
+				ipath->path.rows * cpu_tuple_cost;
+			add_path(rel, (Path *) ipath);
+		}
+	}
 }
 
 bool
@@ -340,6 +467,8 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 			descr = relation_get_descr(relation);
 			Assert(descr != NULL);
 
+			o_maybe_inject_row_array_path(root, rel, descr);
+
 			/*
 			 * transform all postgres scans to custom scans
 			 */
@@ -416,6 +545,344 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 }
 
 /*
+ * Detect a "row-array-IN" qual that pins the same contiguous leading prefix
+ * of the primary key across every OR arm, so the scan can iterate the N
+ * tuples as N per-tuple probes instead of one whole-index prefix scan.
+ *
+ * Given key columns (c1..cn), we handle "(c1..cj) IN (list)" for any leading
+ * prefix length j (1 <= j <= n) where every OR arm pins the SAME contiguous
+ * leading prefix c1..cj to exact equality values.  Each resulting per-tuple
+ * range sets the first j key columns exact and leaves the rest unbounded:
+ *   - j == n -> a point lookup (ostate->exact);
+ *   - j <  n -> a prefix range scan (iterator path), exactly like
+ *               "WHERE c1=.. AND .. AND cj=..".
+ *
+ * We look for exactly one top-level BoolExpr(OR) among the qpqual clauses
+ * where every arm is a conjunction of btree-equalities "keycol = value".
+ * Equalities may also come from the leading index cond (indexqual); those are
+ * shared by all arms.  Value expressions must not reference the scan relation
+ * itself (they must be evaluable as runtime keys).
+ *
+ * On success returns true and sets *out_key_exprs to a flat List (arm-major,
+ * key-position order) of value Exprs of length ntuples*j, *out_ntuples = N,
+ * *out_nkeys = j (the pinned prefix length), and *out_key_types to a List of j
+ * Oid (Integer nodes), one per pinned key position.  On any mismatch returns
+ * false and leaves the outputs unchanged (caller keeps existing behavior).
+ *
+ * The OR clause is intentionally left in the qpqual as a cheap recheck so
+ * results are guaranteed identical for all inputs.
+ */
+static bool
+o_extract_row_array_keys(OIndexDescr *primary, Index scanrelid,
+						 bool prefixUsesIndexVars, bool qpqualUsesIndexVars,
+						 List *indexqual, List *qpqual,
+						 List **out_key_exprs, int *out_ntuples,
+						 int *out_nkeys, List **out_key_types)
+{
+	int			nkeys = primary->nUniqueFields;
+	int		   *keyForAttnum;
+	int			maxAttnum;
+	Expr	  **prefixExpr;
+	Oid		   *prefixType;
+	bool	   *prefixSet;
+	int			prefixLen;		/* contiguous prefix pinned by index cond */
+	BoolExpr   *orExpr = NULL;
+	ListCell   *lc;
+	List	   *armKeyExprs = NIL;
+	List	   *keyTypes = NIL;
+	int			ntuples;
+	int			coverLen = -1;	/* pinned prefix length, shared by all arms */
+	int			i;
+	bool		ok = true;
+
+	if (nkeys <= 1 || nkeys > INDEX_MAX_KEYS)
+		return false;
+	/* Only the plain user-defined primary key, not a surrogate ctid pkey */
+	if (primary->primaryIsCtid)
+		return false;
+
+	/* Find exactly one top-level OR BoolExpr in the qpqual. */
+	foreach(lc, qpqual)
+	{
+		Node	   *clause = (Node *) lfirst(lc);
+
+		if (IsA(clause, BoolExpr) && ((BoolExpr *) clause)->boolop == OR_EXPR)
+		{
+			if (orExpr != NULL)
+				return false;	/* more than one OR: bail */
+			orExpr = (BoolExpr *) clause;
+		}
+	}
+	if (orExpr == NULL || list_length(orExpr->args) < 2)
+		return false;
+
+	/*
+	 * Build the table-attnum -> key-position map for the primary key columns.
+	 * tableAttnums[keypos] is the (1-based) table attnum for key position
+	 * keypos.
+	 */
+	maxAttnum = primary->maxTableAttnum;
+	if (maxAttnum <= 0)
+		return false;
+	keyForAttnum = (int *) palloc(sizeof(int) * (maxAttnum + 1));
+	for (i = 0; i <= maxAttnum; i++)
+		keyForAttnum[i] = -1;
+	for (i = 0; i < nkeys; i++)
+	{
+		AttrNumber	tattno = primary->tableAttnums[i];
+
+		if (tattno <= 0 || tattno > maxAttnum)
+			return false;
+		keyForAttnum[tattno] = i;
+	}
+
+	prefixExpr = (Expr **) palloc0(sizeof(Expr *) * nkeys);
+	prefixType = (Oid *) palloc0(sizeof(Oid) * nkeys);
+	prefixSet = (bool *) palloc0(sizeof(bool) * nkeys);
+
+	/*
+	 * Collect leading equalities pinned by the index cond.  These use
+	 * INDEX_VAR with varattno = index attribute number; for the primary index
+	 * the index attribute i maps to key position i-1.  We only accept plain
+	 * scalar equalities (single constant/param RHS) here; SAOP index conds
+	 * are not eligible for the pointwise expansion.
+	 */
+	foreach(lc, indexqual)
+	{
+		Node	   *clause = (Node *) lfirst(lc);
+		OpExpr	   *op;
+		Node	   *lhs,
+				   *rhs;
+		Var		   *var;
+		int			keypos;
+
+		if (!IsA(clause, OpExpr))
+			return false;		/* e.g. SAOP: not a clean pointwise prefix */
+		op = (OpExpr *) clause;
+		if (list_length(op->args) != 2)
+			return false;
+		lhs = (Node *) linitial(op->args);
+		rhs = (Node *) lsecond(op->args);
+		if (!IsA(lhs, Var))
+			return false;
+		var = (Var *) lhs;
+		if (prefixUsesIndexVars)
+		{
+			if (var->varno != INDEX_VAR)
+				return false;
+			keypos = var->varattno - 1;
+			if (keypos < 0 || keypos >= nkeys)
+				return false;
+		}
+		else
+		{
+			if (var->varno != scanrelid || var->varattno <= 0 ||
+				var->varattno > maxAttnum)
+				return false;
+			keypos = keyForAttnum[var->varattno];
+			if (keypos < 0)
+				return false;
+		}
+		if (get_op_opfamily_strategy(op->opno,
+									 primary->fields[keypos].opfamily)
+			!= BTEqualStrategyNumber)
+			return false;
+		/* value must not depend on the scan relation */
+		if (bms_is_member(scanrelid, pull_varnos(NULL, rhs)))
+			return false;
+		if (prefixSet[keypos])
+			return false;
+		prefixExpr[keypos] = (Expr *) rhs;
+		prefixType[keypos] = exprType(rhs);
+		prefixSet[keypos] = true;
+	}
+
+	/*
+	 * The index-cond equalities must themselves form a contiguous leading
+	 * prefix (they always do for the OrioleDB scan-key builder, but verify).
+	 */
+	prefixLen = 0;
+	while (prefixLen < nkeys && prefixSet[prefixLen])
+		prefixLen++;
+	for (i = prefixLen; i < nkeys; i++)
+	{
+		if (prefixSet[i])
+			return false;		/* gap in the index-cond prefix */
+	}
+
+	/*
+	 * Walk the OR arms.  Each arm's equalities, together with the shared
+	 * index-cond prefix, must pin the SAME contiguous leading prefix c1..cj.
+	 */
+	ntuples = list_length(orExpr->args);
+	foreach(lc, orExpr->args)
+	{
+		Node	   *arm = (Node *) lfirst(lc);
+		List	   *conj;
+		ListCell   *lc2;
+		Expr	  **armExpr = (Expr **) palloc0(sizeof(Expr *) * nkeys);
+		Oid		   *armType = (Oid *) palloc0(sizeof(Oid) * nkeys);
+		bool	   *armSet = (bool *) palloc0(sizeof(bool) * nkeys);
+		int			j;
+		int			k;
+
+		if (IsA(arm, BoolExpr) && ((BoolExpr *) arm)->boolop == AND_EXPR)
+			conj = ((BoolExpr *) arm)->args;
+		else
+			conj = list_make1(arm);
+
+		foreach(lc2, conj)
+		{
+			Node	   *clause = (Node *) lfirst(lc2);
+			OpExpr	   *op;
+			Node	   *lhs,
+					   *rhs;
+			Var		   *var;
+			int			keypos;
+			Relids		rhs_relids;
+
+			if (!IsA(clause, OpExpr))
+			{
+				ok = false;
+				break;
+			}
+			op = (OpExpr *) clause;
+			if (list_length(op->args) != 2)
+			{
+				ok = false;
+				break;
+			}
+			lhs = (Node *) linitial(op->args);
+			rhs = (Node *) lsecond(op->args);
+			if (!IsA(lhs, Var))
+			{
+				ok = false;
+				break;
+			}
+			var = (Var *) lhs;
+
+			/*
+			 * Arm vars reference either the scan relation (plain IndexScan
+			 * qpqual, by table attnum) or INDEX_VAR (IndexOnlyScan qpqual, by
+			 * index attribute = key position + 1).
+			 */
+			if (qpqualUsesIndexVars)
+			{
+				if (var->varno != INDEX_VAR)
+				{
+					ok = false;
+					break;
+				}
+				keypos = var->varattno - 1;
+				if (keypos < 0 || keypos >= nkeys)
+				{
+					ok = false;
+					break;
+				}
+			}
+			else
+			{
+				if (var->varno != scanrelid || var->varattno <= 0 ||
+					var->varattno > maxAttnum)
+				{
+					ok = false;
+					break;
+				}
+				keypos = keyForAttnum[var->varattno];
+				if (keypos < 0)
+				{
+					ok = false;
+					break;
+				}
+			}
+			if (get_op_opfamily_strategy(op->opno,
+										 primary->fields[keypos].opfamily)
+				!= BTEqualStrategyNumber)
+			{
+				ok = false;
+				break;
+			}
+			/* value must not depend on the scan relation */
+			rhs_relids = pull_varnos(NULL, rhs);
+			if (bms_is_member(scanrelid, rhs_relids))
+			{
+				ok = false;
+				break;
+			}
+			if (armSet[keypos] || prefixSet[keypos])
+			{
+				/* duplicate / conflicts with the fixed prefix */
+				ok = false;
+				break;
+			}
+			armExpr[keypos] = (Expr *) rhs;
+			armType[keypos] = exprType(rhs);
+			armSet[keypos] = true;
+		}
+
+		if (!ok)
+			break;
+
+		/* Merge the shared prefix into this arm's coverage */
+		for (k = 0; k < prefixLen; k++)
+		{
+			armExpr[k] = prefixExpr[k];
+			armType[k] = prefixType[k];
+			armSet[k] = true;
+		}
+
+		/* Combined coverage must be a contiguous leading prefix c1..cj */
+		j = 0;
+		while (j < nkeys && armSet[j])
+			j++;
+		if (j == 0)
+		{
+			ok = false;
+			break;
+		}
+		for (k = j; k < nkeys; k++)
+		{
+			if (armSet[k])
+			{
+				ok = false;		/* gap: not a contiguous leading prefix */
+				break;
+			}
+		}
+		if (!ok)
+			break;
+
+		/* All arms must pin the same prefix length */
+		if (coverLen == -1)
+			coverLen = j;
+		else if (coverLen != j)
+		{
+			ok = false;
+			break;
+		}
+
+		for (k = 0; k < j; k++)
+			armKeyExprs = lappend(armKeyExprs, armExpr[k]);
+	}
+
+	if (!ok || coverLen <= 0)
+		return false;
+
+	/* Build the per-key type list (coverLen positions) from the first arm. */
+	for (i = 0; i < coverLen; i++)
+	{
+		Expr	   *e = (Expr *) list_nth(armKeyExprs, i);
+
+		keyTypes = lappend(keyTypes, makeInteger((int) exprType((Node *) e)));
+	}
+
+	*out_key_exprs = armKeyExprs;
+	*out_ntuples = ntuples;
+	*out_nkeys = coverLen;
+	*out_key_types = keyTypes;
+	return true;
+}
+
+/*
  * Creates orioledb CustomScan plan from orioledb CustomPath.
  */
 static Plan *
@@ -463,6 +930,10 @@ o_plan_custom_path(PlannerInfo *root, RelOptInfo *rel,
 	{
 		OIndexPath *ix_path = (OIndexPath *) o_path;
 		bool		onlyCurIx = IsA(custom_plan, IndexOnlyScan);
+		List	   *rowArrayExprs = NIL;
+		int			rowArrayNTuples = 0;
+		int			rowArrayNKeys = 0;
+		List	   *rowArrayKeyTypes = NIL;
 
 		if (custom_plans && IsA(custom_plan, IndexScan))
 		{
@@ -471,6 +942,20 @@ o_plan_custom_path(PlannerInfo *root, RelOptInfo *rel,
 			plan->targetlist = ix_scan->scan.plan.targetlist;
 			custom_scan->custom_scan_tlist = NIL;
 			qpqual = ix_scan->scan.plan.qual;
+
+			/*
+			 * Try to recognize a row-array-IN on the primary key so we can do
+			 * N exact point lookups instead of a whole-index prefix scan.
+			 */
+			if (ix_path->ix_num == PrimaryIndexNumber)
+			{
+				OIndexDescr *primary = GET_PRIMARY(descr);
+
+				o_extract_row_array_keys(primary, rel->relid, true, false,
+										 ix_scan->indexqual, qpqual,
+										 &rowArrayExprs, &rowArrayNTuples,
+										 &rowArrayNKeys, &rowArrayKeyTypes);
+			}
 		}
 		else if (custom_plans && IsA(custom_plan, IndexOnlyScan))
 		{
@@ -479,15 +964,38 @@ o_plan_custom_path(PlannerInfo *root, RelOptInfo *rel,
 			plan->targetlist = ixo_scan->scan.plan.targetlist;
 			custom_scan->custom_scan_tlist = ixo_scan->indextlist;
 			qpqual = ixo_scan->scan.plan.qual;
+
+			/*
+			 * The index-only scan qpqual references the scan relation by
+			 * table attnum (like a plain IndexScan qpqual).  Its indexqual,
+			 * however, is expressed in INDEX_VAR terms.
+			 */
+			if (ix_path->ix_num == PrimaryIndexNumber)
+			{
+				OIndexDescr *primary = GET_PRIMARY(descr);
+
+				o_extract_row_array_keys(primary, rel->relid, true, false,
+										 ixo_scan->indexqual, qpqual,
+										 &rowArrayExprs, &rowArrayNTuples,
+										 &rowArrayNKeys, &rowArrayKeyTypes);
+			}
 		}
 
-		custom_scan->custom_exprs = NIL;
+		custom_scan->custom_exprs = rowArrayExprs;
 		custom_scan->custom_private =
 		/* cppcheck-suppress unknownEvaluationOrder */
 			list_make4(makeInteger(O_IndexPlan),
 					   makeInteger(ix_path->ix_num),
 					   makeInteger(ix_path->scandir),
 					   makeInteger(onlyCurIx));
+		custom_scan->custom_private =
+			lappend(custom_scan->custom_private,
+					makeInteger(rowArrayNTuples));
+		custom_scan->custom_private =
+			lappend(custom_scan->custom_private,
+					makeInteger(rowArrayNKeys));
+		custom_scan->custom_private =
+			lappend(custom_scan->custom_private, rowArrayKeyTypes);
 	}
 	else
 	{
@@ -570,6 +1078,33 @@ o_create_custom_scan_state(CustomScan *cscan)
 		ix_plan_state->ostate.onlyCurIx =
 			intVal(lfourth(cscan->custom_private));
 
+		/*
+		 * Row-array-IN metadata (custom_private positions 5..7 and the value
+		 * expressions in custom_exprs).  rowArrayNTuples == 0 => inactive.
+		 */
+		ix_plan_state->rowArrayNTuples =
+			intVal(list_nth(cscan->custom_private, 4));
+		ix_plan_state->rowArrayNKeys =
+			intVal(list_nth(cscan->custom_private, 5));
+		if (ix_plan_state->rowArrayNTuples > 0)
+		{
+			List	   *typeList = (List *) list_nth(cscan->custom_private, 6);
+			int			k;
+			ListCell   *tlc;
+
+			Assert(list_length(typeList) == ix_plan_state->rowArrayNKeys);
+			ix_plan_state->rowArrayKeyTypes = (Oid *)
+				palloc(sizeof(Oid) * ix_plan_state->rowArrayNKeys);
+			k = 0;
+			foreach(tlc, typeList)
+				ix_plan_state->rowArrayKeyTypes[k++] = (Oid) intVal(lfirst(tlc));
+
+			ix_plan_state->rowArrayKeyExprList = copyObject(cscan->custom_exprs);
+			Assert(list_length(ix_plan_state->rowArrayKeyExprList) ==
+				   ix_plan_state->rowArrayNTuples *
+				   ix_plan_state->rowArrayNKeys);
+		}
+
 		ocstate->o_plan_state = (OPlanState *) ix_plan_state;
 	}
 	else if (plan_tag == O_BitmapHeapPlan)
@@ -644,6 +1179,39 @@ o_begin_custom_scan(CustomScanState *node, EState *estate, int eflags)
 		ix_plan_state->indexRelation = index;
 
 		ix_plan_state->iss_RuntimeContext = CreateExprContext(estate);
+
+		/*
+		 * Set up the row-array-IN value expressions and per-tuple buffers.
+		 * The expressions are evaluated at rescan in iss_RuntimeContext (they
+		 * reference only constants/outer params, never the scan tuple).
+		 */
+		if (ix_plan_state->rowArrayNTuples > 0)
+		{
+			int			ntotal = ix_plan_state->rowArrayNTuples *
+				ix_plan_state->rowArrayNKeys;
+			int			k;
+			ListCell   *elc;
+
+			scan_state->rowArrayNTuples = ix_plan_state->rowArrayNTuples;
+			scan_state->rowArrayNKeys = ix_plan_state->rowArrayNKeys;
+			scan_state->rowArrayKeyTypes = ix_plan_state->rowArrayKeyTypes;
+			scan_state->rowArrayKeyExprs = (ExprState **)
+				palloc(sizeof(ExprState *) * ntotal);
+			scan_state->rowArrayValues = (Datum *) palloc(sizeof(Datum) * ntotal);
+			scan_state->rowArrayNulls = (bool *) palloc(sizeof(bool) * ntotal);
+			scan_state->rowArrayOrder = (int *)
+				palloc(sizeof(int) * scan_state->rowArrayNTuples);
+			scan_state->rowArrayNValid = 0;
+
+			k = 0;
+			foreach(elc, ix_plan_state->rowArrayKeyExprList)
+			{
+				Expr	   *e = (Expr *) lfirst(elc);
+
+				scan_state->rowArrayKeyExprs[k++] =
+					ExecInitExpr(e, &node->ss.ps);
+			}
+		}
 
 		/*
 		 * If no run-time keys to calculate or they are ready, go ahead and
@@ -782,6 +1350,156 @@ o_exec_custom_scan(CustomScanState *node)
 }
 
 /*
+ * Compare two row-array-IN arms by their pinned key columns, using the index
+ * field comparators (with the same coercion fallback as is_tuple_valid).
+ * Returns <0, 0, >0.
+ */
+static int
+o_row_array_cmp(OScanState *ostate, OIndexDescr *id, int a, int b)
+{
+	int			k;
+	int			nkeys = ostate->rowArrayNKeys;
+
+	for (k = 0; k < nkeys; k++)
+	{
+		Datum		va = ostate->rowArrayValues[a * nkeys + k];
+		Datum		vb = ostate->rowArrayValues[b * nkeys + k];
+		OIndexField *field = &id->fields[k];
+		Oid			type = ostate->rowArrayKeyTypes[k];
+		int			cmp;
+
+		if (!OidIsValid(type))
+			type = field->inputtype;
+
+		/*
+		 * If the arm value type is binary-coercible to the field input type
+		 * we compare with the field comparator directly, otherwise use a
+		 * type-specific comparator (mirrors o_bound_is_coercible /
+		 * key_range).
+		 */
+		if (type == field->opclass || type == field->inputtype ||
+			IsBinaryCoercible(type, field->inputtype))
+		{
+			cmp = o_call_comparator(field->comparator, va, vb);
+		}
+		else
+		{
+			OComparator *c = o_find_comparator(field->opfamily, type,
+											   field->inputtype,
+											   field->collation);
+
+			cmp = o_call_comparator(c, va, vb);
+		}
+
+		if (cmp != 0)
+			return field->ascending ? cmp : -cmp;
+	}
+	return 0;
+}
+
+/*
+ * Evaluate the row-array-IN value expressions (runtime keys) and build the
+ * ordering of arms in ascending key order, skipping any arm whose key
+ * contains a NULL (equality never matches NULL).
+ */
+static void
+o_eval_row_array_keys(CustomScanState *node, OIndexPlanState *ix_plan_state)
+{
+	OScanState *ostate = &ix_plan_state->ostate;
+	OTableDescr *descr = relation_get_descr(node->ss.ss_currentRelation);
+	OIndexDescr *id = descr->indices[ostate->ixNum];
+	ExprContext *econtext = ix_plan_state->iss_RuntimeContext;
+	MemoryContext oldcxt;
+	int			nkeys = ostate->rowArrayNKeys;
+	int			t;
+	int			nvalid = 0;
+
+	/*
+	 * Evaluate in the per-scan context so the resulting Datums survive for
+	 * the lifetime of the scan (they are read on every switch_to_next_range).
+	 */
+	ResetExprContext(econtext);
+	oldcxt = MemoryContextSwitchTo(ostate->cxt);
+
+	for (t = 0; t < ostate->rowArrayNTuples; t++)
+	{
+		int			k;
+		bool		hasnull = false;
+
+		for (k = 0; k < nkeys; k++)
+		{
+			int			idx = t * nkeys + k;
+			ExprState  *es = ostate->rowArrayKeyExprs[idx];
+			Datum		val;
+			bool		isnull;
+
+			val = ExecEvalExpr(es, econtext, &isnull);
+			if (isnull)
+			{
+				hasnull = true;
+				ostate->rowArrayValues[idx] = (Datum) 0;
+				ostate->rowArrayNulls[idx] = true;
+			}
+			else
+			{
+				int16		typlen;
+				bool		typbyval;
+
+				/*
+				 * Copy the value into the per-scan context; the runtime
+				 * context is reset on every rescan.
+				 */
+				get_typlenbyval(ostate->rowArrayKeyTypes[k], &typlen, &typbyval);
+				ostate->rowArrayValues[idx] = datumCopy(val, typbyval, typlen);
+				ostate->rowArrayNulls[idx] = false;
+			}
+		}
+
+		if (!hasnull)
+			ostate->rowArrayOrder[nvalid++] = t;
+	}
+
+	ostate->rowArrayCurTuple = 0;
+
+	/* Insertion sort the valid arm indices by ascending key order. */
+	for (t = 1; t < nvalid; t++)
+	{
+		int			cur = ostate->rowArrayOrder[t];
+		int			s = t - 1;
+
+		while (s >= 0 &&
+			   o_row_array_cmp(ostate, id, ostate->rowArrayOrder[s], cur) > 0)
+		{
+			ostate->rowArrayOrder[s + 1] = ostate->rowArrayOrder[s];
+			s--;
+		}
+		ostate->rowArrayOrder[s + 1] = cur;
+	}
+
+	/*
+	 * Drop duplicate keys.  The original whole-index scan visits each
+	 * physical tuple once regardless of how many times its key appears in the
+	 * IN list, so a duplicate arm must not yield the tuple again.  After
+	 * sorting, equal keys are adjacent.
+	 */
+	if (nvalid > 1)
+	{
+		int			w = 1;
+
+		for (t = 1; t < nvalid; t++)
+		{
+			if (o_row_array_cmp(ostate, id, ostate->rowArrayOrder[w - 1],
+								ostate->rowArrayOrder[t]) != 0)
+				ostate->rowArrayOrder[w++] = ostate->rowArrayOrder[t];
+		}
+		nvalid = w;
+	}
+	ostate->rowArrayNValid = nvalid;
+
+	MemoryContextSwitchTo(oldcxt);
+}
+
+/*
  * Restarts the scan.
  */
 static void
@@ -824,6 +1542,10 @@ o_rescan_custom_scan(CustomScanState *node)
 		ix_plan_state->ostate.curKeyRange.low.n_row_keys = 0;
 		ix_plan_state->ostate.curKeyRange.high.n_row_keys = 0;
 		ix_plan_state->ostate.iterator = NULL;
+
+		/* Evaluate row-array-IN value expressions and order the tuples. */
+		if (ix_plan_state->ostate.rowArrayNTuples > 0)
+			o_eval_row_array_keys(node, ix_plan_state);
 	}
 	else if (ocstate->o_plan_state->type == O_BitmapHeapPlan)
 	{

--- a/test/expected/row_array_in.out
+++ b/test/expected/row_array_in.out
@@ -1,0 +1,312 @@
+CREATE SCHEMA row_array_in;
+SET SESSION search_path = 'row_array_in';
+CREATE EXTENSION orioledb;
+-- Composite primary key table (index-organized) and an identical heap twin.
+CREATE TABLE o_orders (
+	w int,
+	d int,
+	o int,
+	c int,
+	payload text,
+	PRIMARY KEY (w, d, o)
+) USING orioledb;
+CREATE TABLE h_orders (
+	w int,
+	d int,
+	o int,
+	c int,
+	payload text,
+	PRIMARY KEY (w, d, o)
+);
+INSERT INTO o_orders
+	SELECT w, d, o, ((w * 97 + d * 7 + o) % 50) + 1, 'p' || (w * 10000 + d * 1000 + o)
+	FROM generate_series(1, 3) w,
+		 generate_series(1, 10) d,
+		 generate_series(1, 40) o;
+INSERT INTO h_orders SELECT * FROM o_orders;
+-- A covering secondary index whose leading column is only the common prefix of
+-- the row-array-IN (mirrors TPCC idx_order); without the fix the planner would
+-- prefer this whole-"w" index scan over pointwise primary-key probes.
+CREATE INDEX o_orders_sec ON o_orders (w, d, c, o);
+CREATE INDEX h_orders_sec ON h_orders (w, d, c, o);
+ANALYZE o_orders;
+ANALYZE h_orders;
+-- A four-column PK table to exercise a PARTIAL leading-prefix row-array-IN.
+CREATE TABLE o_lines (
+	w int,
+	d int,
+	o int,
+	num int,
+	amt int,
+	PRIMARY KEY (w, d, o, num)
+) USING orioledb;
+CREATE TABLE h_lines (
+	w int,
+	d int,
+	o int,
+	num int,
+	amt int,
+	PRIMARY KEY (w, d, o, num)
+);
+INSERT INTO o_lines
+	SELECT w, d, o, num, w * 1000 + d * 100 + o * 10 + num
+	FROM generate_series(1, 3) w,
+		 generate_series(1, 10) d,
+		 generate_series(1, 20) o,
+		 generate_series(1, 5) num;
+INSERT INTO h_lines SELECT * FROM o_lines;
+ANALYZE o_lines;
+ANALYZE h_lines;
+-- Helper: run the same query text against the orioledb table and its heap
+-- twin and report whether the row multiset is identical.  We EXECUTE dynamic
+-- SQL so the same statement runs under whatever plan_cache_mode is in effect;
+-- the printed result is plan-independent so the expected file is stable.
+CREATE FUNCTION cmp(otext text, htext text) RETURNS text AS $$
+DECLARE
+	diff bigint;
+BEGIN
+	EXECUTE format($f$
+		SELECT count(*) FROM (
+			(SELECT * FROM (%s) oq EXCEPT ALL SELECT * FROM (%s) hq)
+			UNION ALL
+			(SELECT * FROM (%s) hq2 EXCEPT ALL SELECT * FROM (%s) oq2)
+		) s
+	$f$, otext, htext, htext, otext) INTO diff;
+	IF diff = 0 THEN
+		RETURN 'OK';
+	ELSE
+		RETURN 'MISMATCH (' || diff || ')';
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+-- Run a battery of shapes under both custom and generic plans.  For each shape
+-- we compare the orioledb result to the heap result.  The genuine row-array-IN
+-- must match; the neighboring NON-row-array shapes (plain equality prefix with
+-- ORDER BY/LIMIT, single-arm IN, range, ScalarArrayOp) must ALSO match and must
+-- keep correct rows/order.
+CREATE FUNCTION run_battery() RETURNS SETOF text AS $$
+DECLARE
+	mode text;
+BEGIN
+	FOREACH mode IN ARRAY ARRAY['force_custom_plan', 'force_generic_plan'] LOOP
+		EXECUTE 'SET LOCAL plan_cache_mode = ' || quote_literal(mode);
+
+		-- 1. genuine full-key row-array-IN (>=2 arms), same leading w
+		RETURN NEXT mode || ' fullkey_in: ' || cmp(
+			'SELECT w,d,o,c FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3),(1,5,40)) ORDER BY w,d,o',
+			'SELECT w,d,o,c FROM h_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3),(1,5,40)) ORDER BY w,d,o');
+
+		-- 2. full-key row-array-IN spanning multiple leading w values
+		RETURN NEXT mode || ' fullkey_in_multiw: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(2,3,4),(3,10,40)) ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,1),(2,3,4),(3,10,40)) ORDER BY w,d,o');
+
+		-- 3. duplicate arms must not multiply rows
+		RETURN NEXT mode || ' fullkey_in_dups: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,1,1),(1,2,2)) ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,1),(1,1,1),(1,2,2)) ORDER BY w,d,o');
+
+		-- 4. partial leading prefix row-array-IN on a 4-column key
+		RETURN NEXT mode || ' prefix_in: ' || cmp(
+			'SELECT w,d,o,num FROM o_lines WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3)) ORDER BY w,d,o,num',
+			'SELECT w,d,o,num FROM h_lines WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3)) ORDER BY w,d,o,num');
+
+		-- 5. NON-matching: plain equality prefix + ORDER BY/LIMIT (backward)
+		RETURN NEXT mode || ' eq_prefix_limit: ' || cmp(
+			'SELECT o,c FROM o_orders WHERE w=1 AND d=3 ORDER BY o DESC LIMIT 3',
+			'SELECT o,c FROM h_orders WHERE w=1 AND d=3 ORDER BY o DESC LIMIT 3');
+
+		-- 6. NON-matching: full equality lookup
+		RETURN NEXT mode || ' eq_full: ' || cmp(
+			'SELECT w,d,o,c FROM o_orders WHERE w=1 AND d=2 AND o=3',
+			'SELECT w,d,o,c FROM h_orders WHERE w=1 AND d=2 AND o=3');
+
+		-- 7. NON-matching: single-arm IN (must behave like plain equality)
+		RETURN NEXT mode || ' single_arm_in: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,5,5))',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,5,5))');
+
+		-- 8. NON-matching: range scan
+		RETURN NEXT mode || ' range: ' || cmp(
+			'SELECT count(*)::text FROM o_orders WHERE w=1 AND d BETWEEN 2 AND 5',
+			'SELECT count(*)::text FROM h_orders WHERE w=1 AND d BETWEEN 2 AND 5');
+
+		-- 9. NON-matching: plain ScalarArrayOp on leading column
+		RETURN NEXT mode || ' saop: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE w IN (1,2) AND d=1 AND o=1 ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE w IN (1,2) AND d=1 AND o=1 ORDER BY w,d,o');
+
+		-- 10. row-array-IN combined with an extra restrict clause on payload
+		RETURN NEXT mode || ' in_plus_filter: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3)) AND c > 0 ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3)) AND c > 0 ORDER BY w,d,o');
+
+		-- 11. no matching rows
+		RETURN NEXT mode || ' no_match: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,999),(2,2,999))',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,999),(2,2,999))');
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+SELECT * FROM run_battery();
+               run_battery                
+------------------------------------------
+ force_custom_plan fullkey_in: OK
+ force_custom_plan fullkey_in_multiw: OK
+ force_custom_plan fullkey_in_dups: OK
+ force_custom_plan prefix_in: OK
+ force_custom_plan eq_prefix_limit: OK
+ force_custom_plan eq_full: OK
+ force_custom_plan single_arm_in: OK
+ force_custom_plan range: OK
+ force_custom_plan saop: OK
+ force_custom_plan in_plus_filter: OK
+ force_custom_plan no_match: OK
+ force_generic_plan fullkey_in: OK
+ force_generic_plan fullkey_in_multiw: OK
+ force_generic_plan fullkey_in_dups: OK
+ force_generic_plan prefix_in: OK
+ force_generic_plan eq_prefix_limit: OK
+ force_generic_plan eq_full: OK
+ force_generic_plan single_arm_in: OK
+ force_generic_plan range: OK
+ force_generic_plan saop: OK
+ force_generic_plan in_plus_filter: OK
+ force_generic_plan no_match: OK
+(22 rows)
+
+-- DML battery: a row-array-IN UPDATE and DELETE must affect exactly the same
+-- rows on the orioledb table as on the heap twin, under both plan modes.  This
+-- exercises the row-identity (rowid) wiring of the pointwise primary path used
+-- for UPDATE/DELETE.  We reset both tables before each check and report the
+-- symmetric row-difference (0 == identical) plus ROW_COUNT parity.
+CREATE FUNCTION run_dml_battery() RETURNS SETOF text AS $$
+DECLARE
+	mode text;
+	oro bigint;
+	hro bigint;
+	symdiff bigint;
+BEGIN
+	FOREACH mode IN ARRAY ARRAY['force_custom_plan', 'force_generic_plan'] LOOP
+		EXECUTE 'SET LOCAL plan_cache_mode = ' || quote_literal(mode);
+
+		-- UPDATE spanning multiple leading w values
+		DELETE FROM h_orders;
+		INSERT INTO h_orders SELECT * FROM o_orders;
+		EXECUTE 'UPDATE o_orders SET c = c + 1000 WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3),(3,10,40))';
+		GET DIAGNOSTICS oro = ROW_COUNT;
+		UPDATE h_orders SET c = c + 1000 WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3),(3,10,40));
+		GET DIAGNOSTICS hro = ROW_COUNT;
+		symdiff := (SELECT count(*) FROM (SELECT * FROM o_orders EXCEPT SELECT * FROM h_orders) a)
+				 + (SELECT count(*) FROM (SELECT * FROM h_orders EXCEPT SELECT * FROM o_orders) b);
+		RETURN NEXT mode || ' UPDATE rowcount_match=' || (oro = hro) || ' state_symdiff=' || symdiff;
+
+		-- DELETE spanning multiple leading w values
+		DELETE FROM o_orders; INSERT INTO o_orders SELECT * FROM h_orders;
+		DELETE FROM h_orders; INSERT INTO h_orders SELECT * FROM o_orders;
+		EXECUTE 'DELETE FROM o_orders WHERE (w,d,o) IN ((1,4,4),(2,5,5),(3,6,6))';
+		GET DIAGNOSTICS oro = ROW_COUNT;
+		DELETE FROM h_orders WHERE (w,d,o) IN ((1,4,4),(2,5,5),(3,6,6));
+		GET DIAGNOSTICS hro = ROW_COUNT;
+		symdiff := (SELECT count(*) FROM (SELECT * FROM o_orders EXCEPT SELECT * FROM h_orders) a)
+				 + (SELECT count(*) FROM (SELECT * FROM h_orders EXCEPT SELECT * FROM o_orders) b);
+		RETURN NEXT mode || ' DELETE rowcount_match=' || (oro = hro) || ' state_symdiff=' || symdiff;
+
+		-- restore both tables to a common baseline for the next iteration
+		DELETE FROM o_orders; DELETE FROM h_orders;
+		INSERT INTO o_orders
+			SELECT w, d, o, ((w * 97 + d * 7 + o) % 50) + 1, 'p' || (w * 10000 + d * 1000 + o)
+			FROM generate_series(1, 3) w, generate_series(1, 10) d, generate_series(1, 40) o;
+		INSERT INTO h_orders SELECT * FROM o_orders;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+SELECT * FROM run_dml_battery();
+                        run_dml_battery                        
+---------------------------------------------------------------
+ force_custom_plan UPDATE rowcount_match=true state_symdiff=0
+ force_custom_plan DELETE rowcount_match=true state_symdiff=0
+ force_generic_plan UPDATE rowcount_match=true state_symdiff=0
+ force_generic_plan DELETE rowcount_match=true state_symdiff=0
+(4 rows)
+
+-- Show the plan shape for the genuine row-array-IN (common leading value): it
+-- must be a pointwise primary-key o_scan, not a whole-warehouse scan on the
+-- covering secondary index with the OR only in the Filter.  (Literal / custom
+-- plan.)  UPDATE and DELETE must likewise use the pointwise primary path.
+SET plan_cache_mode = force_custom_plan;
+EXPLAIN (COSTS off)
+	SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3));
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_orders
+   Filter: ((w = 1) AND (((d = 1) AND (o = 1)) OR ((d = 2) AND (o = 2)) OR ((d = 3) AND (o = 3))))
+   Forward index scan of: o_orders_pkey
+(3 rows)
+
+EXPLAIN (COSTS off)
+	UPDATE o_orders SET c = c WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3));
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Update on o_orders
+   ->  Custom Scan (o_scan) on o_orders
+         Filter: ((w = 1) AND (((d = 1) AND (o = 1)) OR ((d = 2) AND (o = 2)) OR ((d = 3) AND (o = 3))))
+         Forward index scan of: o_orders_pkey
+(4 rows)
+
+EXPLAIN (COSTS off)
+	DELETE FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3));
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Delete on o_orders
+   ->  Custom Scan (o_scan) on o_orders
+         Filter: ((w = 1) AND (((d = 1) AND (o = 1)) OR ((d = 2) AND (o = 2)) OR ((d = 3) AND (o = 3))))
+         Forward index scan of: o_orders_pkey
+(4 rows)
+
+-- FOR UPDATE row-array-IN must NOT use the injected pointwise path.  Row locking
+-- over the pointwise per-tuple scan degrades into a heavyweight tuple-lock convoy
+-- under concurrency (observed as a >10x TPCC collapse), and such queries already
+-- reach a pointwise plan via the planner's ScalarArrayOp collapse when the
+-- leading columns are equal.  So a row-marked relation is left on its ordinary
+-- plan.
+EXPLAIN (COSTS off)
+	SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3)) FOR UPDATE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ LockRows
+   ->  Custom Scan (o_scan) on o_orders
+         Filter: (((d = 1) AND (o = 1)) OR ((d = 2) AND (o = 2)) OR ((d = 3) AND (o = 3)))
+         Forward index scan of: o_orders_pkey
+         Conds: (w = 1)
+(5 rows)
+
+-- Non-matching shapes keep their ordinary plans (no row-array Filter recheck).
+EXPLAIN (COSTS off)
+	SELECT w,d,o,c FROM o_orders WHERE w=1 AND d=2 AND o=3;
+                 QUERY PLAN                 
+--------------------------------------------
+ Custom Scan (o_scan) on o_orders
+   Forward index scan of: o_orders_pkey
+   Conds: ((w = 1) AND (d = 2) AND (o = 3))
+(3 rows)
+
+EXPLAIN (COSTS off)
+	SELECT o,c FROM o_orders WHERE w=1 AND d=3 ORDER BY o DESC LIMIT 3;
+                  QUERY PLAN                   
+-----------------------------------------------
+ Limit
+   ->  Custom Scan (o_scan) on o_orders
+         Backward index scan of: o_orders_pkey
+         Conds: ((w = 1) AND (d = 3))
+(4 rows)
+
+DROP FUNCTION run_dml_battery();
+DROP FUNCTION run_battery();
+DROP FUNCTION cmp(text, text);
+DROP TABLE o_orders;
+DROP TABLE h_orders;
+DROP TABLE o_lines;
+DROP TABLE h_lines;
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA row_array_in;

--- a/test/sql/row_array_in.sql
+++ b/test/sql/row_array_in.sql
@@ -1,0 +1,244 @@
+CREATE SCHEMA row_array_in;
+SET SESSION search_path = 'row_array_in';
+CREATE EXTENSION orioledb;
+
+-- Composite primary key table (index-organized) and an identical heap twin.
+CREATE TABLE o_orders (
+	w int,
+	d int,
+	o int,
+	c int,
+	payload text,
+	PRIMARY KEY (w, d, o)
+) USING orioledb;
+
+CREATE TABLE h_orders (
+	w int,
+	d int,
+	o int,
+	c int,
+	payload text,
+	PRIMARY KEY (w, d, o)
+);
+
+INSERT INTO o_orders
+	SELECT w, d, o, ((w * 97 + d * 7 + o) % 50) + 1, 'p' || (w * 10000 + d * 1000 + o)
+	FROM generate_series(1, 3) w,
+		 generate_series(1, 10) d,
+		 generate_series(1, 40) o;
+INSERT INTO h_orders SELECT * FROM o_orders;
+-- A covering secondary index whose leading column is only the common prefix of
+-- the row-array-IN (mirrors TPCC idx_order); without the fix the planner would
+-- prefer this whole-"w" index scan over pointwise primary-key probes.
+CREATE INDEX o_orders_sec ON o_orders (w, d, c, o);
+CREATE INDEX h_orders_sec ON h_orders (w, d, c, o);
+ANALYZE o_orders;
+ANALYZE h_orders;
+
+-- A four-column PK table to exercise a PARTIAL leading-prefix row-array-IN.
+CREATE TABLE o_lines (
+	w int,
+	d int,
+	o int,
+	num int,
+	amt int,
+	PRIMARY KEY (w, d, o, num)
+) USING orioledb;
+CREATE TABLE h_lines (
+	w int,
+	d int,
+	o int,
+	num int,
+	amt int,
+	PRIMARY KEY (w, d, o, num)
+);
+INSERT INTO o_lines
+	SELECT w, d, o, num, w * 1000 + d * 100 + o * 10 + num
+	FROM generate_series(1, 3) w,
+		 generate_series(1, 10) d,
+		 generate_series(1, 20) o,
+		 generate_series(1, 5) num;
+INSERT INTO h_lines SELECT * FROM o_lines;
+ANALYZE o_lines;
+ANALYZE h_lines;
+
+-- Helper: run the same query text against the orioledb table and its heap
+-- twin and report whether the row multiset is identical.  We EXECUTE dynamic
+-- SQL so the same statement runs under whatever plan_cache_mode is in effect;
+-- the printed result is plan-independent so the expected file is stable.
+CREATE FUNCTION cmp(otext text, htext text) RETURNS text AS $$
+DECLARE
+	diff bigint;
+BEGIN
+	EXECUTE format($f$
+		SELECT count(*) FROM (
+			(SELECT * FROM (%s) oq EXCEPT ALL SELECT * FROM (%s) hq)
+			UNION ALL
+			(SELECT * FROM (%s) hq2 EXCEPT ALL SELECT * FROM (%s) oq2)
+		) s
+	$f$, otext, htext, htext, otext) INTO diff;
+	IF diff = 0 THEN
+		RETURN 'OK';
+	ELSE
+		RETURN 'MISMATCH (' || diff || ')';
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Run a battery of shapes under both custom and generic plans.  For each shape
+-- we compare the orioledb result to the heap result.  The genuine row-array-IN
+-- must match; the neighboring NON-row-array shapes (plain equality prefix with
+-- ORDER BY/LIMIT, single-arm IN, range, ScalarArrayOp) must ALSO match and must
+-- keep correct rows/order.
+CREATE FUNCTION run_battery() RETURNS SETOF text AS $$
+DECLARE
+	mode text;
+BEGIN
+	FOREACH mode IN ARRAY ARRAY['force_custom_plan', 'force_generic_plan'] LOOP
+		EXECUTE 'SET LOCAL plan_cache_mode = ' || quote_literal(mode);
+
+		-- 1. genuine full-key row-array-IN (>=2 arms), same leading w
+		RETURN NEXT mode || ' fullkey_in: ' || cmp(
+			'SELECT w,d,o,c FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3),(1,5,40)) ORDER BY w,d,o',
+			'SELECT w,d,o,c FROM h_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3),(1,5,40)) ORDER BY w,d,o');
+
+		-- 2. full-key row-array-IN spanning multiple leading w values
+		RETURN NEXT mode || ' fullkey_in_multiw: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(2,3,4),(3,10,40)) ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,1),(2,3,4),(3,10,40)) ORDER BY w,d,o');
+
+		-- 3. duplicate arms must not multiply rows
+		RETURN NEXT mode || ' fullkey_in_dups: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,1,1),(1,2,2)) ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,1),(1,1,1),(1,2,2)) ORDER BY w,d,o');
+
+		-- 4. partial leading prefix row-array-IN on a 4-column key
+		RETURN NEXT mode || ' prefix_in: ' || cmp(
+			'SELECT w,d,o,num FROM o_lines WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3)) ORDER BY w,d,o,num',
+			'SELECT w,d,o,num FROM h_lines WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3)) ORDER BY w,d,o,num');
+
+		-- 5. NON-matching: plain equality prefix + ORDER BY/LIMIT (backward)
+		RETURN NEXT mode || ' eq_prefix_limit: ' || cmp(
+			'SELECT o,c FROM o_orders WHERE w=1 AND d=3 ORDER BY o DESC LIMIT 3',
+			'SELECT o,c FROM h_orders WHERE w=1 AND d=3 ORDER BY o DESC LIMIT 3');
+
+		-- 6. NON-matching: full equality lookup
+		RETURN NEXT mode || ' eq_full: ' || cmp(
+			'SELECT w,d,o,c FROM o_orders WHERE w=1 AND d=2 AND o=3',
+			'SELECT w,d,o,c FROM h_orders WHERE w=1 AND d=2 AND o=3');
+
+		-- 7. NON-matching: single-arm IN (must behave like plain equality)
+		RETURN NEXT mode || ' single_arm_in: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,5,5))',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,5,5))');
+
+		-- 8. NON-matching: range scan
+		RETURN NEXT mode || ' range: ' || cmp(
+			'SELECT count(*)::text FROM o_orders WHERE w=1 AND d BETWEEN 2 AND 5',
+			'SELECT count(*)::text FROM h_orders WHERE w=1 AND d BETWEEN 2 AND 5');
+
+		-- 9. NON-matching: plain ScalarArrayOp on leading column
+		RETURN NEXT mode || ' saop: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE w IN (1,2) AND d=1 AND o=1 ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE w IN (1,2) AND d=1 AND o=1 ORDER BY w,d,o');
+
+		-- 10. row-array-IN combined with an extra restrict clause on payload
+		RETURN NEXT mode || ' in_plus_filter: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3)) AND c > 0 ORDER BY w,d,o',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3)) AND c > 0 ORDER BY w,d,o');
+
+		-- 11. no matching rows
+		RETURN NEXT mode || ' no_match: ' || cmp(
+			'SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,999),(2,2,999))',
+			'SELECT w,d,o FROM h_orders WHERE (w,d,o) IN ((1,1,999),(2,2,999))');
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM run_battery();
+
+-- DML battery: a row-array-IN UPDATE and DELETE must affect exactly the same
+-- rows on the orioledb table as on the heap twin, under both plan modes.  This
+-- exercises the row-identity (rowid) wiring of the pointwise primary path used
+-- for UPDATE/DELETE.  We reset both tables before each check and report the
+-- symmetric row-difference (0 == identical) plus ROW_COUNT parity.
+CREATE FUNCTION run_dml_battery() RETURNS SETOF text AS $$
+DECLARE
+	mode text;
+	oro bigint;
+	hro bigint;
+	symdiff bigint;
+BEGIN
+	FOREACH mode IN ARRAY ARRAY['force_custom_plan', 'force_generic_plan'] LOOP
+		EXECUTE 'SET LOCAL plan_cache_mode = ' || quote_literal(mode);
+
+		-- UPDATE spanning multiple leading w values
+		DELETE FROM h_orders;
+		INSERT INTO h_orders SELECT * FROM o_orders;
+		EXECUTE 'UPDATE o_orders SET c = c + 1000 WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3),(3,10,40))';
+		GET DIAGNOSTICS oro = ROW_COUNT;
+		UPDATE h_orders SET c = c + 1000 WHERE (w,d,o) IN ((1,1,1),(1,2,2),(2,3,3),(3,10,40));
+		GET DIAGNOSTICS hro = ROW_COUNT;
+		symdiff := (SELECT count(*) FROM (SELECT * FROM o_orders EXCEPT SELECT * FROM h_orders) a)
+				 + (SELECT count(*) FROM (SELECT * FROM h_orders EXCEPT SELECT * FROM o_orders) b);
+		RETURN NEXT mode || ' UPDATE rowcount_match=' || (oro = hro) || ' state_symdiff=' || symdiff;
+
+		-- DELETE spanning multiple leading w values
+		DELETE FROM o_orders; INSERT INTO o_orders SELECT * FROM h_orders;
+		DELETE FROM h_orders; INSERT INTO h_orders SELECT * FROM o_orders;
+		EXECUTE 'DELETE FROM o_orders WHERE (w,d,o) IN ((1,4,4),(2,5,5),(3,6,6))';
+		GET DIAGNOSTICS oro = ROW_COUNT;
+		DELETE FROM h_orders WHERE (w,d,o) IN ((1,4,4),(2,5,5),(3,6,6));
+		GET DIAGNOSTICS hro = ROW_COUNT;
+		symdiff := (SELECT count(*) FROM (SELECT * FROM o_orders EXCEPT SELECT * FROM h_orders) a)
+				 + (SELECT count(*) FROM (SELECT * FROM h_orders EXCEPT SELECT * FROM o_orders) b);
+		RETURN NEXT mode || ' DELETE rowcount_match=' || (oro = hro) || ' state_symdiff=' || symdiff;
+
+		-- restore both tables to a common baseline for the next iteration
+		DELETE FROM o_orders; DELETE FROM h_orders;
+		INSERT INTO o_orders
+			SELECT w, d, o, ((w * 97 + d * 7 + o) % 50) + 1, 'p' || (w * 10000 + d * 1000 + o)
+			FROM generate_series(1, 3) w, generate_series(1, 10) d, generate_series(1, 40) o;
+		INSERT INTO h_orders SELECT * FROM o_orders;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM run_dml_battery();
+
+-- Show the plan shape for the genuine row-array-IN (common leading value): it
+-- must be a pointwise primary-key o_scan, not a whole-warehouse scan on the
+-- covering secondary index with the OR only in the Filter.  (Literal / custom
+-- plan.)  UPDATE and DELETE must likewise use the pointwise primary path.
+SET plan_cache_mode = force_custom_plan;
+EXPLAIN (COSTS off)
+	SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3));
+EXPLAIN (COSTS off)
+	UPDATE o_orders SET c = c WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3));
+EXPLAIN (COSTS off)
+	DELETE FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3));
+
+-- FOR UPDATE row-array-IN must NOT use the injected pointwise path.  Row locking
+-- over the pointwise per-tuple scan degrades into a heavyweight tuple-lock convoy
+-- under concurrency (observed as a >10x TPCC collapse), and such queries already
+-- reach a pointwise plan via the planner's ScalarArrayOp collapse when the
+-- leading columns are equal.  So a row-marked relation is left on its ordinary
+-- plan.
+EXPLAIN (COSTS off)
+	SELECT w,d,o FROM o_orders WHERE (w,d,o) IN ((1,1,1),(1,2,2),(1,3,3)) FOR UPDATE;
+
+-- Non-matching shapes keep their ordinary plans (no row-array Filter recheck).
+EXPLAIN (COSTS off)
+	SELECT w,d,o,c FROM o_orders WHERE w=1 AND d=2 AND o=3;
+EXPLAIN (COSTS off)
+	SELECT o,c FROM o_orders WHERE w=1 AND d=3 ORDER BY o DESC LIMIT 3;
+
+DROP FUNCTION run_dml_battery();
+DROP FUNCTION run_battery();
+DROP FUNCTION cmp(text, text);
+DROP TABLE o_orders;
+DROP TABLE h_orders;
+DROP TABLE o_lines;
+DROP TABLE h_lines;
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA row_array_in;


### PR DESCRIPTION
## Problem

Under the FETCH iterator (default since eb664825), TPCC throughput collapsed
to ~17k tpmC versus ~68k under IMAGE. The regression was localized to the
delivery transaction's row-array `IN` queries, e.g.

```sql
DELETE FROM new_order WHERE (no_w_id, no_d_id, no_o_id) IN
  ((W,1,o1),(W,2,o2), ... ,(W,10,o10));
```

PostgreSQL plans a row-array `IN (...)` as an OR-of-ANDs. When only the
leading column is a common equality (the trailing columns differ between
tuples — here `no_d_id` runs 1..10), only `no_w_id = W` becomes an indexable
condition; the full list stays as a `Filter` recheck. orioledb faithfully
executed that: it bounded the o_scan by the single common prefix
(`numPrefixExactKeys == 1`) and scanned the **whole warehouse's** slice of the
index, discarding all but the ~10 matching rows.

Results were always correct in both iterator modes — but the wide scan runs
inside a delivery transaction holding `FOR UPDATE` row locks. Under FETCH the
longer scan lengthens that critical section; since a warehouse's deliveries
serialize on the same lock-step minimum rows, the per-warehouse delivery chain
drains far slower, so throughput drops ~3-4x. (Measured with go-tpc delivery
logging: IMAGE ran ~3x more deliveries than FETCH on an identical snapshot,
with no data-level divergence in either mode.)

## Fix

Detect the row-array `IN` shape in the base restrict list, extract each tuple
as an exact key over the leading index columns, and drive the scan as a
sequence of pointwise primary-key lookups (one range per tuple) instead of one
wide scan. The row keys are `Param`/`Const` expressions (prepared statements
with generic plans), so they are evaluated per (re)scan. The path is injected
through a custom path only when it is cheaper than the plain o_scan.

Row-marked (`FOR UPDATE` / `FOR SHARE`) relations are deliberately left on
their ordinary plan (`o_rel_is_rowmarked()` gates both injection and key
extraction): row locking over the pointwise per-tuple scan degrades into a
heavyweight tuple-lock convoy under concurrency (a >10x collapse on the TPCC
new_order `stock ... FOR UPDATE`), and such queries already reach a pointwise
plan via the planner's ScalarArrayOp collapse when their leading columns are
equal.

## Results

- TPCC (w5, FETCH iterator): ~17k -> ~67k tpmC, at parity with IMAGE (~68k);
  IMAGE unchanged.
- New regression test `row_array_in`: pointwise plan shape for
  SELECT/UPDATE/DELETE, the `FOR UPDATE` fallback, and result-equivalence
  against a heap-AM twin table.
- `make regresscheck` 47/47, `make isolationcheck` 31/31.