### PR TITLE
Back the bitmap scan with an adaptive radix tree; support composite PKs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ OBJS = src/btree/btree.o \
 	   src/tableam/key_range.o \
 	   src/tableam/key_bitmap.o \
 	   src/tableam/operations.o \
+	   src/tableam/radix_selftest.o \
 	   src/tableam/scan.o \
 	   src/tableam/tree.o \
 	   src/tableam/vacuum.o \

--- a/ci/cppcheck-suppress
+++ b/ci/cppcheck-suppress
@@ -3,3 +3,5 @@ uselessAssignmentPtrArg:*
 incorrectStringBooleanError:*
 nullPointerRedundantCheck:*
 integerOverflowCond:*/atomics/generic.h
+# Vendored verbatim from PostgreSQL's lib/radixtree.h; not ours to audit.
+*:*/lib/o_radixtree.h

--- a/ci/static.sh
+++ b/ci/static.sh
@@ -10,7 +10,6 @@ cd orioledb
 if [ "$COMPILER" = "clang" ]; then
 	scan-build-$LLVM_VER --status-bugs --use-cc=clang-$LLVM_VER \
 		-disable-checker deadcode.DeadStores \
-		--exclude include/lib/o_radixtree.h \
 		make CLANG=clang-$LLVM_VER USE_PGXS=1 IS_DEV=1 USE_ASSERT_CHECKING=1 || status=$?
 
 elif [ "$COMPILER" = "gcc" ]; then

--- a/ci/static.sh
+++ b/ci/static.sh
@@ -10,6 +10,7 @@ cd orioledb
 if [ "$COMPILER" = "clang" ]; then
 	scan-build-$LLVM_VER --status-bugs --use-cc=clang-$LLVM_VER \
 		-disable-checker deadcode.DeadStores \
+		--exclude include/lib/o_radixtree.h \
 		make CLANG=clang-$LLVM_VER USE_PGXS=1 IS_DEV=1 USE_ASSERT_CHECKING=1 || status=$?
 
 elif [ "$COMPILER" = "gcc" ]; then

--- a/include/btree/iterator.h
+++ b/include/btree/iterator.h
@@ -48,11 +48,31 @@ extern OTuple o_btree_find_tuple_by_key(BTreeDescr *desc, void *key,
 										CommitSeqNo *out_csn,
 										MemoryContext mcxt,
 										BTreeLocationHint *hint);
+extern OTuple o_btree_find_tuples_start(BTreeDescr *desc, void *key,
+										BTreeKeyType kind,
+										OSnapshot *read_o_snapshot,
+										ScanDirection scanDir,
+										CommitSeqNo *out_csn,
+										MemoryContext mcxt,
+										BTreeLocationHint *hint,
+										bool *deleted,
+										TupleFetchCallback cb,
+										void *arg,
+										BTreeIterator **out_it);
+extern OTuple o_btree_find_tuples_continue(BTreeIterator *it,
+										   void *key,
+										   BTreeKeyType kind,
+										   CommitSeqNo *out_csn,
+										   BTreeLocationHint *hint,
+										   bool *deleted);
+extern void o_btree_find_tuples_finish(BTreeIterator *it);
 
 extern BTreeIterator *o_btree_iterator_create(BTreeDescr *desc, void *key,
 											  BTreeKeyType kind,
 											  OSnapshot *o_snapshot,
 											  ScanDirection scanDir);
+extern void o_btree_iterator_advance(BTreeIterator *it,
+									 void *key, BTreeKeyType kind);
 extern void o_btree_iterator_set_tuple_ctx(BTreeIterator *it,
 										   MemoryContext tupleCxt);
 extern void o_btree_iterator_set_callback(BTreeIterator *it,
@@ -60,7 +80,7 @@ extern void o_btree_iterator_set_callback(BTreeIterator *it,
 										  void *arg);
 extern OTuple o_btree_iterator_fetch(BTreeIterator *it,
 									 CommitSeqNo *tuple_csn,
-									 void *end, BTreeKeyType endType,
+									 void *endKey, BTreeKeyType endKind,
 									 bool endIsIncluded,
 									 BTreeLocationHint *hint);
 extern OTuple btree_iterate_raw(BTreeIterator *it, void *end,

--- a/include/btree/scan.h
+++ b/include/btree/scan.h
@@ -31,18 +31,25 @@ typedef struct BTreeSeqScan BTreeSeqScan;
 typedef struct BTreeSeqScanCallbacks
 {
 	bool		(*isRangeValid) (OTuple low, OTuple high, void *arg);
-	bool		(*getNextKey) (OFixedKey *key, bool inclusive, void *arg);
 
 	/*
-	 * Optional (may be NULL).  Given the just-finished internal page's hikey
-	 * in key->tuple (an exclusive upper bound: every key on that page is less
-	 * than it; a NULL tuple means "from the start of the tree"), rewrite key
-	 * with the smallest key the scan still needs that is >= the hikey, as a
-	 * non-leaf key usable for a fresh descent.  Returns false when nothing is
-	 * left, letting the sequential scan skip whole internal pages that hold
-	 * no wanted keys instead of stepping through every one.
+	 * Rewrite key->tuple with the smallest key the scan still needs at or
+	 * after the position it carries (a NULL tuple means "from the start of
+	 * the tree"), returning false when nothing is left.
+	 *
+	 * keyType says how to interpret the incoming position and drives the
+	 * bitmap-directed walk at two levels: - BTreeKeyLeafTuple: the position
+	 * is the current leaf tuple; used by the per-tuple leaf walk. -
+	 * BTreeKeyNonLeafKey: the position is an internal-page boundary (a
+	 * downlink separator or page hikey, an exclusive upper bound); used to
+	 * skip whole internal pages / downlinks that hold no wanted keys and to
+	 * descend straight to the covering one.  Always called with inclusive.
+	 *
+	 * When inclusive is false the result is strictly greater than the
+	 * position.
 	 */
-	bool		(*getNextPageKey) (OFixedKey *key, void *arg);
+	bool		(*getNextKey) (OFixedKey *key, BTreeKeyType keyType,
+							   bool inclusive, void *arg);
 } BTreeSeqScanCallbacks;
 
 extern BTreeScanShmem *btreeScanShmem;

--- a/include/btree/scan.h
+++ b/include/btree/scan.h
@@ -32,6 +32,17 @@ typedef struct BTreeSeqScanCallbacks
 {
 	bool		(*isRangeValid) (OTuple low, OTuple high, void *arg);
 	bool		(*getNextKey) (OFixedKey *key, bool inclusive, void *arg);
+
+	/*
+	 * Optional (may be NULL).  Given the just-finished internal page's hikey
+	 * in key->tuple (an exclusive upper bound: every key on that page is less
+	 * than it; a NULL tuple means "from the start of the tree"), rewrite key
+	 * with the smallest key the scan still needs that is >= the hikey, as a
+	 * non-leaf key usable for a fresh descent.  Returns false when nothing is
+	 * left, letting the sequential scan skip whole internal pages that hold
+	 * no wanted keys instead of stepping through every one.
+	 */
+	bool		(*getNextPageKey) (OFixedKey *key, void *arg);
 } BTreeSeqScanCallbacks;
 
 extern BTreeScanShmem *btreeScanShmem;

--- a/include/lib/o_radixtree.h
+++ b/include/lib/o_radixtree.h
@@ -161,6 +161,30 @@
 #include "storage/lwlock.h"
 #endif
 
+/*
+ * PG16 portability.  This template is taken from PG17's lib/radixtree.h and
+ * relies on helpers that PG17 introduced but PG16 lacks: port/simd.h has no
+ * vector8_highbit_mask()/vector8_min(), and nodes/bitmapset.h has no bmw_*
+ * word helpers.  Every use of the vector8 helpers (and the Vector8 locals they
+ * need) is already guarded by USE_NO_SIMD, so forcing the scalar node-search
+ * paths sidesteps the missing SIMD helpers; the bmw_* helpers are used
+ * unconditionally, so define them here.  Both are no-ops on PG17+.
+ */
+#if PG_VERSION_NUM < 170000
+#ifndef USE_NO_SIMD
+#define USE_NO_SIMD
+#endif
+#ifndef bmw_rightmost_one_pos
+#if BITS_PER_BITMAPWORD == 32
+#define bmw_rightmost_one_pos(w)	pg_rightmost_one_pos32(w)
+#define bmw_popcount(w)				pg_popcount32(w)
+#else
+#define bmw_rightmost_one_pos(w)	pg_rightmost_one_pos64(w)
+#define bmw_popcount(w)				pg_popcount64(w)
+#endif
+#endif
+#endif
+
 /* helpers */
 #define RT_MAKE_PREFIX(a) CppConcat(a,_)
 #define RT_MAKE_NAME(name) RT_MAKE_NAME_(RT_MAKE_PREFIX(RT_PREFIX),name)
@@ -301,8 +325,8 @@ typedef dsa_pointer RT_HANDLE;
 #endif
 
 #ifdef RT_SHMEM
-RT_SCOPE	RT_RADIX_TREE *RT_CREATE(MemoryContext ctx, dsa_area * dsa, int tranche_id);
-RT_SCOPE	RT_RADIX_TREE *RT_ATTACH(dsa_area * dsa, dsa_pointer dp);
+RT_SCOPE	RT_RADIX_TREE *RT_CREATE(MemoryContext ctx, dsa_area *dsa, int tranche_id);
+RT_SCOPE	RT_RADIX_TREE *RT_ATTACH(dsa_area *dsa, dsa_pointer dp);
 RT_SCOPE void RT_DETACH(RT_RADIX_TREE * tree);
 RT_SCOPE	RT_HANDLE RT_GET_HANDLE(RT_RADIX_TREE * tree);
 RT_SCOPE void RT_LOCK_EXCLUSIVE(RT_RADIX_TREE * tree);
@@ -1878,7 +1902,7 @@ have_slot:
  */
 RT_SCOPE	RT_RADIX_TREE *
 #ifdef RT_SHMEM
-RT_CREATE(MemoryContext ctx, dsa_area * dsa, int tranche_id)
+RT_CREATE(MemoryContext ctx, dsa_area *dsa, int tranche_id)
 #else
 RT_CREATE(MemoryContext ctx)
 #endif
@@ -1961,7 +1985,7 @@ RT_CREATE(MemoryContext ctx)
 
 #ifdef RT_SHMEM
 RT_SCOPE	RT_RADIX_TREE *
-RT_ATTACH(dsa_area * dsa, RT_HANDLE handle)
+RT_ATTACH(dsa_area *dsa, RT_HANDLE handle)
 {
 	RT_RADIX_TREE *tree;
 	dsa_pointer control;

--- a/include/lib/o_radixtree.h
+++ b/include/lib/o_radixtree.h
@@ -1,0 +1,3144 @@
+/*-------------------------------------------------------------------------
+ *
+ * radixtree.h
+ *		Template for adaptive radix tree.
+ *
+ * A template to generate an "adaptive radix tree", specialized for value
+ * types and for local/shared memory.
+ *
+ * The concept originates from the paper "The Adaptive Radix Tree: ARTful
+ * Indexing for Main-Memory Databases" by Viktor Leis, Alfons Kemper,
+ * and Thomas Neumann, 2013.
+ *
+ * Radix trees have some advantages over hash tables:
+ * - The keys are logically ordered, allowing efficient sorted iteration
+ *   and range queries
+ * - Operations using keys that are lexicographically close together
+ *   will have favorable memory locality
+ * - Memory use grows gradually rather than by doubling
+ * - The key does not need to be stored with the value, since the key
+ *   is implicitly contained in the path to the value
+ *
+ * Some disadvantages are:
+ * - Point queries (along with insertion and deletion) are slower than
+ *   a linear probing hash table as in simplehash.h
+ * - Memory usage varies by key distribution, so is difficult to predict
+ *
+ * A classic radix tree consists of nodes, each containing an array of
+ * pointers to child nodes.  The size of the array is determined by the
+ * "span" of the tree, which is the number of bits of the key used to
+ * index into the array.  For example, with a span of 6, a "chunk"
+ * of 6 bits is extracted from the key at each node traversal, and
+ * the arrays thus have a "fanout" of 2^6 or 64 entries.  A large span
+ * allows a shorter tree, but requires larger arrays that may be mostly
+ * wasted space.
+ *
+ * The key idea of the adaptive radix tree is to choose different
+ * data structures based on the number of child nodes. A node will
+ * start out small when it is first populated, and when it is full,
+ * it is replaced by the next larger size. Conversely, when a node
+ * becomes mostly empty, it is replaced by the next smaller node. The
+ * bulk of the code complexity in this module stems from this dynamic
+ * switching. One mitigating factor is using a span of 8, since bytes
+ * are directly addressable.
+ *
+ * The ART paper mentions three ways to implement leaves:
+ *
+ * "- Single-value leaves: The values are stored using an addi-
+ *  tional leaf node type which stores one value.
+ *  - Multi-value leaves: The values are stored in one of four
+ *  different leaf node types, which mirror the structure of
+ *  inner nodes, but contain values instead of pointers.
+ *  - Combined pointer/value slots: If values fit into point-
+ *  ers, no separate node types are necessary. Instead, each
+ *  pointer storage location in an inner node can either
+ *  store a pointer or a value."
+ *
+ * We use a form of "combined pointer/value slots", as recommended. Values
+ * of size (if fixed at compile time) equal or smaller than the platform's
+ * pointer type are stored in the child slots of the last level node,
+ * while larger values are the same as "single-value" leaves above. This
+ * offers flexibility and efficiency. Variable-length types are currently
+ * treated as single-value leaves for simplicity, but future work may
+ * allow those to be stored in the child pointer arrays, when they're
+ * small enough.
+ *
+ * There are two other techniques described in the paper that are not
+ * implemented here:
+ * - path compression "...removes all inner nodes that have only a single child."
+ * - lazy path expansion "...inner nodes are only created if they are required
+ *   to distinguish at least two leaf nodes."
+ *
+ * We do have a form of "poor man's path compression", however, enabled by
+ * only supporting unsigned integer keys (for now assumed to be 64-bit):
+ * A tree doesn't contain paths where the highest bytes of all keys are
+ * zero. That way, the tree's height adapts to the distribution of keys.
+ *
+ * To handle concurrency, we use a single reader-writer lock for the
+ * radix tree. If concurrent write operations are possible, the tree
+ * must be exclusively locked during write operations such as RT_SET()
+ * and RT_DELETE(), and share locked during read operations such as
+ * RT_FIND() and RT_BEGIN_ITERATE().
+ *
+ * TODO: The current locking mechanism is not optimized for high
+ * concurrency with mixed read-write workloads. In the future it might
+ * be worthwhile to replace it with the Optimistic Lock Coupling or
+ * ROWEX mentioned in the paper "The ART of Practical Synchronization"
+ * by the same authors as the ART paper, 2016.
+ *
+ * To generate a radix tree and associated functions for a use case
+ * several macros have to be #define'ed before this file is included.
+ * Including the file #undef's all those, so a new radix tree can be
+ * generated afterwards.
+ *
+ * The relevant parameters are:
+ * - RT_PREFIX - prefix for all symbol names generated. A prefix of "foo"
+ * 	 will result in radix tree type "foo_radix_tree" and functions like
+ *	 "foo_create"/"foo_free" and so forth.
+ * - RT_DECLARE - if defined function prototypes and type declarations are
+ *	 generated
+ * - RT_DEFINE - if defined function definitions are generated
+ * - RT_SCOPE - in which scope (e.g. extern, static inline) do function
+ *	 declarations reside
+ * - RT_VALUE_TYPE - the type of the value.
+ * - RT_VARLEN_VALUE_SIZE() - for variable length values, an expression
+ *   involving a pointer to the value type, to calculate size.
+ *     NOTE: implies that the value is in fact variable-length,
+ *     so do not set for fixed-length values.
+ * - RT_RUNTIME_EMBEDDABLE_VALUE - for variable length values, allows
+ *   storing the value in a child pointer slot, rather than as a single-
+ *   value leaf, if small enough. This requires that the value, when
+ *   read as a child pointer, can be tagged in the lowest bit.
+ *
+ * Optional parameters:
+ * - RT_SHMEM - if defined, the radix tree is created in the DSA area
+ *	 so that multiple processes can access it simultaneously.
+ * - RT_DEBUG - if defined add stats tracking and debugging functions
+ *
+ * Interface
+ * ---------
+ *
+ * RT_CREATE		- Create a new, empty radix tree
+ * RT_FREE			- Free the radix tree
+ * RT_FIND			- Lookup the value for a given key
+ * RT_SET			- Set a key-value pair
+ * RT_BEGIN_ITERATE	- Begin iterating through all key-value pairs
+ * RT_ITERATE_NEXT	- Return next key-value pair, if any
+ * RT_END_ITERATE	- End iteration
+ * RT_MEMORY_USAGE	- Get the memory as measured by space in memory context blocks
+ *
+ * Interface for Shared Memory
+ * ---------
+ *
+ * RT_ATTACH		- Attach to the radix tree
+ * RT_DETACH		- Detach from the radix tree
+ * RT_LOCK_EXCLUSIVE - Lock the radix tree in exclusive mode
+ * RT_LOCK_SHARE 	- Lock the radix tree in share mode
+ * RT_UNLOCK		- Unlock the radix tree
+ * RT_GET_HANDLE	- Return the handle of the radix tree
+ *
+ * Optional Interface
+ * ---------
+ *
+ * RT_DELETE		- Delete a key-value pair. Declared/defined if RT_USE_DELETE is defined
+ *
+ *
+ * Copyright (c) 2024, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *	  src/include/lib/radixtree.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "nodes/bitmapset.h"
+#include "port/pg_bitutils.h"
+#include "port/simd.h"
+#include "utils/dsa.h"
+#include "utils/memutils.h"
+#ifdef RT_SHMEM
+#include "miscadmin.h"
+#include "storage/lwlock.h"
+#endif
+
+/* helpers */
+#define RT_MAKE_PREFIX(a) CppConcat(a,_)
+#define RT_MAKE_NAME(name) RT_MAKE_NAME_(RT_MAKE_PREFIX(RT_PREFIX),name)
+#define RT_MAKE_NAME_(a,b) CppConcat(a,b)
+/*
+ * stringify a macro constant, from https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html
+ */
+#define RT_STR(s) RT_STR_(s)
+#define RT_STR_(s) #s
+
+/* function declarations */
+#define RT_CREATE RT_MAKE_NAME(create)
+#define RT_FREE RT_MAKE_NAME(free)
+#define RT_FIND RT_MAKE_NAME(find)
+#ifdef RT_SHMEM
+#define RT_ATTACH RT_MAKE_NAME(attach)
+#define RT_DETACH RT_MAKE_NAME(detach)
+#define RT_GET_HANDLE RT_MAKE_NAME(get_handle)
+#define RT_LOCK_EXCLUSIVE RT_MAKE_NAME(lock_exclusive)
+#define RT_LOCK_SHARE RT_MAKE_NAME(lock_share)
+#define RT_UNLOCK RT_MAKE_NAME(unlock)
+#endif
+#define RT_SET RT_MAKE_NAME(set)
+#define RT_BEGIN_ITERATE RT_MAKE_NAME(begin_iterate)
+#define RT_ITERATE_NEXT RT_MAKE_NAME(iterate_next)
+#define RT_END_ITERATE RT_MAKE_NAME(end_iterate)
+#ifdef RT_USE_DELETE
+#define RT_DELETE RT_MAKE_NAME(delete)
+#endif
+#define RT_MEMORY_USAGE RT_MAKE_NAME(memory_usage)
+#define RT_DUMP_NODE RT_MAKE_NAME(dump_node)
+#define RT_STATS RT_MAKE_NAME(stats)
+
+/* internal helper functions (no externally visible prototypes) */
+#define RT_CHILDPTR_IS_VALUE RT_MAKE_NAME(childptr_is_value)
+#define RT_VALUE_IS_EMBEDDABLE RT_MAKE_NAME(value_is_embeddable)
+#define RT_GET_SLOT_RECURSIVE RT_MAKE_NAME(get_slot_recursive)
+#define RT_DELETE_RECURSIVE RT_MAKE_NAME(delete_recursive)
+#define RT_ALLOC_NODE RT_MAKE_NAME(alloc_node)
+#define RT_ALLOC_LEAF RT_MAKE_NAME(alloc_leaf)
+#define RT_FREE_NODE RT_MAKE_NAME(free_node)
+#define RT_FREE_LEAF RT_MAKE_NAME(free_leaf)
+#define RT_FREE_RECURSE RT_MAKE_NAME(free_recurse)
+#define RT_EXTEND_UP RT_MAKE_NAME(extend_up)
+#define RT_EXTEND_DOWN RT_MAKE_NAME(extend_down)
+#define RT_COPY_COMMON RT_MAKE_NAME(copy_common)
+#define RT_PTR_SET_LOCAL RT_MAKE_NAME(ptr_set_local)
+#define RT_NODE_16_SEARCH_EQ RT_MAKE_NAME(node_16_search_eq)
+#define RT_NODE_4_GET_INSERTPOS RT_MAKE_NAME(node_4_get_insertpos)
+#define RT_NODE_16_GET_INSERTPOS RT_MAKE_NAME(node_16_get_insertpos)
+#define RT_SHIFT_ARRAYS_FOR_INSERT RT_MAKE_NAME(shift_arrays_for_insert)
+#define RT_SHIFT_ARRAYS_AND_DELETE RT_MAKE_NAME(shift_arrays_and_delete)
+#define RT_COPY_ARRAYS_FOR_INSERT RT_MAKE_NAME(copy_arrays_for_insert)
+#define RT_COPY_ARRAYS_AND_DELETE RT_MAKE_NAME(copy_arrays_and_delete)
+#define RT_NODE_48_IS_CHUNK_USED RT_MAKE_NAME(node_48_is_chunk_used)
+#define RT_NODE_48_GET_CHILD RT_MAKE_NAME(node_48_get_child)
+#define RT_NODE_256_IS_CHUNK_USED RT_MAKE_NAME(node_256_is_chunk_used)
+#define RT_NODE_256_GET_CHILD RT_MAKE_NAME(node_256_get_child)
+#define RT_KEY_GET_SHIFT RT_MAKE_NAME(key_get_shift)
+#define RT_SHIFT_GET_MAX_VAL RT_MAKE_NAME(shift_get_max_val)
+#define RT_NODE_SEARCH RT_MAKE_NAME(node_search)
+#define RT_NODE_DELETE RT_MAKE_NAME(node_delete)
+#define RT_NODE_INSERT RT_MAKE_NAME(node_insert)
+#define RT_ADD_CHILD_4 RT_MAKE_NAME(add_child_4)
+#define RT_ADD_CHILD_16 RT_MAKE_NAME(add_child_16)
+#define RT_ADD_CHILD_48 RT_MAKE_NAME(add_child_48)
+#define RT_ADD_CHILD_256 RT_MAKE_NAME(add_child_256)
+#define RT_GROW_NODE_4 RT_MAKE_NAME(grow_node_4)
+#define RT_GROW_NODE_16 RT_MAKE_NAME(grow_node_16)
+#define RT_GROW_NODE_48 RT_MAKE_NAME(grow_node_48)
+#define RT_REMOVE_CHILD_4 RT_MAKE_NAME(remove_child_4)
+#define RT_REMOVE_CHILD_16 RT_MAKE_NAME(remove_child_16)
+#define RT_REMOVE_CHILD_48 RT_MAKE_NAME(remove_child_48)
+#define RT_REMOVE_CHILD_256 RT_MAKE_NAME(remove_child_256)
+#define RT_SHRINK_NODE_16 RT_MAKE_NAME(shrink_child_16)
+#define RT_SHRINK_NODE_48 RT_MAKE_NAME(shrink_child_48)
+#define RT_SHRINK_NODE_256 RT_MAKE_NAME(shrink_child_256)
+#define RT_NODE_ITERATE_NEXT RT_MAKE_NAME(node_iterate_next)
+#define RT_VERIFY_NODE RT_MAKE_NAME(verify_node)
+
+/* type declarations */
+#define RT_RADIX_TREE RT_MAKE_NAME(radix_tree)
+#define RT_RADIX_TREE_CONTROL RT_MAKE_NAME(radix_tree_control)
+#define RT_ITER RT_MAKE_NAME(iter)
+#ifdef RT_SHMEM
+#define RT_HANDLE RT_MAKE_NAME(handle)
+#endif
+#define RT_NODE RT_MAKE_NAME(node)
+#define RT_CHILD_PTR RT_MAKE_NAME(child_ptr)
+#define RT_NODE_ITER RT_MAKE_NAME(node_iter)
+#define RT_NODE_4 RT_MAKE_NAME(node_4)
+#define RT_NODE_16 RT_MAKE_NAME(node_16)
+#define RT_NODE_48 RT_MAKE_NAME(node_48)
+#define RT_NODE_256 RT_MAKE_NAME(node_256)
+#define RT_SIZE_CLASS RT_MAKE_NAME(size_class)
+#define RT_SIZE_CLASS_ELEM RT_MAKE_NAME(size_class_elem)
+#define RT_SIZE_CLASS_INFO RT_MAKE_NAME(size_class_info)
+#define RT_CLASS_4 RT_MAKE_NAME(class_4)
+#define RT_CLASS_16_LO RT_MAKE_NAME(class_32_min)
+#define RT_CLASS_16_HI RT_MAKE_NAME(class_32_max)
+#define RT_CLASS_48 RT_MAKE_NAME(class_48)
+#define RT_CLASS_256 RT_MAKE_NAME(class_256)
+
+/*----------
+ * Key type abstraction.
+ *
+ * By default the radix tree is keyed by a uint64 (upstream behavior).  When
+ * RT_KEY_SIZE is defined (to a fixed byte length N), the tree is instead keyed
+ * by a fixed-length N-byte string, interpreted big-endian (data[0] is the most
+ * significant byte).  Because the tree indexes one byte per level, the byte
+ * order of the key string is exactly its sort order, so callers that want
+ * ordered iteration must supply order-preserving (big-endian, sign-flipped for
+ * signed types) encodings.
+ *
+ * RT_KEY is the caller-facing key type.  Internally keys are always addressed
+ * as a big-endian byte string via RT_KEY_CHUNK(); for the uint64 case we read
+ * the bytes out of the integer with the appropriate shift.
+ *----------
+ */
+#define RT_KEY RT_MAKE_NAME(key)
+#ifdef RT_KEY_SIZE
+typedef struct
+{
+	unsigned char data[RT_KEY_SIZE];
+}			RT_KEY;
+#else
+typedef uint64 RT_KEY;
+#endif
+
+/* generate forward declarations necessary to use the radix tree */
+#ifdef RT_DECLARE
+
+typedef struct RT_RADIX_TREE RT_RADIX_TREE;
+typedef struct RT_ITER RT_ITER;
+
+#ifdef RT_SHMEM
+typedef dsa_pointer RT_HANDLE;
+#endif
+
+#ifdef RT_SHMEM
+RT_SCOPE	RT_RADIX_TREE *RT_CREATE(MemoryContext ctx, dsa_area * dsa, int tranche_id);
+RT_SCOPE	RT_RADIX_TREE *RT_ATTACH(dsa_area * dsa, dsa_pointer dp);
+RT_SCOPE void RT_DETACH(RT_RADIX_TREE * tree);
+RT_SCOPE	RT_HANDLE RT_GET_HANDLE(RT_RADIX_TREE * tree);
+RT_SCOPE void RT_LOCK_EXCLUSIVE(RT_RADIX_TREE * tree);
+RT_SCOPE void RT_LOCK_SHARE(RT_RADIX_TREE * tree);
+RT_SCOPE void RT_UNLOCK(RT_RADIX_TREE * tree);
+#else
+RT_SCOPE	RT_RADIX_TREE *RT_CREATE(MemoryContext ctx);
+#endif
+RT_SCOPE void RT_FREE(RT_RADIX_TREE * tree);
+
+RT_SCOPE	RT_VALUE_TYPE *RT_FIND(RT_RADIX_TREE * tree, RT_KEY key);
+RT_SCOPE bool RT_SET(RT_RADIX_TREE * tree, RT_KEY key, RT_VALUE_TYPE * value_p);
+
+#ifdef RT_USE_DELETE
+RT_SCOPE bool RT_DELETE(RT_RADIX_TREE * tree, RT_KEY key);
+#endif
+
+RT_SCOPE	RT_ITER *RT_BEGIN_ITERATE(RT_RADIX_TREE * tree);
+RT_SCOPE	RT_VALUE_TYPE *RT_ITERATE_NEXT(RT_ITER * iter, RT_KEY * key_p);
+RT_SCOPE void RT_END_ITERATE(RT_ITER * iter);
+
+RT_SCOPE uint64 RT_MEMORY_USAGE(RT_RADIX_TREE * tree);
+
+#ifdef RT_DEBUG
+RT_SCOPE void RT_STATS(RT_RADIX_TREE * tree);
+#endif
+
+#endif							/* RT_DECLARE */
+
+
+/* generate implementation of the radix tree */
+#ifdef RT_DEFINE
+
+/* The number of bits encoded in one tree level */
+#define RT_SPAN	BITS_PER_BYTE
+
+/*
+ * The number of possible partial keys, and thus the maximum number of
+ * child pointers, for a node.
+ */
+#define RT_NODE_MAX_SLOTS (1 << RT_SPAN)
+
+/* Mask for extracting a chunk from a key */
+#define RT_CHUNK_MASK ((1 << RT_SPAN) - 1)
+
+/* Number of bytes in a key */
+#ifdef RT_KEY_SIZE
+#define RT_KEY_BYTES	RT_KEY_SIZE
+#else
+#define RT_KEY_BYTES	sizeof(uint64)
+#endif
+
+/* Maximum shift needed to extract a chunk from a key */
+#define RT_MAX_SHIFT	((RT_KEY_BYTES - 1) * RT_SPAN)
+
+/* Maximum level a tree can reach for a key */
+#define RT_MAX_LEVEL	RT_KEY_BYTES
+
+/*
+ * Get a chunk (one byte) from the key at the given bit shift.  For the uint64
+ * case this is a plain shift-and-mask.  For the fixed-length byte-string case
+ * the key is big-endian, so shift/RT_SPAN counts byte positions up from the
+ * least significant byte, i.e. data[RT_KEY_BYTES - 1 - shift/RT_SPAN].
+ */
+#ifdef RT_KEY_SIZE
+#define RT_GET_KEY_CHUNK(key, shift) \
+	((uint8) ((key).data[RT_KEY_BYTES - 1 - ((shift) / RT_SPAN)]))
+#else
+#define RT_GET_KEY_CHUNK(key, shift) ((uint8) (((key) >> (shift)) & RT_CHUNK_MASK))
+#endif
+
+/*
+ * Whether the given key fits under the tree's current start_shift.  For fixed
+ * length keys the tree always has full height, so every key fits and the tree
+ * is never extended upward.
+ */
+#ifdef RT_KEY_SIZE
+#define RT_KEY_FITS(tree, key)	(true)
+#else
+#define RT_KEY_FITS(tree, key)	((key) <= (tree)->ctl->max_val)
+#endif
+
+/* For accessing bitmaps */
+#define RT_BM_IDX(x)	((x) / BITS_PER_BITMAPWORD)
+#define RT_BM_BIT(x)	((x) % BITS_PER_BITMAPWORD)
+
+/*
+ * Node kinds
+ *
+ * The different node kinds are what make the tree "adaptive".
+ *
+ * Each node kind is associated with a different datatype and different
+ * search/set/delete/iterate algorithms adapted for its size. The largest
+ * kind, node256 is basically the same as a traditional radix tree,
+ * and would be most wasteful of memory when sparsely populated. The
+ * smaller nodes expend some additional CPU time to enable a smaller
+ * memory footprint.
+ *
+ * NOTE: There are 4 node kinds, and this should never be increased,
+ * for several reasons:
+ * 1. With 5 or more kinds, gcc tends to use a jump table for switch
+ *    statements.
+ * 2. The 4 kinds can be represented with 2 bits, so we have the option
+ *    in the future to tag the node pointer with the kind, even on
+ *    platforms with 32-bit pointers. That would touch fewer cache lines
+ *    during traversal and allow faster recovery from branch mispredicts.
+ * 3. We can have multiple size classes per node kind.
+ */
+#define RT_NODE_KIND_4			0x00
+#define RT_NODE_KIND_16			0x01
+#define RT_NODE_KIND_48			0x02
+#define RT_NODE_KIND_256		0x03
+#define RT_NODE_KIND_COUNT		4
+
+/*
+ * Calculate the slab block size so that we can allocate at least 32 chunks
+ * from the block.
+ */
+#define RT_SLAB_BLOCK_SIZE(size)	\
+	Max(SLAB_DEFAULT_BLOCK_SIZE, pg_nextpower2_32(size * 32))
+
+/* Common header for all nodes */
+typedef struct RT_NODE
+{
+	/* Node kind, one per search/set algorithm */
+	uint8		kind;
+
+	/*
+	 * Max capacity for the current size class. Storing this in the node
+	 * enables multiple size classes per node kind. uint8 is sufficient for
+	 * all node kinds, because we only use this number to test if the node
+	 * needs to grow. Since node256 never needs to grow, we let this overflow
+	 * to zero.
+	 */
+	uint8		fanout;
+
+	/*
+	 * Number of children. uint8 is sufficient for all node kinds, because
+	 * nodes shrink when this number gets lower than some threshold. Since
+	 * node256 cannot possibly have zero children, we let the counter overflow
+	 * and we interpret zero as "256" for this node kind.
+	 */
+	uint8		count;
+}			RT_NODE;
+
+
+/* pointer returned by allocation */
+#ifdef RT_SHMEM
+#define RT_PTR_ALLOC dsa_pointer
+#define RT_INVALID_PTR_ALLOC InvalidDsaPointer
+#define RT_PTR_ALLOC_IS_VALID(ptr) DsaPointerIsValid(ptr)
+#else
+#define RT_PTR_ALLOC RT_NODE *
+#define RT_INVALID_PTR_ALLOC NULL
+#define RT_PTR_ALLOC_IS_VALID(ptr) PointerIsValid(ptr)
+#endif
+
+/*
+ * A convenience type used when we need to work with a DSA pointer as well
+ * as its local pointer. For local memory, both members are the same, so
+ * we use a union.
+ */
+#ifdef RT_SHMEM
+typedef struct RT_CHILD_PTR
+#else
+typedef union RT_CHILD_PTR
+#endif
+{
+	RT_PTR_ALLOC alloc;
+	RT_NODE    *local;
+}			RT_CHILD_PTR;
+
+
+/*
+ * Helper macros and functions for value storage.
+ * We either embed values in the child slots of the last level
+ * node or store pointers to values to the child slots,
+ * depending on the value size.
+ */
+
+#ifdef RT_VARLEN_VALUE_SIZE
+#define RT_GET_VALUE_SIZE(v) RT_VARLEN_VALUE_SIZE(v)
+#else
+#define RT_GET_VALUE_SIZE(v) sizeof(RT_VALUE_TYPE)
+#endif
+
+/*
+ * Return true if the value can be stored in the child array
+ * of the lowest-level node, false otherwise.
+ */
+static inline bool
+RT_VALUE_IS_EMBEDDABLE(RT_VALUE_TYPE * value_p)
+{
+#ifdef RT_VARLEN_VALUE_SIZE
+
+#ifdef RT_RUNTIME_EMBEDDABLE_VALUE
+	return RT_GET_VALUE_SIZE(value_p) <= sizeof(RT_PTR_ALLOC);
+#else
+	return false;
+#endif
+
+#else
+	return RT_GET_VALUE_SIZE(value_p) <= sizeof(RT_PTR_ALLOC);
+#endif
+}
+
+/*
+ * Return true if the child pointer contains the value, false
+ * if the child pointer is a leaf pointer.
+ */
+static inline bool
+RT_CHILDPTR_IS_VALUE(RT_PTR_ALLOC child)
+{
+#ifdef RT_VARLEN_VALUE_SIZE
+
+#ifdef RT_RUNTIME_EMBEDDABLE_VALUE
+	/* check for pointer tag */
+#ifdef RT_SHMEM
+	return child & 1;
+#else
+	return ((uintptr_t) child) & 1;
+#endif
+
+#else
+	return false;
+#endif
+
+#else
+	return sizeof(RT_VALUE_TYPE) <= sizeof(RT_PTR_ALLOC);
+#endif
+}
+
+/*
+ * Symbols for maximum possible fanout are declared first as they are
+ * required to declare each node kind. The declarations of other fanout
+ * values are followed as they need the struct sizes of each node kind.
+ */
+
+/* max possible key chunks without struct padding */
+#define RT_FANOUT_4_MAX (8 - sizeof(RT_NODE))
+
+/* equal to two 128-bit SIMD registers, regardless of availability */
+#define RT_FANOUT_16_MAX	32
+
+/*
+ * This also determines the number of bits necessary for the isset array,
+ * so we need to be mindful of the size of bitmapword.  Since bitmapword
+ * can be 64 bits, the only values that make sense here are 64 and 128.
+ * The ART paper uses at most 64 for this node kind, and one advantage
+ * for us is that "isset" is a single bitmapword on most platforms,
+ * rather than an array, allowing the compiler to get rid of loops.
+ */
+#define RT_FANOUT_48_MAX 64
+
+#define RT_FANOUT_256   RT_NODE_MAX_SLOTS
+
+/*
+ * Node structs, one for each "kind"
+ */
+
+/*
+ * node4 and node16 use one array for key chunks and another
+ * array of the same length for children. The keys and children
+ * are stored at corresponding positions, sorted by chunk.
+ */
+
+typedef struct RT_NODE_4
+{
+	RT_NODE		base;
+
+	uint8		chunks[RT_FANOUT_4_MAX];
+
+	/* number of children depends on size class */
+	RT_PTR_ALLOC children[FLEXIBLE_ARRAY_MEMBER];
+}			RT_NODE_4;
+
+typedef struct RT_NODE_16
+{
+	RT_NODE		base;
+
+	uint8		chunks[RT_FANOUT_16_MAX];
+
+	/* number of children depends on size class */
+	RT_PTR_ALLOC children[FLEXIBLE_ARRAY_MEMBER];
+}			RT_NODE_16;
+
+/*
+ * node48 uses a 256-element array indexed by key chunks. This array
+ * stores indexes into a second array containing the children.
+ */
+typedef struct RT_NODE_48
+{
+	RT_NODE		base;
+
+	/* bitmap to track which slots are in use */
+	bitmapword	isset[RT_BM_IDX(RT_FANOUT_48_MAX)];
+
+	/*
+	 * Lookup table for indexes into the children[] array. We make this the
+	 * last fixed-size member so that it's convenient to memset separately
+	 * from the previous members.
+	 */
+	uint8		slot_idxs[RT_NODE_MAX_SLOTS];
+
+/* Invalid index */
+#define RT_INVALID_SLOT_IDX	0xFF
+
+	/* number of children depends on size class */
+	RT_PTR_ALLOC children[FLEXIBLE_ARRAY_MEMBER];
+}			RT_NODE_48;
+
+/*
+ * node256 is the largest node type. This node has an array of
+ * children directly indexed by chunk.  Unlike other node kinds,
+ * its array size is by definition fixed.
+ */
+typedef struct RT_NODE_256
+{
+	RT_NODE		base;
+
+	/* bitmap to track which slots are in use */
+	bitmapword	isset[RT_BM_IDX(RT_FANOUT_256)];
+
+	/* slots for 256 children */
+	RT_PTR_ALLOC children[RT_FANOUT_256];
+}			RT_NODE_256;
+
+#if defined(RT_SHMEM)
+/*
+ * Make sure the all nodes (except for node256) fit neatly into a DSA
+ * size class.  We assume the RT_FANOUT_4 is in the range where DSA size
+ * classes increment by 8 (as of PG17 up to 64 bytes), so we just hard
+ * code that one.
+ */
+
+#if SIZEOF_DSA_POINTER < 8
+#define RT_FANOUT_16_LO	((96 - offsetof(RT_NODE_16, children)) / sizeof(RT_PTR_ALLOC))
+#define RT_FANOUT_16_HI	Min(RT_FANOUT_16_MAX, (160 - offsetof(RT_NODE_16, children)) / sizeof(RT_PTR_ALLOC))
+#define RT_FANOUT_48	Min(RT_FANOUT_48_MAX, (512 - offsetof(RT_NODE_48, children)) / sizeof(RT_PTR_ALLOC))
+#else
+#define RT_FANOUT_16_LO	((160 - offsetof(RT_NODE_16, children)) / sizeof(RT_PTR_ALLOC))
+#define RT_FANOUT_16_HI	Min(RT_FANOUT_16_MAX, (320 - offsetof(RT_NODE_16, children)) / sizeof(RT_PTR_ALLOC))
+#define RT_FANOUT_48	Min(RT_FANOUT_48_MAX, (768 - offsetof(RT_NODE_48, children)) / sizeof(RT_PTR_ALLOC))
+#endif							/* SIZEOF_DSA_POINTER < 8 */
+
+#else							/* ! RT_SHMEM */
+
+/* doesn't really matter, but may as well use the namesake */
+#define RT_FANOUT_16_LO	16
+/* use maximum possible */
+#define RT_FANOUT_16_HI RT_FANOUT_16_MAX
+#define RT_FANOUT_48	RT_FANOUT_48_MAX
+
+#endif							/* RT_SHMEM */
+
+/*
+ * To save memory in trees with sparse keys, it would make sense to have two
+ * size classes for the smallest kind (perhaps a high class of 5 and a low class
+ * of 2), but it would be more effective to utilize lazy expansion and
+ * path compression.
+ */
+#define RT_FANOUT_4		4
+
+StaticAssertDecl(RT_FANOUT_4 <= RT_FANOUT_4_MAX, "watch struct padding");
+StaticAssertDecl(RT_FANOUT_16_LO < RT_FANOUT_16_HI, "LO subclass bigger than HI");
+StaticAssertDecl(RT_FANOUT_48 <= RT_FANOUT_48_MAX, "more slots than isset bits");
+
+/*
+ * Node size classes
+ *
+ * Nodes of different kinds necessarily belong to different size classes.
+ * One innovation in our implementation compared to the ART paper is
+ * decoupling the notion of size class from kind.
+ *
+ * The size classes within a given node kind have the same underlying
+ * type, but a variable number of children/values. This is possible
+ * because each type (except node256) contains metadata that work the
+ * same way regardless of how many child slots there are. The nodes
+ * can introspect their allocated capacity at runtime.
+ */
+typedef enum RT_SIZE_CLASS
+{
+	RT_CLASS_4 = 0,
+	RT_CLASS_16_LO,
+	RT_CLASS_16_HI,
+	RT_CLASS_48,
+	RT_CLASS_256
+}			RT_SIZE_CLASS;
+
+/* Information for each size class */
+typedef struct RT_SIZE_CLASS_ELEM
+{
+	const char *name;
+	int			fanout;
+	size_t		allocsize;
+}			RT_SIZE_CLASS_ELEM;
+
+
+static const RT_SIZE_CLASS_ELEM RT_SIZE_CLASS_INFO[] = {
+	[RT_CLASS_4] = {
+		.name = RT_STR(RT_PREFIX) "_radix_tree node4",
+		.fanout = RT_FANOUT_4,
+		.allocsize = sizeof(RT_NODE_4) + RT_FANOUT_4 * sizeof(RT_PTR_ALLOC),
+	},
+	[RT_CLASS_16_LO] = {
+		.name = RT_STR(RT_PREFIX) "_radix_tree node16_lo",
+		.fanout = RT_FANOUT_16_LO,
+		.allocsize = sizeof(RT_NODE_16) + RT_FANOUT_16_LO * sizeof(RT_PTR_ALLOC),
+	},
+	[RT_CLASS_16_HI] = {
+		.name = RT_STR(RT_PREFIX) "_radix_tree node16_hi",
+		.fanout = RT_FANOUT_16_HI,
+		.allocsize = sizeof(RT_NODE_16) + RT_FANOUT_16_HI * sizeof(RT_PTR_ALLOC),
+	},
+	[RT_CLASS_48] = {
+		.name = RT_STR(RT_PREFIX) "_radix_tree node48",
+		.fanout = RT_FANOUT_48,
+		.allocsize = sizeof(RT_NODE_48) + RT_FANOUT_48 * sizeof(RT_PTR_ALLOC),
+	},
+	[RT_CLASS_256] = {
+		.name = RT_STR(RT_PREFIX) "_radix_tree node256",
+		.fanout = RT_FANOUT_256,
+		.allocsize = sizeof(RT_NODE_256),
+	},
+};
+
+#define RT_NUM_SIZE_CLASSES lengthof(RT_SIZE_CLASS_INFO)
+
+#ifdef RT_SHMEM
+/* A magic value used to identify our radix tree */
+#define RT_RADIX_TREE_MAGIC 0x54A48167
+#endif
+
+/* Contains the actual tree, plus ancillary info */
+typedef struct RT_RADIX_TREE_CONTROL
+{
+#ifdef RT_SHMEM
+	RT_HANDLE	handle;
+	uint32		magic;
+	LWLock		lock;
+#endif
+
+	RT_PTR_ALLOC root;
+	uint64		max_val;
+	int64		num_keys;
+	int			start_shift;
+
+	/* statistics */
+#ifdef RT_DEBUG
+	int64		num_nodes[RT_NUM_SIZE_CLASSES];
+	int64		num_leaves;
+#endif
+}			RT_RADIX_TREE_CONTROL;
+
+/* Entry point for allocating and accessing the tree */
+struct RT_RADIX_TREE
+{
+	MemoryContext context;
+
+	/* pointing to either local memory or DSA */
+	RT_RADIX_TREE_CONTROL *ctl;
+
+#ifdef RT_SHMEM
+	dsa_area   *dsa;
+#else
+	MemoryContextData *node_slabs[RT_NUM_SIZE_CLASSES];
+
+	/* leaf_context is used only for single-value leaves */
+	MemoryContextData *leaf_context;
+#endif
+	MemoryContextData *iter_context;
+};
+
+/*
+ * Iteration support.
+ *
+ * Iterating over the radix tree produces each key/value pair in ascending
+ * order of the key.
+ */
+
+/* state for iterating over a single node */
+typedef struct RT_NODE_ITER
+{
+	RT_CHILD_PTR node;
+
+	/*
+	 * The next index of the chunk array in RT_NODE_KIND_4 and RT_NODE_KIND_16
+	 * nodes, or the next chunk in RT_NODE_KIND_48 and RT_NODE_KIND_256 nodes.
+	 * 0 for the initial value.
+	 */
+	int			idx;
+}			RT_NODE_ITER;
+
+/* state for iterating over the whole radix tree */
+struct RT_ITER
+{
+	RT_RADIX_TREE *tree;
+
+	/*
+	 * A stack to track iteration for each level. Level 0 is the lowest (or
+	 * leaf) level
+	 */
+	RT_NODE_ITER node_iters[RT_MAX_LEVEL];
+	int			top_level;
+	int			cur_level;
+
+	/* The key constructed during iteration */
+	RT_KEY		key;
+};
+
+
+/* verification (available only in assert-enabled builds) */
+static void RT_VERIFY_NODE(RT_NODE * node);
+
+static inline void
+RT_PTR_SET_LOCAL(RT_RADIX_TREE * tree, RT_CHILD_PTR * node)
+{
+#ifdef RT_SHMEM
+	node->local = dsa_get_address(tree->dsa, node->alloc);
+#endif
+}
+
+/* Convenience functions for node48 and node256 */
+
+/* Return true if there is an entry for "chunk" */
+static inline bool
+RT_NODE_48_IS_CHUNK_USED(RT_NODE_48 * node, uint8 chunk)
+{
+	return node->slot_idxs[chunk] != RT_INVALID_SLOT_IDX;
+}
+
+static inline RT_PTR_ALLOC *
+RT_NODE_48_GET_CHILD(RT_NODE_48 * node, uint8 chunk)
+{
+	return &node->children[node->slot_idxs[chunk]];
+}
+
+/* Return true if there is an entry for "chunk" */
+static inline bool
+RT_NODE_256_IS_CHUNK_USED(RT_NODE_256 * node, uint8 chunk)
+{
+	int			idx = RT_BM_IDX(chunk);
+	int			bitnum = RT_BM_BIT(chunk);
+
+	return (node->isset[idx] & ((bitmapword) 1 << bitnum)) != 0;
+}
+
+static inline RT_PTR_ALLOC *
+RT_NODE_256_GET_CHILD(RT_NODE_256 * node, uint8 chunk)
+{
+	Assert(RT_NODE_256_IS_CHUNK_USED(node, chunk));
+	return &node->children[chunk];
+}
+
+/*
+ * Return the smallest shift that will allowing storing the given key.
+ */
+static inline int
+RT_KEY_GET_SHIFT(RT_KEY key)
+{
+#ifdef RT_KEY_SIZE
+	/* Fixed-length keys always use the full tree height. */
+	return RT_MAX_SHIFT;
+#else
+	if (key == 0)
+		return 0;
+	else
+		return (pg_leftmost_one_pos64(key) / RT_SPAN) * RT_SPAN;
+#endif
+}
+
+/*
+ * Return the max value that can be stored in the tree with the given shift.
+ */
+static uint64
+RT_SHIFT_GET_MAX_VAL(int shift)
+{
+	if (shift == RT_MAX_SHIFT)
+		return UINT64_MAX;
+	else
+		return (UINT64CONST(1) << (shift + RT_SPAN)) - 1;
+}
+
+/*
+ * Allocate a new node with the given node kind and size class.
+ */
+static inline RT_CHILD_PTR
+RT_ALLOC_NODE(RT_RADIX_TREE * tree, const uint8 kind, const RT_SIZE_CLASS size_class)
+{
+	RT_CHILD_PTR allocnode;
+	RT_NODE    *node;
+	size_t		allocsize;
+
+	allocsize = RT_SIZE_CLASS_INFO[size_class].allocsize;
+
+#ifdef RT_SHMEM
+	allocnode.alloc = dsa_allocate(tree->dsa, allocsize);
+#else
+	allocnode.alloc = (RT_PTR_ALLOC) MemoryContextAlloc(tree->node_slabs[size_class],
+														allocsize);
+#endif
+
+	RT_PTR_SET_LOCAL(tree, &allocnode);
+	node = allocnode.local;
+
+	/* initialize contents */
+
+	switch (kind)
+	{
+		case RT_NODE_KIND_4:
+			memset(node, 0, offsetof(RT_NODE_4, children));
+			break;
+		case RT_NODE_KIND_16:
+			memset(node, 0, offsetof(RT_NODE_16, children));
+			break;
+		case RT_NODE_KIND_48:
+			{
+				RT_NODE_48 *n48 = (RT_NODE_48 *) node;
+
+				memset(n48, 0, offsetof(RT_NODE_48, slot_idxs));
+				memset(n48->slot_idxs, RT_INVALID_SLOT_IDX, sizeof(n48->slot_idxs));
+				break;
+			}
+		case RT_NODE_KIND_256:
+			memset(node, 0, offsetof(RT_NODE_256, children));
+			break;
+		default:
+			pg_unreachable();
+	}
+
+	node->kind = kind;
+
+	/*
+	 * For node256, this will actually overflow to zero, but that's okay
+	 * because that node doesn't need to introspect this value.
+	 */
+	node->fanout = RT_SIZE_CLASS_INFO[size_class].fanout;
+
+#ifdef RT_DEBUG
+	/* update the statistics */
+	tree->ctl->num_nodes[size_class]++;
+#endif
+
+	return allocnode;
+}
+
+/*
+ * Allocate a new leaf.
+ */
+static RT_CHILD_PTR
+RT_ALLOC_LEAF(RT_RADIX_TREE * tree, size_t allocsize)
+{
+	RT_CHILD_PTR leaf;
+
+#ifdef RT_SHMEM
+	leaf.alloc = dsa_allocate(tree->dsa, allocsize);
+	RT_PTR_SET_LOCAL(tree, &leaf);
+#else
+	leaf.alloc = (RT_PTR_ALLOC) MemoryContextAlloc(tree->leaf_context, allocsize);
+#endif
+
+#ifdef RT_DEBUG
+	tree->ctl->num_leaves++;
+#endif
+
+	return leaf;
+}
+
+/*
+ * Copy relevant members of the node header.
+ * This is a separate function in case other fields are added.
+ */
+static inline void
+RT_COPY_COMMON(RT_CHILD_PTR newnode, RT_CHILD_PTR oldnode)
+{
+	(newnode.local)->count = (oldnode.local)->count;
+}
+
+/* Free the given node */
+static void
+RT_FREE_NODE(RT_RADIX_TREE * tree, RT_CHILD_PTR node)
+{
+#ifdef RT_DEBUG
+	int			i;
+
+	/* update the statistics */
+
+	for (i = 0; i < RT_NUM_SIZE_CLASSES; i++)
+	{
+		if ((node.local)->fanout == RT_SIZE_CLASS_INFO[i].fanout)
+			break;
+	}
+
+	/*
+	 * The fanout of node256 will appear to be zero within the node header
+	 * because of overflow, so we need an extra check here.
+	 */
+	if (i == RT_NUM_SIZE_CLASSES)
+		i = RT_CLASS_256;
+
+	tree->ctl->num_nodes[i]--;
+	Assert(tree->ctl->num_nodes[i] >= 0);
+#endif
+
+#ifdef RT_SHMEM
+	dsa_free(tree->dsa, node.alloc);
+#else
+	pfree(node.alloc);
+#endif
+}
+
+static inline void
+RT_FREE_LEAF(RT_RADIX_TREE * tree, RT_PTR_ALLOC leaf)
+{
+	Assert(leaf != tree->ctl->root);
+
+#ifdef RT_DEBUG
+	/* update the statistics */
+	tree->ctl->num_leaves--;
+	Assert(tree->ctl->num_leaves >= 0);
+#endif
+
+#ifdef RT_SHMEM
+	dsa_free(tree->dsa, leaf);
+#else
+	pfree(leaf);
+#endif
+}
+
+/***************** SEARCH *****************/
+
+/*
+ * Return the address of the child corresponding to "chunk",
+ * or NULL if there is no such element.
+ */
+static inline RT_PTR_ALLOC *
+RT_NODE_16_SEARCH_EQ(RT_NODE_16 * node, uint8 chunk)
+{
+	int			count = node->base.count;
+#ifndef USE_NO_SIMD
+	Vector8		spread_chunk;
+	Vector8		haystack1;
+	Vector8		haystack2;
+	Vector8		cmp1;
+	Vector8		cmp2;
+	uint32		bitfield;
+	RT_PTR_ALLOC *slot_simd = NULL;
+#endif
+
+#if defined(USE_NO_SIMD) || defined(USE_ASSERT_CHECKING)
+	RT_PTR_ALLOC *slot = NULL;
+
+	for (int i = 0; i < count; i++)
+	{
+		if (node->chunks[i] == chunk)
+		{
+			slot = &node->children[i];
+			break;
+		}
+	}
+#endif
+
+#ifndef USE_NO_SIMD
+	/* replicate the search key */
+	spread_chunk = vector8_broadcast(chunk);
+
+	/* compare to all 32 keys stored in the node */
+	vector8_load(&haystack1, &node->chunks[0]);
+	vector8_load(&haystack2, &node->chunks[sizeof(Vector8)]);
+	cmp1 = vector8_eq(spread_chunk, haystack1);
+	cmp2 = vector8_eq(spread_chunk, haystack2);
+
+	/* convert comparison to a bitfield */
+	bitfield = vector8_highbit_mask(cmp1) | (vector8_highbit_mask(cmp2) << sizeof(Vector8));
+
+	/* mask off invalid entries */
+	bitfield &= ((UINT64CONST(1) << count) - 1);
+
+	/* convert bitfield to index by counting trailing zeros */
+	if (bitfield)
+		slot_simd = &node->children[pg_rightmost_one_pos32(bitfield)];
+
+	Assert(slot_simd == slot);
+	return slot_simd;
+#else
+	return slot;
+#endif
+}
+
+/*
+ * Search for the child pointer corresponding to "key" in the given node.
+ *
+ * Return child if the key is found, otherwise return NULL.
+ */
+static inline RT_PTR_ALLOC *
+RT_NODE_SEARCH(RT_NODE * node, uint8 chunk)
+{
+	/* Make sure we already converted to local pointer */
+	Assert(node != NULL);
+
+	switch (node->kind)
+	{
+		case RT_NODE_KIND_4:
+			{
+				RT_NODE_4  *n4 = (RT_NODE_4 *) node;
+
+				for (int i = 0; i < n4->base.count; i++)
+				{
+					if (n4->chunks[i] == chunk)
+						return &n4->children[i];
+				}
+				return NULL;
+			}
+		case RT_NODE_KIND_16:
+			return RT_NODE_16_SEARCH_EQ((RT_NODE_16 *) node, chunk);
+		case RT_NODE_KIND_48:
+			{
+				RT_NODE_48 *n48 = (RT_NODE_48 *) node;
+				int			slotpos = n48->slot_idxs[chunk];
+
+				if (slotpos == RT_INVALID_SLOT_IDX)
+					return NULL;
+
+				return RT_NODE_48_GET_CHILD(n48, chunk);
+			}
+		case RT_NODE_KIND_256:
+			{
+				RT_NODE_256 *n256 = (RT_NODE_256 *) node;
+
+				if (!RT_NODE_256_IS_CHUNK_USED(n256, chunk))
+					return NULL;
+
+				return RT_NODE_256_GET_CHILD(n256, chunk);
+			}
+		default:
+			pg_unreachable();
+	}
+}
+
+/*
+ * Search the given key in the radix tree. Return the pointer to the value if found,
+ * otherwise return NULL.
+ *
+ * Since the function returns a pointer (to support variable-length values),
+ * the caller is responsible for locking until it's finished with the value.
+ */
+RT_SCOPE	RT_VALUE_TYPE *
+RT_FIND(RT_RADIX_TREE * tree, RT_KEY key)
+{
+	RT_CHILD_PTR node;
+	RT_PTR_ALLOC *slot = NULL;
+	int			shift;
+
+#ifdef RT_SHMEM
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+#endif
+
+	if (!RT_KEY_FITS(tree, key))
+		return NULL;
+
+	Assert(RT_PTR_ALLOC_IS_VALID(tree->ctl->root));
+	node.alloc = tree->ctl->root;
+	shift = tree->ctl->start_shift;
+
+	/* Descend the tree */
+	while (shift >= 0)
+	{
+		RT_PTR_SET_LOCAL(tree, &node);
+		slot = RT_NODE_SEARCH(node.local, RT_GET_KEY_CHUNK(key, shift));
+		if (slot == NULL)
+			return NULL;
+
+		node.alloc = *slot;
+		shift -= RT_SPAN;
+	}
+
+	if (RT_CHILDPTR_IS_VALUE(*slot))
+		return (RT_VALUE_TYPE *) slot;
+	else
+	{
+		RT_PTR_SET_LOCAL(tree, &node);
+		return (RT_VALUE_TYPE *) node.local;
+	}
+}
+
+/***************** INSERTION *****************/
+
+#define RT_NODE_MUST_GROW(node) \
+	((node)->count == (node)->fanout)
+
+/*
+ * Return index of the chunk and slot arrays for inserting into the node,
+ * such that the arrays remain ordered.
+ */
+static inline int
+RT_NODE_4_GET_INSERTPOS(RT_NODE_4 * node, uint8 chunk, int count)
+{
+	int			idx;
+
+	for (idx = 0; idx < count; idx++)
+	{
+		if (node->chunks[idx] >= chunk)
+			break;
+	}
+
+	return idx;
+}
+
+/*
+ * Return index of the chunk and slot arrays for inserting into the node,
+ * such that the arrays remain ordered.
+ */
+static inline int
+RT_NODE_16_GET_INSERTPOS(RT_NODE_16 * node, uint8 chunk)
+{
+	int			count = node->base.count;
+#if defined(USE_NO_SIMD) || defined(USE_ASSERT_CHECKING)
+	int			index;
+#endif
+
+#ifndef USE_NO_SIMD
+	Vector8		spread_chunk;
+	Vector8		haystack1;
+	Vector8		haystack2;
+	Vector8		cmp1;
+	Vector8		cmp2;
+	Vector8		min1;
+	Vector8		min2;
+	uint32		bitfield;
+	int			index_simd;
+#endif
+
+	/*
+	 * First compare the last element. There are two reasons to branch here:
+	 *
+	 * 1) A realistic pattern is inserting ordered keys. In that case,
+	 * non-SIMD platforms must do a linear search to the last chunk to find
+	 * the insert position. This will get slower as the node fills up.
+	 *
+	 * 2) On SIMD platforms, we must branch anyway to make sure we don't bit
+	 * scan an empty bitfield. Doing the branch here eliminates some work that
+	 * we might otherwise throw away.
+	 */
+	Assert(count > 0);
+	if (node->chunks[count - 1] < chunk)
+		return count;
+
+#if defined(USE_NO_SIMD) || defined(USE_ASSERT_CHECKING)
+
+	for (index = 0; index < count; index++)
+	{
+		if (node->chunks[index] > chunk)
+			break;
+	}
+#endif
+
+#ifndef USE_NO_SIMD
+
+	/*
+	 * This is a bit more complicated than RT_NODE_16_SEARCH_EQ(), because no
+	 * unsigned uint8 comparison instruction exists, at least for SSE2. So we
+	 * need to play some trickery using vector8_min() to effectively get >=.
+	 * There'll never be any equal elements in current uses, but that's what
+	 * we get here...
+	 */
+	spread_chunk = vector8_broadcast(chunk);
+	vector8_load(&haystack1, &node->chunks[0]);
+	vector8_load(&haystack2, &node->chunks[sizeof(Vector8)]);
+	min1 = vector8_min(spread_chunk, haystack1);
+	min2 = vector8_min(spread_chunk, haystack2);
+	cmp1 = vector8_eq(spread_chunk, min1);
+	cmp2 = vector8_eq(spread_chunk, min2);
+	bitfield = vector8_highbit_mask(cmp1) | (vector8_highbit_mask(cmp2) << sizeof(Vector8));
+
+	Assert((bitfield & ((UINT64CONST(1) << count) - 1)) != 0);
+	index_simd = pg_rightmost_one_pos32(bitfield);
+
+	Assert(index_simd == index);
+	return index_simd;
+#else
+	return index;
+#endif
+}
+
+/* Shift the elements right at "insertpos" by one */
+static inline void
+RT_SHIFT_ARRAYS_FOR_INSERT(uint8 *chunks, RT_PTR_ALLOC * children, int count, int insertpos)
+{
+	/*
+	 * This is basically a memmove, but written in a simple loop for speed on
+	 * small inputs.
+	 */
+	for (int i = count - 1; i >= insertpos; i--)
+	{
+		/* workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101481 */
+#ifdef __GNUC__
+		__asm__("");
+#endif
+		chunks[i + 1] = chunks[i];
+		children[i + 1] = children[i];
+	}
+}
+
+/*
+ * Copy both chunk and slot arrays into the right
+ * place. The caller is responsible for inserting the new element.
+ */
+static inline void
+RT_COPY_ARRAYS_FOR_INSERT(uint8 *dst_chunks, RT_PTR_ALLOC * dst_children,
+						  uint8 *src_chunks, RT_PTR_ALLOC * src_children,
+						  int count, int insertpos)
+{
+	for (int i = 0; i < count; i++)
+	{
+		int			sourceidx = i;
+
+		/* use a branch-free computation to skip the index of the new element */
+		int			destidx = i + (i >= insertpos);
+
+		dst_chunks[destidx] = src_chunks[sourceidx];
+		dst_children[destidx] = src_children[sourceidx];
+	}
+}
+
+static inline RT_PTR_ALLOC *
+RT_ADD_CHILD_256(RT_RADIX_TREE * tree, RT_CHILD_PTR node, uint8 chunk)
+{
+	RT_NODE_256 *n256 = (RT_NODE_256 *) node.local;
+	int			idx = RT_BM_IDX(chunk);
+	int			bitnum = RT_BM_BIT(chunk);
+
+	/* Mark the slot used for "chunk" */
+	n256->isset[idx] |= ((bitmapword) 1 << bitnum);
+
+	n256->base.count++;
+	RT_VERIFY_NODE((RT_NODE *) n256);
+
+	return RT_NODE_256_GET_CHILD(n256, chunk);
+}
+
+static pg_noinline RT_PTR_ALLOC *
+RT_GROW_NODE_48(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node,
+				uint8 chunk)
+{
+	RT_NODE_48 *n48 = (RT_NODE_48 *) node.local;
+	RT_CHILD_PTR newnode;
+	RT_NODE_256 *new256;
+	int			i = 0;
+
+	/* initialize new node */
+	newnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_256, RT_CLASS_256);
+	new256 = (RT_NODE_256 *) newnode.local;
+
+	/* copy over the entries */
+	RT_COPY_COMMON(newnode, node);
+	for (int word_num = 0; word_num < RT_BM_IDX(RT_NODE_MAX_SLOTS); word_num++)
+	{
+		bitmapword	bitmap = 0;
+
+		/*
+		 * Bit manipulation is a surprisingly large portion of the overhead in
+		 * the naive implementation. Doing stores word-at-a-time removes a lot
+		 * of that overhead.
+		 */
+		for (int bit = 0; bit < BITS_PER_BITMAPWORD; bit++)
+		{
+			uint8		offset = n48->slot_idxs[i];
+
+			if (offset != RT_INVALID_SLOT_IDX)
+			{
+				bitmap |= ((bitmapword) 1 << bit);
+				new256->children[i] = n48->children[offset];
+			}
+
+			i++;
+		}
+
+		new256->isset[word_num] = bitmap;
+	}
+
+	/* free old node and update reference in parent */
+	*parent_slot = newnode.alloc;
+	RT_FREE_NODE(tree, node);
+
+	return RT_ADD_CHILD_256(tree, newnode, chunk);
+}
+
+static inline RT_PTR_ALLOC *
+RT_ADD_CHILD_48(RT_RADIX_TREE * tree, RT_CHILD_PTR node, uint8 chunk)
+{
+	RT_NODE_48 *n48 = (RT_NODE_48 *) node.local;
+	int			insertpos;
+	int			idx = 0;
+	bitmapword	w,
+				inverse;
+
+	/* get the first word with at least one bit not set */
+	for (int i = 0; i < RT_BM_IDX(RT_FANOUT_48_MAX); i++)
+	{
+		w = n48->isset[i];
+		if (w < ~((bitmapword) 0))
+		{
+			idx = i;
+			break;
+		}
+	}
+
+	/* To get the first unset bit in w, get the first set bit in ~w */
+	inverse = ~w;
+	insertpos = idx * BITS_PER_BITMAPWORD;
+	insertpos += bmw_rightmost_one_pos(inverse);
+	Assert(insertpos < n48->base.fanout);
+
+	/* mark the slot used by setting the rightmost zero bit */
+	n48->isset[idx] |= w + 1;
+
+	/* insert new chunk into place */
+	n48->slot_idxs[chunk] = insertpos;
+
+	n48->base.count++;
+	RT_VERIFY_NODE((RT_NODE *) n48);
+
+	return &n48->children[insertpos];
+}
+
+static pg_noinline RT_PTR_ALLOC *
+RT_GROW_NODE_16(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node,
+				uint8 chunk)
+{
+	RT_NODE_16 *n16 = (RT_NODE_16 *) node.local;
+	int			insertpos;
+
+	if (n16->base.fanout < RT_FANOUT_16_HI)
+	{
+		RT_CHILD_PTR newnode;
+		RT_NODE_16 *new16;
+
+		Assert(n16->base.fanout == RT_FANOUT_16_LO);
+
+		/* initialize new node */
+		newnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_16, RT_CLASS_16_HI);
+		new16 = (RT_NODE_16 *) newnode.local;
+
+		/* copy over existing entries */
+		RT_COPY_COMMON(newnode, node);
+		Assert(n16->base.count == RT_FANOUT_16_LO);
+		insertpos = RT_NODE_16_GET_INSERTPOS(n16, chunk);
+		RT_COPY_ARRAYS_FOR_INSERT(new16->chunks, new16->children,
+								  n16->chunks, n16->children,
+								  RT_FANOUT_16_LO, insertpos);
+
+		/* insert new chunk into place */
+		new16->chunks[insertpos] = chunk;
+
+		new16->base.count++;
+		RT_VERIFY_NODE((RT_NODE *) new16);
+
+		/* free old node and update references */
+		RT_FREE_NODE(tree, node);
+		*parent_slot = newnode.alloc;
+
+		return &new16->children[insertpos];
+	}
+	else
+	{
+		RT_CHILD_PTR newnode;
+		RT_NODE_48 *new48;
+		int			idx,
+					bit;
+
+		Assert(n16->base.fanout == RT_FANOUT_16_HI);
+
+		/* initialize new node */
+		newnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_48, RT_CLASS_48);
+		new48 = (RT_NODE_48 *) newnode.local;
+
+		/* copy over the entries */
+		RT_COPY_COMMON(newnode, node);
+		for (int i = 0; i < RT_FANOUT_16_HI; i++)
+			new48->slot_idxs[n16->chunks[i]] = i;
+		memcpy(&new48->children[0], &n16->children[0], RT_FANOUT_16_HI * sizeof(new48->children[0]));
+
+		/*
+		 * Since we just copied a dense array, we can fill "isset" using a
+		 * single store, provided the length of that array is at most the
+		 * number of bits in a bitmapword.
+		 */
+		Assert(RT_FANOUT_16_HI <= BITS_PER_BITMAPWORD);
+		new48->isset[0] = (bitmapword) (((uint64) 1 << RT_FANOUT_16_HI) - 1);
+
+		/* put the new child at the end of the copied entries */
+		insertpos = RT_FANOUT_16_HI;
+		idx = RT_BM_IDX(insertpos);
+		bit = RT_BM_BIT(insertpos);
+
+		/* mark the slot used */
+		new48->isset[idx] |= ((bitmapword) 1 << bit);
+
+		/* insert new chunk into place */
+		new48->slot_idxs[chunk] = insertpos;
+
+		new48->base.count++;
+		RT_VERIFY_NODE((RT_NODE *) new48);
+
+		/* free old node and update reference in parent */
+		*parent_slot = newnode.alloc;
+		RT_FREE_NODE(tree, node);
+
+		return &new48->children[insertpos];
+	}
+}
+
+static inline RT_PTR_ALLOC *
+RT_ADD_CHILD_16(RT_RADIX_TREE * tree, RT_CHILD_PTR node, uint8 chunk)
+{
+	RT_NODE_16 *n16 = (RT_NODE_16 *) node.local;
+	int			insertpos = RT_NODE_16_GET_INSERTPOS(n16, chunk);
+
+	/* shift chunks and children */
+	RT_SHIFT_ARRAYS_FOR_INSERT(n16->chunks, n16->children,
+							   n16->base.count, insertpos);
+
+	/* insert new chunk into place */
+	n16->chunks[insertpos] = chunk;
+
+	n16->base.count++;
+	RT_VERIFY_NODE((RT_NODE *) n16);
+
+	return &n16->children[insertpos];
+}
+
+static pg_noinline RT_PTR_ALLOC *
+RT_GROW_NODE_4(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node,
+			   uint8 chunk)
+{
+	RT_NODE_4  *n4 = (RT_NODE_4 *) (node.local);
+	RT_CHILD_PTR newnode;
+	RT_NODE_16 *new16;
+	int			insertpos;
+
+	/* initialize new node */
+	newnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_16, RT_CLASS_16_LO);
+	new16 = (RT_NODE_16 *) newnode.local;
+
+	/* copy over existing entries */
+	RT_COPY_COMMON(newnode, node);
+	Assert(n4->base.count == RT_FANOUT_4);
+	insertpos = RT_NODE_4_GET_INSERTPOS(n4, chunk, RT_FANOUT_4);
+	RT_COPY_ARRAYS_FOR_INSERT(new16->chunks, new16->children,
+							  n4->chunks, n4->children,
+							  RT_FANOUT_4, insertpos);
+
+	/* insert new chunk into place */
+	new16->chunks[insertpos] = chunk;
+
+	new16->base.count++;
+	RT_VERIFY_NODE((RT_NODE *) new16);
+
+	/* free old node and update reference in parent */
+	*parent_slot = newnode.alloc;
+	RT_FREE_NODE(tree, node);
+
+	return &new16->children[insertpos];
+}
+
+static inline RT_PTR_ALLOC *
+RT_ADD_CHILD_4(RT_RADIX_TREE * tree, RT_CHILD_PTR node, uint8 chunk)
+{
+	RT_NODE_4  *n4 = (RT_NODE_4 *) (node.local);
+	int			count = n4->base.count;
+	int			insertpos = RT_NODE_4_GET_INSERTPOS(n4, chunk, count);
+
+	/* shift chunks and children */
+	RT_SHIFT_ARRAYS_FOR_INSERT(n4->chunks, n4->children,
+							   count, insertpos);
+
+	/* insert new chunk into place */
+	n4->chunks[insertpos] = chunk;
+
+	n4->base.count++;
+	RT_VERIFY_NODE((RT_NODE *) n4);
+
+	return &n4->children[insertpos];
+}
+
+/*
+ * Reserve slot in "node"'s child array. The caller will populate it
+ * with the actual child pointer.
+ *
+ * "parent_slot" is the address of the parent's child pointer to "node".
+ * If the node we're inserting into needs to grow, we update the parent's
+ * child pointer with the pointer to the new larger node.
+ */
+static inline RT_PTR_ALLOC *
+RT_NODE_INSERT(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node,
+			   uint8 chunk)
+{
+	RT_NODE    *n = node.local;
+
+	switch (n->kind)
+	{
+		case RT_NODE_KIND_4:
+			{
+				if (unlikely(RT_NODE_MUST_GROW(n)))
+					return RT_GROW_NODE_4(tree, parent_slot, node, chunk);
+
+				return RT_ADD_CHILD_4(tree, node, chunk);
+			}
+		case RT_NODE_KIND_16:
+			{
+				if (unlikely(RT_NODE_MUST_GROW(n)))
+					return RT_GROW_NODE_16(tree, parent_slot, node, chunk);
+
+				return RT_ADD_CHILD_16(tree, node, chunk);
+			}
+		case RT_NODE_KIND_48:
+			{
+				if (unlikely(RT_NODE_MUST_GROW(n)))
+					return RT_GROW_NODE_48(tree, parent_slot, node, chunk);
+
+				return RT_ADD_CHILD_48(tree, node, chunk);
+			}
+		case RT_NODE_KIND_256:
+			return RT_ADD_CHILD_256(tree, node, chunk);
+		default:
+			pg_unreachable();
+	}
+}
+
+/*
+ * The radix tree doesn't have sufficient height. Put new node(s) on top,
+ * and move the old node below it.
+ */
+static pg_noinline void
+RT_EXTEND_UP(RT_RADIX_TREE * tree, RT_KEY key)
+{
+	int			target_shift = RT_KEY_GET_SHIFT(key);
+	int			shift = tree->ctl->start_shift;
+
+	Assert(shift < target_shift);
+
+	/* Grow tree upwards until start shift can accommodate the key */
+	while (shift < target_shift)
+	{
+		RT_CHILD_PTR node;
+		RT_NODE_4  *n4;
+
+		node = RT_ALLOC_NODE(tree, RT_NODE_KIND_4, RT_CLASS_4);
+		n4 = (RT_NODE_4 *) node.local;
+		n4->base.count = 1;
+		n4->chunks[0] = 0;
+		n4->children[0] = tree->ctl->root;
+
+		/* Update the root */
+		tree->ctl->root = node.alloc;
+
+		shift += RT_SPAN;
+	}
+
+	tree->ctl->max_val = RT_SHIFT_GET_MAX_VAL(target_shift);
+	tree->ctl->start_shift = target_shift;
+}
+
+/*
+ * Insert a chain of nodes until we reach the lowest level,
+ * and return the address of a slot to be filled further up
+ * the call stack.
+ */
+static pg_noinline RT_PTR_ALLOC *
+RT_EXTEND_DOWN(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_KEY key, int shift)
+{
+	RT_CHILD_PTR node,
+				child;
+	RT_NODE_4  *n4;
+
+	/*
+	 * The child pointer of the first node in the chain goes in the
+	 * caller-provided slot.
+	 */
+	child = RT_ALLOC_NODE(tree, RT_NODE_KIND_4, RT_CLASS_4);
+	*parent_slot = child.alloc;
+
+	node = child;
+	shift -= RT_SPAN;
+
+	while (shift > 0)
+	{
+		child = RT_ALLOC_NODE(tree, RT_NODE_KIND_4, RT_CLASS_4);
+
+		/* We open-code the insertion ourselves, for speed. */
+		n4 = (RT_NODE_4 *) node.local;
+		n4->base.count = 1;
+		n4->chunks[0] = RT_GET_KEY_CHUNK(key, shift);
+		n4->children[0] = child.alloc;
+
+		node = child;
+		shift -= RT_SPAN;
+	}
+	Assert(shift == 0);
+
+	/* Reserve slot for the value. */
+	n4 = (RT_NODE_4 *) node.local;
+	n4->chunks[0] = RT_GET_KEY_CHUNK(key, 0);
+	n4->base.count = 1;
+
+	return &n4->children[0];
+}
+
+/*
+ * Workhorse for RT_SET
+ *
+ * "parent_slot" is the address of the child pointer we just followed,
+ * in the parent's array of children, needed if inserting into the
+ * current node causes it to grow.
+ */
+static RT_PTR_ALLOC *
+RT_GET_SLOT_RECURSIVE(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_KEY key, int shift, bool *found)
+{
+	RT_PTR_ALLOC *slot;
+	RT_CHILD_PTR node;
+	uint8		chunk = RT_GET_KEY_CHUNK(key, shift);
+
+	node.alloc = *parent_slot;
+	RT_PTR_SET_LOCAL(tree, &node);
+	slot = RT_NODE_SEARCH(node.local, chunk);
+
+	if (slot == NULL)
+	{
+		*found = false;
+
+		/* reserve slot for the caller to populate */
+
+		slot = RT_NODE_INSERT(tree, parent_slot, node, chunk);
+
+		if (shift == 0)
+			return slot;
+		else
+			return RT_EXTEND_DOWN(tree, slot, key, shift);
+	}
+	else
+	{
+		if (shift == 0)
+		{
+			*found = true;
+			return slot;
+		}
+		else
+			return RT_GET_SLOT_RECURSIVE(tree, slot, key, shift - RT_SPAN, found);
+	}
+}
+
+/*
+ * Set key to value that value_p points to. If the entry already exists, we
+ * update its value and return true. Returns false if entry doesn't yet exist.
+ *
+ * Taking a lock in exclusive mode is the caller's responsibility.
+ */
+RT_SCOPE bool
+RT_SET(RT_RADIX_TREE * tree, RT_KEY key, RT_VALUE_TYPE * value_p)
+{
+	bool		found;
+	RT_PTR_ALLOC *slot;
+	size_t		value_sz = RT_GET_VALUE_SIZE(value_p);
+
+#ifdef RT_SHMEM
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+#endif
+
+	Assert(RT_PTR_ALLOC_IS_VALID(tree->ctl->root));
+
+	/* Extend the tree if necessary */
+	if (unlikely(!RT_KEY_FITS(tree, key)))
+	{
+		if (tree->ctl->num_keys == 0)
+		{
+			RT_CHILD_PTR node;
+			RT_NODE_4  *n4;
+			int			start_shift = RT_KEY_GET_SHIFT(key);
+
+			/*
+			 * With an empty root node, we don't extend the tree upwards,
+			 * since that would result in orphan empty nodes. Instead we open
+			 * code inserting into the root node and extend downward from
+			 * there.
+			 */
+			node.alloc = tree->ctl->root;
+			RT_PTR_SET_LOCAL(tree, &node);
+			n4 = (RT_NODE_4 *) node.local;
+			n4->base.count = 1;
+			n4->chunks[0] = RT_GET_KEY_CHUNK(key, start_shift);
+
+			slot = RT_EXTEND_DOWN(tree, &n4->children[0], key, start_shift);
+			found = false;
+			tree->ctl->start_shift = start_shift;
+			tree->ctl->max_val = RT_SHIFT_GET_MAX_VAL(start_shift);
+			goto have_slot;
+		}
+		else
+			RT_EXTEND_UP(tree, key);
+	}
+
+	slot = RT_GET_SLOT_RECURSIVE(tree, &tree->ctl->root,
+								 key, tree->ctl->start_shift, &found);
+
+have_slot:
+	Assert(slot != NULL);
+
+	if (RT_VALUE_IS_EMBEDDABLE(value_p))
+	{
+		/* free the existing leaf */
+		if (found && !RT_CHILDPTR_IS_VALUE(*slot))
+			RT_FREE_LEAF(tree, *slot);
+
+		/* store value directly in child pointer slot */
+		memcpy(slot, value_p, value_sz);
+
+#ifdef RT_RUNTIME_EMBEDDABLE_VALUE
+		/* tag child pointer */
+#ifdef RT_SHMEM
+		*slot |= 1;
+#else
+		*((uintptr_t *) slot) |= 1;
+#endif
+#endif
+	}
+	else
+	{
+		RT_CHILD_PTR leaf;
+
+		if (found && !RT_CHILDPTR_IS_VALUE(*slot))
+		{
+			Assert(RT_PTR_ALLOC_IS_VALID(*slot));
+			leaf.alloc = *slot;
+			RT_PTR_SET_LOCAL(tree, &leaf);
+
+			if (RT_GET_VALUE_SIZE((RT_VALUE_TYPE *) leaf.local) != value_sz)
+			{
+				/*
+				 * different sizes, so first free the existing leaf before
+				 * allocating a new one
+				 */
+				RT_FREE_LEAF(tree, *slot);
+				leaf = RT_ALLOC_LEAF(tree, value_sz);
+				*slot = leaf.alloc;
+			}
+		}
+		else
+		{
+			/* allocate new leaf and store it in the child array */
+			leaf = RT_ALLOC_LEAF(tree, value_sz);
+			*slot = leaf.alloc;
+		}
+
+		memcpy(leaf.local, value_p, value_sz);
+	}
+
+	/* Update the statistics */
+	if (!found)
+		tree->ctl->num_keys++;
+
+	return found;
+}
+
+/***************** SETUP / TEARDOWN *****************/
+
+/*
+ * Create the radix tree in the given memory context and return it.
+ *
+ * All local memory required for a radix tree is allocated in the given
+ * memory context and its children. Note that RT_FREE() will delete all
+ * allocated space within the given memory context, so the dsa_area should
+ * be created in a different context.
+ */
+RT_SCOPE	RT_RADIX_TREE *
+#ifdef RT_SHMEM
+RT_CREATE(MemoryContext ctx, dsa_area * dsa, int tranche_id)
+#else
+RT_CREATE(MemoryContext ctx)
+#endif
+{
+	RT_RADIX_TREE *tree;
+	MemoryContext old_ctx;
+	RT_CHILD_PTR rootnode;
+#ifdef RT_SHMEM
+	dsa_pointer dp;
+#endif
+
+	old_ctx = MemoryContextSwitchTo(ctx);
+
+	tree = (RT_RADIX_TREE *) palloc0(sizeof(RT_RADIX_TREE));
+	tree->context = ctx;
+
+	/*
+	 * Separate context for iteration in case the tree context doesn't support
+	 * pfree
+	 */
+	tree->iter_context = AllocSetContextCreate(ctx,
+											   RT_STR(RT_PREFIX) "_radix_tree iter context",
+											   ALLOCSET_SMALL_SIZES);
+
+#ifdef RT_SHMEM
+	tree->dsa = dsa;
+	dp = dsa_allocate0(dsa, sizeof(RT_RADIX_TREE_CONTROL));
+	tree->ctl = (RT_RADIX_TREE_CONTROL *) dsa_get_address(dsa, dp);
+	tree->ctl->handle = dp;
+	tree->ctl->magic = RT_RADIX_TREE_MAGIC;
+	LWLockInitialize(&tree->ctl->lock, tranche_id);
+#else
+	tree->ctl = (RT_RADIX_TREE_CONTROL *) palloc0(sizeof(RT_RADIX_TREE_CONTROL));
+
+	/* Create a slab context for each size class */
+	for (int i = 0; i < RT_NUM_SIZE_CLASSES; i++)
+	{
+		RT_SIZE_CLASS_ELEM size_class = RT_SIZE_CLASS_INFO[i];
+		size_t		inner_blocksize = RT_SLAB_BLOCK_SIZE(size_class.allocsize);
+
+		tree->node_slabs[i] = SlabContextCreate(ctx,
+												size_class.name,
+												inner_blocksize,
+												size_class.allocsize);
+	}
+
+	/* By default we use the passed context for leaves. */
+	tree->leaf_context = tree->context;
+
+#ifndef RT_VARLEN_VALUE_SIZE
+
+	/*
+	 * For leaves storing fixed-length values, we use a slab context to avoid
+	 * the possibility of space wastage by power-of-2 rounding up.
+	 */
+	if (sizeof(RT_VALUE_TYPE) > sizeof(RT_PTR_ALLOC))
+		tree->leaf_context = SlabContextCreate(ctx,
+											   RT_STR(RT_PREFIX) "_radix_tree leaf context",
+											   RT_SLAB_BLOCK_SIZE(sizeof(RT_VALUE_TYPE)),
+											   sizeof(RT_VALUE_TYPE));
+#endif							/* !RT_VARLEN_VALUE_SIZE */
+#endif							/* RT_SHMEM */
+
+	/* add root node now so that RT_SET can assume it exists */
+	rootnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_4, RT_CLASS_4);
+	tree->ctl->root = rootnode.alloc;
+#ifdef RT_KEY_SIZE
+	/* Fixed-length keys always use the full tree height. */
+	tree->ctl->start_shift = RT_MAX_SHIFT;
+	tree->ctl->max_val = UINT64_MAX;
+#else
+	tree->ctl->start_shift = 0;
+	tree->ctl->max_val = RT_SHIFT_GET_MAX_VAL(0);
+#endif
+
+	MemoryContextSwitchTo(old_ctx);
+
+	return tree;
+}
+
+#ifdef RT_SHMEM
+RT_SCOPE	RT_RADIX_TREE *
+RT_ATTACH(dsa_area * dsa, RT_HANDLE handle)
+{
+	RT_RADIX_TREE *tree;
+	dsa_pointer control;
+
+	tree = (RT_RADIX_TREE *) palloc0(sizeof(RT_RADIX_TREE));
+	tree->context = CurrentMemoryContext;
+
+	/* Find the control object in shared memory */
+	control = handle;
+
+	tree->dsa = dsa;
+	tree->ctl = (RT_RADIX_TREE_CONTROL *) dsa_get_address(dsa, control);
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+
+	/*
+	 * Create the iteration context so that the attached backend also can
+	 * begin the iteration.
+	 */
+	tree->iter_context = AllocSetContextCreate(CurrentMemoryContext,
+											   RT_STR(RT_PREFIX) "_radix_tree iter context",
+											   ALLOCSET_SMALL_SIZES);
+
+	return tree;
+}
+
+RT_SCOPE void
+RT_DETACH(RT_RADIX_TREE * tree)
+{
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+	MemoryContextDelete(tree->iter_context);
+	pfree(tree);
+}
+
+RT_SCOPE	RT_HANDLE
+RT_GET_HANDLE(RT_RADIX_TREE * tree)
+{
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+	return tree->ctl->handle;
+}
+
+RT_SCOPE void
+RT_LOCK_EXCLUSIVE(RT_RADIX_TREE * tree)
+{
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+	LWLockAcquire(&tree->ctl->lock, LW_EXCLUSIVE);
+}
+
+RT_SCOPE void
+RT_LOCK_SHARE(RT_RADIX_TREE * tree)
+{
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+	LWLockAcquire(&tree->ctl->lock, LW_SHARED);
+}
+
+RT_SCOPE void
+RT_UNLOCK(RT_RADIX_TREE * tree)
+{
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+	LWLockRelease(&tree->ctl->lock);
+}
+
+/*
+ * Recursively free all nodes allocated in the DSA area.
+ */
+static void
+RT_FREE_RECURSE(RT_RADIX_TREE * tree, RT_PTR_ALLOC ptr, int shift)
+{
+	RT_CHILD_PTR node;
+
+	check_stack_depth();
+
+	node.alloc = ptr;
+	RT_PTR_SET_LOCAL(tree, &node);
+
+	switch (node.local->kind)
+	{
+		case RT_NODE_KIND_4:
+			{
+				RT_NODE_4  *n4 = (RT_NODE_4 *) node.local;
+
+				for (int i = 0; i < n4->base.count; i++)
+				{
+					RT_PTR_ALLOC child = n4->children[i];
+
+					if (shift > 0)
+						RT_FREE_RECURSE(tree, child, shift - RT_SPAN);
+					else if (!RT_CHILDPTR_IS_VALUE(child))
+						dsa_free(tree->dsa, child);
+				}
+
+				break;
+			}
+		case RT_NODE_KIND_16:
+			{
+				RT_NODE_16 *n16 = (RT_NODE_16 *) node.local;
+
+				for (int i = 0; i < n16->base.count; i++)
+				{
+					RT_PTR_ALLOC child = n16->children[i];
+
+					if (shift > 0)
+						RT_FREE_RECURSE(tree, child, shift - RT_SPAN);
+					else if (!RT_CHILDPTR_IS_VALUE(child))
+						dsa_free(tree->dsa, child);
+				}
+
+				break;
+			}
+		case RT_NODE_KIND_48:
+			{
+				RT_NODE_48 *n48 = (RT_NODE_48 *) node.local;
+
+				for (int i = 0; i < RT_NODE_MAX_SLOTS; i++)
+				{
+					RT_PTR_ALLOC child;
+
+					if (!RT_NODE_48_IS_CHUNK_USED(n48, i))
+						continue;
+
+					child = *RT_NODE_48_GET_CHILD(n48, i);
+
+					if (shift > 0)
+						RT_FREE_RECURSE(tree, child, shift - RT_SPAN);
+					else if (!RT_CHILDPTR_IS_VALUE(child))
+						dsa_free(tree->dsa, child);
+				}
+
+				break;
+			}
+		case RT_NODE_KIND_256:
+			{
+				RT_NODE_256 *n256 = (RT_NODE_256 *) node.local;
+
+				for (int i = 0; i < RT_NODE_MAX_SLOTS; i++)
+				{
+					RT_PTR_ALLOC child;
+
+					if (!RT_NODE_256_IS_CHUNK_USED(n256, i))
+						continue;
+
+					child = *RT_NODE_256_GET_CHILD(n256, i);
+
+					if (shift > 0)
+						RT_FREE_RECURSE(tree, child, shift - RT_SPAN);
+					else if (!RT_CHILDPTR_IS_VALUE(child))
+						dsa_free(tree->dsa, child);
+				}
+
+				break;
+			}
+	}
+
+	/* Free the inner node */
+	dsa_free(tree->dsa, ptr);
+}
+#endif
+
+/*
+ * Free the radix tree, including all nodes and leaves.
+ */
+RT_SCOPE void
+RT_FREE(RT_RADIX_TREE * tree)
+{
+#ifdef RT_SHMEM
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+
+	/* Free all memory used for radix tree nodes */
+	Assert(RT_PTR_ALLOC_IS_VALID(tree->ctl->root));
+	RT_FREE_RECURSE(tree, tree->ctl->root, tree->ctl->start_shift);
+
+	/*
+	 * Vandalize the control block to help catch programming error where other
+	 * backends access the memory formerly occupied by this radix tree.
+	 */
+	tree->ctl->magic = 0;
+	dsa_free(tree->dsa, tree->ctl->handle);
+#endif
+
+	/*
+	 * Free all space allocated within the tree's context and delete all child
+	 * contexts such as those used for nodes.
+	 */
+	MemoryContextReset(tree->context);
+}
+
+/***************** ITERATION *****************/
+
+/*
+ * Create and return the iterator for the given radix tree.
+ *
+ * Taking a lock in shared mode during the iteration is the caller's
+ * responsibility.
+ */
+RT_SCOPE	RT_ITER *
+RT_BEGIN_ITERATE(RT_RADIX_TREE * tree)
+{
+	RT_ITER    *iter;
+	RT_CHILD_PTR root;
+
+	iter = (RT_ITER *) MemoryContextAllocZero(tree->iter_context,
+											  sizeof(RT_ITER));
+	iter->tree = tree;
+
+	Assert(RT_PTR_ALLOC_IS_VALID(tree->ctl->root));
+	root.alloc = iter->tree->ctl->root;
+	RT_PTR_SET_LOCAL(tree, &root);
+
+	iter->top_level = iter->tree->ctl->start_shift / RT_SPAN;
+
+	/* Set the root to start */
+	iter->cur_level = iter->top_level;
+	iter->node_iters[iter->cur_level].node = root;
+	iter->node_iters[iter->cur_level].idx = 0;
+
+	return iter;
+}
+
+/*
+ * Scan the inner node and return the next child pointer if one exists, otherwise
+ * return NULL.
+ */
+static inline RT_PTR_ALLOC *
+RT_NODE_ITERATE_NEXT(RT_ITER * iter, int level)
+{
+	uint8		key_chunk = 0;
+	RT_NODE_ITER *node_iter;
+	RT_CHILD_PTR node;
+	RT_PTR_ALLOC *slot = NULL;
+
+#ifdef RT_SHMEM
+	Assert(iter->tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+#endif
+
+	node_iter = &(iter->node_iters[level]);
+	node = node_iter->node;
+
+	Assert(node.local != NULL);
+
+	switch ((node.local)->kind)
+	{
+		case RT_NODE_KIND_4:
+			{
+				RT_NODE_4  *n4 = (RT_NODE_4 *) (node.local);
+
+				if (node_iter->idx >= n4->base.count)
+					return NULL;
+
+				slot = &n4->children[node_iter->idx];
+				key_chunk = n4->chunks[node_iter->idx];
+				node_iter->idx++;
+				break;
+			}
+		case RT_NODE_KIND_16:
+			{
+				RT_NODE_16 *n16 = (RT_NODE_16 *) (node.local);
+
+				if (node_iter->idx >= n16->base.count)
+					return NULL;
+
+				slot = &n16->children[node_iter->idx];
+				key_chunk = n16->chunks[node_iter->idx];
+				node_iter->idx++;
+				break;
+			}
+		case RT_NODE_KIND_48:
+			{
+				RT_NODE_48 *n48 = (RT_NODE_48 *) (node.local);
+				int			chunk;
+
+				for (chunk = node_iter->idx; chunk < RT_NODE_MAX_SLOTS; chunk++)
+				{
+					if (RT_NODE_48_IS_CHUNK_USED(n48, chunk))
+						break;
+				}
+
+				if (chunk >= RT_NODE_MAX_SLOTS)
+					return NULL;
+
+				slot = RT_NODE_48_GET_CHILD(n48, chunk);
+
+				key_chunk = chunk;
+				node_iter->idx = chunk + 1;
+				break;
+			}
+		case RT_NODE_KIND_256:
+			{
+				RT_NODE_256 *n256 = (RT_NODE_256 *) (node.local);
+				int			chunk;
+
+				for (chunk = node_iter->idx; chunk < RT_NODE_MAX_SLOTS; chunk++)
+				{
+					if (RT_NODE_256_IS_CHUNK_USED(n256, chunk))
+						break;
+				}
+
+				if (chunk >= RT_NODE_MAX_SLOTS)
+					return NULL;
+
+				slot = RT_NODE_256_GET_CHILD(n256, chunk);
+
+				key_chunk = chunk;
+				node_iter->idx = chunk + 1;
+				break;
+			}
+	}
+
+	/* Update the key */
+#ifdef RT_KEY_SIZE
+	iter->key.data[RT_KEY_BYTES - 1 - level] = key_chunk;
+#else
+	iter->key &= ~(((uint64) RT_CHUNK_MASK) << (level * RT_SPAN));
+	iter->key |= (((uint64) key_chunk) << (level * RT_SPAN));
+#endif
+
+	return slot;
+}
+
+/*
+ * Return pointer to value and set key_p as long as there is a key.  Otherwise
+ * return NULL.
+ */
+RT_SCOPE	RT_VALUE_TYPE *
+RT_ITERATE_NEXT(RT_ITER * iter, RT_KEY * key_p)
+{
+	RT_PTR_ALLOC *slot = NULL;
+
+	while (iter->cur_level <= iter->top_level)
+	{
+		RT_CHILD_PTR node;
+
+		slot = RT_NODE_ITERATE_NEXT(iter, iter->cur_level);
+
+		if (iter->cur_level == 0 && slot != NULL)
+		{
+			/* Found a value at the leaf node */
+			*key_p = iter->key;
+			node.alloc = *slot;
+
+			if (RT_CHILDPTR_IS_VALUE(*slot))
+				return (RT_VALUE_TYPE *) slot;
+			else
+			{
+				RT_PTR_SET_LOCAL(iter->tree, &node);
+				return (RT_VALUE_TYPE *) node.local;
+			}
+		}
+
+		if (slot != NULL)
+		{
+			/* Found the child slot, move down the tree */
+			node.alloc = *slot;
+			RT_PTR_SET_LOCAL(iter->tree, &node);
+
+			iter->cur_level--;
+			iter->node_iters[iter->cur_level].node = node;
+			iter->node_iters[iter->cur_level].idx = 0;
+		}
+		else
+		{
+			/* Not found the child slot, move up the tree */
+			iter->cur_level++;
+		}
+	}
+
+	/* We've visited all nodes, so the iteration finished */
+	return NULL;
+}
+
+/*
+ * Terminate the iteration. The caller is responsible for releasing any locks.
+ */
+RT_SCOPE void
+RT_END_ITERATE(RT_ITER * iter)
+{
+	pfree(iter);
+}
+
+/***************** DELETION *****************/
+
+#ifdef RT_USE_DELETE
+
+/* Delete the element at "deletepos" */
+static inline void
+RT_SHIFT_ARRAYS_AND_DELETE(uint8 *chunks, RT_PTR_ALLOC * children, int count, int deletepos)
+{
+	/*
+	 * This is basically a memmove, but written in a simple loop for speed on
+	 * small inputs.
+	 */
+	for (int i = deletepos; i < count - 1; i++)
+	{
+		/* workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101481 */
+#ifdef __GNUC__
+		__asm__("");
+#endif
+		chunks[i] = chunks[i + 1];
+		children[i] = children[i + 1];
+	}
+}
+
+/*
+ * Copy both chunk and slot arrays into the right
+ * place. The element at "deletepos" is deleted by skipping it.
+ */
+static inline void
+RT_COPY_ARRAYS_AND_DELETE(uint8 *dst_chunks, RT_PTR_ALLOC * dst_children,
+						  uint8 *src_chunks, RT_PTR_ALLOC * src_children,
+						  int count, int deletepos)
+{
+	for (int i = 0; i < count - 1; i++)
+	{
+		/*
+		 * use a branch-free computation to skip the index of the deleted
+		 * element
+		 */
+		int			sourceidx = i + (i >= deletepos);
+		int			destidx = i;
+
+		dst_chunks[destidx] = src_chunks[sourceidx];
+		dst_children[destidx] = src_children[sourceidx];
+	}
+}
+
+/*
+ * Note: While all node-growing functions are called to perform an insertion
+ * when no more space is available, shrinking is not a hard-and-fast requirement.
+ * When shrinking nodes, we generally wait until the count is about 3/4 of
+ * the next lower node's fanout. This prevents ping-ponging between different
+ * node sizes.
+ *
+ * Some shrinking functions delete first and then shrink, either because we
+ * must or because it's fast and simple that way. Sometimes it's faster to
+ * delete while shrinking.
+ */
+
+/*
+ * Move contents of a node256 to a node48. Any deletion should have happened
+ * in the caller.
+ */
+static void pg_noinline
+RT_SHRINK_NODE_256(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 chunk)
+{
+	RT_NODE_256 *n256 = (RT_NODE_256 *) node.local;
+	RT_CHILD_PTR newnode;
+	RT_NODE_48 *new48;
+	int			slot_idx = 0;
+
+	/* initialize new node */
+	newnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_48, RT_CLASS_48);
+	new48 = (RT_NODE_48 *) newnode.local;
+
+	/* copy over the entries */
+	RT_COPY_COMMON(newnode, node);
+	for (int i = 0; i < RT_NODE_MAX_SLOTS; i++)
+	{
+		if (RT_NODE_256_IS_CHUNK_USED(n256, i))
+		{
+			new48->slot_idxs[i] = slot_idx;
+			new48->children[slot_idx] = n256->children[i];
+			slot_idx++;
+		}
+	}
+
+	/*
+	 * Since we just copied a dense array, we can fill "isset" using a single
+	 * store, provided the length of that array is at most the number of bits
+	 * in a bitmapword.
+	 */
+	Assert(n256->base.count <= BITS_PER_BITMAPWORD);
+	new48->isset[0] = (bitmapword) (((uint64) 1 << n256->base.count) - 1);
+
+	/* free old node and update reference in parent */
+	*parent_slot = newnode.alloc;
+	RT_FREE_NODE(tree, node);
+}
+
+static inline void
+RT_REMOVE_CHILD_256(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 chunk)
+{
+	int			shrink_threshold;
+	RT_NODE_256 *n256 = (RT_NODE_256 *) node.local;
+	int			idx = RT_BM_IDX(chunk);
+	int			bitnum = RT_BM_BIT(chunk);
+
+	/* Mark the slot free for "chunk" */
+	n256->isset[idx] &= ~((bitmapword) 1 << bitnum);
+
+	n256->base.count--;
+
+	/*
+	 * A full node256 will have a count of zero because of overflow, so we
+	 * delete first before checking the shrink threshold.
+	 */
+	Assert(n256->base.count > 0);
+
+	/* This simplifies RT_SHRINK_NODE_256() */
+	shrink_threshold = BITS_PER_BITMAPWORD;
+	shrink_threshold = Min(RT_FANOUT_48 / 4 * 3, shrink_threshold);
+
+	if (n256->base.count <= shrink_threshold)
+		RT_SHRINK_NODE_256(tree, parent_slot, node, chunk);
+}
+
+/*
+ * Move contents of a node48 to a node16. Any deletion should have happened
+ * in the caller.
+ */
+static void pg_noinline
+RT_SHRINK_NODE_48(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 chunk)
+{
+	RT_NODE_48 *n48 = (RT_NODE_48 *) (node.local);
+	RT_CHILD_PTR newnode;
+	RT_NODE_16 *new16;
+	int			destidx = 0;
+
+	/*
+	 * Initialize new node. For now we skip the larger node16 size class for
+	 * simplicity.
+	 */
+	newnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_16, RT_CLASS_16_LO);
+	new16 = (RT_NODE_16 *) newnode.local;
+
+	/* copy over all existing entries */
+	RT_COPY_COMMON(newnode, node);
+	for (int chunk = 0; chunk < RT_NODE_MAX_SLOTS; chunk++)
+	{
+		if (n48->slot_idxs[chunk] != RT_INVALID_SLOT_IDX)
+		{
+			new16->chunks[destidx] = chunk;
+			new16->children[destidx] = n48->children[n48->slot_idxs[chunk]];
+			destidx++;
+		}
+	}
+
+	Assert(destidx < new16->base.fanout);
+
+	RT_VERIFY_NODE((RT_NODE *) new16);
+
+	/* free old node and update reference in parent */
+	*parent_slot = newnode.alloc;
+	RT_FREE_NODE(tree, node);
+}
+
+static inline void
+RT_REMOVE_CHILD_48(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 chunk)
+{
+	RT_NODE_48 *n48 = (RT_NODE_48 *) node.local;
+	int			deletepos = n48->slot_idxs[chunk];
+
+	/* For now we skip the larger node16 size class for simplicity */
+	int			shrink_threshold = RT_FANOUT_16_LO / 4 * 3;
+	int			idx;
+	int			bitnum;
+
+	Assert(deletepos != RT_INVALID_SLOT_IDX);
+
+	idx = RT_BM_IDX(deletepos);
+	bitnum = RT_BM_BIT(deletepos);
+	n48->isset[idx] &= ~((bitmapword) 1 << bitnum);
+	n48->slot_idxs[chunk] = RT_INVALID_SLOT_IDX;
+
+	n48->base.count--;
+
+	/*
+	 * To keep shrinking simple, do it after deleting, which is fast for
+	 * node48 anyway.
+	 */
+	if (n48->base.count <= shrink_threshold)
+		RT_SHRINK_NODE_48(tree, parent_slot, node, chunk);
+}
+
+/*
+ * Move contents of a node16 to a node4, and delete the one at "deletepos".
+ * By deleting as we move, we can avoid memmove operations in the new
+ * node.
+ */
+static void pg_noinline
+RT_SHRINK_NODE_16(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 deletepos)
+{
+	RT_NODE_16 *n16 = (RT_NODE_16 *) (node.local);
+	RT_CHILD_PTR newnode;
+	RT_NODE_4  *new4;
+
+	/* initialize new node */
+	newnode = RT_ALLOC_NODE(tree, RT_NODE_KIND_4, RT_CLASS_4);
+	new4 = (RT_NODE_4 *) newnode.local;
+
+	/* copy over existing entries, except for the one at "deletepos" */
+	RT_COPY_COMMON(newnode, node);
+	RT_COPY_ARRAYS_AND_DELETE(new4->chunks, new4->children,
+							  n16->chunks, n16->children,
+							  n16->base.count, deletepos);
+
+	new4->base.count--;
+	RT_VERIFY_NODE((RT_NODE *) new4);
+
+	/* free old node and update reference in parent */
+	*parent_slot = newnode.alloc;
+	RT_FREE_NODE(tree, node);
+}
+
+static inline void
+RT_REMOVE_CHILD_16(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 chunk, RT_PTR_ALLOC * slot)
+{
+	RT_NODE_16 *n16 = (RT_NODE_16 *) node.local;
+	int			deletepos = slot - n16->children;
+
+	/*
+	 * When shrinking to node4, 4 is hard-coded. After shrinking, the new node
+	 * will end up with 3 elements and 3 is the largest count where linear
+	 * search is faster than SIMD, at least on x86-64.
+	 */
+	if (n16->base.count <= 4)
+	{
+		RT_SHRINK_NODE_16(tree, parent_slot, node, deletepos);
+		return;
+	}
+
+	Assert(deletepos >= 0);
+	Assert(n16->chunks[deletepos] == chunk);
+
+	RT_SHIFT_ARRAYS_AND_DELETE(n16->chunks, n16->children,
+							   n16->base.count, deletepos);
+	n16->base.count--;
+}
+
+static inline void
+RT_REMOVE_CHILD_4(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 chunk, RT_PTR_ALLOC * slot)
+{
+	RT_NODE_4  *n4 = (RT_NODE_4 *) node.local;
+
+	if (n4->base.count == 1)
+	{
+		Assert(n4->chunks[0] == chunk);
+
+		/*
+		 * If we're deleting the last entry from the root child node don't
+		 * free it, but mark both the tree and the root child node empty. That
+		 * way, RT_SET can assume it exists.
+		 */
+		if (parent_slot == &tree->ctl->root)
+		{
+			n4->base.count = 0;
+#ifdef RT_KEY_SIZE
+			tree->ctl->start_shift = RT_MAX_SHIFT;
+			tree->ctl->max_val = UINT64_MAX;
+#else
+			tree->ctl->start_shift = 0;
+			tree->ctl->max_val = RT_SHIFT_GET_MAX_VAL(0);
+#endif
+		}
+		else
+		{
+			/*
+			 * Deleting last entry, so just free the entire node.
+			 * RT_DELETE_RECURSIVE has already freed the value and lower-level
+			 * children.
+			 */
+			RT_FREE_NODE(tree, node);
+
+			/*
+			 * Also null out the parent's slot -- this tells the next higher
+			 * level to delete its child pointer
+			 */
+			*parent_slot = RT_INVALID_PTR_ALLOC;
+		}
+	}
+	else
+	{
+		int			deletepos = slot - n4->children;
+
+		Assert(deletepos >= 0);
+		Assert(n4->chunks[deletepos] == chunk);
+
+		RT_SHIFT_ARRAYS_AND_DELETE(n4->chunks, n4->children,
+								   n4->base.count, deletepos);
+
+		n4->base.count--;
+	}
+}
+
+/*
+ * Delete the child pointer corresponding to "key" in the given node.
+ */
+static inline void
+RT_NODE_DELETE(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_CHILD_PTR node, uint8 chunk, RT_PTR_ALLOC * slot)
+{
+	switch ((node.local)->kind)
+	{
+		case RT_NODE_KIND_4:
+			{
+				RT_REMOVE_CHILD_4(tree, parent_slot, node, chunk, slot);
+				return;
+			}
+		case RT_NODE_KIND_16:
+			{
+				RT_REMOVE_CHILD_16(tree, parent_slot, node, chunk, slot);
+				return;
+			}
+		case RT_NODE_KIND_48:
+			{
+				RT_REMOVE_CHILD_48(tree, parent_slot, node, chunk);
+				return;
+			}
+		case RT_NODE_KIND_256:
+			{
+				RT_REMOVE_CHILD_256(tree, parent_slot, node, chunk);
+				return;
+			}
+		default:
+			pg_unreachable();
+	}
+}
+
+/* workhorse for RT_DELETE */
+static bool
+RT_DELETE_RECURSIVE(RT_RADIX_TREE * tree, RT_PTR_ALLOC * parent_slot, RT_KEY key, int shift)
+{
+	RT_PTR_ALLOC *slot;
+	RT_CHILD_PTR node;
+	uint8		chunk = RT_GET_KEY_CHUNK(key, shift);
+
+	node.alloc = *parent_slot;
+	RT_PTR_SET_LOCAL(tree, &node);
+	slot = RT_NODE_SEARCH(node.local, chunk);
+
+	if (slot == NULL)
+		return false;
+
+	if (shift == 0)
+	{
+		if (!RT_CHILDPTR_IS_VALUE(*slot))
+			RT_FREE_LEAF(tree, *slot);
+
+		RT_NODE_DELETE(tree, parent_slot, node, chunk, slot);
+		return true;
+	}
+	else
+	{
+		bool		deleted;
+
+		deleted = RT_DELETE_RECURSIVE(tree, slot, key, shift - RT_SPAN);
+
+		/* Child node was freed, so delete its slot now */
+		if (*slot == RT_INVALID_PTR_ALLOC)
+		{
+			Assert(deleted);
+			RT_NODE_DELETE(tree, parent_slot, node, chunk, slot);
+		}
+
+		return deleted;
+	}
+}
+
+/*
+ * Delete the given key from the radix tree. If the key is found delete it
+ * and return true, otherwise do nothing and return false.
+ *
+ * Taking a lock in exclusive mode is the caller's responsibility.
+ */
+RT_SCOPE bool
+RT_DELETE(RT_RADIX_TREE * tree, RT_KEY key)
+{
+	bool		deleted;
+
+#ifdef RT_SHMEM
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+#endif
+
+	if (!RT_KEY_FITS(tree, key))
+		return false;
+
+	Assert(RT_PTR_ALLOC_IS_VALID(tree->ctl->root));
+	deleted = RT_DELETE_RECURSIVE(tree, &tree->ctl->root,
+								  key, tree->ctl->start_shift);
+
+	/* Found the key to delete. Update the statistics */
+	if (deleted)
+	{
+		tree->ctl->num_keys--;
+		Assert(tree->ctl->num_keys >= 0);
+	}
+
+	return deleted;
+}
+
+#endif							/* RT_USE_DELETE */
+
+/***************** UTILITY FUNCTIONS *****************/
+
+/*
+ * Return the statistics of the amount of memory used by the radix tree.
+ *
+ * Since dsa_get_total_size() does appropriate locking, the caller doesn't
+ * need to take a lock.
+ */
+RT_SCOPE uint64
+RT_MEMORY_USAGE(RT_RADIX_TREE * tree)
+{
+	size_t		total = 0;
+
+#ifdef RT_SHMEM
+	Assert(tree->ctl->magic == RT_RADIX_TREE_MAGIC);
+	total = dsa_get_total_size(tree->dsa);
+#else
+	total = MemoryContextMemAllocated(tree->context, true);
+#endif
+
+	return total;
+}
+
+/*
+ * Perform some sanity checks on the given node.
+ */
+static void
+RT_VERIFY_NODE(RT_NODE * node)
+{
+#ifdef USE_ASSERT_CHECKING
+
+	switch (node->kind)
+	{
+		case RT_NODE_KIND_4:
+			{
+				RT_NODE_4  *n4 = (RT_NODE_4 *) node;
+
+				/* RT_DUMP_NODE(node); */
+
+				for (int i = 1; i < n4->base.count; i++)
+					Assert(n4->chunks[i - 1] < n4->chunks[i]);
+
+				break;
+			}
+		case RT_NODE_KIND_16:
+			{
+				RT_NODE_16 *n16 = (RT_NODE_16 *) node;
+
+				/* RT_DUMP_NODE(node); */
+
+				for (int i = 1; i < n16->base.count; i++)
+					Assert(n16->chunks[i - 1] < n16->chunks[i]);
+
+				break;
+			}
+		case RT_NODE_KIND_48:
+			{
+				RT_NODE_48 *n48 = (RT_NODE_48 *) node;
+				int			cnt = 0;
+
+				/* RT_DUMP_NODE(node); */
+
+				for (int i = 0; i < RT_NODE_MAX_SLOTS; i++)
+				{
+					uint8		slot = n48->slot_idxs[i];
+					int			idx = RT_BM_IDX(slot);
+					int			bitnum = RT_BM_BIT(slot);
+
+					if (!RT_NODE_48_IS_CHUNK_USED(n48, i))
+						continue;
+
+					/* Check if the corresponding slot is used */
+					Assert(slot < node->fanout);
+					Assert((n48->isset[idx] & ((bitmapword) 1 << bitnum)) != 0);
+
+					cnt++;
+				}
+
+				Assert(n48->base.count == cnt);
+
+				break;
+			}
+		case RT_NODE_KIND_256:
+			{
+				RT_NODE_256 *n256 = (RT_NODE_256 *) node;
+				int			cnt = 0;
+
+				/* RT_DUMP_NODE(node); */
+
+				for (int i = 0; i < RT_BM_IDX(RT_NODE_MAX_SLOTS); i++)
+					cnt += bmw_popcount(n256->isset[i]);
+
+				/*
+				 * Check if the number of used chunk matches, accounting for
+				 * overflow
+				 */
+				if (cnt == RT_FANOUT_256)
+					Assert(n256->base.count == 0);
+				else
+					Assert(n256->base.count == cnt);
+
+				break;
+			}
+	}
+#endif
+}
+
+/***************** DEBUG FUNCTIONS *****************/
+
+#ifdef RT_DEBUG
+
+/*
+ * Print out tree stats, some of which are only collected in debugging builds.
+ */
+RT_SCOPE void
+RT_STATS(RT_RADIX_TREE * tree)
+{
+	fprintf(stderr, "max_val = " UINT64_FORMAT "\n", tree->ctl->max_val);
+	fprintf(stderr, "num_keys = %lld\n", (long long) tree->ctl->num_keys);
+
+#ifdef RT_SHMEM
+	fprintf(stderr, "handle = " DSA_POINTER_FORMAT "\n", tree->ctl->handle);
+#endif
+
+	fprintf(stderr, "height = %d", tree->ctl->start_shift / RT_SPAN);
+
+	for (int i = 0; i < RT_NUM_SIZE_CLASSES; i++)
+	{
+		RT_SIZE_CLASS_ELEM size_class = RT_SIZE_CLASS_INFO[i];
+
+		fprintf(stderr, ", n%d = %lld", size_class.fanout, (long long) tree->ctl->num_nodes[i]);
+	}
+
+	fprintf(stderr, ", leaves = %lld", (long long) tree->ctl->num_leaves);
+
+	fprintf(stderr, "\n");
+}
+
+/*
+ * Print out debugging information about the given node.
+ */
+static void
+pg_attribute_unused()
+RT_DUMP_NODE(RT_NODE * node)
+{
+#ifdef RT_SHMEM
+#define RT_CHILD_PTR_FORMAT DSA_POINTER_FORMAT
+#else
+#define RT_CHILD_PTR_FORMAT "%p"
+#endif
+
+	fprintf(stderr, "kind %d, fanout %d, count %u\n",
+			(node->kind == RT_NODE_KIND_4) ? 4 :
+			(node->kind == RT_NODE_KIND_16) ? 16 :
+			(node->kind == RT_NODE_KIND_48) ? 48 : 256,
+			node->fanout == 0 ? 256 : node->fanout,
+			node->count == 0 ? 256 : node->count);
+
+	switch (node->kind)
+	{
+		case RT_NODE_KIND_4:
+			{
+				RT_NODE_4  *n4 = (RT_NODE_4 *) node;
+
+				fprintf(stderr, "chunks and slots:\n");
+				for (int i = 0; i < n4->base.count; i++)
+				{
+					fprintf(stderr, "  [%d] chunk %x slot " RT_CHILD_PTR_FORMAT "\n",
+							i, n4->chunks[i], n4->children[i]);
+				}
+
+				break;
+			}
+		case RT_NODE_KIND_16:
+			{
+				RT_NODE_16 *n16 = (RT_NODE_16 *) node;
+
+				fprintf(stderr, "chunks and slots:\n");
+				for (int i = 0; i < n16->base.count; i++)
+				{
+					fprintf(stderr, "  [%d] chunk %x slot " RT_CHILD_PTR_FORMAT "\n",
+							i, n16->chunks[i], n16->children[i]);
+				}
+				break;
+			}
+		case RT_NODE_KIND_48:
+			{
+				RT_NODE_48 *n48 = (RT_NODE_48 *) node;
+				char	   *sep = "";
+
+				fprintf(stderr, "slot_idxs: \n");
+				for (int chunk = 0; chunk < RT_NODE_MAX_SLOTS; chunk++)
+				{
+					if (!RT_NODE_48_IS_CHUNK_USED(n48, chunk))
+						continue;
+
+					fprintf(stderr, "  idx[%d] = %d\n",
+							chunk, n48->slot_idxs[chunk]);
+				}
+
+				fprintf(stderr, "isset-bitmap: ");
+				for (int i = 0; i < (RT_FANOUT_48_MAX / BITS_PER_BYTE); i++)
+				{
+					fprintf(stderr, "%s%x", sep, ((uint8 *) n48->isset)[i]);
+					sep = " ";
+				}
+				fprintf(stderr, "\n");
+
+				fprintf(stderr, "chunks and slots:\n");
+				for (int chunk = 0; chunk < RT_NODE_MAX_SLOTS; chunk++)
+				{
+					if (!RT_NODE_48_IS_CHUNK_USED(n48, chunk))
+						continue;
+
+					fprintf(stderr, "  chunk %x slot " RT_CHILD_PTR_FORMAT "\n",
+							chunk,
+							*RT_NODE_48_GET_CHILD(n48, chunk));
+				}
+				break;
+			}
+		case RT_NODE_KIND_256:
+			{
+				RT_NODE_256 *n256 = (RT_NODE_256 *) node;
+				char	   *sep = "";
+
+				fprintf(stderr, "isset-bitmap: ");
+				for (int i = 0; i < (RT_FANOUT_256 / BITS_PER_BYTE); i++)
+				{
+					fprintf(stderr, "%s%x", sep, ((uint8 *) n256->isset)[i]);
+					sep = " ";
+				}
+				fprintf(stderr, "\n");
+
+				fprintf(stderr, "chunks and slots:\n");
+				for (int chunk = 0; chunk < RT_NODE_MAX_SLOTS; chunk++)
+				{
+					if (!RT_NODE_256_IS_CHUNK_USED(n256, chunk))
+						continue;
+
+					fprintf(stderr, "  chunk %x slot " RT_CHILD_PTR_FORMAT "\n",
+							chunk,
+							*RT_NODE_256_GET_CHILD(n256, chunk));
+				}
+				break;
+			}
+	}
+}
+#endif							/* RT_DEBUG */
+
+#endif							/* RT_DEFINE */
+
+
+/* undefine external parameters, so next radix tree can be defined */
+#undef RT_PREFIX
+#undef RT_SCOPE
+#undef RT_DECLARE
+#undef RT_DEFINE
+#undef RT_VALUE_TYPE
+#undef RT_VARLEN_VALUE_SIZE
+#undef RT_RUNTIME_EMBEDDABLE_VALUE
+#undef RT_SHMEM
+#undef RT_USE_DELETE
+#undef RT_DEBUG
+#undef RT_KEY_SIZE
+
+/* locally declared macros */
+#undef RT_KEY
+#undef RT_KEY_BYTES
+#undef RT_KEY_FITS
+#undef RT_MAKE_PREFIX
+#undef RT_MAKE_NAME
+#undef RT_MAKE_NAME_
+#undef RT_STR
+#undef RT_STR_
+#undef RT_SPAN
+#undef RT_NODE_MAX_SLOTS
+#undef RT_CHUNK_MASK
+#undef RT_MAX_SHIFT
+#undef RT_MAX_LEVEL
+#undef RT_GET_KEY_CHUNK
+#undef RT_BM_IDX
+#undef RT_BM_BIT
+#undef RT_NODE_MUST_GROW
+#undef RT_NODE_KIND_COUNT
+#undef RT_NUM_SIZE_CLASSES
+#undef RT_INVALID_SLOT_IDX
+#undef RT_SLAB_BLOCK_SIZE
+#undef RT_RADIX_TREE_MAGIC
+#undef RT_CHILD_PTR_FORMAT
+
+/* type declarations */
+#undef RT_RADIX_TREE
+#undef RT_RADIX_TREE_CONTROL
+#undef RT_CHILD_PTR
+#undef RT_PTR_ALLOC
+#undef RT_INVALID_PTR_ALLOC
+#undef RT_HANDLE
+#undef RT_ITER
+#undef RT_NODE
+#undef RT_NODE_ITER
+#undef RT_NODE_KIND_4
+#undef RT_NODE_KIND_16
+#undef RT_NODE_KIND_48
+#undef RT_NODE_KIND_256
+#undef RT_NODE_4
+#undef RT_NODE_16
+#undef RT_NODE_48
+#undef RT_NODE_256
+#undef RT_SIZE_CLASS
+#undef RT_SIZE_CLASS_ELEM
+#undef RT_SIZE_CLASS_INFO
+#undef RT_CLASS_4
+#undef RT_CLASS_16_LO
+#undef RT_CLASS_16_HI
+#undef RT_CLASS_48
+#undef RT_CLASS_256
+#undef RT_FANOUT_4
+#undef RT_FANOUT_4_MAX
+#undef RT_FANOUT_16_LO
+#undef RT_FANOUT_16_HI
+#undef RT_FANOUT_16_MAX
+#undef RT_FANOUT_48
+#undef RT_FANOUT_48_MAX
+#undef RT_FANOUT_256
+
+/* function declarations */
+#undef RT_CREATE
+#undef RT_FREE
+#undef RT_ATTACH
+#undef RT_DETACH
+#undef RT_LOCK_EXCLUSIVE
+#undef RT_LOCK_SHARE
+#undef RT_UNLOCK
+#undef RT_GET_HANDLE
+#undef RT_FIND
+#undef RT_SET
+#undef RT_BEGIN_ITERATE
+#undef RT_ITERATE_NEXT
+#undef RT_END_ITERATE
+#undef RT_DELETE
+#undef RT_MEMORY_USAGE
+#undef RT_DUMP_NODE
+#undef RT_STATS
+
+/* internal helper functions */
+#undef RT_GET_VALUE_SIZE
+#undef RT_VALUE_IS_EMBEDDABLE
+#undef RT_CHILDPTR_IS_VALUE
+#undef RT_GET_SLOT_RECURSIVE
+#undef RT_DELETE_RECURSIVE
+#undef RT_ALLOC_NODE
+#undef RT_ALLOC_LEAF
+#undef RT_FREE_NODE
+#undef RT_FREE_LEAF
+#undef RT_FREE_RECURSE
+#undef RT_EXTEND_UP
+#undef RT_EXTEND_DOWN
+#undef RT_COPY_COMMON
+#undef RT_PTR_SET_LOCAL
+#undef RT_PTR_ALLOC_IS_VALID
+#undef RT_NODE_16_SEARCH_EQ
+#undef RT_NODE_4_GET_INSERTPOS
+#undef RT_NODE_16_GET_INSERTPOS
+#undef RT_SHIFT_ARRAYS_FOR_INSERT
+#undef RT_SHIFT_ARRAYS_AND_DELETE
+#undef RT_COPY_ARRAYS_FOR_INSERT
+#undef RT_COPY_ARRAYS_AND_DELETE
+#undef RT_NODE_48_IS_CHUNK_USED
+#undef RT_NODE_48_GET_CHILD
+#undef RT_NODE_256_IS_CHUNK_USED
+#undef RT_NODE_256_GET_CHILD
+#undef RT_KEY_GET_SHIFT
+#undef RT_SHIFT_GET_MAX_VAL
+#undef RT_NODE_SEARCH
+#undef RT_ADD_CHILD_4
+#undef RT_ADD_CHILD_16
+#undef RT_ADD_CHILD_48
+#undef RT_ADD_CHILD_256
+#undef RT_GROW_NODE_4
+#undef RT_GROW_NODE_16
+#undef RT_GROW_NODE_48
+#undef RT_REMOVE_CHILD_4
+#undef RT_REMOVE_CHILD_16
+#undef RT_REMOVE_CHILD_48
+#undef RT_REMOVE_CHILD_256
+#undef RT_SHRINK_NODE_16
+#undef RT_SHRINK_NODE_48
+#undef RT_SHRINK_NODE_256
+#undef RT_NODE_DELETE
+#undef RT_NODE_INSERT
+#undef RT_NODE_ITERATE_NEXT
+#undef RT_VERIFY_NODE

--- a/include/lib/o_radixtree.h
+++ b/include/lib/o_radixtree.h
@@ -162,6 +162,16 @@
 #endif
 
 /*
+ * This is a verbatim copy of PostgreSQL's lib/radixtree.h -- upstream code we
+ * don't audit.  Mark it a system header so the clang static analyzer skips its
+ * (benign) reports; guarded for clang so GCC's -Werror doesn't trip over an
+ * unknown pragma.  cppcheck is handled separately via ci/cppcheck-suppress.
+ */
+#ifdef __clang__
+#pragma clang system_header
+#endif
+
+/*
  * PG16 portability.  This template is taken from PG17's lib/radixtree.h and
  * relies on helpers that PG17 introduced but PG16 lacks: port/simd.h has no
  * vector8_highbit_mask()/vector8_min(), and nodes/bitmapset.h has no bmw_*

--- a/include/lib/o_radixtree.h
+++ b/include/lib/o_radixtree.h
@@ -162,16 +162,6 @@
 #endif
 
 /*
- * This is a verbatim copy of PostgreSQL's lib/radixtree.h -- upstream code we
- * don't audit.  Mark it a system header so the clang static analyzer skips its
- * (benign) reports; guarded for clang so GCC's -Werror doesn't trip over an
- * unknown pragma.  cppcheck is handled separately via ci/cppcheck-suppress.
- */
-#ifdef __clang__
-#pragma clang system_header
-#endif
-
-/*
  * PG16 portability.  This template is taken from PG17's lib/radixtree.h and
  * relies on helpers that PG17 introduced but PG16 lacks: port/simd.h has no
  * vector8_highbit_mask()/vector8_min(), and nodes/bitmapset.h has no bmw_*
@@ -1212,6 +1202,18 @@ RT_FIND(RT_RADIX_TREE * tree, RT_KEY key)
 		node.alloc = *slot;
 		shift -= RT_SPAN;
 	}
+
+#ifdef __clang_analyzer__
+
+	/*
+	 * start_shift is always >= 0, so the descent above always runs and either
+	 * sets slot or returns; the clang analyzer can't prove that and flags the
+	 * *slot dereference below as a possible null dereference.  This guard is
+	 * compiled only under the analyzer and has no runtime effect.
+	 */
+	if (slot == NULL)
+		return NULL;
+#endif
 
 	if (RT_CHILDPTR_IS_VALUE(*slot))
 		return (RT_VALUE_TYPE *) slot;

--- a/include/tableam/bitmap_scan.h
+++ b/include/tableam/bitmap_scan.h
@@ -68,6 +68,7 @@ extern void o_keybitmap_union(OKeyBitmap *a, OKeyBitmap *b);
 extern void o_keybitmap_free(OKeyBitmap *bm);
 extern bool o_keybitmap_is_empty(OKeyBitmap *bm);
 extern bool o_keybitmap_test(OKeyBitmap *bm, uint64 value);
+extern bool o_keybitmap_emit(OKeyBitmap *bm, uint64 value);
 extern bool o_keybitmap_range_is_valid(OKeyBitmap *bm, uint64 low, uint64 high);
 extern uint64 o_keybitmap_get_next(OKeyBitmap *bm, uint64 prev, bool *found);
 
@@ -95,6 +96,7 @@ extern OKeyBitmapMode o_keybitmap_pk_mode(OIndexDescr *primary,
 extern OKeyBitmap *o_keybitmap_create_fixed(void);
 extern void o_keybitmap_insert_key(OKeyBitmap *bm, const uint8 *key);
 extern bool o_keybitmap_test_key(OKeyBitmap *bm, const uint8 *key);
+extern bool o_keybitmap_emit_key(OKeyBitmap *bm, const uint8 *key);
 extern bool o_keybitmap_range_is_valid_key(OKeyBitmap *bm, const uint8 *low,
 										   const uint8 *high);
 extern bool o_keybitmap_get_next_key(OKeyBitmap *bm, const uint8 *prev,

--- a/include/tableam/bitmap_scan.h
+++ b/include/tableam/bitmap_scan.h
@@ -19,7 +19,12 @@
 #include "tableam/scan.h"
 
 #include "executor/executor.h"
-#include "lib/rbtree.h"
+
+/*
+ * Opaque set of uint64 keys backing the orioledb bitmap scan.  Implemented in
+ * key_bitmap.c on top of the adaptive radix tree.
+ */
+typedef struct OKeyBitmap OKeyBitmap;
 
 typedef struct OBitmapScan OBitmapScan;
 
@@ -48,14 +53,51 @@ extern TupleTableSlot *o_exec_bitmap_fetch(OBitmapScan *scan,
 										   CustomScanState *node);
 extern void o_free_bitmap_scan(OBitmapScan *scan);
 
-extern RBTree *o_keybitmap_create(void);
-extern void o_keybitmap_insert(RBTree *rbtree, uint64 value);
-extern void o_keybitmap_intersect(RBTree *a, RBTree *b);
-extern void o_keybitmap_union(RBTree *a, RBTree *b);
-extern void o_keybitmap_free(RBTree *tree);
-extern bool o_keybitmap_is_empty(RBTree *rbtree);
-extern bool o_keybitmap_test(RBTree *rbtree, uint64 value);
-extern bool o_keybitmap_range_is_valid(RBTree *rbtree, uint64 low, uint64 high);
-extern uint64 o_keybitmap_get_next(RBTree *rbtree, uint64 prev, bool *found);
+/*
+ * Maximum length, in bytes, of an order-preserving encoded composite primary
+ * key handled by the fixed-key bitmap.  Keys shorter than this are encoded
+ * right-aligned with a zero high-pad; wider primary keys are not eligible for
+ * a bitmap scan.
+ */
+#define OKBM_FIXED_BYTES 24
+
+extern OKeyBitmap *o_keybitmap_create(void);
+extern void o_keybitmap_insert(OKeyBitmap *bm, uint64 value);
+extern void o_keybitmap_intersect(OKeyBitmap *a, OKeyBitmap *b);
+extern void o_keybitmap_union(OKeyBitmap *a, OKeyBitmap *b);
+extern void o_keybitmap_free(OKeyBitmap *bm);
+extern bool o_keybitmap_is_empty(OKeyBitmap *bm);
+extern bool o_keybitmap_test(OKeyBitmap *bm, uint64 value);
+extern bool o_keybitmap_range_is_valid(OKeyBitmap *bm, uint64 low, uint64 high);
+extern uint64 o_keybitmap_get_next(OKeyBitmap *bm, uint64 prev, bool *found);
+
+/*
+ * Which bitmap encoding a table's primary key is eligible for.  NONE means the
+ * primary key can't back a bitmap scan (the planner then won't offer one).
+ */
+typedef enum OKeyBitmapMode
+{
+	O_KEYBITMAP_NONE,
+	O_KEYBITMAP_UINT64,			/* single int4/int8/ctid field, densified */
+	O_KEYBITMAP_FIXED			/* composite of small ints, order-preserving */
+} OKeyBitmapMode;
+
+/*
+ * Classify a table's primary key.  On O_KEYBITMAP_FIXED, *fixedKeyLen (if not
+ * NULL) receives the meaningful encoded length in bytes.  Defined in
+ * bitmap_scan.c; used both by the planner (get_relation_info_hook) and the
+ * executor so the two always agree.
+ */
+extern OKeyBitmapMode o_keybitmap_pk_mode(OIndexDescr *primary,
+										  int *fixedKeyLen);
+
+/* Fixed-key (composite primary key) variant. */
+extern OKeyBitmap *o_keybitmap_create_fixed(void);
+extern void o_keybitmap_insert_key(OKeyBitmap *bm, const uint8 *key);
+extern bool o_keybitmap_test_key(OKeyBitmap *bm, const uint8 *key);
+extern bool o_keybitmap_range_is_valid_key(OKeyBitmap *bm, const uint8 *low,
+										   const uint8 *high);
+extern bool o_keybitmap_get_next_key(OKeyBitmap *bm, const uint8 *prev,
+									 uint8 *result);
 
 #endif							/* __TABLEAM_BITMAP_SCAN_H__ */

--- a/include/tableam/key_range.h
+++ b/include/tableam/key_range.h
@@ -91,4 +91,10 @@ extern bool o_key_data_to_key_range(OBTreeKeyRange *res,
 									int resultNKeys,
 									OIndexField *fields);
 
+extern void o_key_data_update_array_key_range(OBTreeKeyRange *res,
+											  ScanKeyData *keyData,
+											  int numberOfKeys, BTArrayKeyInfo *arrayKeys,
+											  int numPrefixExactKeys,
+											  int resultNKeys, OIndexField *fields);
+
 #endif

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -913,27 +913,45 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 		 * to leafLokey for the leaf case (targetLevel == 0); otherwise fall
 		 * through to context->lokey.
 		 */
-		if (keepLokeyFlag && level > targetLevel &&
-			BTREE_PAGE_LOCATOR_GET_OFFSET(intCxt.pagePtr, &loc) > 0)
+		if (keepLokeyFlag && level > targetLevel)
 		{
 			OTuple		lokey;
 
-			Assert(nonLeafHdr);
+			/*
+			 * A FETCH-mode descent locates the downlink via the fastpath,
+			 * which does not materialize parentImg
+			 * (can_fastpath_find_downlink() only enables the fastpath in
+			 * FETCH mode).  The offset check and the lokey read below both
+			 * touch parentImg -- the offset needs the hikeys chunk (chunk
+			 * descriptors) and the read needs the chunk holding `loc` -- so
+			 * materialize them.  This is a no-op when the parent was read
+			 * whole (IMAGE/MODIFY disable the fastpath) or the chunk is
+			 * already loaded; a lost race re-descends from the top.
+			 */
+			if (context->parentPartial.isPartial &&
+				intCxt.pagePtr == context->parentImg &&
+				!convert_fastpath_parent_to_img(context, &loc))
+				continue;
 
-			BTREE_PAGE_READ_INTERNAL_TUPLE(lokey, intCxt.pagePtr, &loc);
-
-			if (level == targetLevel + 1 && targetLevel == 0)
-				copy_fixed_key(context->desc, &context->leafLokey, lokey);
-			else
+			if (BTREE_PAGE_LOCATOR_GET_OFFSET(intCxt.pagePtr, &loc) > 0)
 			{
-				copy_fixed_key(context->desc, &context->lokey, lokey);
-				BTREE_PAGE_FIND_SET(context, LOKEY_EXISTS);
-				BTREE_PAGE_FIND_UNSET(context, LOKEY_SIBLING);
-				BTREE_PAGE_FIND_UNSET(context, LOKEY_UNDO);
+				Assert(nonLeafHdr);
+
+				BTREE_PAGE_READ_INTERNAL_TUPLE(lokey, intCxt.pagePtr, &loc);
+
+				if (level == targetLevel + 1 && targetLevel == 0)
+					copy_fixed_key(context->desc, &context->leafLokey, lokey);
+				else
+				{
+					copy_fixed_key(context->desc, &context->lokey, lokey);
+					BTREE_PAGE_FIND_SET(context, LOKEY_EXISTS);
+					BTREE_PAGE_FIND_UNSET(context, LOKEY_SIBLING);
+					BTREE_PAGE_FIND_UNSET(context, LOKEY_UNDO);
+				}
 			}
 		}
 
-		if (level != targetLevel && (!imageFlag || level > targetLevel) && !nonLeafHdr)
+		if (level != targetLevel && ((!imageFlag && !fetchFlag) || level > targetLevel) && !nonLeafHdr)
 		{
 			Assert(tryFlag);
 			if (intCxt.haveLock)
@@ -944,7 +962,7 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 			return OFindPageResultFailure;
 		}
 
-		if (level == targetLevel || (imageFlag && level <= targetLevel))
+		if (level == targetLevel || ((imageFlag || fetchFlag) && level <= targetLevel))
 		{
 			if (intCxt.haveLock)
 			{

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1991,6 +1991,12 @@ btree_page_search(BTreeDescr *desc, Page p, Pointer key, BTreeKeyType keyType,
 	OffsetNumber chunkOffset;
 	bool		isLeaf = O_PAGE_IS(p, LEAF);
 
+	if (partial && partial->isPartial && !partial->hikeysChunkIsLoaded)
+	{
+		if (!partial_load_hikeys_chunk(partial, p))
+			return false;
+	}
+
 	if (keyType == BTreeKeyPageHiKey && isLeaf)
 	{
 		BTREE_PAGE_LOCATOR_LAST(p, locator);

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1502,8 +1502,7 @@ write_page_to_disk(BTreeDescr *desc, FileExtent *extent, uint32 curChkpNum,
 void
 load_page(OBTreeFindPageContext *context)
 {
-	OrioleDBPageDesc *parent_page_desc,
-			   *page_desc;
+	OrioleDBPageDesc *page_desc;
 	BTreeDescr *desc = context->desc;
 	OInMemoryBlkno parent_blkno;
 	Page		parent_page;
@@ -1564,7 +1563,6 @@ load_page(OBTreeFindPageContext *context)
 
 	Assert(OInMemoryBlknoIsValid(blkno));
 	page = O_GET_IN_MEMORY_PAGE(blkno);
-	parent_page_desc = O_GET_IN_MEMORY_PAGEDESC(parent_blkno);
 	page_desc = O_GET_IN_MEMORY_PAGEDESC(blkno);
 
 	page_desc->flags = 0;
@@ -1586,8 +1584,18 @@ load_page(OBTreeFindPageContext *context)
 
 	put_page_image(blkno, buf);
 	ppool_ucm_init(desc->ppool, blkno);
-	page_desc->type = parent_page_desc->type;
-	page_desc->oids = parent_page_desc->oids;
+
+	/*
+	 * Stamp the page's identity from the descriptor of the tree we are
+	 * descending, not from the parent's page descriptor: the parent was
+	 * unlocked above and may have been evicted/reused (potentially by the
+	 * reentrant eviction inside ppool_alloc_page() just above), in which case
+	 * its page descriptor's oids would be invalid (0,0,0) or belong to
+	 * another tree.  The loaded page belongs to desc, so use desc's oids/type
+	 * -- which is exactly what init_new_btree_page() does.
+	 */
+	page_desc->type = desc->type;
+	page_desc->oids = desc->oids;
 
 	Assert(O_PAGE_IS(page, LEAF) ||
 		   (PAGE_GET_N_ONDISK(page) == BTREE_PAGE_ITEMS_COUNT(page)));

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -3640,6 +3640,18 @@ try_to_punch_holes(BTreeDescr *desc)
 							errmsg("could not open file %s: %m", filename)));
 		file_size = FileSize(file);
 
+		/*
+		 * Each -N.tmp file is a self-contained list of freed block offsets
+		 * and must be read from its own offset 0.  Reset the read cursor /
+		 * byte counter for every file: when a single try_to_punch_holes()
+		 * call drains more than one checkpoint's tmp file (several
+		 * checkpoints accumulated undrained files), a stale len would seek
+		 * past the next file's EOF and trip the file_size != len check below.
+		 * (add_free_extents_from_tmp() declares len inside its loop for the
+		 * same reason.)
+		 */
+		len = 0;
+
 		while (true)
 		{
 			BlockNumber *cur_off;

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -99,12 +99,41 @@ struct BTreeIterator
 #endif
 };
 
+/*
+ * Specifies key to end the iteration.  A handy struct to pass as a function
+ * argument.
+ */
+typedef struct
+{
+	void	   *key;
+	BTreeKeyType keyKind;
+	bool		isIncluded;
+} BtreeIterationEnd;
+
+static OTuple fetch_our_tuple_from_page(BTreeDescr *desc, Page p,
+										BTreePageItemLocator *loc, void *key,
+										BTreeKeyType kind, MemoryContext mcxt,
+										CommitSeqNo *out_csn, bool *deleted);
+static OTuple fetch_tuple_from_page(BTreeDescr *desc, Page p,
+									BTreePageItemLocator *loc,
+									void *key, BTreeKeyType kind,
+									OSnapshot *read_o_snapshot,
+									MemoryContext mcxt,
+									CommitSeqNo *out_csn, bool *deleted,
+									TupleFetchCallback cb, void *arg);
+static bool page_contains_key(BTreeIterator *it, void *key,
+							  BTreeKeyType kind, Page p, OTuple lokey);
+static OTuple get_lokey_if_exists(BTreeIterator *it);
 static void get_next_combined_location(BTreeIterator *it);
 static void load_page_from_undo(BTreeIterator *it, void *key, BTreeKeyType kind);
-static bool btree_iterator_check_load_next_page(BTreeIterator *it);
+static bool btree_iterator_check_load_next_page(BTreeIterator *it,
+												BtreeIterationEnd *end);
 static OTuple o_btree_iterator_fetch_internal(BTreeIterator *it,
-											  CommitSeqNo *tupleCsn);
-static bool o_btree_interator_can_fetch_from_undo(BTreeDescr *desc, BTreeIterator *it);
+											  CommitSeqNo *tupleCsn,
+											  BtreeIterationEnd *end);
+static bool o_btree_interator_can_fetch_from_undo(BTreeDescr *desc,
+												  BTreeIterator *it,
+												  BtreeIterationEnd *end);
 static bool can_fetch_from_undo(BTreeIterator *it);
 static void undo_it_create(UndoIterator *undoIt, BTreeIterator *it);
 static void undo_it_init(UndoIterator *undoIt, UndoLocation location, void *key, BTreeKeyType kind);
@@ -201,59 +230,10 @@ retry:
 		 * Have to combine the results.  First look for a matching tuple on
 		 * the data page modified by us.
 		 */
-		if (BTREE_PAGE_LOCATOR_IS_VALID(img, &loc))
-		{
-			BTreeLeafTuphdr *tupHdrPtr;
-			OTuple		curTuple;
-			int			result_size;
-
-			BTREE_PAGE_READ_LEAF_ITEM(tupHdrPtr, curTuple, img, &loc);
-			tupHdrPtr = (BTreeLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(img, &loc);
-
-			if (o_btree_cmp(desc, key, kind, &curTuple, BTreeKeyLeafTuple) == 0)
-			{
-				BTreeLeafTuphdr tupHdr = *tupHdrPtr;
-
-				/*
-				 * We found the matching tuple.  Now check if it is modified
-				 * by us.  Even if tuple is modified by us, there might be FOR
-				 * KEY SHARE locks placed by concurrent transactions. Find the
-				 * first non-lock-only undo record in the chain and check if
-				 * it belongs to our transaction.
-				 */
-				(void) find_non_lock_only_undo_record(desc->undoType, &tupHdr);
-
-				if (!XACT_INFO_IS_LOCK_ONLY(tupHdr.xactInfo) &&
-					XACT_INFO_OXID_IS_CURRENT(tupHdr.xactInfo))
-				{
-					/*
-					 * OK, we found the tuple modified by us.  It overrides
-					 * whatever we could have from the undo log page image.
-					 * Return it right away.
-					 */
-					if (out_csn)
-						*out_csn = COMMITSEQNO_INPROGRESS;
-
-					if (deleted)
-						*deleted = (tupHdrPtr->deleted != BTreeLeafTupleNonDeleted);
-
-					if (tupHdrPtr->deleted == BTreeLeafTupleNonDeleted)
-					{
-						result_size = o_btree_len(desc, curTuple, OTupleLength);
-						result.data = (Pointer) MemoryContextAlloc(mcxt, result_size);
-						memcpy(result.data, curTuple.data, result_size);
-						result.formatFlags = curTuple.formatFlags;
-						return result;
-					}
-					else
-					{
-						O_TUPLE_SET_NULL(result);
-						/* cppcheck-suppress uninitvar */
-						return result;
-					}
-				}
-			}
-		}
+		result = fetch_our_tuple_from_page(desc, img, &loc, key, kind, mcxt,
+										   out_csn, deleted);
+		if (!O_TUPLE_IS_NULL(result))
+			return result;
 
 		/*
 		 * There is no matching tuple modified by us.  So, we have to fetch
@@ -277,13 +257,292 @@ retry:
 		page_locator_find_real_item(img, NULL, &loc);
 	}
 
-	if (BTREE_PAGE_LOCATOR_IS_VALID(img, &loc))
+	/*
+	 * Fetch the relevant tuple version for the page.
+	 */
+	return fetch_tuple_from_page(desc, img, &loc, key, kind, read_o_snapshot,
+								 mcxt, out_csn, deleted, cb, arg);
+}
+
+OTuple
+o_btree_find_tuples_start(BTreeDescr *desc, void *key,
+						  BTreeKeyType kind, OSnapshot *read_o_snapshot,
+						  ScanDirection scanDir,
+						  CommitSeqNo *out_csn, MemoryContext mcxt,
+						  BTreeLocationHint *hint,
+						  bool *deleted,
+						  TupleFetchCallback cb,
+						  void *arg,
+						  BTreeIterator **out_it)
+{
+	Pointer		img;
+	BTreePageItemLocator loc;
+	BTreeIterator *it;
+	OBTreeFindPageContext *context;
+	BTreePageHeader *header;
+	OTuple		result;
+	uint16		findFlags = BTREE_PAGE_FIND_FETCH;
+	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
+
+	it = (BTreeIterator *) palloc(sizeof(BTreeIterator));
+	*out_it = it;
+
+	if (!IS_SYS_TREE_OIDS(desc->oids))
+	{
+		it->oidescr = (OIndexDescr *) desc->arg;
+		ResourceOwnerRememberOIndexDescr(CurrentResourceOwner, it->oidescr);
+	}
+	else
+		it->oidescr = NULL;
+
+	it->combinedResult = have_current_undo(desc->undoType) && COMMITSEQNO_IS_NORMAL(read_o_snapshot->csn);
+	it->oSnapshot = *read_o_snapshot;
+	it->scanDir = scanDir;
+	it->tupleCxt = mcxt;
+	it->fetchCallback = cb;
+	it->fetchCallbackArg = arg;
+
+	undo_it_create(&it->undoIt, it);
+
+	/*
+	 * If we don't need to combine results, then ask find_page() to load the
+	 * relevant page item from undo log for us by passing our snapshot csn.
+	 */
+	context = &it->context;
+	if (IT_IS_BACKWARD(it))
+		findFlags |= BTREE_PAGE_FIND_KEEP_LOKEY;
+	init_page_find_context(context, desc,
+						   it->combinedResult ? COMMITSEQNO_INPROGRESS : read_o_snapshot->csn,
+						   findFlags);
+
+	/* Use page location hint if provided */
+	if (hint && OInMemoryBlknoIsValid(hint->blkno))
+		findResult = refind_page(context, key, kind, 0, hint->blkno, hint->pageChangeCount);
+	else
+		findResult = find_page(context, key, kind, 0);
+
+	Assert(findResult == OFindPageResultSuccess);
+
+	loc = context->items[context->index].locator;
+	img = context->img;
+	header = (BTreePageHeader *) img;
+
+	/* Adjust hint if given */
+	if (hint)
+	{
+		hint->blkno = context->items[context->index].blkno;
+		hint->pageChangeCount = context->items[context->index].pageChangeCount;
+	}
+
+	if (it->combinedResult && header->csn >= read_o_snapshot->csn)
+	{
+		/*
+		 * Have to combine the results.  First look for a matching tuple on
+		 * the data page modified by us.
+		 */
+		result = fetch_our_tuple_from_page(desc, img, &loc, key, kind, mcxt,
+										   out_csn, deleted);
+		if (!O_TUPLE_IS_NULL(result))
+			return result;
+
+		load_page_from_undo(it, key, kind);
+		Assert(it->combinedPage);
+
+		return fetch_tuple_from_page(desc, it->undoIt.image, &it->undoLoc,
+									 key, kind, read_o_snapshot,
+									 mcxt, out_csn, deleted, cb, arg);
+	}
+
+	/*
+	 * Fetch the relevant tuple version for the page.
+	 */
+	return fetch_tuple_from_page(desc, img, &loc, key, kind, read_o_snapshot,
+								 mcxt, out_csn, deleted, cb, arg);
+}
+
+OTuple
+o_btree_find_tuples_continue(BTreeIterator *it,
+							 void *key,
+							 BTreeKeyType kind,
+							 CommitSeqNo *out_csn,
+							 BTreeLocationHint *hint,
+							 bool *deleted)
+{
+	bool		needToReloadPage = true;
+	OBTreeFindPageContext *context = &it->context;
+	BTreeDescr *desc = context->desc;
+	BTreePageItemLocator *loc = &it->context.items[it->context.index].locator;
+	Pointer		img = context->img;
+	BTreePageHeader *header = (BTreePageHeader *) img;
+	OTuple		result;
+
+	if (page_contains_key(it, key, kind, img, get_lokey_if_exists(it)))
+	{
+		/* Search within the loaded page */
+		if (btree_page_search(desc, img, key, kind, &context->partial, loc))
+			needToReloadPage = false;
+	}
+
+	if (needToReloadPage)
+	{
+		OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
+
+		/* Use the page location hint if provided */
+		if (hint && OInMemoryBlknoIsValid(hint->blkno))
+			findResult = refind_page(context, key, kind, 0,
+									 hint->blkno, hint->pageChangeCount);
+		else
+			findResult = find_page(context, key, kind, 0);
+
+		Assert(findResult == OFindPageResultSuccess);
+	}
+
+	/* Adjust hint if given */
+	if (hint)
+	{
+		hint->blkno = context->items[context->index].blkno;
+		hint->pageChangeCount = context->items[context->index].pageChangeCount;
+	}
+
+	if (it->combinedResult && header->csn >= it->oSnapshot.csn)
+	{
+		/*
+		 * Have to combine the results.  First look for a matching tuple on
+		 * the data page modified by us.
+		 */
+		result = fetch_our_tuple_from_page(desc, img, loc, key, kind,
+										   it->tupleCxt, out_csn, deleted);
+		if (!O_TUPLE_IS_NULL(result))
+			return result;
+
+		if (it->combinedPage)
+		{
+			if (page_contains_key(it, key, kind,
+								  it->undoIt.image, it->undoIt.lokey.tuple))
+			{
+				btree_page_search(it->context.desc,
+								  it->undoIt.image,
+								  key, kind, NULL,
+								  &it->undoLoc);
+			}
+			else
+			{
+				load_page_from_undo(it, key,
+									kind != BTreeKeyRightmost ? kind : BTreeKeyNone);
+			}
+		}
+
+		Assert(it->combinedPage);
+
+		return fetch_tuple_from_page(desc, it->undoIt.image, &it->undoLoc,
+									 key, kind, &it->oSnapshot,
+									 it->tupleCxt, out_csn, deleted,
+									 it->fetchCallback, it->fetchCallbackArg);
+	}
+
+	/*
+	 * Fetch the relevant tuple version from the page.
+	 */
+	return fetch_tuple_from_page(desc, img, loc, key, kind, &it->oSnapshot,
+								 it->tupleCxt, out_csn, deleted,
+								 it->fetchCallback, it->fetchCallbackArg);
+}
+
+void
+o_btree_find_tuples_finish(BTreeIterator *it)
+{
+	pfree(it);
+}
+
+/*
+ * Check if there is a matching tuple modified by us on the given location on
+ * the page.  Return this tuple if so, or a null tuple otherwise.
+ */
+static OTuple
+fetch_our_tuple_from_page(BTreeDescr *desc, Page p, BTreePageItemLocator *loc,
+						  void *key, BTreeKeyType kind, MemoryContext mcxt,
+						  CommitSeqNo *out_csn, bool *deleted)
+{
+	OTuple		result;
+
+	if (BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
+	{
+		BTreeLeafTuphdr *tupHdrPtr;
+		OTuple		curTuple;
+		int			result_size;
+
+		BTREE_PAGE_READ_LEAF_ITEM(tupHdrPtr, curTuple, p, loc);
+		tupHdrPtr = (BTreeLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(p, loc);
+
+		if (o_btree_cmp(desc, key, kind, &curTuple, BTreeKeyLeafTuple) == 0)
+		{
+			BTreeLeafTuphdr tupHdr = *tupHdrPtr;
+
+			/*
+			 * We found the matching tuple.  Now check if it is modified by
+			 * us.  Even if tuple is modified by us, there might be FOR KEY
+			 * SHARE locks placed by concurrent transactions. Find the first
+			 * non-lock-only undo record in the chain and check if it belongs
+			 * to our transaction.
+			 */
+			(void) find_non_lock_only_undo_record(desc->undoType, &tupHdr);
+
+			if (!XACT_INFO_IS_LOCK_ONLY(tupHdr.xactInfo) &&
+				XACT_INFO_OXID_IS_CURRENT(tupHdr.xactInfo))
+			{
+				/*
+				 * OK, we found the tuple modified by us.  It overrides
+				 * whatever we could have from the undo log page image. Return
+				 * it right away.
+				 */
+				if (out_csn)
+					*out_csn = COMMITSEQNO_INPROGRESS;
+
+				if (deleted)
+					*deleted = (tupHdrPtr->deleted != BTreeLeafTupleNonDeleted);
+
+				if (tupHdrPtr->deleted == BTreeLeafTupleNonDeleted)
+				{
+					result_size = o_btree_len(desc, curTuple, OTupleLength);
+					result.data = (Pointer) MemoryContextAlloc(mcxt, result_size);
+					memcpy(result.data, curTuple.data, result_size);
+					result.formatFlags = curTuple.formatFlags;
+					return result;
+				}
+				else
+				{
+					O_TUPLE_SET_NULL(result);
+					/* cppcheck-suppress uninitvar */
+					return result;
+				}
+			}
+		}
+	}
+	O_TUPLE_SET_NULL(result);
+	return result;
+}
+
+/*
+ * Check if there is a matching tuple on the given location on the page.
+ * Return the appropriate version of this tuple if so, or a null tuple
+ * otherwise.
+ */
+static OTuple
+fetch_tuple_from_page(BTreeDescr *desc, Page p, BTreePageItemLocator *loc,
+					  void *key, BTreeKeyType kind,
+					  OSnapshot *read_o_snapshot, MemoryContext mcxt,
+					  CommitSeqNo *out_csn, bool *deleted,
+					  TupleFetchCallback cb, void *arg)
+{
+	OTuple		result;
+
+	if (BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
 	{
 		BTreeLeafTuphdr *tupHdr;
 		OTuple		curTuple;
 		int			cmp;
 
-		BTREE_PAGE_READ_LEAF_ITEM(tupHdr, curTuple, img, &loc);
+		BTREE_PAGE_READ_LEAF_ITEM(tupHdr, curTuple, p, loc);
 		cmp = o_btree_cmp(desc, key, kind, &curTuple, BTreeKeyLeafTuple);
 
 		if (deleted)
@@ -295,7 +554,7 @@ retry:
 			 * The matching tuple is found.  Traverse the row-level undo chain
 			 * for the relevant version and return it.
 			 */
-			return o_find_tuple_version(desc, img, &loc, read_o_snapshot,
+			return o_find_tuple_version(desc, p, loc, read_o_snapshot,
 										out_csn, mcxt, cb, arg);
 		}
 	}
@@ -534,6 +793,46 @@ o_find_tuple_version(BTreeDescr *desc, Page p, BTreePageItemLocator *loc,
 	return result;
 }
 
+/*
+ * Adcance page location after finding an appropriate key to prepare for the
+ * iteration.  btree_page_search() prepares a location perfectly for the
+ * forward interation.  The backward iteration might need to advance the
+ * position.
+ */
+static void
+advance_page_location_if_needed(BTreeIterator *it, void *key,
+								BTreeKeyType kind, Page p,
+								BTreePageItemLocator *loc)
+{
+	if (key != NULL && IT_IS_BACKWARD(it))
+	{
+		bool		make_dec = false;
+
+		/*
+		 * From btree_page_search(): "When nextkey is false (this case), we
+		 * are looking for the first item >= scankey."
+		 *
+		 * If it's next item than decrement item offset. In case item ==
+		 * search key no need to do this.
+		 */
+		Assert(BTREE_PAGE_LOCATOR_GET_OFFSET(p, loc) <= BTREE_PAGE_ITEMS_COUNT(p));
+
+		if (BTREE_PAGE_LOCATOR_GET_OFFSET(p, loc) == BTREE_PAGE_ITEMS_COUNT(p))
+			make_dec = true;
+		else
+		{
+			OTuple		tup;
+
+			BTREE_PAGE_READ_TUPLE(tup, p, loc);
+			if (o_btree_cmp(it->context.desc, key, kind, &tup, BTreeKeyLeafTuple) < 0)
+				make_dec = true;
+		}
+
+		if (make_dec)
+			BTREE_PAGE_LOCATOR_PREV(p, loc);
+	}
+}
+
 BTreeIterator *
 o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 						OSnapshot *o_snapshot, ScanDirection scanDir)
@@ -599,16 +898,13 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 
 	if (key != NULL && IT_IS_BACKWARD(it))
 	{
-		BTreePageItemLocator *loc = &it->context.items[it->context.index].locator;
-		bool		make_dec = false;
-
 		/*
 		 * Positioning the backward start reads the leaf's chunk descriptor
-		 * array (BTREE_PAGE_LOCATOR_GET_OFFSET / _PREV), which a partial
-		 * (FETCH) image read through the fastpath does not contain
-		 * (loadHikeys = !fastpath).  Load the hikeys chunk so the descriptors
-		 * are present; if the backing page changed, fall back to a whole-page
-		 * image read and re-position there.
+		 * array (in advance_page_location_if_needed), which a partial (FETCH)
+		 * image read through the fastpath does not contain (loadHikeys =
+		 * !fastpath).  Load the hikeys chunk so the descriptors are present;
+		 * if the backing page changed, fall back to a whole-page image read
+		 * and re-position there.
 		 */
 		if (BTREE_PAGE_FIND_IS(&it->context, FETCH) &&
 			!partial_load_hikeys_chunk(&it->context.partial, it->context.img))
@@ -617,32 +913,11 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 			BTREE_PAGE_FIND_SET(&it->context, IMAGE);
 			findResult = find_page(&it->context, key, kind, 0);
 			Assert(findResult == OFindPageResultSuccess);
-			loc = &it->context.items[it->context.index].locator;
 		}
-
-		/*
-		 * From btree_page_binary_search(): "When nextkey is false (this
-		 * case), we are looking for the first item >= scankey."
-		 *
-		 * If it's next item than decrement item offset. In case item ==
-		 * search key no need to do this.
-		 */
-		Assert(BTREE_PAGE_LOCATOR_GET_OFFSET(it->context.img, loc) <= BTREE_PAGE_ITEMS_COUNT(it->context.img));
-
-		if (BTREE_PAGE_LOCATOR_GET_OFFSET(it->context.img, loc) == BTREE_PAGE_ITEMS_COUNT(it->context.img))
-			make_dec = true;
-		else
-		{
-			OTuple		tup;
-
-			BTREE_PAGE_READ_TUPLE(tup, it->context.img, loc);
-			if (o_btree_cmp(desc, key, kind, &tup, BTreeKeyLeafTuple) < 0)
-				make_dec = true;
-		}
-
-		if (make_dec)
-			BTREE_PAGE_LOCATOR_PREV(it->context.img, loc);
 	}
+
+	advance_page_location_if_needed(it, key, kind, it->context.img,
+									&it->context.items[it->context.index].locator);
 
 	load_page_from_undo(it, key,
 						kind != BTreeKeyRightmost ? kind : BTreeKeyNone);
@@ -674,6 +949,160 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 	return it;
 }
 
+/*
+ * Check if the page still contains the given key.  It's assumed that we're
+ * continuing the scan in its direction.  This function checks with the page
+ * hikey for forward direction and with the given lokey for backward
+ * direction.
+ */
+static bool
+page_contains_key(BTreeIterator *it, void *key, BTreeKeyType kind,
+				  Page p, OTuple lokey)
+{
+	PartialPageState *partial = &it->context.partial;
+
+	if (partial && partial->isPartial && !partial->hikeysChunkIsLoaded)
+	{
+		if (!partial_load_hikeys_chunk(partial, p))
+			return false;
+	}
+
+	/* Check if the new value fits the same leaf page */
+	if (IT_IS_FORWARD(it))
+	{
+		OTuple		hikey;
+		int			cmp;
+
+		if (O_PAGE_IS(p, RIGHTMOST))
+			return true;
+
+		BTREE_PAGE_GET_HIKEY(hikey, p);
+		cmp = o_btree_cmp(it->context.desc,
+						  key, kind,
+						  &hikey, BTreeKeyNonLeafKey);
+		return (cmp < 0);
+	}
+	else
+	{
+		int			cmp;
+
+		if (O_PAGE_IS(p, LEFTMOST))
+			return true;
+
+		cmp = o_btree_cmp(it->context.desc,
+						  key, kind,
+						  &lokey, BTreeKeyNonLeafKey);
+		return (cmp >= 0);
+	}
+}
+
+/*
+ * Fetches low key for the current page if appropriate.  Returns NULL tuple
+ * otherwise.
+ */
+static OTuple
+get_lokey_if_exists(BTreeIterator *it)
+{
+	OTuple		result;
+
+	if (IT_IS_BACKWARD(it) && !O_PAGE_IS(it->context.img, LEFTMOST))
+		result = btree_find_context_lokey(&it->context);
+	else
+		O_TUPLE_SET_NULL(result);
+
+
+	return result;
+}
+
+/*
+ * Advance the iterator position to the given key.  The key must be taken in
+ * the direction of the scan.  That means, a new key must be >= to the end key
+ * last time used during the fetching.
+ */
+void
+o_btree_iterator_advance(BTreeIterator *it, void *key, BTreeKeyType kind)
+{
+	Assert(key != NULL && kind != BTreeKeyNone);
+
+	BTreePageItemLocator *loc = &it->context.items[it->context.index].locator;
+	bool		found_in_page = false;
+
+	/*
+	 * Try to reposition within the already-loaded leaf.  btree_page_search()
+	 * must be given the partial-read state: on a FETCH (partial) image
+	 * searching with a NULL partial reads unloaded chunks as garbage and
+	 * mis-positions the locator (e.g. a sparse "col = ANY" scan leaking
+	 * tuples of the values between array elements).  A failed partial load
+	 * falls through to the re-find below.
+	 */
+	if (page_contains_key(it, key, kind,
+						  it->context.img, get_lokey_if_exists(it)) &&
+		btree_page_search(it->context.desc, it->context.img, key, kind,
+						  &it->context.partial, loc) &&
+		(!IT_IS_FORWARD(it) ||
+		 BTREE_PAGE_LOCATOR_IS_VALID(it->context.img, loc)))
+	{
+		/*
+		 * A forward search that ran off the end of the page means the key
+		 * actually begins on the next page: page_contains_key() admitted us
+		 * because the key compares less than this page's hikey, yet no item
+		 * on the page is >= the key.  The invalid locator must be rejected
+		 * before page_locator_find_real_item(), which would otherwise
+		 * re-anchor it to the page's first real item and restart the scan
+		 * there, re-emitting already-returned rows (the array recheck still
+		 * accepts them, as they match some other array element).  Fall
+		 * through to the re-find below. Backward stepping lands past-the-end
+		 * legitimately: advance_page_ location_if_needed() steps it back to
+		 * the last item <= key.
+		 */
+		page_locator_find_real_item(it->context.img, &it->context.partial, loc);
+
+		found_in_page = !IT_IS_FORWARD(it) ||
+			BTREE_PAGE_LOCATOR_IS_VALID(it->context.img, loc);
+	}
+
+	if (found_in_page)
+	{
+		advance_page_location_if_needed(it, key, kind, it->context.img,
+										&it->context.items[it->context.index].locator);
+
+		if (it->combinedPage)
+		{
+			if (page_contains_key(it, key, kind,
+								  it->undoIt.image, it->undoIt.lokey.tuple))
+			{
+				btree_page_search(it->context.desc,
+								  it->undoIt.image,
+								  key, kind, NULL,
+								  &it->undoLoc);
+				page_locator_find_real_item(it->undoIt.image, NULL,
+											&it->undoLoc);
+
+				advance_page_location_if_needed(it, key, kind,
+												it->undoIt.image, &it->undoLoc);
+			}
+			else
+			{
+				load_page_from_undo(it, key,
+									kind != BTreeKeyRightmost ? kind : BTreeKeyNone);
+			}
+		}
+	}
+	else
+	{
+		/* Otherwise, re-find the leaf page if needed */
+		OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
+
+		findResult = find_page(&it->context, key, kind, 0);
+		Assert(findResult == OFindPageResultSuccess);
+
+		advance_page_location_if_needed(it, key, kind, it->context.img,
+										&it->context.items[it->context.index].locator);
+		load_page_from_undo(it, key,
+							kind != BTreeKeyRightmost ? kind : BTreeKeyNone);
+	}
+}
+
 void
 o_btree_iterator_set_tuple_ctx(BTreeIterator *it, MemoryContext tupleCxt)
 {
@@ -697,21 +1126,39 @@ o_btree_iterator_set_callback(BTreeIterator *it,
  * The result's OTuple.data is allocated in it->tupleCxt memory context.  It's
  * the caller's responsibility to free this memory.
  */
+/* Supress strange asan complaint using clang attribute */
+#if defined(__clang__)
+__attribute__((no_sanitize("address")))
+#endif
 OTuple
 o_btree_iterator_fetch(BTreeIterator *it, CommitSeqNo *tupleCsn,
-					   void *end, BTreeKeyType endType,
+					   void *endKey, BTreeKeyType endKind,
 					   bool endIsIncluded, BTreeLocationHint *hint)
 {
 	BTreeDescr *desc = it->context.desc;
 	OTuple		result;
+	BtreeIterationEnd end;
+	BtreeIterationEnd *endPtr;
+
+	if (endKey != NULL && endKind != BTreeKeyNone)
+	{
+		end.key = endKey;
+		end.keyKind = endKind;
+		end.isIncluded = endIsIncluded;
+		endPtr = &end;
+	}
+	else
+	{
+		endPtr = NULL;
+	}
 
 	ASAN_UNPOISON_MEMORY_REGION(&result, sizeof(result));
 
-	result = o_btree_iterator_fetch_internal(it, tupleCsn);
+	result = o_btree_iterator_fetch_internal(it, tupleCsn, endPtr);
 
-	if (!O_TUPLE_IS_NULL(result) && end != NULL)
+	if (!O_TUPLE_IS_NULL(result) && endKey != NULL)
 	{
-		int			cmp = o_btree_cmp(desc, &result, BTreeKeyLeafTuple, end, endType);
+		int			cmp = o_btree_cmp(desc, &result, BTreeKeyLeafTuple, endKey, endKind);
 
 		if (IT_IS_BACKWARD(it))
 			cmp *= -1;
@@ -783,27 +1230,8 @@ load_page_from_undo(BTreeIterator *it, void *key, BTreeKeyType kind)
 			page_locator_find_real_item(it->undoIt.image, NULL,
 										&it->undoLoc);
 
-			if (IT_IS_BACKWARD(it))
-			{
-				OTuple		founded;
-				OffsetNumber undoOffset;
-
-				BTREE_PAGE_READ_TUPLE(founded, it->undoIt.image, &it->undoLoc);
-
-				/*
-				 * From btree_page_binary_search(): "When nextkey is false
-				 * (this case), we are looking for the first item >= scankey."
-				 *
-				 * If it's next item than decrement item offset. In case item
-				 * == key bound no need to do this.
-				 */
-				undoOffset = BTREE_PAGE_LOCATOR_GET_OFFSET(it->undoIt.image, &it->undoLoc);
-				Assert(undoOffset <= BTREE_PAGE_ITEMS_COUNT(it->undoIt.image));
-				if (undoOffset == BTREE_PAGE_ITEMS_COUNT(it->undoIt.image) ||
-					o_btree_cmp(desc, key, kind, &founded, BTreeKeyLeafTuple))
-					BTREE_PAGE_LOCATOR_PREV(it->undoIt.image, &it->undoLoc);
-			}
-
+			advance_page_location_if_needed(it, key, kind,
+											it->undoIt.image, &it->undoLoc);
 		}
 		else if (IT_IS_FORWARD(it))
 		{
@@ -1025,7 +1453,8 @@ iterator_advance_leaf(BTreeIterator *it, BTreePageItemLocator *loc)
  * Fetch next tuple without checking for end condition.
  */
 static OTuple
-o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
+o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn,
+								BtreeIterationEnd *end)
 {
 	BTreeDescr *desc = it->context.desc;
 	OBTreeFindPageContext *context = &it->context;
@@ -1039,7 +1468,7 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn)
 
 	while (true)
 	{
-		if (!btree_iterator_check_load_next_page(it))
+		if (!btree_iterator_check_load_next_page(it, end))
 		{
 			O_TUPLE_SET_NULL(result);
 			return result;
@@ -1156,12 +1585,54 @@ iterator_maybe_switch_to_image(BTreeIterator *it)
 	}
 }
 
+
+/*
+ * Checks if the page contains the given iteration end key.  More practically,
+ * it checks if we can finish the iteration without switching this page.
+ */
+static bool
+page_contains_end(BTreeIterator *it, Page p,
+				  OTuple lokey, BtreeIterationEnd *end)
+{
+	ASAN_UNPOISON_MEMORY_REGION(end, sizeof(*end));
+
+	if (IT_IS_FORWARD(it))
+	{
+		OTuple		hikey;
+		int			cmp;
+
+		if (O_PAGE_IS(p, RIGHTMOST))
+			return true;
+
+		BTREE_PAGE_GET_HIKEY(hikey, p);
+		cmp = o_btree_cmp(it->context.desc,
+						  end->key, end->keyKind,
+						  &hikey, BTreeKeyNonLeafKey);
+		if (cmp < 0 || (cmp == 0 && !end->isIncluded))
+			return true;
+	}
+	else
+	{
+		int			cmp;
+
+		if (O_PAGE_IS(p, LEFTMOST))
+			return true;
+
+		cmp = o_btree_cmp(it->context.desc,
+						  end->key, end->keyKind,
+						  &lokey, BTreeKeyNonLeafKey);
+		if (cmp >= 0)
+			return true;
+	}
+	return false;
+}
+
 /*
  * Check and load the next tree page if needed.  Works with both normal and undo
  * pages.  Return true on success.  False means there is nothing more to read.
  */
 static bool
-btree_iterator_check_load_next_page(BTreeIterator *it)
+btree_iterator_check_load_next_page(BTreeIterator *it, BtreeIterationEnd *end)
 {
 	OBTreeFindPageContext *context = &it->context;
 	Page		img = context->img,
@@ -1169,7 +1640,7 @@ btree_iterator_check_load_next_page(BTreeIterator *it)
 	BTreeDescr *desc = context->desc;
 	OFixedKey	key_buf;
 
-	if (o_btree_interator_can_fetch_from_undo(context->desc, it))
+	if (o_btree_interator_can_fetch_from_undo(context->desc, it, end))
 		return true;
 
 	while (!BTREE_PAGE_LOCATOR_IS_VALID(img, &context->items[context->index].locator))
@@ -1213,6 +1684,16 @@ btree_iterator_check_load_next_page(BTreeIterator *it)
 			continue;
 		}
 
+		/*
+		 * Stop before stepping to the next page if the iteration end key
+		 * already falls on the current page.  Placed after the FETCH block
+		 * above so the forward hikey / backward lokey it reads are loaded
+		 * (partial_load_hikeys_chunk / the lokey check), not a stale fastpath
+		 * image.
+		 */
+		if (end && page_contains_end(it, img, get_lokey_if_exists(it), end))
+			return false;
+
 		if (IT_IS_FORWARD(it))
 			step_result = find_right_page(context, &key_buf);
 		else
@@ -1228,7 +1709,7 @@ btree_iterator_check_load_next_page(BTreeIterator *it)
 			bool		reload = true;
 
 			if (it->combinedPage)
-				reload = !o_btree_interator_can_fetch_from_undo(context->desc, it);
+				reload = !o_btree_interator_can_fetch_from_undo(context->desc, it, NULL);
 
 			if (reload)
 			{
@@ -1270,7 +1751,8 @@ btree_iterator_check_load_next_page(BTreeIterator *it)
  * Can we fetch more pages form undo page image?
  */
 static bool
-o_btree_interator_can_fetch_from_undo(BTreeDescr *desc, BTreeIterator *it)
+o_btree_interator_can_fetch_from_undo(BTreeDescr *desc, BTreeIterator *it,
+									  BtreeIterationEnd *end)
 {
 	Page		hImg = it->undoIt.image,
 				img = it->context.img;
@@ -1283,6 +1765,14 @@ o_btree_interator_can_fetch_from_undo(BTreeDescr *desc, BTreeIterator *it)
 	 */
 	if (!it->combinedPage)
 		return false;
+
+	/*
+	 * Return immediately if the loaded page contains the whole remained key
+	 * range.
+	 */
+	if (end && page_contains_end(it, it->undoIt.image,
+								 it->undoIt.lokey.tuple, end))
+		return can_fetch_from_undo(it);
 
 	Assert(it->combinedResult && header->csn >= it->oSnapshot.csn);
 

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -86,6 +86,19 @@ struct BTreeIterator
 	bool		curKeyReturned;
 
 	/*
+	 * Optimistic array-advance parking.  When o_btree_iterator_fetch()
+	 * discards a tuple that overshot the end bound -- e.g. the first row of
+	 * the next array element in a "col = ANY" scan -- it rewinds the leaf
+	 * locator to that tuple (resumeLoc), so o_btree_iterator_advance() to
+	 * that element can verify the already-loaded tuple directly and skip the
+	 * per-key binary search.  resumeLocValid is set only when the discarded
+	 * tuple came from the plain in-memory leaf path with a clean (non-refind)
+	 * advance.
+	 */
+	BTreePageItemLocator resumeLoc;
+	bool		resumeLocValid;
+
+	/*
 	 * The scan's original start key/kind.  Contract: the caller must keep the
 	 * key alive and unmodified for the iterator's lifetime; the !curKeySet
 	 * branch of iterator_refind_partial_leaf() reads it to re-find the scan
@@ -378,8 +391,42 @@ o_btree_find_tuples_continue(BTreeIterator *it,
 
 	if (page_contains_key(it, key, kind, img, get_lokey_if_exists(it)))
 	{
+		/*
+		 * Optimistic next-item check.  A dense "col IN (...)" / "col = ANY"
+		 * list asks for consecutive keys, and fetch_tuple_from_page() leaves
+		 * the locator on the previous element's matching item, so the next
+		 * element is frequently the immediately following item on the same
+		 * page.  Peek that item and, on an exact match, skip the per-key
+		 * binary search below (btree_page_search() was the dominant cost of
+		 * the array scan on this path).  Restricted to the forward case and
+		 * to a step that stays within the already-loaded chunk, so no extra
+		 * partial-chunk load is needed; every other case (chunk crossing,
+		 * gaps, backward) falls through to the search unchanged.  Since the
+		 * keys are unique this only ever replaces a search that would have
+		 * landed on the very same item.
+		 */
+		if (IT_IS_FORWARD(it) && BTREE_PAGE_LOCATOR_IS_VALID(img, loc))
+		{
+			BTreePageItemLocator next = *loc;
+
+			BTREE_PAGE_LOCATOR_NEXT(img, &next);
+			if (BTREE_PAGE_LOCATOR_IS_VALID(img, &next) &&
+				next.chunkOffset == loc->chunkOffset)
+			{
+				OTuple		cur;
+
+				BTREE_PAGE_READ_TUPLE(cur, img, &next);
+				if (o_btree_cmp(desc, key, kind, &cur, BTreeKeyLeafTuple) == 0)
+				{
+					*loc = next;
+					needToReloadPage = false;
+				}
+			}
+		}
+
 		/* Search within the loaded page */
-		if (btree_page_search(desc, img, key, kind, &context->partial, loc))
+		if (needToReloadPage &&
+			btree_page_search(desc, img, key, kind, &context->partial, loc))
 			needToReloadPage = false;
 	}
 
@@ -1022,20 +1069,42 @@ get_lokey_if_exists(BTreeIterator *it)
 void
 o_btree_iterator_advance(BTreeIterator *it, void *key, BTreeKeyType kind)
 {
-	Assert(key != NULL && kind != BTreeKeyNone);
-
 	BTreePageItemLocator *loc = &it->context.items[it->context.index].locator;
 	bool		found_in_page = false;
 
+	Assert(key != NULL && kind != BTreeKeyNone);
+
 	/*
-	 * Try to reposition within the already-loaded leaf.  btree_page_search()
-	 * must be given the partial-read state: on a FETCH (partial) image
-	 * searching with a NULL partial reads unloaded chunks as garbage and
-	 * mis-positions the locator (e.g. a sparse "col = ANY" scan leaking
-	 * tuples of the values between array elements).  A failed partial load
-	 * falls through to the re-find below.
+	 * Optimistic next-item check.  The previous element's scan left the leaf
+	 * locator on the first item past its end bound (rewound there by
+	 * o_btree_iterator_fetch() after discarding it), which for an adjacent /
+	 * dense "col = ANY" element is already the first item >= the new key.
+	 * Verify that item directly and skip the per-key binary search below.
+	 * Forward only: a backward scan parks the locator differently.
 	 */
-	if (page_contains_key(it, key, kind,
+	if (IT_IS_FORWARD(it) &&
+		BTREE_PAGE_LOCATOR_IS_VALID(it->context.img, loc) &&
+		partial_load_chunk(&it->context.partial, it->context.img,
+						   loc->chunkOffset, NULL))
+	{
+		OTuple		cur;
+
+		BTREE_PAGE_READ_TUPLE(cur, it->context.img, loc);
+		if (o_btree_cmp(it->context.desc, key, kind,
+						&cur, BTreeKeyLeafTuple) <= 0)
+			found_in_page = true;
+	}
+
+	/*
+	 * Otherwise reposition within the already-loaded leaf.
+	 * btree_page_search() must be given the partial-read state: on a FETCH
+	 * (partial) image searching with a NULL partial reads unloaded chunks as
+	 * garbage and mis-positions the locator (e.g. a sparse "col = ANY" scan
+	 * leaking tuples of the values between array elements).  A failed partial
+	 * load falls through to the re-find below.
+	 */
+	if (!found_in_page &&
+		page_contains_key(it, key, kind,
 						  it->context.img, get_lokey_if_exists(it)) &&
 		btree_page_search(it->context.desc, it->context.img, key, kind,
 						  &it->context.partial, loc) &&
@@ -1154,6 +1223,7 @@ o_btree_iterator_fetch(BTreeIterator *it, CommitSeqNo *tupleCsn,
 
 	ASAN_UNPOISON_MEMORY_REGION(&result, sizeof(result));
 
+	it->resumeLocValid = false;
 	result = o_btree_iterator_fetch_internal(it, tupleCsn, endPtr);
 
 	if (!O_TUPLE_IS_NULL(result) && endKey != NULL)
@@ -1167,6 +1237,20 @@ o_btree_iterator_fetch(BTreeIterator *it, CommitSeqNo *tupleCsn,
 		{
 			pfree(result.data);
 			O_TUPLE_SET_NULL(result);
+
+			/*
+			 * This tuple overshot the end bound and o_btree_iterator_fetch_
+			 * internal() already advanced the leaf locator past it.  Rewind
+			 * to it so an advance to the next "col = ANY" array element can
+			 * verify it in place (o_btree_iterator_advance()) instead of
+			 * re-searching. It was never delivered, so mark it
+			 * not-yet-returned.
+			 */
+			if (it->resumeLocValid)
+			{
+				it->context.items[it->context.index].locator = it->resumeLoc;
+				it->curKeyReturned = false;
+			}
 			return result;
 		}
 	}
@@ -1559,8 +1643,19 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn,
 										  it->fetchCallback,
 										  it->fetchCallbackArg);
 
+			/*
+			 * Remember this tuple's position before advancing, so a caller
+			 * that discards it for overshooting the end bound can rewind here
+			 * (see o_btree_iterator_fetch()).  A refind re-descends the page,
+			 * making the saved locator stale.
+			 */
+			it->resumeLoc = leaf_item->locator;
+			it->resumeLocValid = true;
 			if (!iterator_advance_leaf(it, &leaf_item->locator))
+			{
+				it->resumeLocValid = false;
 				iterator_refind_partial_leaf(it);
+			}
 
 			if (!O_TUPLE_IS_NULL(result))
 				return result;

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -764,6 +764,16 @@ page_block_reads(OInMemoryBlkno blkno)
 	Assert((myLockedPages[i].state & PAGE_STATE_CHANGE_NON_WAITERS_MASK) ==
 		   (pg_atomic_read_u64(&(O_PAGE_HEADER(p)->state)) & PAGE_STATE_CHANGE_NON_WAITERS_MASK));
 
+	/*
+	 * Idempotent: if reads are already blocked on this locked page, a
+	 * repeated call is a no-op.  Callers may legitimately double up -- e.g.
+	 * o_ppool_free_page() now blocks reads defensively on every free, which
+	 * can stack with a caller (such as free_page()) that already blocked
+	 * them.
+	 */
+	if (myLockedPages[i].state & PAGE_STATE_NO_READ_FLAG)
+		return;
+
 	state = pg_atomic_fetch_or_u64(&(O_PAGE_HEADER(p)->state), PAGE_STATE_NO_READ_FLAG);
 	Assert((state & PAGE_STATE_LOCKED_FLAG));
 	myLockedPages[i].state = state | PAGE_STATE_NO_READ_FLAG;

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -102,6 +102,32 @@ struct BTreeSeqScan
 	bool		leafPartialFailed;
 
 	/*
+	 * FETCH-mode partial read of the level-1 internal page.  When `fetch` is
+	 * set the internal page is read partially into scan->context.img via
+	 * scan->context.partial (find_page FETCH mode): only the hikeys chunk
+	 * plus the chunks holding downlinks the bitmap walk actually visits are
+	 * materialized.  The bitmap-driven walk skips whole chunks of downlinks
+	 * via their chunk hikeys (get_next_downlink ->
+	 * internal_skip_to_next_key), exactly mirroring the leaf's
+	 * adjust_location_with_next_key(). intPartialFailed is raised when an
+	 * on-demand chunk load loses the race with a concurrent page
+	 * modification; load_next_internal_page then re-reads the whole page
+	 * (IMAGE) and the walk continues on the full image.
+	 */
+	bool		intPartialFailed;
+
+	/*
+	 * High key of the last downlink get_next_downlink() returned (the low
+	 * bound of where the walk should resume).  When an on-demand
+	 * internal-chunk load fails mid-walk, get_next_downlink() re-reads the
+	 * internal page whole (IMAGE) by descending to this key, so
+	 * already-returned downlinks are not revisited.  haveIntResumeKey is
+	 * false before the first downlink of a scan.
+	 */
+	bool		haveIntResumeKey;
+	OFixedKey	intResumeKey;
+
+	/*
 	 * Key of the last leaf tuple emitted from the current partially-read leaf
 	 * (valid only while haveLastLeafKey).  When a partial chunk load loses
 	 * the race with a concurrent modification after some tuples of the leaf
@@ -264,6 +290,48 @@ seq_leaf_partial_ensure(BTreeSeqScan *scan, Page p, BTreePageItemLocator *loc)
 	return true;
 }
 
+/*
+ * Materialize the hikeys chunk of the partially-read internal page (bitmap
+ * FETCH scan).  The chunk-descriptor array and the chunk hikeys used to skip
+ * downlinks live in it.  No-op for a whole-page image.  Sets
+ * scan->intPartialFailed and returns false on a concurrent modification.
+ */
+static inline bool
+seq_int_partial_ensure_hikeys(BTreeSeqScan *scan)
+{
+	if (!scan->context.partial.isPartial ||
+		scan->context.partial.hikeysChunkIsLoaded)
+		return true;
+
+	if (!partial_load_hikeys_chunk(&scan->context.partial, scan->context.img))
+	{
+		scan->intPartialFailed = true;
+		return false;
+	}
+	return true;
+}
+
+/*
+ * Materialize the data chunk that `loc` points into for the partially-read
+ * internal page in scan->context.img.  No-op for a whole-page image (every
+ * parallel scan and any page re-read in IMAGE mode after a partial failure).
+ * Sets scan->intPartialFailed and returns false on a concurrent modification.
+ */
+static inline bool
+seq_int_partial_ensure(BTreeSeqScan *scan, BTreePageItemLocator *loc)
+{
+	if (!scan->context.partial.isPartial)
+		return true;
+
+	if (!partial_load_chunk(&scan->context.partial, scan->context.img,
+							loc->chunkOffset, NULL))
+	{
+		scan->intPartialFailed = true;
+		return false;
+	}
+	return true;
+}
+
 static void
 load_first_historical_page(BTreeSeqScan *scan)
 {
@@ -414,24 +482,89 @@ load_next_internal_page(BTreeSeqScan *scan, OTuple prevHikey,
 
 	CHECK_FOR_INTERRUPTS();
 	elog(DEBUG3, "load_next_internal_page");
-	scan->context.flags |= BTREE_PAGE_FIND_DOWNLINK_LOCATION;
 
-	if (!O_TUPLE_IS_NULL(prevHikey))
+	/*
+	 * A non-parallel bitmap (FETCH) scan reads the level-1 internal page
+	 * partially: find_page() in FETCH mode leaves it in scan->context.img
+	 * with scan->context.partial tracking the loaded chunks, and the
+	 * bitmap-driven walk below skips whole chunks of downlinks it does not
+	 * need.  Parallel scans (page != NULL) share the whole page through DSM,
+	 * and a page whose partial read lost a race (intPartialFailed) is re-read
+	 * whole; both use IMAGE.  The retry loop below re-reads whole if
+	 * materializing the hikeys chunk (needed to iterate/skip) loses a race
+	 * after the partial read.
+	 */
+	while (true)
 	{
-		STOPEVENT(STOPEVENT_SEQ_SCAN_LOAD_INTERNAL_PAGE,
-				  btree_lokey_stopevent_params(scan->desc, prevHikey, prevIsLeftmostOrNone));
-		findResult = find_page(&scan->context, &prevHikey, BTreeKeyNonLeafKey, 1);
+		bool		useFetch = scan->fetch && !page && !scan->intPartialFailed;
+
+		if (useFetch)
+		{
+			BTREE_PAGE_FIND_UNSET(&scan->context, IMAGE);
+			BTREE_PAGE_FIND_SET(&scan->context, FETCH);
+		}
+		else
+		{
+			BTREE_PAGE_FIND_UNSET(&scan->context, FETCH);
+			BTREE_PAGE_FIND_SET(&scan->context, IMAGE);
+		}
+		scan->context.flags |= BTREE_PAGE_FIND_DOWNLINK_LOCATION;
+
+		if (!O_TUPLE_IS_NULL(prevHikey))
+		{
+			STOPEVENT(STOPEVENT_SEQ_SCAN_LOAD_INTERNAL_PAGE,
+					  btree_lokey_stopevent_params(scan->desc, prevHikey, prevIsLeftmostOrNone));
+			findResult = find_page(&scan->context, &prevHikey, BTreeKeyNonLeafKey, 1);
+		}
+		else
+		{
+			findResult = find_page(&scan->context, NULL, BTreeKeyNone, 1);
+		}
+		Assert(findResult == OFindPageResultSuccess);
+
+		if (scan->context.partial.isPartial)
+		{
+			/*
+			 * find_page() returns a page below targetLevel when the tree is
+			 * shallower than requested (a single leaf, no level-1 page).  The
+			 * level-0 branch below copies the whole page into leafImg, so
+			 * re-read it in IMAGE mode.  (The fixed page header is
+			 * materialized by the partial read, so PAGE_GET_LEVEL is valid
+			 * here.)
+			 */
+			if (PAGE_GET_LEVEL(scan->context.img) != 1)
+			{
+				scan->intPartialFailed = true;
+				continue;
+			}
+
+			/*
+			 * A partial read needs the hikeys chunk materialized before we
+			 * touch item offsets, iterate, or skip.  If that loses a race
+			 * with a concurrent modification, fall back to a whole-page IMAGE
+			 * read.
+			 */
+			if (!seq_int_partial_ensure_hikeys(scan))
+			{
+				Assert(scan->intPartialFailed);
+				continue;
+			}
+		}
+		break;
 	}
-	else
-	{
-		findResult = find_page(&scan->context, NULL, BTreeKeyNone, 1);
-	}
-	Assert(findResult == OFindPageResultSuccess);
+
+	/*
+	 * The page is now consistently loaded (partially in FETCH, whole after an
+	 * IMAGE fallback).  Clear the failure latch so the next page can be tried
+	 * partially again.
+	 */
+	scan->intPartialFailed = false;
 
 	/* In case of parallel scan copy page image into shared state */
 	if (page)
 	{
 		Assert(scan->poscan);
+		Assert(!scan->context.partial.isPartial);
 		memcpy(page, scan->context.img, ORIOLEDB_BLCKSZ);
 	}
 	else
@@ -731,6 +864,18 @@ get_current_downlink_key(BTreeSeqScan *scan,
 	BTreeNonLeafTuphdr *tuphdr;
 	OTuple		tuple;
 
+	/*
+	 * Partial FETCH read of the internal page: materialize the chunk holding
+	 * this downlink before reading it.  On a concurrent modification bail
+	 * with intPartialFailed set; get_next_downlink() re-reads the page whole.
+	 */
+	if (!seq_int_partial_ensure(scan, loc))
+	{
+		*downlink = 0;
+		clear_fixed_key(curKey);
+		return;
+	}
+
 	STOPEVENT(STOPEVENT_STEP_DOWN, btree_downlink_stopevent_params(scan->desc,
 																   page, loc));
 
@@ -763,11 +908,90 @@ get_next_key(BTreeSeqScan *scan, BTreePageItemLocator *intLoc, OFixedKey *nextKe
 {
 	BTREE_PAGE_LOCATOR_NEXT(page, intLoc);
 	if (BTREE_PAGE_LOCATOR_IS_VALID(page, intLoc))
+	{
+		/*
+		 * The chunk-descriptor array in the (loaded) hikeys chunk lets
+		 * BTREE_PAGE_LOCATOR_NEXT step across a chunk boundary without the
+		 * data chunk; materialize the landed chunk before reading its key.
+		 */
+		if (!seq_int_partial_ensure(scan, intLoc))
+		{
+			clear_fixed_key(nextKey);
+			return;
+		}
 		copy_fixed_page_key(scan->desc, nextKey, page, intLoc);
+	}
 	else if (!O_PAGE_IS(page, RIGHTMOST))
 		copy_fixed_hikey(scan->desc, nextKey, page);
 	else
 		clear_fixed_key(nextKey);
+}
+
+/*
+ * Bitmap FETCH within-page skip.  On entry scan->intLoc points at the downlink
+ * immediately following the one just returned (its low bound is `boundary`).
+ * Advance scan->intLoc to the downlink covering the next bitmap key at or after
+ * `boundary`, skipping whole chunks of unwanted downlinks -- btree_page_search()
+ * jumps via the chunk hikeys and materializes only the target chunk, so the
+ * skipped chunks are never copied out of the shared page.  Mirrors the leaf's
+ * adjust_location_with_next_key().
+ *
+ * Leaves scan->intLoc invalid (caller loads/descends to the next page) when the
+ * next wanted key is beyond this page's hikey or the bitmap is exhausted.  On a
+ * concurrent modification sets scan->intPartialFailed and returns; scan->intLoc
+ * is then unusable and the next get_next_downlink() call re-reads the page whole
+ * before touching it.
+ */
+static void
+internal_skip_to_next_key(BTreeSeqScan *scan, Page page,
+						  BTreePageItemLocator *intLoc, OTuple boundary)
+{
+	OFixedKey	probe;
+
+	/* A leftmost gap has no key to probe with; fall back to sequential. */
+	if (O_TUPLE_IS_NULL(boundary))
+		return;
+
+	copy_fixed_key(scan->desc, &probe, boundary);
+	if (!scan->cb->getNextPageKey(&probe, scan->arg))
+	{
+		/* Nothing left in the bitmap anywhere. */
+		BTREE_PAGE_LOCATOR_SET_INVALID(intLoc);
+		return;
+	}
+
+	/* Beyond this page: let the caller descend to the covering page. */
+	if (!O_PAGE_IS(page, RIGHTMOST))
+	{
+		OFixedKey	hikey;
+
+		copy_fixed_hikey(scan->desc, &hikey, page);
+		if (o_btree_cmp(scan->desc, &probe.tuple, BTreeKeyNonLeafKey,
+						&hikey.tuple, BTreeKeyNonLeafKey) >= 0)
+		{
+			BTREE_PAGE_LOCATOR_SET_INVALID(intLoc);
+			return;
+		}
+	}
+
+	/*
+	 * Within this page: position intLoc on the downlink covering the key.
+	 * btree_page_search() lands one past the covering downlink (on the first
+	 * separator strictly greater than the key), so step back and materialize
+	 * the landed chunk -- exactly as page_find_downlink() does during
+	 * descent.
+	 */
+	if (!btree_page_search(scan->desc, page, (Pointer) &probe.tuple,
+						   BTreeKeyNonLeafKey, &scan->context.partial, intLoc))
+	{
+		scan->intPartialFailed = true;
+		return;
+	}
+	BTREE_PAGE_LOCATOR_PREV(page, intLoc);
+	if (scan->context.partial.isPartial &&
+		!partial_load_chunk(&scan->context.partial, page, intLoc->chunkOffset,
+							NULL))
+		scan->intPartialFailed = true;
 }
 
 /*
@@ -872,6 +1096,35 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 				}
 			}
 
+			/*
+			 * A prior call's within-page skip lost the race with a concurrent
+			 * modification after it had already returned its downlink,
+			 * leaving scan->intLoc unusable.  Re-read the internal page whole
+			 * (IMAGE) by descending to the resume boundary before touching
+			 * it; load_next_internal_page() clears intPartialFailed and lands
+			 * scan->intLoc on the downlink covering intResumeKey.
+			 */
+			if (pageIsLoaded && scan->intPartialFailed)
+			{
+				OTuple		resumeKey;
+
+				if (scan->haveIntResumeKey)
+					resumeKey = scan->intResumeKey.tuple;
+				else
+					O_TUPLE_SET_NULL(resumeKey);
+
+				if (!load_next_internal_page(scan, resumeKey, NULL,
+											 &scan->intLoc, &scan->intStartOffset,
+											 true, true))
+				{
+					scan->isSingleLeafPage = true;
+					clear_fixed_key(keyRangeLow);
+					clear_fixed_key(keyRangeHigh);
+					return false;
+				}
+				Assert(!scan->intPartialFailed);
+			}
+
 			if (BTREE_PAGE_LOCATOR_IS_VALID(scan->context.img, &scan->intLoc))
 			{
 				get_current_downlink_key(scan, &scan->intLoc, scan->intStartOffset,
@@ -882,7 +1135,54 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 				 * construct fixed hikey of internal item and get next
 				 * internal locator
 				 */
-				get_next_key(scan, &scan->intLoc, keyRangeHigh, scan->context.img);
+				if (!scan->intPartialFailed)
+					get_next_key(scan, &scan->intLoc, keyRangeHigh, scan->context.img);
+
+				if (scan->intPartialFailed)
+				{
+					/*
+					 * A partial chunk load for the current downlink lost the
+					 * race.  Re-read the page whole from the resume boundary
+					 * and recompute this downlink (it has not been returned
+					 * yet).
+					 */
+					OTuple		resumeKey;
+
+					if (scan->haveIntResumeKey)
+						resumeKey = scan->intResumeKey.tuple;
+					else
+						O_TUPLE_SET_NULL(resumeKey);
+
+					if (!load_next_internal_page(scan, resumeKey, NULL,
+												 &scan->intLoc, &scan->intStartOffset,
+												 true, true))
+					{
+						scan->isSingleLeafPage = true;
+						clear_fixed_key(keyRangeLow);
+						clear_fixed_key(keyRangeHigh);
+						return false;
+					}
+					Assert(!scan->intPartialFailed);
+					continue;
+				}
+
+				/* Remember where the walk resumes (this downlink's high key). */
+				scan->haveIntResumeKey = !O_TUPLE_IS_NULL(keyRangeHigh->tuple);
+				if (scan->haveIntResumeKey)
+					copy_fixed_key(scan->desc, &scan->intResumeKey,
+								   keyRangeHigh->tuple);
+
+				/*
+				 * Bitmap-driven within-page skip: advance scan->intLoc
+				 * straight to the downlink covering the next wanted key,
+				 * skipping whole chunks of downlinks the bitmap does not
+				 * need.
+				 */
+				if (scan->fetch && scan->cb && scan->cb->getNextPageKey &&
+					BTREE_PAGE_LOCATOR_IS_VALID(scan->context.img, &scan->intLoc))
+					internal_skip_to_next_key(scan, scan->context.img,
+											  &scan->intLoc, keyRangeHigh->tuple);
+
 				return true;
 			}
 
@@ -1502,6 +1802,8 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 	scan->leafPartialFailed = false;
 	scan->haveLastLeafKey = false;
 	scan->iterSkipKey = false;
+	scan->intPartialFailed = false;
+	scan->haveIntResumeKey = false;
 
 	scan->firstPageIsLoaded = false;
 	scan->intStartOffset = 0;

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -392,7 +392,8 @@ load_next_internal_page(BTreeSeqScan *scan, OTuple prevHikey,
 						Page page,
 						BTreePageItemLocator *intLoc,
 						OffsetNumber *startOffset,
-						const bool prevIsLeftmostOrNone)
+						const bool prevIsLeftmostOrNone,
+						bool isBitmapJump)
 {
 	bool		has_next = false;
 	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
@@ -434,7 +435,23 @@ load_next_internal_page(BTreeSeqScan *scan, OTuple prevHikey,
 		 */
 		*intLoc = scan->context.items[scan->context.index].locator;
 		*startOffset = BTREE_PAGE_LOCATOR_GET_OFFSET(page, intLoc);
-		if (!O_TUPLE_IS_NULL(prevHikey))
+		if (isBitmapJump)
+		{
+			/*
+			 * A bitmap page skip is a fresh descent straight to the wanted
+			 * key, so there is no continuity with a previous page to verify
+			 * (and hence no iterator to build).  find_page() landed on the
+			 * downlink covering the key; record the page's low key as
+			 * prevHikey so get_current_downlink_key() derives the first
+			 * downlink's low bound from it.
+			 */
+			if (O_TUPLE_IS_NULL(scan->context.lokey.tuple))
+				clear_fixed_key(&scan->prevHikey);
+			else
+				copy_fixed_key(scan->desc, &scan->prevHikey,
+							   scan->context.lokey.tuple);
+		}
+		else if (!O_TUPLE_IS_NULL(prevHikey))
 		{
 			OTuple		intTup;
 
@@ -764,30 +781,77 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 			/* Try to load next internal page if needed */
 			if (!pageIsLoaded)
 			{
-				if (scan->firstPageIsLoaded)
+				/*
+				 * A bitmap scan can skip whole internal pages that hold no
+				 * wanted keys: ask the callback for the next needed key at or
+				 * after the finished page's hikey and descend straight to the
+				 * page covering it, instead of stepping to the immediate next
+				 * page.  The landed downlink is fed to the same in-memory /
+				 * on-disk handling below, so the per-leaf FETCH walk still
+				 * applies.
+				 */
+				if (scan->cb && scan->cb->getNextPageKey)
 				{
-					Assert(!O_PAGE_IS(scan->context.img, RIGHTMOST));
-					if (scan->context.img)
-						prevIsLeftmostOrNone = O_PAGE_IS(scan->context.img, LEFTMOST);
-					copy_fixed_hikey(scan->desc, &scan->prevHikey, scan->context.img);
-				}
+					OFixedKey	jumpKey;
 
-				if (!load_next_internal_page(scan, scan->prevHikey.tuple,
-											 NULL,
-											 &scan->intLoc,
-											 &scan->intStartOffset,
-											 prevIsLeftmostOrNone))
+					if (scan->firstPageIsLoaded)
+						copy_fixed_hikey(scan->desc, &jumpKey, scan->context.img);
+					else
+						clear_fixed_key(&jumpKey);
+
+					if (!scan->cb->getNextPageKey(&jumpKey, scan->arg))
+					{
+						/* Nothing left in the bitmap. */
+						clear_fixed_key(keyRangeLow);
+						clear_fixed_key(keyRangeHigh);
+						return false;
+					}
+
+					if (!load_next_internal_page(scan, jumpKey.tuple,
+												 NULL,
+												 &scan->intLoc,
+												 &scan->intStartOffset,
+												 true,
+												 true))
+					{
+						/* Single leaf page (tree has no internal level). */
+						scan->isSingleLeafPage = true;
+						clear_fixed_key(keyRangeLow);
+						clear_fixed_key(keyRangeHigh);
+						return false;
+					}
+
+					/* A jump is a fresh descent; it never builds an iterator. */
+					Assert(!scan->iter);
+				}
+				else
 				{
-					/* first page only */
-					Assert(O_PAGE_IS(scan->context.img, LEFTMOST));
-					scan->isSingleLeafPage = true;
-					clear_fixed_key(keyRangeLow);
-					clear_fixed_key(keyRangeHigh);
-					return false;
-				}
+					if (scan->firstPageIsLoaded)
+					{
+						Assert(!O_PAGE_IS(scan->context.img, RIGHTMOST));
+						if (scan->context.img)
+							prevIsLeftmostOrNone = O_PAGE_IS(scan->context.img, LEFTMOST);
+						copy_fixed_hikey(scan->desc, &scan->prevHikey, scan->context.img);
+					}
 
-				if (scan->iter)
-					return false;
+					if (!load_next_internal_page(scan, scan->prevHikey.tuple,
+												 NULL,
+												 &scan->intLoc,
+												 &scan->intStartOffset,
+												 prevIsLeftmostOrNone,
+												 false))
+					{
+						/* first page only */
+						Assert(O_PAGE_IS(scan->context.img, LEFTMOST));
+						scan->isSingleLeafPage = true;
+						clear_fixed_key(keyRangeLow);
+						clear_fixed_key(keyRangeHigh);
+						return false;
+					}
+
+					if (scan->iter)
+						return false;
+				}
 			}
 
 			if (BTREE_PAGE_LOCATOR_IS_VALID(scan->context.img, &scan->intLoc))
@@ -856,6 +920,7 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 													  curPage->img,
 													  &loc,
 													  &curPage->startOffset,
+													  false,
 													  false);
 				if (!next_loaded)
 				{
@@ -903,6 +968,7 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 													  nextPage->img,
 													  &loc,
 													  &nextPage->startOffset,
+													  false,
 													  false);
 				Assert(next_loaded);
 

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -101,6 +101,20 @@ struct BTreeSeqScan
 	PartialPageState leafPartial;
 	bool		leafPartialFailed;
 
+	/*
+	 * Key of the last leaf tuple emitted from the current partially-read leaf
+	 * (valid only while haveLastLeafKey).  When a partial chunk load loses
+	 * the race with a concurrent modification after some tuples of the leaf
+	 * were already emitted, the fallback iterator must resume strictly after
+	 * this key rather than re-read the whole leaf range (which would emit
+	 * those tuples a second time).  iterSkipKey asks the iterator to drop a
+	 * leading tuple that is <= this key (the resume point is inclusive).
+	 */
+	bool		haveLastLeafKey;
+	OFixedKey	lastLeafKey;
+	bool		iterSkipKey;
+	OFixedKey	iterSkipKeyVal;
+
 	bool		initialized;
 	bool		checkpointNumberSet;
 	OSnapshot	oSnapshot;
@@ -477,6 +491,9 @@ load_next_internal_page(BTreeSeqScan *scan, OTuple prevHikey,
 	{
 		Assert(PAGE_GET_LEVEL(page) == 0);
 		memcpy(scan->leafImg, page, ORIOLEDB_BLCKSZ);
+		/* A whole-page leaf: no partial-read state must leak into it. */
+		scan->leafPartial.isPartial = false;
+		scan->haveLastLeafKey = false;
 		BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
 		scan->hint.blkno = scan->context.items[0].blkno;
 		scan->hint.pageChangeCount = scan->context.items[0].pageChangeCount;
@@ -698,6 +715,7 @@ scan_make_iterator(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRangeHigh)
 	 */
 	scan->leafPartial.isPartial = false;
 	scan->leafPartialFailed = false;
+	scan->haveLastLeafKey = false;
 }
 
 /* Output item downlink and key using provided page and current locator */
@@ -1123,6 +1141,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 					memset(scan->leafPartial.chunkIsLoaded, 0,
 						   sizeof(scan->leafPartial.chunkIsLoaded));
 					scan->leafPartialFailed = false;
+					scan->haveLastLeafKey = false;
 					leafPartial = &scan->leafPartial;
 				}
 
@@ -1261,6 +1280,15 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 
 	if (!success)
 		elog(ERROR, "can not read leaf page from disk");
+
+	/*
+	 * A disk leaf is read whole into the private leafImg, so any partial-read
+	 * state left over from a previous in-memory leaf must not leak into it
+	 * (it would make seq_leaf_partial_ensure() re-read chunks from a stale
+	 * source).
+	 */
+	scan->leafPartial.isPartial = false;
+	scan->haveLastLeafKey = false;
 
 	BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
 	scan->downlinkIndex++;
@@ -1472,6 +1500,8 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 	scan->leafPartial.isPartial = false;
 	scan->leafPartial.src = NULL;
 	scan->leafPartialFailed = false;
+	scan->haveLastLeafKey = false;
+	scan->iterSkipKey = false;
 
 	scan->firstPageIsLoaded = false;
 	scan->intStartOffset = 0;
@@ -1521,14 +1551,29 @@ btree_seq_scan_get_tuple_from_iterator(BTreeSeqScan *scan,
 {
 	OTuple		result;
 
-	if (!O_TUPLE_IS_NULL(scan->iterEnd))
-		result = o_btree_iterator_fetch(scan->iter, tupleCsn,
-										&scan->iterEnd, BTreeKeyNonLeafKey,
-										false, hint);
-	else
-		result = o_btree_iterator_fetch(scan->iter, tupleCsn,
-										NULL, BTreeKeyNone,
-										false, hint);
+	while (true)
+	{
+		if (!O_TUPLE_IS_NULL(scan->iterEnd))
+			result = o_btree_iterator_fetch(scan->iter, tupleCsn,
+											&scan->iterEnd, BTreeKeyNonLeafKey,
+											false, hint);
+		else
+			result = o_btree_iterator_fetch(scan->iter, tupleCsn,
+											NULL, BTreeKeyNone,
+											false, hint);
+
+		/*
+		 * When a partial-read fallback resumed the scan at (inclusive) the
+		 * last already-emitted key, drop that leading duplicate so count/rows
+		 * aren't doubled.
+		 */
+		if (scan->iterSkipKey && !O_TUPLE_IS_NULL(result) &&
+			o_btree_cmp(scan->desc, &result, BTreeKeyLeafTuple,
+						&scan->iterSkipKeyVal.tuple, BTreeKeyNonLeafKey) <= 0)
+			continue;
+		scan->iterSkipKey = false;
+		break;
+	}
 
 	if (O_TUPLE_IS_NULL(result))
 	{
@@ -1799,16 +1844,29 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 		if (scan->leafPartialFailed)
 		{
+			OTuple		resumeLow;
+
 			/*
 			 * A partial leaf chunk load lost its race with a concurrent page
-			 * modification.  Abandon the partial image and re-read the
-			 * current downlink's key range through an iterator; the bitmap
-			 * fetch layer rechecks every tuple, so over-reading the range is
-			 * safe.
+			 * modification.  Abandon the partial image and re-read the rest
+			 * of the current downlink's key range through an iterator; the
+			 * bitmap fetch layer rechecks every tuple, so over-reading is
+			 * safe as long as we don't re-emit tuples already returned.  If
+			 * we already emitted tuples from this leaf, resume from the last
+			 * of them (inclusive) and let the iterator drop that leading
+			 * duplicate; otherwise re-read the whole range.
 			 */
 			scan->leafPartialFailed = false;
-			scan_make_iterator(scan, scan->keyRangeLow.tuple,
-							   scan->keyRangeHigh.tuple);
+			if (scan->haveLastLeafKey)
+			{
+				resumeLow = scan->lastLeafKey.tuple;
+				copy_fixed_key(scan->desc, &scan->iterSkipKeyVal,
+							   scan->lastLeafKey.tuple);
+				scan->iterSkipKey = true;
+			}
+			else
+				resumeLow = scan->keyRangeLow.tuple;
+			scan_make_iterator(scan, resumeLow, scan->keyRangeHigh.tuple);
 			tuple = btree_seq_scan_get_tuple_from_iterator(scan, tupleCsn, hint);
 			if (!O_TUPLE_IS_NULL(tuple))
 				return tuple;
@@ -1845,6 +1903,20 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 				}
 			}
 			continue;
+		}
+
+		/*
+		 * While reading a leaf partially, remember the key we're about to
+		 * process so a later partial-read failure can resume just after it
+		 * instead of re-reading (and re-emitting) the whole leaf.
+		 * scan->nextKey is the bitmap key positioned by apply_next_key(),
+		 * i.e. the key of the tuple at leafLoc, already in the non-leaf key
+		 * form comparisons use.
+		 */
+		if (scan->leafPartial.isPartial && !O_TUPLE_IS_NULL(scan->nextKey.tuple))
+		{
+			copy_fixed_key(scan->desc, &scan->lastLeafKey, scan->nextKey.tuple);
+			scan->haveLastLeafKey = true;
 		}
 
 		tuple = o_find_tuple_version(scan->desc,

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -85,6 +85,22 @@ struct BTreeSeqScan
 	char		leafImg[ORIOLEDB_BLCKSZ];
 	char		histImg[ORIOLEDB_BLCKSZ];
 
+	/*
+	 * FETCH-mode partial reads for bitmap scans.  When `fetch` is set (bitmap
+	 * callbacks present and non-parallel scan) the in-memory leaf page is
+	 * read partially into leafImg: only the chunks actually visited by the
+	 * bitmap's key-driven iteration are materialized from the live shared
+	 * page via `leafPartial`.  `leafPartialFailed` is raised when a chunk
+	 * load detects a concurrent modification; the caller then falls back to
+	 * an iterator over the current key range.  Parallel scans keep whole-page
+	 * IMAGE reads (they share the page image through DSM, which a partial
+	 * image can't back), and pages carrying historical/undo data are fully
+	 * materialized (IMAGE).
+	 */
+	bool		fetch;
+	PartialPageState leafPartial;
+	bool		leafPartialFailed;
+
 	bool		initialized;
 	bool		checkpointNumberSet;
 	OSnapshot	oSnapshot;
@@ -205,6 +221,34 @@ btree_scan_init_shmem(Pointer ptr, bool found)
 						  "OBTreeScanDownlinksPublishTrancheId");
 }
 
+
+/*
+ * Materialize the data chunk that `loc` points into for a partially-read leaf
+ * image (bitmap FETCH scan).
+ *
+ * For a whole-page image -- every non-fetch scan, the historical image, and any
+ * leaf we fully materialized because it carried undo -- leafPartial.isPartial
+ * is false and this is a no-op.  Otherwise it copies the chunk from the live
+ * shared page (rechecking the page change count); the chunk boundaries live in
+ * the hikeys chunk, which o_btree_try_read_page already loaded, so the
+ * locator's item offset is preserved.  A concurrent modification raises
+ * scan->leafPartialFailed and returns false, and the caller must abandon the
+ * partial image and re-read the current key range through an iterator (the
+ * bitmap fetch layer rechecks each tuple, so over-reading the range is safe).
+ */
+static inline bool
+seq_leaf_partial_ensure(BTreeSeqScan *scan, Page p, BTreePageItemLocator *loc)
+{
+	if (!scan->leafPartial.isPartial || p != scan->leafImg)
+		return true;
+
+	if (!partial_load_chunk(&scan->leafPartial, p, loc->chunkOffset, NULL))
+	{
+		scan->leafPartialFailed = true;
+		return false;
+	}
+	return true;
+}
 
 static void
 load_first_historical_page(BTreeSeqScan *scan)
@@ -629,6 +673,14 @@ scan_make_iterator(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRangeHigh)
 	BTREE_PAGE_LOCATOR_SET_INVALID(&scan->leafLoc);
 	scan->haveHistImg = false;
 	scan->iterEnd = keyRangeHigh;
+
+	/*
+	 * The iterator produces tuples directly; the partial leaf image (if any)
+	 * is abandoned, so make on-demand chunk loads inert until the next leaf
+	 * read.
+	 */
+	scan->leafPartial.isPartial = false;
+	scan->leafPartialFailed = false;
 }
 
 /* Output item downlink and key using provided page and current locator */
@@ -987,9 +1039,26 @@ iterate_internal_page(BTreeSeqScan *scan)
 			else if (DOWNLINK_IS_IN_MEMORY(downlink))
 			{
 				ReadPageResult result;
+				PartialPageState *leafPartial = NULL;
 
 				if (scan->poscan)
 					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
+
+				if (scan->fetch)
+				{
+					/*
+					 * Read the leaf partially: only the chunks the bitmap's
+					 * key-driven walk actually visits are copied from the
+					 * live shared page (on demand, via
+					 * seq_leaf_partial_ensure).
+					 */
+					scan->leafPartial.isPartial = true;
+					scan->leafPartial.hikeysChunkIsLoaded = false;
+					memset(scan->leafPartial.chunkIsLoaded, 0,
+						   sizeof(scan->leafPartial.chunkIsLoaded));
+					scan->leafPartialFailed = false;
+					leafPartial = &scan->leafPartial;
+				}
 
 				result = o_btree_try_read_page(scan->desc,
 											   DOWNLINK_GET_IN_MEMORY_BLKNO(downlink),
@@ -998,7 +1067,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 											   scan->context.imgReadCsn,
 											   NULL,
 											   BTreeKeyNone,
-											   NULL,
+											   leafPartial,
 											   true,
 											   NULL);
 
@@ -1007,6 +1076,31 @@ iterate_internal_page(BTreeSeqScan *scan)
 					check_in_memory_leaf_page(scan, scan->keyRangeLow.tuple, scan->keyRangeHigh.tuple);
 					if (scan->iter)
 						return true;
+
+					/*
+					 * A leaf carrying historical/undo data is read whole: the
+					 * historical merge in btree_seq_scan_getnext_internal()
+					 * and load_first_historical_page() walk leaf items
+					 * directly and seed histImg with the full page.
+					 * o_btree_try_read_page() already materialized the page
+					 * for its own undo replay when imgReadCsn required it;
+					 * materialize explicitly against the scan snapshot too so
+					 * a partial image never reaches those paths.  A
+					 * concurrent change during materialization falls back to
+					 * an iterator over the current key range.
+					 */
+					if (leafPartial && scan->leafPartial.isPartial &&
+						COMMITSEQNO_IS_NORMAL(scan->oSnapshot.csn) &&
+						((BTreePageHeader *) scan->leafImg)->csn >= scan->oSnapshot.csn)
+					{
+						if (!partial_load_full_page(&scan->leafPartial, scan->leafImg))
+						{
+							scan_make_iterator(scan, scan->keyRangeLow.tuple,
+											   scan->keyRangeHigh.tuple);
+							Assert(scan->iter);
+							return true;
+						}
+					}
 
 					scan->hint.blkno = DOWNLINK_GET_IN_MEMORY_BLKNO(downlink);
 					scan->hint.pageChangeCount = DOWNLINK_GET_IN_MEMORY_CHANGECOUNT(downlink);
@@ -1302,6 +1396,17 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 	scan->iter = NULL;
 	scan->cb = cb;
 	scan->arg = arg;
+
+	/*
+	 * A bitmap scan (callbacks with getNextKey) that isn't parallel drives a
+	 * key-directed walk of each leaf, so we can read leaves partially.  See
+	 * the comment on BTreeSeqScan.fetch.
+	 */
+	scan->fetch = (cb != NULL && cb->getNextKey != NULL && poscan == NULL);
+	scan->leafPartial.isPartial = false;
+	scan->leafPartial.src = NULL;
+	scan->leafPartialFailed = false;
+
 	scan->firstPageIsLoaded = false;
 	scan->intStartOffset = 0;
 	scan->samplingNumber = 0;
@@ -1380,6 +1485,8 @@ adjust_location_with_next_key(BTreeSeqScan *scan,
 	if (!BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
 		return false;
 
+	if (!seq_leaf_partial_ensure(scan, p, loc))
+		return false;
 	BTREE_PAGE_READ_LEAF_TUPLE(key, p, loc);
 
 	cmp = o_btree_cmp(desc, &key, BTreeKeyLeafTuple,
@@ -1410,6 +1517,14 @@ adjust_location_with_next_key(BTreeSeqScan *scan,
 
 	while (BTREE_PAGE_LOCATOR_IS_VALID(p, loc))
 	{
+		/*
+		 * The chunk-skip loop above navigates via chunk hikeys (in the loaded
+		 * hikeys chunk), and BTREE_PAGE_LOCATOR_NEXT below can step across a
+		 * chunk boundary when nextKey falls in the gap between a chunk's last
+		 * item and its hikey; materialize the current chunk before reading.
+		 */
+		if (!seq_leaf_partial_ensure(scan, p, loc))
+			return false;
 		BTREE_PAGE_READ_LEAF_TUPLE(key, p, loc);
 		cmp = o_btree_cmp(desc,
 						  &key, BTreeKeyLeafTuple,
@@ -1439,7 +1554,11 @@ apply_next_key(BTreeSeqScan *scan)
 					histResult;
 
 		if (BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
+		{
+			if (!seq_leaf_partial_ensure(scan, scan->leafImg, &scan->leafLoc))
+				return;
 			BTREE_PAGE_READ_LEAF_TUPLE(key, scan->leafImg, &scan->leafLoc);
+		}
 		else
 			O_TUPLE_SET_NULL(key);
 
@@ -1611,6 +1730,24 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 		if (scan->cb && scan->cb->getNextKey &&
 			BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
 			apply_next_key(scan);
+
+		if (scan->leafPartialFailed)
+		{
+			/*
+			 * A partial leaf chunk load lost its race with a concurrent page
+			 * modification.  Abandon the partial image and re-read the
+			 * current downlink's key range through an iterator; the bitmap
+			 * fetch layer rechecks every tuple, so over-reading the range is
+			 * safe.
+			 */
+			scan->leafPartialFailed = false;
+			scan_make_iterator(scan, scan->keyRangeLow.tuple,
+							   scan->keyRangeHigh.tuple);
+			tuple = btree_seq_scan_get_tuple_from_iterator(scan, tupleCsn, hint);
+			if (!O_TUPLE_IS_NULL(tuple))
+				return tuple;
+			continue;
+		}
 
 		if (!BTREE_PAGE_LOCATOR_IS_VALID(scan->leafImg, &scan->leafLoc))
 		{

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -953,7 +953,7 @@ internal_skip_to_next_key(BTreeSeqScan *scan, Page page,
 		return;
 
 	copy_fixed_key(scan->desc, &probe, boundary);
-	if (!scan->cb->getNextPageKey(&probe, scan->arg))
+	if (!scan->cb->getNextKey(&probe, BTreeKeyNonLeafKey, true, scan->arg))
 	{
 		/* Nothing left in the bitmap anywhere. */
 		BTREE_PAGE_LOCATOR_SET_INVALID(intLoc);
@@ -1032,7 +1032,7 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 				 * on-disk handling below, so the per-leaf FETCH walk still
 				 * applies.
 				 */
-				if (scan->cb && scan->cb->getNextPageKey)
+				if (scan->cb && scan->cb->getNextKey)
 				{
 					OFixedKey	jumpKey;
 
@@ -1041,7 +1041,8 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 					else
 						clear_fixed_key(&jumpKey);
 
-					if (!scan->cb->getNextPageKey(&jumpKey, scan->arg))
+					if (!scan->cb->getNextKey(&jumpKey, BTreeKeyNonLeafKey,
+											  true, scan->arg))
 					{
 						/* Nothing left in the bitmap. */
 						clear_fixed_key(keyRangeLow);
@@ -1178,7 +1179,7 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 				 * skipping whole chunks of downlinks the bitmap does not
 				 * need.
 				 */
-				if (scan->fetch && scan->cb && scan->cb->getNextPageKey &&
+				if (scan->fetch && scan->cb && scan->cb->getNextKey &&
 					BTREE_PAGE_LOCATOR_IS_VALID(scan->context.img, &scan->intLoc))
 					internal_skip_to_next_key(scan, scan->context.img,
 											  &scan->intLoc, keyRangeHigh->tuple);
@@ -1996,7 +1997,8 @@ apply_next_key(BTreeSeqScan *scan)
 
 		scan->nextKey.tuple = key;
 		if (O_TUPLE_IS_NULL(key) ||
-			!scan->cb->getNextKey(&scan->nextKey, true, scan->arg))
+			!scan->cb->getNextKey(&scan->nextKey, BTreeKeyLeafTuple, true,
+								  scan->arg))
 		{
 			BTREE_PAGE_LOCATOR_SET_INVALID(&scan->leafLoc);
 			return;

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -36,6 +36,7 @@
 #include "s3/requests.h"
 #include "s3/worker.h"
 #include "storage/standby.h"
+#include "tableam/bitmap_scan.h"
 #include "tableam/handler.h"
 #include "tableam/scan.h"
 #include "tableam/toast.h"
@@ -2026,7 +2027,6 @@ orioledb_get_relation_info_hook(PlannerInfo *root,
 
 		if (relation->rd_rel->relhasindex)
 		{
-			int			i;
 			ListCell   *lc;
 			OTableDescr *descr = relation_get_descr(relation);
 			OIndexDescr *primary;
@@ -2055,18 +2055,25 @@ orioledb_get_relation_info_hook(PlannerInfo *root,
 					 * implemented
 					 */
 					info->amcanparallel = false;
-					hasbitmap = info->indexoid != primary->oids.reloid &&
-						primary->nFields <= 1;
-					for (i = 0;
-						 hasbitmap && i < primary->nFields; i++)
-					{
-						Oid			typeoid = primary->fields[i].inputtype;
-						bool		valid = typeoid == INT4OID ||
-							typeoid == INT8OID ||
-							typeoid == TIDOID;
 
-						hasbitmap = hasbitmap && valid;
-					}
+					/*
+					 * Only the single-field uint64 encoding is enabled in the
+					 * planner for now.  The composite (fixed-key) path is
+					 * fully implemented and unit-tested, but choosing it well
+					 * needs a bitmap-heap cost that reflects orioledb's
+					 * primary-index scan at plan-generation time (a
+					 * patched-PG change); until then it stays out of
+					 * amhasgetbitmap.
+					 */
+
+					/*
+					 * Offer a bitmap scan whenever the primary key can back
+					 * one (single int/ctid, or a composite of small ints).
+					 * This covers row-array IN() on a composite primary key,
+					 * planned as a BitmapOr of per-tuple primary-index scans,
+					 * which on large tables beats the common-prefix scan.
+					 */
+					hasbitmap = o_keybitmap_pk_mode(primary, NULL) != O_KEYBITMAP_NONE;
 					info->amhasgetbitmap = hasbitmap;
 
 					if (index->rd_rel->relam != BTREE_AM_OID || (options && !options->orioledb_index))

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -26,7 +26,6 @@
 #include "access/table.h"
 #include "catalog/pg_type.h"
 #include "executor/nodeIndexscan.h"
-#include "lib/rbtree.h"
 #include "nodes/execnodes.h"
 #include "utils/memutils.h"
 
@@ -36,7 +35,7 @@
 typedef struct BitmapSeqScanArg
 {
 	OTableDescr *tbl_desc;
-	RBTree	   *bitmap;
+	OKeyBitmap *bitmap;
 } BitmapSeqScanArg;
 
 typedef struct BridgeIterator
@@ -225,10 +224,263 @@ primary_tuple_get_data(OTuple tuple, OIndexDescr *primary, bool onlyPkey)
 	return val_get_uint64(val, attr->atttypid);
 }
 
+/* ---- composite (fixed-key) primary key encoding ---- */
+
+static int
+o_pk_int_width(Oid typeoid)
+{
+	switch (typeoid)
+	{
+		case INT2OID:
+			return 2;
+		case INT4OID:
+			return 4;
+		case INT8OID:
+			return 8;
+		default:
+			return -1;
+	}
+}
+
+OKeyBitmapMode
+o_keybitmap_pk_mode(OIndexDescr *primary, int *fixedKeyLen)
+{
+	int			i;
+	int			len = 0;
+
+	/*
+	 * For the primary index descriptor the PK columns are its own key fields
+	 * (nKeyFields; INCLUDE columns in nFields are not part of the ordering
+	 * and must be ignored).  nPrimaryFields is zero here (it counts the PK
+	 * columns appended to *secondary* indexes).
+	 */
+
+	/*
+	 * uint64 densified mode: the historically supported single-field case.
+	 * Gated on nFields (not nKeyFields) so a single-key PK with INCLUDE
+	 * columns falls through to fixed-key mode rather than the uint64 helpers,
+	 * whose asserts require nFields == 1.
+	 */
+	if (primary->nFields <= 1)
+	{
+		bool		ok = true;
+
+		for (i = 0; i < primary->nFields; i++)
+		{
+			Oid			t = primary->fields[i].inputtype;
+
+			if (!(t == INT4OID || t == INT8OID || t == TIDOID))
+			{
+				ok = false;
+				break;
+			}
+		}
+		if (ok)
+			return O_KEYBITMAP_UINT64;
+	}
+
+	/* fixed-key mode: composite of small, ascending integer fields */
+	if (primary->primaryIsCtid)
+		return O_KEYBITMAP_NONE;
+	for (i = 0; i < primary->nKeyFields; i++)
+	{
+		int			w = o_pk_int_width(primary->fields[i].inputtype);
+
+		if (w < 0 || !primary->fields[i].ascending)
+			return O_KEYBITMAP_NONE;
+		len += w;
+	}
+	if (len == 0 || len > OKBM_FIXED_BYTES)
+		return O_KEYBITMAP_NONE;
+	if (fixedKeyLen)
+		*fixedKeyLen = len;
+	return O_KEYBITMAP_FIXED;
+}
+
+/* order-preserving big-endian encode of one integer Datum; returns width */
+static int
+o_pk_encode_one(Datum val, Oid typeoid, uint8 *out)
+{
+	int			i,
+				w;
+	uint64		u;
+
+	switch (typeoid)
+	{
+		case INT2OID:
+			u = (uint16) DatumGetInt16(val) ^ UINT64CONST(0x8000);
+			w = 2;
+			break;
+		case INT4OID:
+			u = (uint32) DatumGetInt32(val) ^ UINT64CONST(0x80000000);
+			w = 4;
+			break;
+		case INT8OID:
+			u = (uint64) DatumGetInt64(val) ^ UINT64CONST(0x8000000000000000);
+			w = 8;
+			break;
+		default:
+			elog(ERROR, "unsupported fixed keybitmap type %u", typeoid);
+			return 0;
+	}
+	for (i = w - 1; i >= 0; i--)
+	{
+		out[i] = (uint8) (u & 0xFF);
+		u >>= 8;
+	}
+	return w;
+}
+
+static Datum
+o_pk_decode_one(const uint8 *in, Oid typeoid, int *width)
+{
+	uint64		u = 0;
+	int			i,
+				w;
+
+	switch (typeoid)
+	{
+		case INT2OID:
+			w = 2;
+			break;
+		case INT4OID:
+			w = 4;
+			break;
+		case INT8OID:
+			w = 8;
+			break;
+		default:
+			elog(ERROR, "unsupported fixed keybitmap type %u", typeoid);
+			return (Datum) 0;
+	}
+	for (i = 0; i < w; i++)
+		u = (u << 8) | in[i];
+	*width = w;
+	switch (typeoid)
+	{
+		case INT2OID:
+			return Int16GetDatum((int16) (uint16) (u ^ UINT64CONST(0x8000)));
+		case INT4OID:
+			return Int32GetDatum((int32) (uint32) (u ^ UINT64CONST(0x80000000)));
+		default:
+			return Int64GetDatum((int64) (u ^ UINT64CONST(0x8000000000000000)));
+	}
+}
+
+/*
+ * Encode the primary key held in a leaf tuple of index "id" (primary or a
+ * secondary, which carries the pk fields) into a right-aligned, zero-high-
+ * padded OKBM_FIXED_BYTES buffer.
+ */
+static void
+o_pk_encode_leaf(OTuple tuple, OIndexDescr *id, uint8 *out)
+{
+	bool		isPrimary = (id->desc.type == oIndexPrimary);
+	int			npk = isPrimary ? id->nKeyFields : id->nPrimaryFields;
+	int			pk_from = id->nFields - id->nPrimaryFields;
+	AttrNumber	attnums[INDEX_MAX_KEYS];
+	Oid			types[INDEX_MAX_KEYS];
+	int			i;
+	int			len = 0;
+	int			off;
+
+	for (i = 0; i < npk; i++)
+	{
+		if (isPrimary)
+			attnums[i] = OIndexKeyAttnumToTupleAttnum(BTreeKeyLeafTuple, id, i + 1);
+		else
+			attnums[i] = id->primaryFieldsAttnums[i];
+		types[i] = TupleDescAttr(id->leafTupdesc,
+								 isPrimary ? attnums[i] - 1 : pk_from + i)->atttypid;
+		len += o_pk_int_width(types[i]);
+	}
+
+	memset(out, 0, OKBM_FIXED_BYTES);
+	off = OKBM_FIXED_BYTES - len;
+	for (i = 0; i < npk; i++)
+	{
+		bool		isnull;
+		Datum		val = o_fastgetattr(tuple, attnums[i], id->leafTupdesc,
+										&id->leafSpec, &isnull);
+
+		off += o_pk_encode_one(val, types[i], out + off);
+	}
+}
+
+/* Encode the primary key held in a non-leaf (pk-only) tuple. */
+static void
+o_pk_encode_nonleaf(OTuple tuple, OIndexDescr *primary, uint8 *out)
+{
+	AttrNumber	attnums[INDEX_MAX_KEYS];
+	Oid			types[INDEX_MAX_KEYS];
+	int			i;
+	int			len = 0;
+	int			off;
+
+	for (i = 0; i < primary->nKeyFields; i++)
+	{
+		attnums[i] = OIndexKeyAttnumToTupleAttnum(BTreeKeyNonLeafKey, primary, i + 1);
+		types[i] = TupleDescAttr(primary->nonLeafTupdesc, attnums[i] - 1)->atttypid;
+		len += o_pk_int_width(types[i]);
+	}
+
+	memset(out, 0, OKBM_FIXED_BYTES);
+	off = OKBM_FIXED_BYTES - len;
+	for (i = 0; i < primary->nKeyFields; i++)
+	{
+		bool		isnull;
+		Datum		val = o_fastgetattr(tuple, attnums[i], primary->nonLeafTupdesc,
+										&primary->nonLeafSpec, &isnull);
+
+		off += o_pk_encode_one(val, types[i], out + off);
+	}
+}
+
+/* Decode a fixed key back into a non-leaf pk tuple stored in key->fixedData. */
+static void
+o_pk_decode_to_key(const uint8 *keybytes, OIndexDescr *primary, OFixedKey *key)
+{
+	Datum		values[INDEX_MAX_KEYS];
+	bool		isnull[INDEX_MAX_KEYS];
+	AttrNumber	attnums[INDEX_MAX_KEYS];
+	Oid			types[INDEX_MAX_KEYS];
+	int			natts = primary->nonLeafTupdesc->natts;
+	int			i;
+	int			len = 0;
+	int			off;
+	OTuple		tup;
+
+	for (i = 0; i < natts; i++)
+		isnull[i] = false;		/* pk columns are NOT NULL */
+
+	for (i = 0; i < primary->nKeyFields; i++)
+	{
+		attnums[i] = OIndexKeyAttnumToTupleAttnum(BTreeKeyNonLeafKey, primary, i + 1);
+		types[i] = TupleDescAttr(primary->nonLeafTupdesc, attnums[i] - 1)->atttypid;
+		len += o_pk_int_width(types[i]);
+	}
+
+	off = OKBM_FIXED_BYTES - len;
+	for (i = 0; i < primary->nKeyFields; i++)
+	{
+		int			w;
+
+		values[attnums[i] - 1] = o_pk_decode_one(keybytes + off, types[i], &w);
+		off += w;
+	}
+
+	tup = o_form_tuple(primary->nonLeafTupdesc, &primary->nonLeafSpec, 0,
+					   values, isnull, NULL);
+	key->tuple.formatFlags = tup.formatFlags;
+	memcpy(key->fixedData, tup.data, o_tuple_size(tup, &primary->nonLeafSpec));
+	pfree(tup.data);
+	key->tuple.data = key->fixedData;
+}
+
 static double
 o_index_getbitmap(OBitmapHeapPlanState *bitmap_state,
 				  BitmapIndexScanState *node,
-				  RBTree *bitmap, TIDBitmap *tbm_result)
+				  OKeyBitmap *bitmap, TIDBitmap *tbm_result)
 {
 	OScanState	ostate = {0};
 	OTableDescr *descr;
@@ -351,8 +603,27 @@ o_index_getbitmap(OBitmapHeapPlanState *bitmap_state,
 
 			if (!tbm_result)
 			{
-				data = seconary_tuple_get_pk_data(tuple, indexDescr);
-				o_keybitmap_insert(bitmap, data);
+				if (o_keybitmap_pk_mode(GET_PRIMARY(descr), NULL) == O_KEYBITMAP_FIXED)
+				{
+					uint8		key[OKBM_FIXED_BYTES];
+
+					o_pk_encode_leaf(tuple, indexDescr, key);
+					o_keybitmap_insert_key(bitmap, key);
+				}
+				else
+				{
+					/*
+					 * The scanned index may be the primary index itself (e.g.
+					 * a bitmap index scan over the primary for a row-array
+					 * IN), in which case the pk is the tuple's own key rather
+					 * than an appended secondary payload.
+					 */
+					if (indexDescr->desc.type == oIndexPrimary)
+						data = primary_tuple_get_data(tuple, indexDescr, false);
+					else
+						data = seconary_tuple_get_pk_data(tuple, indexDescr);
+					o_keybitmap_insert(bitmap, data);
+				}
 			}
 			else
 			{
@@ -433,7 +704,7 @@ o_index_getbitmap(OBitmapHeapPlanState *bitmap_state,
 
 static void
 exec_bitmap_index_state(OBitmapHeapPlanState *bitmap_state, PlanState *planstate,
-						RBTree **rbt_result, TIDBitmap **tbm_result)
+						OKeyBitmap **rbt_result, TIDBitmap **tbm_result)
 {
 	double		nTuples = 0;
 	BitmapIndexScanState *node;
@@ -512,7 +783,14 @@ exec_bitmap_index_state(OBitmapHeapPlanState *bitmap_state, PlanState *planstate
 	else
 	{
 		if (*tbm_result == NULL && *rbt_result == NULL)
-			*rbt_result = o_keybitmap_create();
+		{
+			OIndexDescr *primary = GET_PRIMARY(bitmap_state->scan->arg.tbl_desc);
+
+			if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
+				*rbt_result = o_keybitmap_create_fixed();
+			else
+				*rbt_result = o_keybitmap_create();
+		}
 #if PG_VERSION_NUM >= 180000
 		node->biss_Instrument.nsearches++;
 #endif
@@ -523,7 +801,7 @@ exec_bitmap_index_state(OBitmapHeapPlanState *bitmap_state, PlanState *planstate
 }
 
 static void
-add_rbt_to_tbm(OBitmapHeapPlanState *bitmap_state, TIDBitmap *tbm, RBTree *rbt)
+add_rbt_to_tbm(OBitmapHeapPlanState *bitmap_state, TIDBitmap *tbm, OKeyBitmap *rbt)
 {
 	BTreeSeqScan *seq_scan;
 	BitmapSeqScanArg arg;
@@ -572,7 +850,7 @@ add_rbt_to_tbm(OBitmapHeapPlanState *bitmap_state, TIDBitmap *tbm, RBTree *rbt)
 
 static void
 o_exec_bitmapqual(OBitmapHeapPlanState *bitmap_state, PlanState *planstate,
-				  RBTree **rbt_result, TIDBitmap **tbm_result)
+				  OKeyBitmap **rbt_result, TIDBitmap **tbm_result)
 {
 	Assert(rbt_result && tbm_result);
 	Assert(*rbt_result == NULL || *tbm_result == NULL);
@@ -591,7 +869,7 @@ o_exec_bitmapqual(OBitmapHeapPlanState *bitmap_state, PlanState *planstate,
 				for (i = 0; i < node->nplans; i++)
 				{
 					PlanState  *subnode = node->bitmapplans[i];
-					RBTree	   *rbt_subresult = NULL;
+					OKeyBitmap *rbt_subresult = NULL;
 					TIDBitmap  *tbm_subresult = NULL;
 
 					o_exec_bitmapqual(bitmap_state, subnode, &rbt_subresult, &tbm_subresult);
@@ -673,7 +951,7 @@ o_exec_bitmapqual(OBitmapHeapPlanState *bitmap_state, PlanState *planstate,
 				for (i = 0; i < node->nplans; i++)
 				{
 					PlanState  *subnode = node->bitmapplans[i];
-					RBTree	   *rbt_subresult = NULL;
+					OKeyBitmap *rbt_subresult = NULL;
 					TIDBitmap  *tbm_subresult = NULL;
 
 					if (IsA(subnode, BitmapIndexScanState))
@@ -830,7 +1108,7 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 				bridge_next_page(scan, bitmap_state);
 		}
 
-		/* Path 2: Iterate using RBTree bitmap with seq scan */
+		/* Path 2: Iterate using OKeyBitmap bitmap with seq scan */
 		if (!fetched)
 		{
 			Assert(scan->seq_scan);
@@ -866,12 +1144,27 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 			else
 			{
 				OTableDescr *descr;
+				OIndexDescr *primary;
 				uint64		value;
+				bool		in_bitmap;
 
 				descr = relation_get_descr(node->ss.ss_currentRelation);
-				value = primary_tuple_get_data(tuple, GET_PRIMARY(descr), false);
+				primary = GET_PRIMARY(descr);
 
-				if (o_keybitmap_test(scan->arg.bitmap, value))
+				if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
+				{
+					uint8		key[OKBM_FIXED_BYTES];
+
+					o_pk_encode_leaf(tuple, primary, key);
+					in_bitmap = o_keybitmap_test_key(scan->arg.bitmap, key);
+				}
+				else
+				{
+					value = primary_tuple_get_data(tuple, primary, false);
+					in_bitmap = o_keybitmap_test(scan->arg.bitmap, value);
+				}
+
+				if (in_bitmap)
 				{
 					slot = node->ss.ss_ScanTupleSlot;
 					tts_orioledb_store_tuple(slot, tuple,
@@ -965,6 +1258,24 @@ o_bitmap_is_range_valid(OTuple low, OTuple high, void *arg)
 	uint64		lowValue,
 				highValue;
 
+	if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
+	{
+		uint8		lowKey[OKBM_FIXED_BYTES];
+		uint8		highKey[OKBM_FIXED_BYTES];
+
+		if (!O_TUPLE_IS_NULL(low))
+			o_pk_encode_nonleaf(low, primary, lowKey);
+		else
+			memset(lowKey, 0, OKBM_FIXED_BYTES);
+
+		if (!O_TUPLE_IS_NULL(high))
+			o_pk_encode_nonleaf(high, primary, highKey);
+		else
+			memset(highKey, 0xFF, OKBM_FIXED_BYTES);
+
+		return o_keybitmap_range_is_valid_key(barg->bitmap, lowKey, highKey);
+	}
+
 	if (!O_TUPLE_IS_NULL(low))
 		lowValue = primary_tuple_get_data(low, primary, true);
 	else
@@ -988,6 +1299,42 @@ o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg)
 	uint64		res_value;
 	OTupleHeader tuphdr;
 	OIndexDescr *primary = GET_PRIMARY(barg->tbl_desc);
+
+	if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
+	{
+		uint8		prevKey[OKBM_FIXED_BYTES];
+		uint8		outKey[OKBM_FIXED_BYTES];
+
+		if (!O_TUPLE_IS_NULL(key->tuple))
+		{
+			/* apply_next_key() passes the current leaf tuple as the position */
+			o_pk_encode_leaf(key->tuple, primary, prevKey);
+			if (!inclusive)
+			{
+				int			i;
+
+				/* smallest key strictly greater than prev */
+				for (i = OKBM_FIXED_BYTES - 1; i >= 0; i--)
+					if (++prevKey[i] != 0)
+						break;
+				if (i < 0)
+				{
+					O_TUPLE_SET_NULL(key->tuple);
+					return false;
+				}
+			}
+		}
+		else
+			memset(prevKey, 0, OKBM_FIXED_BYTES);
+
+		if (o_keybitmap_get_next_key(barg->bitmap, prevKey, outKey))
+		{
+			o_pk_decode_to_key(outKey, primary, key);
+			return true;
+		}
+		O_TUPLE_SET_NULL(key->tuple);
+		return false;
+	}
 
 	if (!O_TUPLE_IS_NULL(key->tuple))
 	{

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -380,8 +380,8 @@ o_pk_encode_leaf(OTuple tuple, OIndexDescr *id, uint8 *out)
 	bool		isPrimary = (id->desc.type == oIndexPrimary);
 	int			npk = isPrimary ? id->nKeyFields : id->nPrimaryFields;
 	int			pk_from = id->nFields - id->nPrimaryFields;
-	AttrNumber	attnums[INDEX_MAX_KEYS];
-	Oid			types[INDEX_MAX_KEYS];
+	AttrNumber	attnums[INDEX_MAX_KEYS] = {0};
+	Oid			types[INDEX_MAX_KEYS] = {0};
 	int			i;
 	int			len = 0;
 	int			off;
@@ -413,8 +413,8 @@ o_pk_encode_leaf(OTuple tuple, OIndexDescr *id, uint8 *out)
 static void
 o_pk_encode_nonleaf(OTuple tuple, OIndexDescr *primary, uint8 *out)
 {
-	AttrNumber	attnums[INDEX_MAX_KEYS];
-	Oid			types[INDEX_MAX_KEYS];
+	AttrNumber	attnums[INDEX_MAX_KEYS] = {0};
+	Oid			types[INDEX_MAX_KEYS] = {0};
 	int			i;
 	int			len = 0;
 	int			off;
@@ -444,8 +444,8 @@ o_pk_decode_to_key(const uint8 *keybytes, OIndexDescr *primary, OFixedKey *key)
 {
 	Datum		values[INDEX_MAX_KEYS];
 	bool		isnull[INDEX_MAX_KEYS];
-	AttrNumber	attnums[INDEX_MAX_KEYS];
-	Oid			types[INDEX_MAX_KEYS];
+	AttrNumber	attnums[INDEX_MAX_KEYS] = {0};
+	Oid			types[INDEX_MAX_KEYS] = {0};
 	int			natts = primary->nonLeafTupdesc->natts;
 	int			i;
 	int			len = 0;

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -104,8 +104,8 @@ typedef struct OBitmapScan
 } OBitmapScan;
 
 static bool o_bitmap_is_range_valid(OTuple low, OTuple high, void *arg);
-static bool o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg);
-static bool o_bitmap_get_next_page_key(OFixedKey *key, void *arg);
+static bool o_bitmap_get_next_key(OFixedKey *key, BTreeKeyType keyType,
+								  bool inclusive, void *arg);
 
 static void bridge_begin_iterate(BridgeIterator *iter);
 static bool bridge_iterate(BridgeIterator *iter);
@@ -114,8 +114,7 @@ static void bridge_next_page(OBitmapScan *scan,
 
 static BTreeSeqScanCallbacks bitmap_seq_scan_callbacks = {
 	.isRangeValid = o_bitmap_is_range_valid,
-	.getNextKey = o_bitmap_get_next_key,
-	.getNextPageKey = o_bitmap_get_next_page_key
+	.getNextKey = o_bitmap_get_next_key
 };
 
 #define UINT64_HIGH_BIT (UINT64CONST(1) << 63)
@@ -1304,15 +1303,31 @@ o_bitmap_is_range_valid(OTuple low, OTuple high, void *arg)
 									  lowValue, highValue);
 }
 
+/*
+ * Rewrite key->tuple with the smallest bitmap key at or after the position it
+ * carries (NULL tuple => from the start of the tree); return false when none
+ * remains.  keyType selects how the incoming position is decoded and drives the
+ * two levels of the bitmap-directed walk (see BTreeSeqScanCallbacks.getNextKey):
+ *   - BTreeKeyLeafTuple: position is the current leaf tuple (per-tuple walk);
+ *   - BTreeKeyNonLeafKey: position is an internal-page boundary -- a downlink
+ *     separator or page hikey (skip whole pages / downlinks, always inclusive).
+ * The two only differ in how the position's PK value is read (leaf vs non-leaf
+ * layout); the value is looked up in the same bitmap and the result is built as
+ * the same key either way.
+ */
 static bool
-o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg)
+o_bitmap_get_next_key(OFixedKey *key, BTreeKeyType keyType, bool inclusive,
+					  void *arg)
 {
 	BitmapSeqScanArg *barg = (BitmapSeqScanArg *) arg;
+	bool		nonLeaf = (keyType == BTreeKeyNonLeafKey);
 	bool		found;
 	uint64		prev_value = 0;
 	uint64		res_value;
 	OTupleHeader tuphdr;
 	OIndexDescr *primary = GET_PRIMARY(barg->tbl_desc);
+
+	Assert(keyType == BTreeKeyLeafTuple || keyType == BTreeKeyNonLeafKey);
 
 	if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
 	{
@@ -1321,8 +1336,11 @@ o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg)
 
 		if (!O_TUPLE_IS_NULL(key->tuple))
 		{
-			/* apply_next_key() passes the current leaf tuple as the position */
-			o_pk_encode_leaf(key->tuple, primary, prevKey);
+			if (nonLeaf)
+				o_pk_encode_nonleaf(key->tuple, primary, prevKey);
+			else
+				o_pk_encode_leaf(key->tuple, primary, prevKey);
+
 			if (!inclusive)
 			{
 				int			i;
@@ -1352,11 +1370,14 @@ o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg)
 
 	if (!O_TUPLE_IS_NULL(key->tuple))
 	{
-		prev_value = primary_tuple_get_data(key->tuple, primary, false);
+		prev_value = primary_tuple_get_data(key->tuple, primary, nonLeaf);
 		if (!inclusive)
 		{
 			if (prev_value == UINT64_MAX)
+			{
+				O_TUPLE_SET_NULL(key->tuple);
 				return false;
+			}
 			prev_value++;
 		}
 	}
@@ -1385,70 +1406,6 @@ o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg)
 	}
 
 	return found;
-}
-
-/*
- * Non-leaf-key variant of o_bitmap_get_next_key used to skip whole internal
- * pages.  key->tuple carries the finished internal page's hikey (an exclusive
- * page boundary, or NULL to start from the tree's beginning); rewrite it with
- * the smallest bitmap key >= that boundary, encoded as a non-leaf key.  Returns
- * false when no such key remains.
- */
-static bool
-o_bitmap_get_next_page_key(OFixedKey *key, void *arg)
-{
-	BitmapSeqScanArg *barg = (BitmapSeqScanArg *) arg;
-	OIndexDescr *primary = GET_PRIMARY(barg->tbl_desc);
-
-	if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
-	{
-		uint8		prevKey[OKBM_FIXED_BYTES];
-		uint8		outKey[OKBM_FIXED_BYTES];
-
-		if (!O_TUPLE_IS_NULL(key->tuple))
-			o_pk_encode_nonleaf(key->tuple, primary, prevKey);
-		else
-			memset(prevKey, 0, OKBM_FIXED_BYTES);
-
-		if (o_keybitmap_get_next_key(barg->bitmap, prevKey, outKey))
-		{
-			o_pk_decode_to_key(outKey, primary, key);
-			return true;
-		}
-		O_TUPLE_SET_NULL(key->tuple);
-		return false;
-	}
-	else
-	{
-		uint64		prev_value = 0;
-		uint64		res_value;
-		bool		found;
-		FormData_pg_attribute *attr;
-		OTupleHeader tuphdr;
-
-		if (!O_TUPLE_IS_NULL(key->tuple))
-			prev_value = primary_tuple_get_data(key->tuple, primary, true);
-
-		res_value = o_keybitmap_get_next(barg->bitmap, prev_value, &found);
-		if (!found)
-		{
-			O_TUPLE_SET_NULL(key->tuple);
-			return false;
-		}
-
-		attr = TupleDescAttr(primary->nonLeafTupdesc, 0);
-		Assert(primary->nFields == 1);
-		tuphdr = (OTupleHeader) key->fixedData;
-		tuphdr->hasnulls = false;
-		tuphdr->natts = 1;
-		tuphdr->len = SizeOfOTupleHeader + attr->attlen;
-		uint64_get_val(res_value,
-					   attr->atttypid,
-					   &key->fixedData[SizeOfOTupleHeader]);
-		key->tuple.data = key->fixedData;
-		key->tuple.formatFlags = 0;
-		return true;
-	}
 }
 
 static void

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -452,8 +452,19 @@ o_pk_decode_to_key(const uint8 *keybytes, OIndexDescr *primary, OFixedKey *key)
 	int			off;
 	OTuple		tup;
 
+	/*
+	 * Only the ordering key columns can be recovered from the encoded key.  A
+	 * covering primary key also carries INCLUDE columns in nonLeafTupdesc,
+	 * but they are not part of the ordering and can't be navigated by, so the
+	 * seek key needs only the ordering columns; leave the rest NULL.  Marking
+	 * any attribute NULL makes o_form_tuple() build a non-fixed tuple with a
+	 * null bitmap and skip those attributes, so it never reads the
+	 * uninitialized INCLUDE values (which would be undefined behavior -- e.g.
+	 * a bogus by-ref box).  o_btree_cmp() on the result only touches the
+	 * nKeyFields columns.
+	 */
 	for (i = 0; i < natts; i++)
-		isnull[i] = false;		/* pk columns are NOT NULL */
+		isnull[i] = true;
 
 	for (i = 0; i < primary->nKeyFields; i++)
 	{
@@ -468,6 +479,7 @@ o_pk_decode_to_key(const uint8 *keybytes, OIndexDescr *primary, OFixedKey *key)
 		int			w;
 
 		values[attnums[i] - 1] = o_pk_decode_one(keybytes + off, types[i], &w);
+		isnull[attnums[i] - 1] = false; /* ordering key column is present */
 		off += w;
 	}
 

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -105,6 +105,7 @@ typedef struct OBitmapScan
 
 static bool o_bitmap_is_range_valid(OTuple low, OTuple high, void *arg);
 static bool o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg);
+static bool o_bitmap_get_next_page_key(OFixedKey *key, void *arg);
 
 static void bridge_begin_iterate(BridgeIterator *iter);
 static bool bridge_iterate(BridgeIterator *iter);
@@ -113,7 +114,8 @@ static void bridge_next_page(OBitmapScan *scan,
 
 static BTreeSeqScanCallbacks bitmap_seq_scan_callbacks = {
 	.isRangeValid = o_bitmap_is_range_valid,
-	.getNextKey = o_bitmap_get_next_key
+	.getNextKey = o_bitmap_get_next_key,
+	.getNextPageKey = o_bitmap_get_next_page_key
 };
 
 #define UINT64_HIGH_BIT (UINT64CONST(1) << 63)
@@ -1371,6 +1373,70 @@ o_bitmap_get_next_key(OFixedKey *key, bool inclusive, void *arg)
 	}
 
 	return found;
+}
+
+/*
+ * Non-leaf-key variant of o_bitmap_get_next_key used to skip whole internal
+ * pages.  key->tuple carries the finished internal page's hikey (an exclusive
+ * page boundary, or NULL to start from the tree's beginning); rewrite it with
+ * the smallest bitmap key >= that boundary, encoded as a non-leaf key.  Returns
+ * false when no such key remains.
+ */
+static bool
+o_bitmap_get_next_page_key(OFixedKey *key, void *arg)
+{
+	BitmapSeqScanArg *barg = (BitmapSeqScanArg *) arg;
+	OIndexDescr *primary = GET_PRIMARY(barg->tbl_desc);
+
+	if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
+	{
+		uint8		prevKey[OKBM_FIXED_BYTES];
+		uint8		outKey[OKBM_FIXED_BYTES];
+
+		if (!O_TUPLE_IS_NULL(key->tuple))
+			o_pk_encode_nonleaf(key->tuple, primary, prevKey);
+		else
+			memset(prevKey, 0, OKBM_FIXED_BYTES);
+
+		if (o_keybitmap_get_next_key(barg->bitmap, prevKey, outKey))
+		{
+			o_pk_decode_to_key(outKey, primary, key);
+			return true;
+		}
+		O_TUPLE_SET_NULL(key->tuple);
+		return false;
+	}
+	else
+	{
+		uint64		prev_value = 0;
+		uint64		res_value;
+		bool		found;
+		FormData_pg_attribute *attr;
+		OTupleHeader tuphdr;
+
+		if (!O_TUPLE_IS_NULL(key->tuple))
+			prev_value = primary_tuple_get_data(key->tuple, primary, true);
+
+		res_value = o_keybitmap_get_next(barg->bitmap, prev_value, &found);
+		if (!found)
+		{
+			O_TUPLE_SET_NULL(key->tuple);
+			return false;
+		}
+
+		attr = TupleDescAttr(primary->nonLeafTupdesc, 0);
+		Assert(primary->nFields == 1);
+		tuphdr = (OTupleHeader) key->fixedData;
+		tuphdr->hasnulls = false;
+		tuphdr->natts = 1;
+		tuphdr->len = SizeOfOTupleHeader + attr->attlen;
+		uint64_get_val(res_value,
+					   attr->atttypid,
+					   &key->fixedData[SizeOfOTupleHeader]);
+		key->tuple.data = key->fixedData;
+		key->tuple.formatFlags = 0;
+		return true;
+	}
 }
 
 static void

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -89,6 +89,16 @@ typedef struct BridgeIterator
 #define BRIDGE_ITER_NTUPLES(iter) ((iter)->tbmres->ntuples)
 #endif
 
+/* One streamed primary index scan (a single BitmapIndexScan node). */
+typedef struct OBitmapStreamChild
+{
+	OScanState	ostate;
+	OIndexDescr *ix;
+	Relation	index;			/* kept open for scandesc.indexRelation */
+	bool		scandesc_ready; /* scandesc + cxt were initialized */
+	bool		empty;			/* qual_ok false / empty array: no rows */
+} OBitmapStreamChild;
+
 typedef struct OBitmapScan
 {
 	ScanState  *ss;
@@ -101,6 +111,25 @@ typedef struct OBitmapScan
 	BitmapSeqScanArg arg;
 
 	BridgeIterator bridge_iter;
+
+	/*
+	 * Primary-scan streaming.  When the bitmap qual is a single
+	 * BitmapIndexScan over the primary index -- or a BitmapOr of such scans
+	 * (e.g. a row-array "(a,b,c) IN (...)" on a composite pk) -- there is
+	 * nothing to intersect and the union only needs de-duplication.  Instead
+	 * of materializing a key bitmap and re-reading the primary tree we drive
+	 * the primary index scan(s) directly and hand their live tuples straight
+	 * to the output (o_exec_fetch-style), keeping full orioledb row identity
+	 * (csn / hint / rowid) for locking, EPQ and toast and skipping the second
+	 * pass.  For a BitmapOr the children can produce the same pk (duplicate /
+	 * overlapping branches), so a dedup bitmap carries the "already emitted"
+	 * bit.
+	 */
+	bool		stream_primary;
+	OBitmapStreamChild *stream_children;
+	int			stream_nchildren;
+	int			stream_cur;
+	OKeyBitmap *stream_dedup;	/* NULL for a single child (no dup possible) */
 } OBitmapScan;
 
 static bool o_bitmap_is_range_valid(OTuple low, OTuple high, void *arg);
@@ -1038,6 +1067,293 @@ o_exec_bitmapqual(OBitmapHeapPlanState *bitmap_state, PlanState *planstate,
 	}
 }
 
+/*
+ * Set up one streamed primary index scan for a BitmapIndexScan node (mirroring
+ * exec_bitmap_index_state() + o_index_getbitmap()'s setup, minus the collect
+ * loop) that o_bitmap_stream_fetch() drives directly.  Returns false -- leaving
+ * *child untouched apart from a closed index -- when this node is not a
+ * streamable primary orioledb index scan, so the caller falls back to building
+ * a key bitmap.
+ */
+static bool
+setup_primary_stream(OBitmapHeapPlanState *bitmap_state, OBitmapScan *scan,
+					 BitmapIndexScanState *node, OBitmapStreamChild *child)
+{
+	OScanState *ostate = &child->ostate;
+	OTableDescr *descr = scan->arg.tbl_desc;
+	OIndexDescr *indexDescr = NULL;
+	OIndexNumber ix_num;
+	Relation	index;
+	BitmapIndexScan *bitmap_ix_scan = (BitmapIndexScan *) node->ss.ps.plan;
+	ExprContext *econtext = scan->ss->ps.ps_ExprContext;
+	OBTOptions *options = (OBTOptions *) node->biss_RelationDesc->rd_options;
+	BTScanOpaque so;
+
+	/* Non-orioledb (bridged) indexes go through the TIDBitmap path. */
+	if (node->biss_RelationDesc->rd_rel->relam != BTREE_AM_OID ||
+		(options && !options->orioledb_index))
+		return false;
+
+	index = index_open(bitmap_ix_scan->indexid, AccessShareLock);
+	for (ix_num = 0; ix_num < descr->nIndices; ix_num++)
+	{
+		indexDescr = descr->indices[ix_num];
+		if (indexDescr->oids.reloid == bitmap_ix_scan->indexid)
+			break;
+	}
+	Assert(ix_num < descr->nIndices && indexDescr != NULL);
+
+	/* Only the primary index scan yields the table's own rows directly. */
+	if (indexDescr->desc.type != oIndexPrimary)
+	{
+		index_close(index, AccessShareLock);
+		return false;
+	}
+
+	child->index = index;
+	child->ix = indexDescr;
+
+	/* Evaluate runtime / array keys (cf. exec_bitmap_index_state()). */
+	if (node->biss_NumRuntimeKeys != 0)
+		ExecIndexEvalRuntimeKeys(econtext, node->biss_RuntimeKeys,
+								 node->biss_NumRuntimeKeys);
+	if (node->biss_NumArrayKeys != 0)
+		node->biss_RuntimeKeysReady =
+			ExecIndexEvalArrayKeys(econtext, node->biss_ArrayKeys,
+								   node->biss_NumArrayKeys);
+	else
+		node->biss_RuntimeKeysReady = true;
+
+	/* Empty array key: the scan yields nothing. */
+	if (!node->biss_RuntimeKeysReady)
+	{
+		child->empty = true;
+		return true;
+	}
+
+	/* Build the orioledb scan state (cf. o_index_getbitmap()). */
+	memset(ostate, 0, sizeof(*ostate));
+	ostate->ixNum = ix_num;
+	ostate->scanDir = ForwardScanDirection;
+	ostate->indexQuals = bitmap_ix_scan->indexqual;
+	bitmap_state->o_plan_state.plan_state = &node->ss.ps;
+	ResetExprContext(econtext);
+
+	if (node->biss_ScanKeys)
+	{
+		pfree(node->biss_ScanKeys);
+		node->biss_ScanKeys = NULL;
+	}
+	if (node->biss_RuntimeKeys)
+	{
+		pfree(node->biss_RuntimeKeys);
+		node->biss_RuntimeKeys = NULL;
+		node->biss_NumRuntimeKeys = 0;
+	}
+
+	init_index_scan_state(&bitmap_state->o_plan_state, ostate, index, econtext,
+#if PG_VERSION_NUM >= 180000
+						  bitmap_state->bitmapqualplanstate->state->es_snapshot,
+#endif
+						  &node->biss_RuntimeKeys, &node->biss_NumRuntimeKeys,
+						  &node->biss_ScanKeys, &node->biss_NumScanKeys);
+
+	if (node->biss_NumRuntimeKeys != 0)
+	{
+		ResetExprContext(node->biss_RuntimeContext);
+		ExecIndexEvalRuntimeKeys(node->biss_RuntimeContext,
+								 node->biss_RuntimeKeys,
+								 node->biss_NumRuntimeKeys);
+		node->biss_RuntimeKeysReady = true;
+	}
+
+	if ((node->biss_NumRuntimeKeys == 0 && node->biss_NumArrayKeys == 0) ||
+		node->biss_RuntimeKeysReady)
+	{
+		btrescan(&ostate->scandesc, node->biss_ScanKeys,
+				 node->biss_NumScanKeys, NULL, 0);
+		ostate->numPrefixExactKeys =
+			o_get_num_prefix_exact_keys(node->biss_ScanKeys, node->biss_NumScanKeys);
+	}
+
+	ostate->oSnapshot = scan->oSnapshot;
+	ostate->onlyCurIx = true;
+	ostate->cxt = AllocSetContextCreate(scan->cxt,
+										"orioledb bitmap primary stream",
+										ALLOCSET_DEFAULT_SIZES);
+	ostate->curKeyRangeIsLoaded = false;
+	ostate->curKeyRange.empty = true;
+	ostate->curKeyRange.low.n_row_keys = 0;
+	ostate->curKeyRange.high.n_row_keys = 0;
+	child->scandesc_ready = true;
+
+	so = (BTScanOpaque) ostate->scandesc.opaque;
+	_bt_preprocess_keys(&ostate->scandesc);
+	if (!so->qual_ok)
+	{
+		child->empty = true;
+		return true;
+	}
+	ostate->numPrefixExactKeys =
+		o_adjust_num_prefix_exact_keys(so, ostate->numPrefixExactKeys);
+	if (so->numArrayKeys)
+		_bt_start_array_keys(&ostate->scandesc, ForwardScanDirection);
+	ostate->curKeyRange.empty = true;
+
+	return true;
+}
+
+/*
+ * Set up primary-scan streaming for the whole bitmap qual, if it is a single
+ * BitmapIndexScan over the primary index or a BitmapOr of only such scans.
+ * Returns false (having freed anything it opened) to fall back to a key bitmap.
+ */
+static bool
+setup_primary_stream_qual(OBitmapHeapPlanState *bitmap_state, OBitmapScan *scan,
+						  PlanState *qual)
+{
+	if (IsA(qual, BitmapIndexScanState))
+	{
+		scan->stream_children = MemoryContextAllocZero(scan->cxt,
+													   sizeof(OBitmapStreamChild));
+		if (!setup_primary_stream(bitmap_state, scan,
+								  (BitmapIndexScanState *) qual,
+								  &scan->stream_children[0]))
+		{
+			pfree(scan->stream_children);
+			scan->stream_children = NULL;
+			return false;
+		}
+		scan->stream_nchildren = 1;
+		/* a single scan never yields the same pk twice: no dedup needed */
+		return true;
+	}
+	else if (IsA(qual, BitmapOrState))
+	{
+		BitmapOrState *orstate = (BitmapOrState *) qual;
+		int			i;
+
+		/* Only when every branch is itself a plain BitmapIndexScan. */
+		for (i = 0; i < orstate->nplans; i++)
+			if (!IsA(orstate->bitmapplans[i], BitmapIndexScanState))
+				return false;
+
+		scan->stream_children = MemoryContextAllocZero(scan->cxt,
+													   sizeof(OBitmapStreamChild) * orstate->nplans);
+		for (i = 0; i < orstate->nplans; i++)
+		{
+			if (!setup_primary_stream(bitmap_state, scan,
+									  (BitmapIndexScanState *) orstate->bitmapplans[i],
+									  &scan->stream_children[i]))
+			{
+				/* tear down the children already set up, then fall back */
+				int			j;
+
+				for (j = 0; j <= i; j++)
+				{
+					OBitmapStreamChild *c = &scan->stream_children[j];
+
+					if (c->scandesc_ready)
+					{
+						if (c->ostate.iterator)
+							btree_iterator_free(c->ostate.iterator);
+						btendscan(&c->ostate.scandesc);
+						if (c->ostate.cxt)
+							MemoryContextDelete(c->ostate.cxt);
+					}
+					if (c->index)
+						index_close(c->index, AccessShareLock);
+				}
+				pfree(scan->stream_children);
+				scan->stream_children = NULL;
+				return false;
+			}
+			scan->stream_nchildren++;
+		}
+
+		/* Branches can overlap / duplicate pks: dedup emitted rows. */
+		if (o_keybitmap_pk_mode(GET_PRIMARY(scan->arg.tbl_desc), NULL) == O_KEYBITMAP_FIXED)
+			scan->stream_dedup = o_keybitmap_create_fixed();
+		else
+			scan->stream_dedup = o_keybitmap_create();
+		return true;
+	}
+
+	return false;
+}
+
+/*
+ * Fetch the next tuple of a primary-scan-streamed bitmap scan.  Mirrors
+ * o_exec_fetch(): pull one live primary tuple from the current child scan and
+ * hand it to the scan slot with full row identity, applying the node qual.  A
+ * BitmapOr's branches are streamed in turn; a dedup bitmap drops any pk already
+ * emitted by an earlier (overlapping / duplicate) branch.
+ */
+static TupleTableSlot *
+o_bitmap_stream_fetch(OBitmapScan *scan, CustomScanState *node)
+{
+	ScanState  *ss = &node->ss;
+	OTableDescr *descr = relation_get_descr(ss->ss_currentRelation);
+	OIndexDescr *primary = GET_PRIMARY(scan->arg.tbl_desc);
+	MemoryContext tupleCxt = ss->ss_ScanTupleSlot->tts_mcxt;
+	TupleTableSlot *slot;
+
+	while (scan->stream_cur < scan->stream_nchildren)
+	{
+		OBitmapStreamChild *child = &scan->stream_children[scan->stream_cur];
+		BTreeLocationHint hint = {OInvalidInMemoryBlkno, 0};
+		CommitSeqNo tupleCsn;
+		OTuple		tuple;
+
+		if (child->empty)
+		{
+			scan->stream_cur++;
+			continue;
+		}
+
+		tuple = o_iterate_index(child->ix, &child->ostate, &tupleCsn, tupleCxt,
+								&hint);
+		if (O_TUPLE_IS_NULL(tuple))
+		{
+			scan->stream_cur++;
+			continue;
+		}
+
+		/* Dedup across BitmapOr branches. */
+		if (scan->stream_dedup)
+		{
+			bool		fresh;
+
+			if (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_FIXED)
+			{
+				uint8		key[OKBM_FIXED_BYTES];
+
+				o_pk_encode_leaf(tuple, child->ix, key);
+				fresh = o_keybitmap_emit_key(scan->stream_dedup, key);
+			}
+			else
+				fresh = o_keybitmap_emit(scan->stream_dedup,
+										 primary_tuple_get_data(tuple, child->ix, false));
+
+			if (!fresh)
+			{
+				pfree(tuple.data);
+				continue;		/* already emitted by an earlier branch */
+			}
+		}
+
+		tts_orioledb_store_tuple(ss->ss_ScanTupleSlot, tuple, descr, tupleCsn,
+								 PrimaryIndexNumber, true, &hint);
+		slot = ss->ss_ScanTupleSlot;
+
+		if (o_exec_qual(ss->ps.ps_ExprContext, ss->ps.qual, slot))
+			return slot;
+		/* qual failed: keep scanning */
+	}
+
+	return ExecClearTuple(ss->ss_ScanTupleSlot);
+}
+
 OBitmapScan *
 o_make_bitmap_scan(OBitmapHeapPlanState *bitmap_state, ScanState *ss,
 				   PlanState *bitmapqualplanstate, Relation rel,
@@ -1052,6 +1368,18 @@ o_make_bitmap_scan(OBitmapHeapPlanState *bitmap_state, ScanState *ss,
 	scan->ss = ss;
 	scan->arg.tbl_desc = relation_get_descr(rel);
 	bitmap_state->scan = scan;
+
+	/*
+	 * Fast path: a single primary BitmapIndexScan, or a BitmapOr of only such
+	 * scans, is executed as live primary index scan(s) -- no key bitmap, no
+	 * second pass over the primary tree.
+	 */
+	if (setup_primary_stream_qual(bitmap_state, scan, bitmapqualplanstate))
+	{
+		scan->stream_primary = true;
+		return scan;
+	}
+
 	o_exec_bitmapqual(bitmap_state, bitmapqualplanstate,
 					  &scan->arg.bitmap,
 					  &scan->bridge_iter.tidbitmap);
@@ -1079,6 +1407,9 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 	OBitmapHeapPlanState *bitmap_state =
 		(OBitmapHeapPlanState *) ocstate->o_plan_state;
 	BridgeIterator *bridge_iter = &scan->bridge_iter;
+
+	if (scan->stream_primary)
+		return o_bitmap_stream_fetch(scan, node);
 
 	do
 	{
@@ -1248,6 +1579,33 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 void
 o_free_bitmap_scan(OBitmapScan *scan)
 {
+	if (scan->stream_primary)
+	{
+		int			i;
+
+		for (i = 0; i < scan->stream_nchildren; i++)
+		{
+			OBitmapStreamChild *c = &scan->stream_children[i];
+
+			if (c->scandesc_ready)
+			{
+				if (c->ostate.iterator)
+					btree_iterator_free(c->ostate.iterator);
+				btendscan(&c->ostate.scandesc);
+				if (c->ostate.cxt)
+					MemoryContextDelete(c->ostate.cxt);
+			}
+			if (c->index)
+				index_close(c->index, AccessShareLock);
+		}
+		if (scan->stream_children)
+			pfree(scan->stream_children);
+		if (scan->stream_dedup)
+			o_keybitmap_free(scan->stream_dedup);
+		pfree(scan);
+		return;
+	}
+
 	if (scan->seq_scan)
 		free_btree_seq_scan(scan->seq_scan);
 	if (scan->arg.bitmap)

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -349,21 +349,32 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	if (ostate->curKeyRangeIsLoaded)
 		result = o_bt_advance_array_keys_increment(ostate, ostate->scanDir);
 #endif
-	ostate->curKeyRangeIsLoaded = true;
 
-	ostate->exact = result;
 	if (!result)
+	{
+		ostate->curKeyRangeIsLoaded = true;
 		return false;
-
+	}
 
 	oldcontext = MemoryContextSwitchTo(ostate->cxt);
-	ostate->exact = o_key_data_to_key_range(&ostate->curKeyRange,
-											so->keyData,
-											so->numberOfKeys,
-											(so->numArrayKeys > 0) ? so->arrayKeys : NULL,
-											ostate->numPrefixExactKeys,
-											indexDescr->nonLeafTupdesc->natts,
-											indexDescr->fields);
+
+	if (!ostate->curKeyRangeIsLoaded)
+		ostate->exact = o_key_data_to_key_range(&ostate->curKeyRange,
+												so->keyData,
+												so->numberOfKeys,
+												(so->numArrayKeys > 0) ? so->arrayKeys : NULL,
+												ostate->numPrefixExactKeys,
+												indexDescr->nonLeafTupdesc->natts,
+												indexDescr->fields);
+	else
+		o_key_data_update_array_key_range(&ostate->curKeyRange,
+										  so->keyData,
+										  so->numberOfKeys,
+										  (so->numArrayKeys > 0) ? so->arrayKeys : NULL,
+										  ostate->numPrefixExactKeys,
+										  indexDescr->nonLeafTupdesc->natts,
+										  indexDescr->fields);
+	ostate->curKeyRangeIsLoaded = true;
 
 	if (!ostate->exact)
 	{

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -113,13 +113,6 @@ row_key_tuple_is_valid(OBtreeRowKeyBound *row_key, OTuple tup, OIndexDescr *id,
 	return valid;
 }
 
-static inline bool
-o_bound_is_coercible(OBTreeValueBound *bound, OIndexField *field)
-{
-	return (bound->flags & O_VALUE_BOUND_COERCIBLE) ||
-		IsBinaryCoercible(bound->type, field->inputtype);
-}
-
 static bool
 is_tuple_valid(OTuple tup, OIndexDescr *id, OBTreeKeyRange *range,
 			   BTScanOpaque so, int numPrefixExactKeys)

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -355,11 +355,6 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	if (!result)
 		return false;
 
-	if (ostate->iterator != NULL)
-	{
-		btree_iterator_free(ostate->iterator);
-		ostate->iterator = NULL;
-	}
 
 	oldcontext = MemoryContextSwitchTo(ostate->cxt);
 	ostate->exact = o_key_data_to_key_range(&ostate->curKeyRange,
@@ -375,9 +370,18 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 		bound = (ostate->scanDir == ForwardScanDirection
 				 ? &ostate->curKeyRange.low
 				 : &ostate->curKeyRange.high);
-		ostate->iterator = o_btree_iterator_create(&indexDescr->desc, (Pointer) bound,
-												   BTreeKeyBound, &ostate->oSnapshot,
-												   ostate->scanDir);
+
+		/* Re-use the existing iterator when possible */
+		if (!ostate->iterator)
+			ostate->iterator = o_btree_iterator_create(&indexDescr->desc,
+													   (Pointer) bound,
+													   BTreeKeyBound,
+													   &ostate->oSnapshot,
+													   ostate->scanDir);
+		else
+			o_btree_iterator_advance(ostate->iterator,
+									 (Pointer) bound,
+									 BTreeKeyBound);
 		o_btree_iterator_set_tuple_ctx(ostate->iterator, tupleCxt);
 	}
 
@@ -415,10 +419,32 @@ o_iterate_index(OIndexDescr *indexDescr, OScanState *ostate,
 			if (hint)
 				hint->blkno = OInvalidInMemoryBlkno;
 
-			tup = o_btree_find_tuple_by_key(&indexDescr->desc,
-											&ostate->curKeyRange.low,
-											BTreeKeyBound, &ostate->oSnapshot,
-											tupleCsn, tupleCxt, hint);
+			if (!so->numArrayKeys)
+			{
+				tup = o_btree_find_tuple_by_key(&indexDescr->desc,
+												&ostate->curKeyRange.low,
+												BTreeKeyBound, &ostate->oSnapshot,
+												tupleCsn, tupleCxt, hint);
+			}
+			else
+			{
+				if (!ostate->iterator)
+				{
+					tup = o_btree_find_tuples_start(&indexDescr->desc,
+													&ostate->curKeyRange.low,
+													BTreeKeyBound, &ostate->oSnapshot,
+													ostate->scanDir,
+													tupleCsn, tupleCxt, hint,
+													NULL, NULL, NULL, &ostate->iterator);
+				}
+				else
+				{
+					tup = o_btree_find_tuples_continue(ostate->iterator,
+													   &ostate->curKeyRange.low,
+													   BTreeKeyBound,
+													   tupleCsn, hint, NULL);
+				}
+			}
 			if (!O_TUPLE_IS_NULL(tup))
 				tup_fetched = true;
 		}
@@ -516,8 +542,6 @@ o_index_scan_getnext(OTableDescr *descr, OScanState *ostate,
 				/* cppcheck-suppress uninitvar */
 				return tup;
 			}
-
-			_bt_start_array_keys(&ostate->scandesc, ForwardScanDirection);
 		}
 		_bt_preprocess_keys(&ostate->scandesc);
 		ostate->numPrefixExactKeys =

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -304,6 +304,26 @@ o_bt_advance_array_keys_increment(OScanState *ostate, ScanDirection dir)
 	return false;
 }
 
+#if PG_VERSION_NUM >= 180000
+/*
+ * Does the scan have any PG18 skip array?  A skip array (num_elems == -1)
+ * carries a dynamic range (low_compare / high_compare) that changes from one
+ * range to the next, so the o_key_data_update_array_key_range() shortcut --
+ * which only refreshes fixed array element values -- cannot represent it and
+ * switch_to_next_range() must rebuild the full key range instead.
+ */
+static bool
+scan_has_skip_array(BTScanOpaque so)
+{
+	int			i;
+
+	for (i = 0; i < so->numArrayKeys; i++)
+		if (so->arrayKeys[i].num_elems == -1)
+			return true;
+	return false;
+}
+#endif
+
 static bool
 switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 					 MemoryContext tupleCxt)
@@ -358,7 +378,12 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 
 	oldcontext = MemoryContextSwitchTo(ostate->cxt);
 
-	if (!ostate->curKeyRangeIsLoaded)
+	if (!ostate->curKeyRangeIsLoaded
+#if PG_VERSION_NUM >= 180000
+	/* skip arrays have dynamic ranges: rebuild fully, see comment above */
+		|| (so->numArrayKeys > 0 && scan_has_skip_array(so))
+#endif
+		)
 		ostate->exact = o_key_data_to_key_range(&ostate->curKeyRange,
 												so->keyData,
 												so->numberOfKeys,

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -192,7 +192,8 @@ is_tuple_valid(OTuple tup, OIndexDescr *id, OBTreeKeyRange *range,
 
 		if (arrayKey->scan_key >= numPrefixExactKeys)
 		{
-			int			j;
+			int			lo = 0;
+			int			hi = arrayKey->num_elems - 1;
 			bool		isnull;
 			int			attnum = OIndexKeyAttnumToTupleAttnum(BTreeKeyLeafTuple,
 															  id,
@@ -202,28 +203,41 @@ is_tuple_valid(OTuple tup, OIndexDescr *id, OBTreeKeyRange *range,
 			bool		found = false;
 			OBTreeValueBound *bound = &low->keys[key->sk_attno - 1];
 			OIndexField *field = &id->fields[key->sk_attno - 1];
+			OComparator *comparator;
 
 			Assert(arrayKey->num_elems > 0);
 
-			for (j = 0; j < arrayKey->num_elems; j++)
+			/*
+			 * The array elements are sorted in index-column order, so the
+			 * membership test is a binary search rather than a linear scan.
+			 * Pick the comparator once (out of the loop): a coercible bound
+			 * uses the field comparator, otherwise the bound's own one.  The
+			 * comparator orders by the datum's ascending value, so flip its
+			 * result for a descending column to match the element order.
+			 */
+			if (o_bound_is_coercible(bound, field))
+				comparator = field->comparator;
+			else
+				comparator = bound->comparator;
+
+			while (lo <= hi)
 			{
+				int			mid = lo + (hi - lo) / 2;
 				int			cmp;
 
-				if (o_bound_is_coercible(bound, field))
-				{
-					cmp = o_call_comparator(field->comparator,
-											value, arrayKey->elem_values[j]);
-				}
-				else
-				{
-					cmp = o_call_comparator(bound->comparator,
-											value, arrayKey->elem_values[j]);
-				}
+				cmp = o_call_comparator(comparator, value,
+										arrayKey->elem_values[mid]);
+				if (!field->ascending)
+					cmp = -cmp;
 				if (cmp == 0)
 				{
 					found = true;
 					break;
 				}
+				else if (cmp < 0)
+					hi = mid - 1;
+				else
+					lo = mid + 1;
 			}
 
 			if (!found)

--- a/src/tableam/key_bitmap.c
+++ b/src/tableam/key_bitmap.c
@@ -225,6 +225,26 @@ o_keybitmap_test_key(OKeyBitmap *bm, const uint8 *key)
 	return okbmf_find(bm->ftree, k) != NULL;
 }
 
+/*
+ * Insert key and report whether it was newly added.  Used as a dedup
+ * test-and-set while streaming a BitmapOr of primary scans: a true return
+ * means this is the first time the key is seen (emit it), false means a prior
+ * branch already produced it (skip).
+ */
+bool
+o_keybitmap_emit_key(OKeyBitmap *bm, const uint8 *key)
+{
+	okbmf_key	k = okbmf_mkkey(key);
+	OKbmDummy	dummy = {0};
+
+	Assert(bm->fixed);
+	if (okbmf_find(bm->ftree, k) != NULL)
+		return false;
+	(void) okbmf_set(bm->ftree, k, &dummy);
+	bm->finalized = false;
+	return true;
+}
+
 void
 o_keybitmap_insert(OKeyBitmap *bm, uint64 value)
 {
@@ -257,6 +277,33 @@ o_keybitmap_test(OKeyBitmap *bm, uint64 value)
 		return false;
 
 	return (entry->bitmap[offset >> 3] & (1 << (offset & 7))) != 0;
+}
+
+/* uint64 variant of o_keybitmap_emit_key(): insert, return true if newly added. */
+bool
+o_keybitmap_emit(OKeyBitmap *bm, uint64 value)
+{
+	uint64		chunk = value >> OKBM_CHUNK_BITS;
+	int			offset = value & OKBM_LOW_MASK;
+	int			byte = offset >> 3;
+	uint8		mask = 1 << (offset & 7);
+	OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
+
+	if (entry == NULL)
+	{
+		OKeyBitmapChunk newentry;
+
+		memset(&newentry, 0, sizeof(newentry));
+		newentry.bitmap[byte] |= mask;
+		(void) okbm_set(bm->tree, chunk, &newentry);
+		bm->finalized = false;
+		return true;
+	}
+	if (entry->bitmap[byte] & mask)
+		return false;
+	entry->bitmap[byte] |= mask;
+	bm->finalized = false;
+	return true;
 }
 
 bool

--- a/src/tableam/key_bitmap.c
+++ b/src/tableam/key_bitmap.c
@@ -1,7 +1,18 @@
 /*-------------------------------------------------------------------------
  *
  * key_bitmap.c
- *		Routines for bitmap scan of orioledb table
+ *		Routines for bitmap scan of orioledb table.
+ *
+ *		The bitmap is a set of uint64 keys, stored densely: the key is split
+ *		into a high part (the chunk, key >> OKBM_CHUNK_BITS) and a low part
+ *		(OKBM_CHUNK_BITS bits).  Each chunk maps to a bitmap covering its
+ *		OKBM_CHUNK_VALUES low-part offsets.  Chunks are held in an adaptive
+ *		radix tree (include/lib/o_radixtree.h), which keeps them ordered so
+ *		iteration and range queries are efficient.
+ *
+ *		Ordered seeks (o_keybitmap_range_is_valid / o_keybitmap_get_next) are
+ *		served from a sorted array of chunk keys built lazily once the bitmap
+ *		stops being mutated (the build phase always precedes the scan phase).
  *
  * Copyright (c) 2021-2026, Oriole DB Inc.
  * Copyright (c) 2025-2026, Supabase Inc.
@@ -14,181 +25,85 @@
 
 #include "orioledb.h"
 
-#include "btree/io.h"
-#include "btree/iterator.h"
-#include "btree/page_chunks.h"
 #include "tableam/bitmap_scan.h"
-#include "tableam/index_scan.h"
-#include "tuple/slot.h"
 
-#include "lib/rbtree.h"
+#include "utils/memutils.h"
 
-static int	bm_rbt_comparator(const RBTNode *a, const RBTNode *b, void *arg);
-static void bm_rbt_combiner(RBTNode *existing, const RBTNode *newdata, void *arg);
-static RBTNode *bm_rbt_allocfunc(void *arg);
-static void bm_rbt_freefunc(RBTNode *x, void *arg);
+#define OKBM_CHUNK_BITS		10
+#define OKBM_CHUNK_VALUES	(UINT64CONST(1) << OKBM_CHUNK_BITS)
+#define OKBM_LOW_MASK		(OKBM_CHUNK_VALUES - 1)
+#define OKBM_BITMAP_BYTES	(OKBM_CHUNK_VALUES / 8)
 
-#define HIGH_PART_MASK	(0xFFFFFFFFFFFFFC00)
-#define LOW_PART_MASK	(0x00000000000003FF)
-#define BITMAP_SIZE		0x80
-
-typedef struct
+typedef struct OKeyBitmapChunk
 {
-	RBTNode		rbtnode;
-	uint64		key;
-	uint8	   *bitmap;
-} OKeyBitmapRBTNode;
+	uint8		bitmap[OKBM_BITMAP_BYTES];
+} OKeyBitmapChunk;
 
-RBTree *
-o_keybitmap_create(void)
-{
-	return rbt_create(sizeof(OKeyBitmapRBTNode),
-					  bm_rbt_comparator,
-					  bm_rbt_combiner,
-					  bm_rbt_allocfunc,
-					  bm_rbt_freefunc,
-					  NULL);
-}
+#define RT_PREFIX okbm
+#define RT_SCOPE static
+#define RT_DECLARE
+#define RT_DEFINE
+#define RT_USE_DELETE
+#define RT_VALUE_TYPE OKeyBitmapChunk
+#include "lib/o_radixtree.h"
 
-void
-o_keybitmap_insert(RBTree *rbtree, uint64 value)
+/*
+ * Fixed-key mode: for composite / non-int primary keys the key is an
+ * order-preserving byte string of OKBM_FIXED_BYTES bytes (see
+ * include/tableam/bitmap_scan.h).  These are stored, un-densified, in a
+ * fixed-length-key radix tree whose value carries no information.
+ */
+typedef struct OKbmDummy
 {
-	OKeyBitmapRBTNode node;
-	bool		is_new;
+	uint8		unused;
+} OKbmDummy;
+
+#define RT_PREFIX okbmf
+#define RT_SCOPE static
+#define RT_DECLARE
+#define RT_DEFINE
+#define RT_USE_DELETE
+#define RT_KEY_SIZE OKBM_FIXED_BYTES
+#define RT_VALUE_TYPE OKbmDummy
+#include "lib/o_radixtree.h"
+
+struct OKeyBitmap
+{
+	bool		fixed;			/* false: uint64 densified; true: fixed-key */
+
+	okbm_radix_tree *tree;		/* uint64 mode */
+	okbmf_radix_tree *ftree;	/* fixed-key mode */
+
+	/* dedicated context owned by the radix tree (reset/freed by okbm*_free) */
+	MemoryContext treeCxt;
+	/* context holding this struct and the seek arrays */
+	MemoryContext cxt;
 
 	/*
-	 * For the moment, fill only the fields of node that will be looked at by
-	 * bm_rbt_combiner or bm_rbt_comparator.
+	 * Sorted key arrays, built lazily by okbm_finalize() to serve ordered
+	 * seeks.  Invalidated (finalized = false) on every mutation.  uint64 mode
+	 * stores chunk keys in chunks[]; fixed mode stores whole keys, each
+	 * OKBM_FIXED_BYTES bytes, in fkeys[].
 	 */
-	node.key = value;
-	node.bitmap = NULL;
-	(void) rbt_insert(rbtree, (RBTNode *) &node, &is_new);
-}
+	uint64	   *chunks;
+	uint8	   *fkeys;
+	int			nchunks;
+	int			chunksCapacity;
+	bool		finalized;
+};
 
-bool
-o_keybitmap_test(RBTree *rbtree, uint64 value)
-{
-	OKeyBitmapRBTNode node;
-	OKeyBitmapRBTNode *found;
-
-	/*
-	 * For the moment, fill only the fields of node that will be looked at by
-	 * bm_rbt_comparator.
-	 */
-	node.key = value;
-	node.bitmap = NULL;
-	found = (OKeyBitmapRBTNode *) rbt_find(rbtree, (RBTNode *) &node);
-	if (!found)
-		return false;
-
-	if (found->bitmap)
-	{
-		int			offset = (value & LOW_PART_MASK);
-
-		if (found->bitmap[offset >> 3] & (1 << (offset & 7)))
-			return true;
-		else
-			return false;
-	}
-	else
-	{
-		return (found->key == value);
-	}
-}
-
-bool
-o_keybitmap_range_is_valid(RBTree *rbtree, uint64 low, uint64 high)
-{
-	OKeyBitmapRBTNode lowNode;
-	OKeyBitmapRBTNode *node;
-	int			i,
-				iStart,
-				iEnd;
-	uint8		startMask,
-				endMask;
-	bool		valid = false;
-	bool		first = true;
-
-	while (!valid && ((low & HIGH_PART_MASK) <= (high & HIGH_PART_MASK)))
-	{
-		bool		skip_step = false;
-
-		/*
-		 * For the moment, fill only the fields of node that will be looked at
-		 * by bt_rbt_comparator.
-		 */
-		lowNode.key = low;
-		lowNode.bitmap = NULL;
-
-		node = (OKeyBitmapRBTNode *) rbt_find_great(rbtree,
-													(RBTNode *) &lowNode,
-													true);
-		if (!node)
-			break;
-
-		if (!node->bitmap)
-		{
-			if (node->key >= low && node->key < high)
-				valid = true;
-			skip_step = true;
-		}
-
-		if (!skip_step)
-		{
-			if ((low & HIGH_PART_MASK) == (node->key & HIGH_PART_MASK))
-			{
-				iStart = (low & LOW_PART_MASK) >> 3;
-				startMask = 0xFF << ((low & LOW_PART_MASK) & 7);
-			}
-			else
-			{
-				iStart = 0;
-				startMask = 0xFF;
-			}
-
-			if ((high & HIGH_PART_MASK) == (node->key & HIGH_PART_MASK))
-			{
-				iEnd = ((high - 1) & LOW_PART_MASK) >> 3;
-				endMask = 0xFF >> (7 - (((high - 1) & LOW_PART_MASK) & 7));
-			}
-			else
-			{
-				iEnd = BITMAP_SIZE - 1;
-				endMask = 0xFF;
-			}
-			for (i = iStart; i <= iEnd; i++)
-			{
-				uint8		mask;
-
-				mask = (i == iStart) ? startMask : 0xFF;
-				if (i == iEnd)
-					mask &= endMask;
-
-				if (node->bitmap[i] & mask)
-					valid = true;
-			}
-		}
-		if (!valid)
-		{
-			low = node->key;
-			if (!first)
-				low += (1L << 10);
-		}
-		first = false;
-	}
-
-	return valid;
-}
-
+/*
+ * Return the first set bit offset >= minOffset within a chunk bitmap, or -1.
+ */
 static int
-find_next_offset(uint8 *bitmap, int minOffset)
+find_next_offset(const uint8 *bitmap, int minOffset)
 {
 	int			i;
 	uint8		mask;
 
 	i = minOffset >> 3;
 	mask = 0xFF << (minOffset & 7);
-	while (i < BITMAP_SIZE)
+	while (i < OKBM_BITMAP_BYTES)
 	{
 		mask &= bitmap[i];
 		if (mask)
@@ -209,310 +124,535 @@ find_next_offset(uint8 *bitmap, int minOffset)
 	return -1;
 }
 
-
-uint64
-o_keybitmap_get_next(RBTree *rbtree, uint64 prev, bool *found)
+OKeyBitmap *
+o_keybitmap_create(void)
 {
-	OKeyBitmapRBTNode lowNode;
-	OKeyBitmapRBTNode *node;
-	RBTreeIterator iter;
+	OKeyBitmap *bm = palloc0(sizeof(OKeyBitmap));
+
+	/* okbm_memory_usage() is part of the generated API but unused here */
+	(void) okbm_memory_usage;
+
+	bm->cxt = CurrentMemoryContext;
 
 	/*
-	 * For the moment, fill only the fields of node that will be looked at by
-	 * bm_rbt_comparator.
+	 * The radix tree owns the context it is created in: okbm_free() resets it
+	 * and deletes its child contexts.  Give it a dedicated child context so
+	 * that freeing the tree does not clobber this struct or the chunks array,
+	 * which live in bm->cxt.
 	 */
-	lowNode.key = prev;
-	lowNode.bitmap = NULL;
-	node = (OKeyBitmapRBTNode *) rbt_find_great(rbtree,
-												(RBTNode *) &lowNode,
-												true);
-	if (!node)
-	{
-		*found = false;
-		return 0;
-	}
-
-	if (!node->bitmap)
-	{
-		if (node->key >= prev)
-		{
-			*found = true;
-			return node->key;
-		}
-	}
-	else if ((prev & HIGH_PART_MASK) == (node->key & HIGH_PART_MASK))
-	{
-		int			nextOffset;
-
-		nextOffset = find_next_offset(node->bitmap, prev & LOW_PART_MASK);
-
-		if (nextOffset >= 0)
-		{
-			*found = true;
-			return node->key + nextOffset;
-		}
-	}
-
-	if ((prev & HIGH_PART_MASK) == (node->key & HIGH_PART_MASK))
-	{
-		rbt_begin_iterate(rbtree, LeftRightWalk, &iter);
-		iter.last_visited = (RBTNode *) node;
-		node = (OKeyBitmapRBTNode *) rbt_iterate(&iter);
-	}
-
-	if (!node)
-	{
-		*found = false;
-		return 0;
-	}
-
-	if (!node->bitmap)
-	{
-		*found = true;
-		return node->key;
-	}
-	else
-	{
-		int			nextOffset = find_next_offset(node->bitmap, 0);
-
-		Assert(nextOffset >= 0);
-		*found = true;
-		return node->key + nextOffset;
-	}
+	bm->treeCxt = AllocSetContextCreate(bm->cxt, "o_keybitmap radix tree",
+										ALLOCSET_SMALL_SIZES);
+	bm->fixed = false;
+	bm->tree = okbm_create(bm->treeCxt);
+	bm->ftree = NULL;
+	bm->chunks = NULL;
+	bm->fkeys = NULL;
+	bm->nchunks = 0;
+	bm->chunksCapacity = 0;
+	bm->finalized = false;
+	return bm;
 }
 
-static void
-free_tree_node(RBTNode *node)
+OKeyBitmap *
+o_keybitmap_create_fixed(void)
 {
-	OKeyBitmapRBTNode *keyNode = (OKeyBitmapRBTNode *) node;
+	OKeyBitmap *bm = palloc0(sizeof(OKeyBitmap));
 
-	if (node->left == node)
-	{
-		Assert(node->right == node);
-		return;
-	}
-	if (keyNode->bitmap)
-		pfree(keyNode->bitmap);
-	free_tree_node(node->left);
-	free_tree_node(node->right);
-	pfree(node);
+	/* okbmf_memory_usage() is part of the generated API but unused here */
+	(void) okbmf_memory_usage;
+
+	bm->cxt = CurrentMemoryContext;
+	bm->treeCxt = AllocSetContextCreate(bm->cxt, "o_keybitmap radix tree",
+										ALLOCSET_SMALL_SIZES);
+	bm->fixed = true;
+	bm->tree = NULL;
+	bm->ftree = okbmf_create(bm->treeCxt);
+	bm->chunks = NULL;
+	bm->fkeys = NULL;
+	bm->nchunks = 0;
+	bm->chunksCapacity = 0;
+	bm->finalized = false;
+	return bm;
 }
 
 void
-o_keybitmap_free(RBTree *tree)
+o_keybitmap_free(OKeyBitmap *bm)
 {
-	free_tree_node(*((RBTNode **) tree));
-	pfree(tree);
+	if (bm->fixed)
+		okbmf_free(bm->ftree);
+	else
+		okbm_free(bm->tree);
+	MemoryContextDelete(bm->treeCxt);
+	if (bm->chunks)
+		pfree(bm->chunks);
+	if (bm->fkeys)
+		pfree(bm->fkeys);
+	pfree(bm);
+}
+
+/* --- fixed-key mode helpers --- */
+
+static inline okbmf_key
+okbmf_mkkey(const uint8 *key)
+{
+	okbmf_key	k;
+
+	memcpy(k.data, key, OKBM_FIXED_BYTES);
+	return k;
+}
+
+void
+o_keybitmap_insert_key(OKeyBitmap *bm, const uint8 *key)
+{
+	okbmf_key	k = okbmf_mkkey(key);
+
+	Assert(bm->fixed);
+	if (okbmf_find(bm->ftree, k) == NULL)
+	{
+		OKbmDummy	dummy = {0};
+
+		(void) okbmf_set(bm->ftree, k, &dummy);
+	}
+	bm->finalized = false;
 }
 
 bool
-o_keybitmap_is_empty(RBTree *rbtree)
+o_keybitmap_test_key(OKeyBitmap *bm, const uint8 *key)
 {
-	return rbt_leftmost(rbtree) == NULL;
+	okbmf_key	k = okbmf_mkkey(key);
+
+	Assert(bm->fixed);
+	return okbmf_find(bm->ftree, k) != NULL;
 }
 
 void
-o_keybitmap_intersect(RBTree *a, RBTree *b)
+o_keybitmap_insert(OKeyBitmap *bm, uint64 value)
 {
-	RBTreeIterator iterA;
-	RBTreeIterator iterB;
-	OKeyBitmapRBTNode *nodeA;
-	OKeyBitmapRBTNode *nodeB;
-	List	   *removing = NIL;
-	ListCell   *lc;
+	uint64		chunk = value >> OKBM_CHUNK_BITS;
+	int			offset = value & OKBM_LOW_MASK;
+	OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
 
-	rbt_begin_iterate(a, LeftRightWalk, &iterA);
-	rbt_begin_iterate(b, LeftRightWalk, &iterB);
-
-	nodeB = (OKeyBitmapRBTNode *) rbt_iterate(&iterB);
-	while ((nodeA = (OKeyBitmapRBTNode *) rbt_iterate(&iterA)) != NULL)
+	if (entry == NULL)
 	{
-		while (nodeB &&
-			   (nodeB->key & HIGH_PART_MASK) < (nodeA->key & HIGH_PART_MASK))
-		{
-			nodeB = (OKeyBitmapRBTNode *) rbt_iterate(&iterB);
-		}
+		OKeyBitmapChunk newentry;
 
-		if (!nodeB ||
-			(nodeB->key & HIGH_PART_MASK) > (nodeA->key & HIGH_PART_MASK))
-		{
-			OKeyBitmapRBTNode *removed_node;
-
-			removed_node = palloc0(sizeof(OKeyBitmapRBTNode));
-			memcpy(removed_node, nodeA, sizeof(OKeyBitmapRBTNode));
-			removing = lappend(removing, removed_node);
-			continue;
-		}
-
-		Assert((nodeA->key & HIGH_PART_MASK) == (nodeB->key & HIGH_PART_MASK));
-
-		if (!nodeA->bitmap)
-		{
-			if (!nodeB->bitmap)
-			{
-				if (nodeA->key != nodeB->key)
-				{
-					OKeyBitmapRBTNode *removed_node;
-
-					removed_node = palloc0(sizeof(OKeyBitmapRBTNode));
-					memcpy(removed_node, nodeA, sizeof(OKeyBitmapRBTNode));
-					removing = lappend(removing, removed_node);
-					continue;
-				}
-			}
-			else
-			{
-				int			offset = (nodeA->key & LOW_PART_MASK);
-
-				if (!(nodeB->bitmap[offset >> 3] & (1 << (offset & 7))))
-				{
-					OKeyBitmapRBTNode *removed_node;
-
-					removed_node = palloc0(sizeof(OKeyBitmapRBTNode));
-					memcpy(removed_node, nodeA, sizeof(OKeyBitmapRBTNode));
-					removing = lappend(removing, removed_node);
-					continue;
-				}
-			}
-		}
-		else
-		{
-			if (!nodeB->bitmap)
-			{
-				int			offset = (nodeB->key & LOW_PART_MASK);
-
-				if (!(nodeA->bitmap[offset >> 3] & (1 << (offset & 7))))
-				{
-					OKeyBitmapRBTNode *removed_node;
-
-					removed_node = palloc0(sizeof(OKeyBitmapRBTNode));
-					memcpy(removed_node, nodeA, sizeof(OKeyBitmapRBTNode));
-					removing = lappend(removing, removed_node);
-					continue;
-				}
-				pfree(nodeA->bitmap);
-				nodeA->bitmap = NULL;
-				nodeA->key = nodeB->key;
-			}
-			else
-			{
-				int			i;
-				bool		empty = true;
-
-				for (i = 0; i < BITMAP_SIZE; i++)
-				{
-					nodeA->bitmap[i] &= nodeB->bitmap[i];
-					if (nodeA->bitmap[i] != 0)
-						empty = false;
-				}
-
-				if (empty)
-				{
-					OKeyBitmapRBTNode *removed_node;
-
-					removed_node = palloc0(sizeof(OKeyBitmapRBTNode));
-					memcpy(removed_node, nodeA, sizeof(OKeyBitmapRBTNode));
-					removing = lappend(removing, removed_node);
-					continue;
-				}
-			}
-		}
+		memset(&newentry, 0, sizeof(newentry));
+		newentry.bitmap[offset >> 3] |= (1 << (offset & 7));
+		(void) okbm_set(bm->tree, chunk, &newentry);
 	}
+	else
+		entry->bitmap[offset >> 3] |= (1 << (offset & 7));
 
-	foreach(lc, removing)
-	{
-		OKeyBitmapRBTNode *search_node;
-		OKeyBitmapRBTNode *removing_node;
-
-		search_node = (OKeyBitmapRBTNode *) lfirst(lc);
-		if (search_node->bitmap)
-			pfree(search_node->bitmap);
-		removing_node = (OKeyBitmapRBTNode *) rbt_find(a,
-													   (RBTNode *) search_node);
-		rbt_delete(a, (RBTNode *) removing_node);
-		pfree(search_node);
-	}
-	list_free(removing);
+	bm->finalized = false;
 }
 
-void
-o_keybitmap_union(RBTree *a, RBTree *b)
+bool
+o_keybitmap_test(OKeyBitmap *bm, uint64 value)
 {
-	RBTreeIterator iterB;
-	OKeyBitmapRBTNode *nodeB;
+	uint64		chunk = value >> OKBM_CHUNK_BITS;
+	int			offset = value & OKBM_LOW_MASK;
+	OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
 
-	rbt_begin_iterate(b, LeftRightWalk, &iterB);
-	while ((nodeB = (OKeyBitmapRBTNode *) rbt_iterate(&iterB)) != NULL)
-	{
-		bool		is_new;
+	if (entry == NULL)
+		return false;
 
-		rbt_insert(a, &nodeB->rbtnode, &is_new);
-	}
+	return (entry->bitmap[offset >> 3] & (1 << (offset & 7))) != 0;
 }
 
-static int
-bm_rbt_comparator(const RBTNode *a, const RBTNode *b, void *arg)
+bool
+o_keybitmap_is_empty(OKeyBitmap *bm)
 {
-	const OKeyBitmapRBTNode *keyA = (OKeyBitmapRBTNode *) a;
-	const OKeyBitmapRBTNode *keyB = (OKeyBitmapRBTNode *) b;
-	uint64		va = keyA->key & HIGH_PART_MASK;
-	uint64		vb = keyB->key & HIGH_PART_MASK;
+	bool		empty;
 
-	return va > vb ? 1 : va < vb ? -1 : 0;
-}
-
-static void
-node_make_bitmap(OKeyBitmapRBTNode *node)
-{
-	int			offset;
-
-	node->bitmap = palloc0(BITMAP_SIZE);
-	offset = node->key & LOW_PART_MASK;
-
-	node->bitmap[offset >> 3] |= 1 << (offset & 7);
-	node->key &= HIGH_PART_MASK;
-}
-
-static void
-bm_rbt_combiner(RBTNode *existing,
-				const RBTNode *newdata,
-				void *arg)
-{
-	OKeyBitmapRBTNode *old = (OKeyBitmapRBTNode *) existing;
-	OKeyBitmapRBTNode *new = (OKeyBitmapRBTNode *) newdata;
-
-	if (!old->bitmap)
+	if (bm->fixed)
 	{
-		if (!new->bitmap && new->key == old->key)
-			return;
-		node_make_bitmap(old);
-	}
+		okbmf_iter *iter = okbmf_begin_iterate(bm->ftree);
+		okbmf_key	k;
 
-	if (!new->bitmap)
-	{
-		int			offset = new->key & LOW_PART_MASK;
-
-		old->bitmap[offset >> 3] |= 1 << (offset & 7);
+		empty = (okbmf_iterate_next(iter, &k) == NULL);
+		okbmf_end_iterate(iter);
 	}
 	else
 	{
-		int			i;
+		okbm_iter  *iter = okbm_begin_iterate(bm->tree);
+		uint64		chunk;
 
-		for (i = 0; i < BITMAP_SIZE; i++)
-			old->bitmap[i] |= new->bitmap[i];
+		empty = (okbm_iterate_next(iter, &chunk) == NULL);
+		okbm_end_iterate(iter);
 	}
+	return empty;
 }
 
-static RBTNode *
-bm_rbt_allocfunc(void *arg)
+void
+o_keybitmap_union(OKeyBitmap *a, OKeyBitmap *b)
 {
-	RBTNode    *result = palloc0(sizeof(OKeyBitmapRBTNode));
+	okbm_iter  *iter;
+	OKeyBitmapChunk *bentry;
+	uint64		chunk;
 
-	return result;
+	Assert(a->fixed == b->fixed);
+
+	if (a->fixed)
+	{
+		okbmf_iter *fiter = okbmf_begin_iterate(b->ftree);
+		okbmf_key	k;
+
+		while (okbmf_iterate_next(fiter, &k) != NULL)
+		{
+			if (okbmf_find(a->ftree, k) == NULL)
+			{
+				OKbmDummy	dummy = {0};
+
+				(void) okbmf_set(a->ftree, k, &dummy);
+			}
+		}
+		okbmf_end_iterate(fiter);
+		a->finalized = false;
+		return;
+	}
+
+	iter = okbm_begin_iterate(b->tree);
+
+	while ((bentry = okbm_iterate_next(iter, &chunk)) != NULL)
+	{
+		OKeyBitmapChunk *aentry = okbm_find(a->tree, chunk);
+
+		if (aentry == NULL)
+			(void) okbm_set(a->tree, chunk, bentry);
+		else
+		{
+			int			i;
+
+			for (i = 0; i < OKBM_BITMAP_BYTES; i++)
+				aentry->bitmap[i] |= bentry->bitmap[i];
+		}
+	}
+	okbm_end_iterate(iter);
+	a->finalized = false;
 }
 
+void
+o_keybitmap_intersect(OKeyBitmap *a, OKeyBitmap *b)
+{
+	okbm_iter  *iter;
+	OKeyBitmapChunk *aentry;
+	uint64		chunk;
+	uint64	   *toDelete = NULL;
+	int			nDelete = 0;
+	int			deleteCap = 0;
+	int			i;
+
+	Assert(a->fixed == b->fixed);
+
+	if (a->fixed)
+	{
+		okbmf_iter *fiter = okbmf_begin_iterate(a->ftree);
+		okbmf_key	k;
+		okbmf_key  *fdel = NULL;
+		int			nfdel = 0;
+		int			fcap = 0;
+
+		while (okbmf_iterate_next(fiter, &k) != NULL)
+		{
+			if (okbmf_find(b->ftree, k) == NULL)
+			{
+				if (nfdel >= fcap)
+				{
+					fcap = fcap ? fcap * 2 : 16;
+					if (fdel == NULL)
+						fdel = MemoryContextAlloc(a->cxt, sizeof(okbmf_key) * fcap);
+					else
+						fdel = repalloc(fdel, sizeof(okbmf_key) * fcap);
+				}
+				fdel[nfdel++] = k;
+			}
+		}
+		okbmf_end_iterate(fiter);
+
+		for (i = 0; i < nfdel; i++)
+			(void) okbmf_delete(a->ftree, fdel[i]);
+		if (fdel)
+			pfree(fdel);
+
+		a->finalized = false;
+		return;
+	}
+
+	iter = okbm_begin_iterate(a->tree);
+
+	/*
+	 * AND each of a's chunks in place with the matching chunk of b.  Chunks
+	 * that become empty (or have no counterpart in b) are collected and
+	 * removed after iteration; deleting during iteration would invalidate the
+	 * iterator.  Modifying leaf values in place is safe.
+	 */
+	while ((aentry = okbm_iterate_next(iter, &chunk)) != NULL)
+	{
+		OKeyBitmapChunk *bentry = okbm_find(b->tree, chunk);
+		bool		empty = true;
+
+		if (bentry != NULL)
+		{
+			for (i = 0; i < OKBM_BITMAP_BYTES; i++)
+			{
+				aentry->bitmap[i] &= bentry->bitmap[i];
+				if (aentry->bitmap[i] != 0)
+					empty = false;
+			}
+		}
+
+		if (empty)
+		{
+			if (nDelete >= deleteCap)
+			{
+				deleteCap = deleteCap ? deleteCap * 2 : 16;
+				if (toDelete == NULL)
+					toDelete = MemoryContextAlloc(a->cxt,
+												  sizeof(uint64) * deleteCap);
+				else
+					toDelete = repalloc(toDelete, sizeof(uint64) * deleteCap);
+			}
+			toDelete[nDelete++] = chunk;
+		}
+	}
+	okbm_end_iterate(iter);
+
+	for (i = 0; i < nDelete; i++)
+		(void) okbm_delete(a->tree, toDelete[i]);
+	if (toDelete)
+		pfree(toDelete);
+
+	a->finalized = false;
+}
+
+/*
+ * Build the sorted array of chunk keys.  okbm iteration already yields chunks
+ * in ascending order, so we just collect them.  No-op if already finalized.
+ */
 static void
-bm_rbt_freefunc(RBTNode *x, void *arg)
+okbm_finalize(OKeyBitmap *bm)
 {
-	pfree(x);
+	okbm_iter  *iter;
+	uint64		chunk;
+
+	if (bm->finalized)
+		return;
+
+	bm->nchunks = 0;
+
+	if (bm->fixed)
+	{
+		okbmf_iter *fiter = okbmf_begin_iterate(bm->ftree);
+		okbmf_key	k;
+
+		while (okbmf_iterate_next(fiter, &k) != NULL)
+		{
+			if (bm->nchunks >= bm->chunksCapacity)
+			{
+				bm->chunksCapacity = bm->chunksCapacity ? bm->chunksCapacity * 2 : 64;
+				if (bm->fkeys == NULL)
+					bm->fkeys = MemoryContextAlloc(bm->cxt,
+												   (Size) OKBM_FIXED_BYTES * bm->chunksCapacity);
+				else
+					bm->fkeys = repalloc(bm->fkeys,
+										 (Size) OKBM_FIXED_BYTES * bm->chunksCapacity);
+			}
+			memcpy(bm->fkeys + (Size) bm->nchunks * OKBM_FIXED_BYTES,
+				   k.data, OKBM_FIXED_BYTES);
+			bm->nchunks++;
+		}
+		okbmf_end_iterate(fiter);
+		bm->finalized = true;
+		return;
+	}
+
+	iter = okbm_begin_iterate(bm->tree);
+	while (okbm_iterate_next(iter, &chunk) != NULL)
+	{
+		if (bm->nchunks >= bm->chunksCapacity)
+		{
+			bm->chunksCapacity = bm->chunksCapacity ? bm->chunksCapacity * 2 : 64;
+			if (bm->chunks == NULL)
+				bm->chunks = MemoryContextAlloc(bm->cxt,
+												sizeof(uint64) * bm->chunksCapacity);
+			else
+				bm->chunks = repalloc(bm->chunks,
+									  sizeof(uint64) * bm->chunksCapacity);
+		}
+		bm->chunks[bm->nchunks++] = chunk;
+	}
+	okbm_end_iterate(iter);
+
+	bm->finalized = true;
+}
+
+/* Index of the first chunk key >= target. */
+static int
+okbm_lower_bound(OKeyBitmap *bm, uint64 target)
+{
+	int			lo = 0,
+				hi = bm->nchunks;
+
+	while (lo < hi)
+	{
+		int			mid = lo + (hi - lo) / 2;
+
+		if (bm->chunks[mid] < target)
+			lo = mid + 1;
+		else
+			hi = mid;
+	}
+	return lo;
+}
+
+bool
+o_keybitmap_range_is_valid(OKeyBitmap *bm, uint64 low, uint64 high)
+{
+	uint64		chunkLow;
+	uint64		chunkHigh;
+	int			idx;
+
+	if (high <= low)
+		return false;
+
+	okbm_finalize(bm);
+
+	chunkLow = low >> OKBM_CHUNK_BITS;
+	chunkHigh = (high - 1) >> OKBM_CHUNK_BITS;
+
+	for (idx = okbm_lower_bound(bm, chunkLow); idx < bm->nchunks; idx++)
+	{
+		uint64		chunk = bm->chunks[idx];
+		OKeyBitmapChunk *entry;
+		int			iStart,
+					iEnd,
+					i;
+		uint8		startMask,
+					endMask;
+
+		if (chunk > chunkHigh)
+			break;
+
+		entry = okbm_find(bm->tree, chunk);
+
+		if (chunk == chunkLow)
+		{
+			iStart = (low & OKBM_LOW_MASK) >> 3;
+			startMask = 0xFF << (low & 7);
+		}
+		else
+		{
+			iStart = 0;
+			startMask = 0xFF;
+		}
+
+		if (chunk == chunkHigh)
+		{
+			iEnd = ((high - 1) & OKBM_LOW_MASK) >> 3;
+			endMask = 0xFF >> (7 - ((high - 1) & 7));
+		}
+		else
+		{
+			iEnd = OKBM_BITMAP_BYTES - 1;
+			endMask = 0xFF;
+		}
+
+		for (i = iStart; i <= iEnd; i++)
+		{
+			uint8		mask = (i == iStart) ? startMask : 0xFF;
+
+			if (i == iEnd)
+				mask &= endMask;
+
+			if (entry->bitmap[i] & mask)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+uint64
+o_keybitmap_get_next(OKeyBitmap *bm, uint64 prev, bool *found)
+{
+	uint64		chunkPrev = prev >> OKBM_CHUNK_BITS;
+	int			offPrev = prev & OKBM_LOW_MASK;
+	int			idx;
+
+	okbm_finalize(bm);
+
+	for (idx = okbm_lower_bound(bm, chunkPrev); idx < bm->nchunks; idx++)
+	{
+		uint64		chunk = bm->chunks[idx];
+		OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
+		int			startOff = (chunk == chunkPrev) ? offPrev : 0;
+		int			nextOff = find_next_offset(entry->bitmap, startOff);
+
+		if (nextOff >= 0)
+		{
+			*found = true;
+			return (chunk << OKBM_CHUNK_BITS) + nextOff;
+		}
+	}
+
+	*found = false;
+	return 0;
+}
+
+/* --- fixed-key mode ordered seeks --- */
+
+/* Index of the first key >= target (memcmp order) in the finalized fkeys[]. */
+static int
+okbmf_lower_bound(OKeyBitmap *bm, const uint8 *target)
+{
+	int			lo = 0,
+				hi = bm->nchunks;
+
+	while (lo < hi)
+	{
+		int			mid = lo + (hi - lo) / 2;
+
+		if (memcmp(bm->fkeys + (Size) mid * OKBM_FIXED_BYTES, target,
+				   OKBM_FIXED_BYTES) < 0)
+			lo = mid + 1;
+		else
+			hi = mid;
+	}
+	return lo;
+}
+
+bool
+o_keybitmap_range_is_valid_key(OKeyBitmap *bm, const uint8 *low, const uint8 *high)
+{
+	int			idx;
+
+	Assert(bm->fixed);
+	if (memcmp(low, high, OKBM_FIXED_BYTES) >= 0)
+		return false;
+
+	okbm_finalize(bm);
+
+	idx = okbmf_lower_bound(bm, low);
+	if (idx >= bm->nchunks)
+		return false;
+
+	/* the first key >= low is in range iff it is < high */
+	return memcmp(bm->fkeys + (Size) idx * OKBM_FIXED_BYTES, high,
+				  OKBM_FIXED_BYTES) < 0;
+}
+
+bool
+o_keybitmap_get_next_key(OKeyBitmap *bm, const uint8 *prev, uint8 *result)
+{
+	int			idx;
+
+	Assert(bm->fixed);
+	okbm_finalize(bm);
+
+	idx = okbmf_lower_bound(bm, prev);
+	if (idx >= bm->nchunks)
+		return false;
+
+	memcpy(result, bm->fkeys + (Size) idx * OKBM_FIXED_BYTES, OKBM_FIXED_BYTES);
+	return true;
 }

--- a/src/tableam/key_bitmap.c
+++ b/src/tableam/key_bitmap.c
@@ -586,7 +586,11 @@ o_keybitmap_get_next(OKeyBitmap *bm, uint64 prev, bool *found)
 		uint64		chunk = bm->chunks[idx];
 		OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
 		int			startOff = (chunk == chunkPrev) ? offPrev : 0;
-		int			nextOff = find_next_offset(entry->bitmap, startOff);
+		int			nextOff;
+
+		/* chunk came from bm->chunks[], so the tree always has it */
+		Assert(entry != NULL);
+		nextOff = find_next_offset(entry->bitmap, startOff);
 
 		if (nextOff >= 0)
 		{

--- a/src/tableam/key_range.c
+++ b/src/tableam/key_range.c
@@ -79,6 +79,33 @@ o_fill_row_key_bound(OBTreeKeyBound *bound,
 	return result;
 }
 
+void
+o_key_data_update_array_key_range(OBTreeKeyRange *res, ScanKeyData *keyData,
+								  int numberOfKeys, BTArrayKeyInfo *arrayKeys,
+								  int numPrefixExactKeys,
+								  int resultNKeys, OIndexField *fields)
+{
+	int			i;
+
+	for (i = 0; i < numberOfKeys; i++)
+	{
+		ScanKeyData *key = &keyData[i];
+		AttrNumber	attnum = key->sk_attno - 1;
+
+		if ((key->sk_flags & SK_SEARCHARRAY) &&
+			key->sk_strategy == BTEqualStrategyNumber)
+		{
+			Assert(arrayKeys && arrayKeys->num_elems > 0);
+			if (i < numPrefixExactKeys)
+			{
+				res->low.keys[attnum].value = arrayKeys->elem_values[arrayKeys->cur_elem];
+				res->high.keys[attnum].value = arrayKeys->elem_values[arrayKeys->cur_elem];
+			}
+			arrayKeys++;
+		}
+	}
+}
+
 bool
 o_key_data_to_key_range(OBTreeKeyRange *res, ScanKeyData *keyData,
 						int numberOfKeys, BTArrayKeyInfo *arrayKeys,

--- a/src/tableam/key_range.c
+++ b/src/tableam/key_range.c
@@ -378,8 +378,7 @@ o_fill_key_bounds(Datum v, Oid type,
 		low->type = type;
 		low->comparator = comparator;
 		low->exclusion_fn = NULL;
-		if (coercible)
-			low->flags |= O_VALUE_BOUND_COERCIBLE;
+		low->flags |= coercible ? O_VALUE_BOUND_COERCIBLE : O_VALUE_BOUND_NON_COERCIBLE;
 	}
 	if (high != NULL)
 	{
@@ -387,8 +386,7 @@ o_fill_key_bounds(Datum v, Oid type,
 		high->type = type;
 		high->comparator = comparator;
 		high->exclusion_fn = NULL;
-		if (coercible)
-			high->flags |= O_VALUE_BOUND_COERCIBLE;
+		high->flags |= coercible ? O_VALUE_BOUND_COERCIBLE : O_VALUE_BOUND_NON_COERCIBLE;
 	}
 }
 

--- a/src/tableam/radix_selftest.c
+++ b/src/tableam/radix_selftest.c
@@ -1,0 +1,420 @@
+/*-------------------------------------------------------------------------
+ *
+ * radix_selftest.c
+ *		Runtime self-test for the fixed-length-key variant of the vendored
+ *		radix tree (include/lib/o_radixtree.h with RT_KEY_SIZE).
+ *
+ *		Exposed as SQL function orioledb_radixtree_selftest(nkeys int).
+ *		Returns 'ok' on success or a description of the first failure.
+ *		Dev-only helper; not part of the shipped SQL.
+ *
+ * Copyright (c) 2021-2026, Oriole DB Inc.
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "orioledb.h"
+
+#include "fmgr.h"
+#include "lib/qunique.h"
+#include "tableam/bitmap_scan.h"
+#include "utils/builtins.h"
+#include "utils/memutils.h"
+
+/* Two instances: a multiple-of-8 length and an odd length. */
+#define RT_PREFIX rtst12
+#define RT_SCOPE static
+#define RT_DECLARE
+#define RT_DEFINE
+#define RT_USE_DELETE
+#define RT_KEY_SIZE 12
+typedef struct
+{
+	uint32		id;
+} RtstVal;
+#define RT_VALUE_TYPE RtstVal
+#include "lib/o_radixtree.h"
+
+#define RT_PREFIX rtst5
+#define RT_SCOPE static
+#define RT_DECLARE
+#define RT_DEFINE
+#define RT_USE_DELETE
+#define RT_KEY_SIZE 5
+#define RT_VALUE_TYPE RtstVal
+#include "lib/o_radixtree.h"
+
+PG_FUNCTION_INFO_V1(orioledb_radixtree_selftest);
+PG_FUNCTION_INFO_V1(orioledb_encode_selftest);
+
+/*
+ * Order-preserving big-endian encoding of an unsigned integer of nbytes into
+ * out.  For signed values the caller flips the sign bit first, so that the
+ * unsigned byte ordering matches signed ordering.
+ */
+static void
+enc_be(uint64 u, int nbytes, uint8 *out)
+{
+	int			i;
+
+	for (i = nbytes - 1; i >= 0; i--)
+	{
+		out[i] = (uint8) (u & 0xFF);
+		u >>= 8;
+	}
+}
+
+#define ENC_MAX 32
+
+/* one test tuple: (int4 a, int8 b, int2 c) */
+typedef struct
+{
+	int32		a;
+	int64		b;
+	int16		c;
+} EncTuple;
+
+static int
+enc_tuple_cmp(const void *x, const void *y)
+{
+	const EncTuple *p = x;
+	const EncTuple *q = y;
+
+	if (p->a != q->a)
+		return p->a < q->a ? -1 : 1;
+	if (p->b != q->b)
+		return p->b < q->b ? -1 : 1;
+	if (p->c != q->c)
+		return p->c < q->c ? -1 : 1;
+	return 0;
+}
+
+/*
+ * Encode (a,b,c) order-preservingly, right-aligned into a fixed ENC_MAX-byte
+ * buffer with a zero high-pad, matching the composite-PK keybitmap scheme.
+ */
+static void
+enc_tuple(const EncTuple *t, uint8 *out)
+{
+	int			off;
+
+	memset(out, 0, ENC_MAX);
+	off = ENC_MAX - (4 + 8 + 2);
+	enc_be((uint32) t->a ^ UINT64CONST(0x80000000), 4, out + off);
+	enc_be((uint64) t->b ^ UINT64CONST(0x8000000000000000), 8, out + off + 4);
+	enc_be((uint16) t->c ^ 0x8000, 2, out + off + 12);
+}
+
+Datum
+orioledb_encode_selftest(PG_FUNCTION_ARGS)
+{
+	int			nkeys = PG_GETARG_INT32(0);
+	MemoryContext cxt = AllocSetContextCreate(CurrentMemoryContext,
+											  "enc", ALLOCSET_DEFAULT_SIZES);
+	MemoryContext old = MemoryContextSwitchTo(cxt);
+	EncTuple   *tuples = palloc(sizeof(EncTuple) * nkeys);
+	uint8	   *encs;
+	uint64		rng = UINT64CONST(0xdeadbeefcafef00d);
+	int			i;
+	char	   *err = NULL;
+
+	for (i = 0; i < nkeys; i++)
+	{
+		rng = rng * UINT64CONST(6364136223846793005) + 1;
+		tuples[i].a = (int32) (rng >> 33) - 100;	/* include negatives */
+		rng = rng * UINT64CONST(6364136223846793005) + 1;
+		tuples[i].b = (int64) (rng >> 20) - 1000000;
+		rng = rng * UINT64CONST(6364136223846793005) + 1;
+		tuples[i].c = (int16) ((rng >> 40) % 200) - 100;
+	}
+
+	qsort(tuples, nkeys, sizeof(EncTuple), enc_tuple_cmp);
+
+	encs = palloc(ENC_MAX * nkeys);
+	for (i = 0; i < nkeys; i++)
+		enc_tuple(&tuples[i], encs + (size_t) i * ENC_MAX);
+
+	/*
+	 * encodings must be non-decreasing, and strictly increasing iff tuples
+	 * differ
+	 */
+	for (i = 1; i < nkeys; i++)
+	{
+		int			tc = enc_tuple_cmp(&tuples[i - 1], &tuples[i]);
+		int			ec = memcmp(encs + (size_t) (i - 1) * ENC_MAX,
+								encs + (size_t) i * ENC_MAX, ENC_MAX);
+
+		if ((tc == 0 && ec != 0) || (tc < 0 && ec >= 0) || (tc > 0))
+		{
+			err = psprintf("order mismatch at %d: tuplecmp=%d enccmp=%d", i, tc, ec);
+			break;
+		}
+	}
+
+	if (err)
+		err = MemoryContextStrdup(old, err);
+	MemoryContextSwitchTo(old);
+	MemoryContextDelete(cxt);
+
+	PG_RETURN_TEXT_P(cstring_to_text(err ? err : "ok"));
+}
+
+static int
+rtst_memcmp(const void *a, const void *b, void *arg)
+{
+	size_t		n = *((size_t *) arg);
+
+	return memcmp(a, b, n);
+}
+
+/*
+ * Generate `count` pseudo-random keys of `n` bytes into `buf` using a
+ * deterministic LCG seeded from `seed`, so runs are reproducible.
+ */
+static void
+rtst_gen(unsigned char *buf, int count, int n, uint64 seed)
+{
+	uint64		rng = seed;
+	int			i,
+				b;
+
+	for (i = 0; i < count; i++)
+	{
+		for (b = 0; b < n; b++)
+		{
+			rng = rng * UINT64CONST(6364136223846793005) +
+				UINT64CONST(1442695040888963407);
+			buf[i * n + b] = (unsigned char) (rng >> 33);
+		}
+	}
+}
+
+/*
+ * Body of the test for a given instance/length.  Returns NULL on success or a
+ * palloc'd failure description.  Generated per (PREFIX, N) so the exact same
+ * logic exercises every key length.
+ */
+#define DEFINE_RTST_RUN(PREFIX, N)											\
+static char *																\
+PREFIX##_run(int nkeys, uint64 seed)										\
+{																			\
+	MemoryContext cxt = AllocSetContextCreate(CurrentMemoryContext,			\
+											  "rtst", ALLOCSET_DEFAULT_SIZES); \
+	MemoryContext old = MemoryContextSwitchTo(cxt);							\
+	PREFIX##_radix_tree *tree = PREFIX##_create(cxt);						\
+	size_t		nsz = (N);												\
+	unsigned char *keys = palloc((Size) nkeys * (N));					\
+	unsigned char *sorted = palloc((Size) nkeys * (N));					\
+	unsigned char prev[(N)];											\
+	int			i;														\
+	int			ndistinct;												\
+	int			cnt;													\
+	char	   *err = NULL;											\
+	PREFIX##_iter *it;													\
+	PREFIX##_key ik;													\
+	RtstVal    *pv;														\
+																			\
+	/* silence unused-function for API entry points this test doesn't call */ \
+	(void) PREFIX##_free;												\
+	(void) PREFIX##_memory_usage;										\
+	rtst_gen(keys, nkeys, (N), seed);									\
+	for (i = 0; i < nkeys; i++)											\
+	{																	\
+		PREFIX##_key k;												\
+		RtstVal		v;											\
+		memcpy(k.data, keys + (size_t) i * (N), (N));				\
+		v.id = i;													\
+		(void) PREFIX##_set(tree, k, &v);							\
+	}																	\
+	/* find roundtrip */												\
+	for (i = 0; i < nkeys; i++)											\
+	{																	\
+		PREFIX##_key k;												\
+		memcpy(k.data, keys + (size_t) i * (N), (N));				\
+		pv = PREFIX##_find(tree, k);								\
+		if (pv == NULL)												\
+		{ err = psprintf("N=%d find missing at %d", (N), i); goto done; } \
+		if (memcmp(keys + (size_t) pv->id * (N), k.data, (N)) != 0)	\
+		{ err = psprintf("N=%d find wrong value at %d", (N), i); goto done; } \
+	}																	\
+	/* build sorted-distinct reference */								\
+	memcpy(sorted, keys, (size_t) nkeys * (N));						\
+	qsort_arg(sorted, nkeys, (N), rtst_memcmp, &nsz);				\
+	ndistinct = qunique_arg(sorted, nkeys, (N), rtst_memcmp, &nsz);	\
+	/* iterate: strictly ascending, matches sorted-distinct exactly */	\
+	it = PREFIX##_begin_iterate(tree);									\
+	cnt = 0;															\
+	while ((pv = PREFIX##_iterate_next(it, &ik)) != NULL)				\
+	{																	\
+		if (cnt > 0 && memcmp(prev, ik.data, (N)) >= 0)				\
+		{ err = psprintf("N=%d iter not ascending at %d", (N), cnt); PREFIX##_end_iterate(it); goto done; } \
+		if (memcmp(sorted + (size_t) cnt * (N), ik.data, (N)) != 0)	\
+		{ err = psprintf("N=%d iter != sorted at %d", (N), cnt); PREFIX##_end_iterate(it); goto done; } \
+		if (memcmp(keys + (size_t) pv->id * (N), ik.data, (N)) != 0)	\
+		{ err = psprintf("N=%d iter value mismatch at %d", (N), cnt); PREFIX##_end_iterate(it); goto done; } \
+		memcpy(prev, ik.data, (N));									\
+		cnt++;														\
+	}																	\
+	PREFIX##_end_iterate(it);											\
+	if (cnt != ndistinct)												\
+	{ err = psprintf("N=%d iter count %d != distinct %d", (N), cnt, ndistinct); goto done; } \
+	/* delete half, re-check find */									\
+	for (i = 0; i < nkeys; i += 2)										\
+	{																	\
+		PREFIX##_key k;												\
+		memcpy(k.data, keys + (size_t) i * (N), (N));				\
+		(void) PREFIX##_delete(tree, k);							\
+	}																	\
+done:																	\
+	if (err)															\
+		err = MemoryContextStrdup(old, err);							\
+	MemoryContextSwitchTo(old);											\
+	MemoryContextDelete(cxt);											\
+	return err;															\
+}
+
+DEFINE_RTST_RUN(rtst12, 12)
+DEFINE_RTST_RUN(rtst5, 5)
+
+Datum
+orioledb_radixtree_selftest(PG_FUNCTION_ARGS)
+{
+	int			nkeys = PG_GETARG_INT32(0);
+	char	   *err;
+
+	err = rtst12_run(nkeys, UINT64CONST(0x9e3779b97f4a7c15));
+	if (err)
+		PG_RETURN_TEXT_P(cstring_to_text(err));
+	err = rtst5_run(nkeys, UINT64CONST(0x123456789abcdef0));
+	if (err)
+		PG_RETURN_TEXT_P(cstring_to_text(err));
+
+	PG_RETURN_TEXT_P(cstring_to_text("ok"));
+}
+
+PG_FUNCTION_INFO_V1(orioledb_keybitmap_selftest);
+
+static int
+fkey_cmp(const void *a, const void *b, void *arg)
+{
+	return memcmp(a, b, OKBM_FIXED_BYTES);
+}
+
+/* big-endian increment of an OKBM_FIXED_BYTES key; returns false on overflow */
+static bool
+fkey_inc(uint8 *key)
+{
+	int			i;
+
+	for (i = OKBM_FIXED_BYTES - 1; i >= 0; i--)
+	{
+		if (++key[i] != 0)
+			return true;
+	}
+	return false;
+}
+
+Datum
+orioledb_keybitmap_selftest(PG_FUNCTION_ARGS)
+{
+	int			nkeys = PG_GETARG_INT32(0);
+	MemoryContext cxt = AllocSetContextCreate(CurrentMemoryContext,
+											  "kbm", ALLOCSET_DEFAULT_SIZES);
+	MemoryContext old = MemoryContextSwitchTo(cxt);
+	uint8	   *keys = palloc((Size) nkeys * OKBM_FIXED_BYTES);
+	uint8	   *sorted;
+	uint64		rng = UINT64CONST(0x51ed270b);
+	OKeyBitmap *bm = o_keybitmap_create_fixed();
+	OKeyBitmap *bm2 = o_keybitmap_create_fixed();
+	size_t		nsz = OKBM_FIXED_BYTES;
+	int			i,
+				ndistinct,
+				cnt;
+	uint8		cur[OKBM_FIXED_BYTES];
+	uint8		out[OKBM_FIXED_BYTES];
+	char	   *err = NULL;
+
+	/* random keys, using only the low 12 bytes so collisions/order both occur */
+	for (i = 0; i < nkeys; i++)
+	{
+		int			b;
+
+		memset(keys + (size_t) i * OKBM_FIXED_BYTES, 0, OKBM_FIXED_BYTES);
+		for (b = OKBM_FIXED_BYTES - 12; b < OKBM_FIXED_BYTES; b++)
+		{
+			rng = rng * UINT64CONST(6364136223846793005) + 1;
+			keys[(size_t) i * OKBM_FIXED_BYTES + b] = (uint8) (rng >> 40);
+		}
+		o_keybitmap_insert_key(bm, keys + (size_t) i * OKBM_FIXED_BYTES);
+	}
+
+	for (i = 0; i < nkeys; i++)
+		if (!o_keybitmap_test_key(bm, keys + (size_t) i * OKBM_FIXED_BYTES))
+		{
+			err = psprintf("test_key missing at %d", i);
+			goto done;
+		}
+
+	sorted = palloc((Size) nkeys * OKBM_FIXED_BYTES);
+	memcpy(sorted, keys, (Size) nkeys * OKBM_FIXED_BYTES);
+	qsort_arg(sorted, nkeys, OKBM_FIXED_BYTES, fkey_cmp, &nsz);
+	ndistinct = qunique_arg(sorted, nkeys, OKBM_FIXED_BYTES, fkey_cmp, &nsz);
+
+	/* ordered walk via get_next_key must reproduce sorted-distinct exactly */
+	memset(cur, 0, OKBM_FIXED_BYTES);
+	cnt = 0;
+	while (o_keybitmap_get_next_key(bm, cur, out))
+	{
+		if (cnt >= ndistinct)
+		{
+			err = psprintf("walk overran distinct=%d", ndistinct);
+			goto done;
+		}
+		if (memcmp(out, sorted + (size_t) cnt * OKBM_FIXED_BYTES, OKBM_FIXED_BYTES) != 0)
+		{
+			err = psprintf("walk != sorted at %d", cnt);
+			goto done;
+		}
+		if (!o_keybitmap_range_is_valid_key(bm, out, (const uint8 *) "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"))
+		{
+			err = psprintf("range_is_valid false at %d", cnt);
+			goto done;
+		}
+		cnt++;
+		memcpy(cur, out, OKBM_FIXED_BYTES);
+		if (!fkey_inc(cur))
+			break;
+	}
+	if (cnt != ndistinct)
+	{
+		err = psprintf("walk count %d != distinct %d", cnt, ndistinct);
+		goto done;
+	}
+
+	/* intersect with self is a no-op; union with empty is a no-op */
+	o_keybitmap_intersect(bm, bm);
+	for (i = 0; i < nkeys; i++)
+		if (!o_keybitmap_test_key(bm, keys + (size_t) i * OKBM_FIXED_BYTES))
+		{
+			err = "self-intersect dropped a key";
+			goto done;
+		}
+
+	/* intersect with disjoint (empty bm2) -> empty */
+	o_keybitmap_intersect(bm, bm2);
+	if (!o_keybitmap_is_empty(bm))
+	{
+		err = "intersect with empty not empty";
+		goto done;
+	}
+
+done:
+	if (err)
+		err = MemoryContextStrdup(old, err);
+	o_keybitmap_free(bm);
+	o_keybitmap_free(bm2);
+	MemoryContextSwitchTo(old);
+	MemoryContextDelete(cxt);
+	PG_RETURN_TEXT_P(cstring_to_text(err ? err : "ok"));
+}

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -493,16 +493,23 @@ o_plan_custom_path(PlannerInfo *root, RelOptInfo *rel,
 	{
 		BitmapHeapScan *bh_scan = (BitmapHeapScan *) custom_plan;
 		OIndexDescr *primary = GET_PRIMARY(descr);
+		Oid			typeoid;
 
 		custom_scan->scan.plan.targetlist =
 			copyObject(bh_scan->scan.plan.targetlist);
 		qpqual = bh_scan->scan.plan.qual;
 
-		Assert(primary->nFields == 1);
+		/*
+		 * typeoid is consumed only by the single-field uint64 encoding; the
+		 * composite fixed-key path derives everything from the descriptor at
+		 * run time, so a placeholder is fine there.
+		 */
+		typeoid = (o_keybitmap_pk_mode(primary, NULL) == O_KEYBITMAP_UINT64)
+			? primary->fields[0].inputtype : InvalidOid;
 		custom_scan->custom_private =
 		/* cppcheck-suppress unknownEvaluationOrder */
 			list_make2(makeInteger(O_BitmapHeapPlan),
-					   makeInteger(primary->fields[0].inputtype));
+					   makeInteger(typeoid));
 	}
 
 	table_close(relation, NoLock);

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -476,14 +476,6 @@ o_sidx_tuple_make_key(BTreeDescr *desc, OTuple tuple, Pointer data,
 	return o_create_key_tuple(desc, tuple, data, oIndexRegular, keep_version);
 }
 
-
-static inline bool
-o_bound_is_coercible(OBTreeValueBound *bound, OIndexField *field)
-{
-	return (bound->flags & O_VALUE_BOUND_COERCIBLE) ||
-		IsBinaryCoercible(bound->type, field->inputtype);
-}
-
 /* fills key bound from tuple or index tuple that belongs to current BTree */
 void
 o_fill_key_bound(OIndexDescr *id, OTuple tuple,

--- a/src/utils/page_pool.c
+++ b/src/utils/page_pool.c
@@ -322,9 +322,16 @@ o_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock)
 	/*
 	 * Reset page header and descriptor.  Do this while holding a page lock in
 	 * order to prevent race condition with walk_page().
+	 *
+	 * Block reads before changing the identity: bumping pageChangeCount alone
+	 * lets a lockless reader observe the invalidated oids without the count
+	 * bump and slip past the change-count check.  page_block_reads() makes
+	 * unlock_page() bump the state change count, forcing such a reader to
+	 * retry (idempotent if the caller already blocked reads).
 	 */
 	if (!haveLock)
 		lock_page(blkno);
+	page_block_reads(blkno);
 	O_PAGE_CHANGE_COUNT_INC(p);
 	ORelOidsSetInvalid(page_desc->oids);
 	page_desc->type = 0;

--- a/test/expected/bitmap_scan.out
+++ b/test/expected/bitmap_scan.out
@@ -3897,6 +3897,42 @@ BEGIN
 END $$;
 DROP TABLE bitmap_jump_test;
 DROP TABLE bitmap_jump_ctest;
+-- Covering primary key (INCLUDE columns, incl. a by-ref type): the fixed-key
+-- bitmap must build the seek key from the ordering columns only and leave the
+-- INCLUDE columns out, or it would form a tuple over uninitialized values.
+-- Row-comparison range that indexes on the leading key columns.  Result must
+-- match a sequential scan.
+CREATE TABLE bitmap_cover_test (c1 int, c2 int, c3 int, c4 box,
+	CONSTRAINT bitmap_cover_pk PRIMARY KEY (c1, c2) INCLUDE (c3, c4))
+	USING orioledb;
+INSERT INTO bitmap_cover_test
+	SELECT 1, 2, 3 * x, box('4,4,4,4') FROM generate_series(1, 10) x
+	ON CONFLICT DO NOTHING;
+INSERT INTO bitmap_cover_test
+	SELECT x, 2 * x, NULL, NULL FROM generate_series(1, 300) x
+	ON CONFLICT DO NOTHING;
+ANALYZE bitmap_cover_test;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*) INTO bmp_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SET LOCAL enable_indexscan = off;
+	SELECT count(*) INTO seq_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	IF bmp_cnt <> seq_cnt THEN
+		RAISE EXCEPTION 'covering-pk bitmap mismatch: bmp=% seq=%',
+			bmp_cnt, seq_cnt;
+	END IF;
+END $$;
+DROP TABLE bitmap_cover_test;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to table bitmap_test

--- a/test/expected/bitmap_scan.out
+++ b/test/expected/bitmap_scan.out
@@ -2134,12 +2134,14 @@ INSERT INTO pkey_bitmap_test (i)
 	SELECT pseudo_random(5, v) * 20000 FROM generate_series(1,5000) v
 		ON CONFLICT DO NOTHING;
 EXPLAIN (COSTS OFF) SELECT * FROM pkey_bitmap_test WHERE i < 100;
-                     QUERY PLAN                      
------------------------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on pkey_bitmap_test
-   Forward index only scan of: pkey_bitmap_test_pkey
-   Conds: (i < 100)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (i < 100)
+   ->  Bitmap Index Scan on pkey_bitmap_test_pkey
+         Index Cond: (i < 100)
+(5 rows)
 
 -- Test ctid bitmap
 CREATE TABLE bitmap_test_ctid
@@ -3571,12 +3573,15 @@ INSERT INTO bitmap_test_multi (i)
 ANALYZE bitmap_test_multi;
 CREATE INDEX bitmap_test_multi_ix1 ON bitmap_test_multi (i);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Aggregate
-   ->  Index Only Scan using bitmap_test_multi_ix1 on bitmap_test_multi
-         Index Cond: (i < 100)
-(3 rows)
+   ->  Custom Scan (o_scan) on bitmap_test_multi
+         Bitmap heap scan
+         Recheck Cond: (i < 100)
+         ->  Bitmap Index Scan on bitmap_test_multi_ix1
+               Index Cond: (i < 100)
+(6 rows)
 
 SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
  count 
@@ -3586,12 +3591,17 @@ SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
 
 EXPLAIN (COSTS OFF)
 	SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Limit
-   ->  Index Only Scan using bitmap_test_multi_ix1 on bitmap_test_multi
-         Index Cond: (i < 100)
-(3 rows)
+   ->  Sort
+         Sort Key: i
+         ->  Custom Scan (o_scan) on bitmap_test_multi
+               Bitmap heap scan
+               Recheck Cond: (i < 100)
+               ->  Bitmap Index Scan on bitmap_test_multi_ix1
+                     Index Cond: (i < 100)
+(8 rows)
 
 SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
    id   |  id2   | i  
@@ -3610,14 +3620,51 @@ SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
  101672 | 101672 | 67
  100431 | 100431 | 72
  102448 | 102448 | 73
- 102088 | 102088 | 81
  104447 | 104447 | 81
+ 102088 | 102088 | 81
  102646 | 102646 | 85
  102805 | 102805 | 86
  101322 | 101322 | 87
  102688 | 102688 | 87
 (20 rows)
 
+-- Row-array IN() over a composite primary key: planned as a BitmapOr of
+-- per-tuple primary-index scans (the shape that was slow in TPCC delivery).
+-- The result must match a sequential scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM bitmap_test_multi
+		WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (o_scan) on bitmap_test_multi
+         Bitmap heap scan
+         Recheck Cond: (((id = 100001) AND (id2 = 100001)) OR ((id = 100050) AND (id2 = 100050)) OR ((id = 104000) AND (id2 = 104000)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 100001) AND (id2 = 100001))
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 100050) AND (id2 = 100050))
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 104000) AND (id2 = 104000))
+(11 rows)
+
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+ count 
+-------
+     3
+(1 row)
+
+SET enable_bitmapscan = off;
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+ count 
+-------
+     3
+(1 row)
+
+SET enable_bitmapscan = on;
 CREATE SEQUENCE bitmap_test_multi_inval_id2_seq AS integer;
 -- Test multi column some not valid bitmap
 CREATE TABLE bitmap_test_multi_inval

--- a/test/expected/bitmap_scan.out
+++ b/test/expected/bitmap_scan.out
@@ -3797,6 +3797,59 @@ SELECT * FROM bitmap_test_complex WHERE val < '13!';
  11 |   5 |   2 | 11!
 (2 rows)
 
+-- A bitmap scan skips internal pages that hold no wanted keys by descending
+-- straight to the next needed key.  Check it returns exactly the same rows as
+-- a plain scan for keys scattered across a table spanning several pages, for
+-- both a single-column and a composite primary key.  Raises on any mismatch.
+CREATE TABLE bitmap_jump_test (id int8 PRIMARY KEY, v int8) USING orioledb;
+INSERT INTO bitmap_jump_test
+	SELECT g, g * 7 % 100000 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_test;
+CREATE TABLE bitmap_jump_ctest (a int4, b int4, x int8, PRIMARY KEY (a, b))
+	USING orioledb;
+INSERT INTO bitmap_jump_ctest
+	SELECT g / 200, g % 200, g * 3 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_ctest;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+	bmp_sum		bigint;
+	seq_sum		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(v), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(v), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'single-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(x), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(x), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'composite-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+END $$;
+DROP TABLE bitmap_jump_test;
+DROP TABLE bitmap_jump_ctest;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to table bitmap_test

--- a/test/expected/bitmap_scan_1.out
+++ b/test/expected/bitmap_scan_1.out
@@ -3897,6 +3897,42 @@ BEGIN
 END $$;
 DROP TABLE bitmap_jump_test;
 DROP TABLE bitmap_jump_ctest;
+-- Covering primary key (INCLUDE columns, incl. a by-ref type): the fixed-key
+-- bitmap must build the seek key from the ordering columns only and leave the
+-- INCLUDE columns out, or it would form a tuple over uninitialized values.
+-- Row-comparison range that indexes on the leading key columns.  Result must
+-- match a sequential scan.
+CREATE TABLE bitmap_cover_test (c1 int, c2 int, c3 int, c4 box,
+	CONSTRAINT bitmap_cover_pk PRIMARY KEY (c1, c2) INCLUDE (c3, c4))
+	USING orioledb;
+INSERT INTO bitmap_cover_test
+	SELECT 1, 2, 3 * x, box('4,4,4,4') FROM generate_series(1, 10) x
+	ON CONFLICT DO NOTHING;
+INSERT INTO bitmap_cover_test
+	SELECT x, 2 * x, NULL, NULL FROM generate_series(1, 300) x
+	ON CONFLICT DO NOTHING;
+ANALYZE bitmap_cover_test;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*) INTO bmp_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SET LOCAL enable_indexscan = off;
+	SELECT count(*) INTO seq_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	IF bmp_cnt <> seq_cnt THEN
+		RAISE EXCEPTION 'covering-pk bitmap mismatch: bmp=% seq=%',
+			bmp_cnt, seq_cnt;
+	END IF;
+END $$;
+DROP TABLE bitmap_cover_test;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to table bitmap_test

--- a/test/expected/bitmap_scan_1.out
+++ b/test/expected/bitmap_scan_1.out
@@ -3844,6 +3844,59 @@ SELECT * FROM bitmap_test_complex WHERE val < '13!';
  11 |   5 |   2 | 11!
 (2 rows)
 
+-- A bitmap scan skips internal pages that hold no wanted keys by descending
+-- straight to the next needed key.  Check it returns exactly the same rows as
+-- a plain scan for keys scattered across a table spanning several pages, for
+-- both a single-column and a composite primary key.  Raises on any mismatch.
+CREATE TABLE bitmap_jump_test (id int8 PRIMARY KEY, v int8) USING orioledb;
+INSERT INTO bitmap_jump_test
+	SELECT g, g * 7 % 100000 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_test;
+CREATE TABLE bitmap_jump_ctest (a int4, b int4, x int8, PRIMARY KEY (a, b))
+	USING orioledb;
+INSERT INTO bitmap_jump_ctest
+	SELECT g / 200, g % 200, g * 3 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_ctest;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+	bmp_sum		bigint;
+	seq_sum		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(v), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(v), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'single-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(x), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(x), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'composite-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+END $$;
+DROP TABLE bitmap_jump_test;
+DROP TABLE bitmap_jump_ctest;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to table bitmap_test

--- a/test/expected/bitmap_scan_1.out
+++ b/test/expected/bitmap_scan_1.out
@@ -2134,12 +2134,14 @@ INSERT INTO pkey_bitmap_test (i)
 	SELECT pseudo_random(5, v) * 20000 FROM generate_series(1,5000) v
 		ON CONFLICT DO NOTHING;
 EXPLAIN (COSTS OFF) SELECT * FROM pkey_bitmap_test WHERE i < 100;
-                     QUERY PLAN                      
------------------------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on pkey_bitmap_test
-   Forward index only scan of: pkey_bitmap_test_pkey
-   Conds: (i < 100)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (i < 100)
+   ->  Bitmap Index Scan on pkey_bitmap_test_pkey
+         Index Cond: (i < 100)
+(5 rows)
 
 -- Test ctid bitmap
 CREATE TABLE bitmap_test_ctid
@@ -3571,12 +3573,15 @@ INSERT INTO bitmap_test_multi (i)
 ANALYZE bitmap_test_multi;
 CREATE INDEX bitmap_test_multi_ix1 ON bitmap_test_multi (i);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Aggregate
-   ->  Index Only Scan using bitmap_test_multi_ix1 on bitmap_test_multi
-         Index Cond: (i < 100)
-(3 rows)
+   ->  Custom Scan (o_scan) on bitmap_test_multi
+         Bitmap heap scan
+         Recheck Cond: (i < 100)
+         ->  Bitmap Index Scan on bitmap_test_multi_ix1
+               Index Cond: (i < 100)
+(6 rows)
 
 SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
  count 
@@ -3586,12 +3591,17 @@ SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
 
 EXPLAIN (COSTS OFF)
 	SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Limit
-   ->  Index Only Scan using bitmap_test_multi_ix1 on bitmap_test_multi
-         Index Cond: (i < 100)
-(3 rows)
+   ->  Sort
+         Sort Key: i
+         ->  Custom Scan (o_scan) on bitmap_test_multi
+               Bitmap heap scan
+               Recheck Cond: (i < 100)
+               ->  Bitmap Index Scan on bitmap_test_multi_ix1
+                     Index Cond: (i < 100)
+(8 rows)
 
 SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
    id   |  id2   | i  
@@ -3610,14 +3620,51 @@ SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
  101672 | 101672 | 67
  100431 | 100431 | 72
  102448 | 102448 | 73
- 102088 | 102088 | 81
  104447 | 104447 | 81
+ 102088 | 102088 | 81
  102646 | 102646 | 85
  102805 | 102805 | 86
  101322 | 101322 | 87
  102688 | 102688 | 87
 (20 rows)
 
+-- Row-array IN() over a composite primary key: planned as a BitmapOr of
+-- per-tuple primary-index scans (the shape that was slow in TPCC delivery).
+-- The result must match a sequential scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM bitmap_test_multi
+		WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (o_scan) on bitmap_test_multi
+         Bitmap heap scan
+         Recheck Cond: (((id = 100001) AND (id2 = 100001)) OR ((id = 100050) AND (id2 = 100050)) OR ((id = 104000) AND (id2 = 104000)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 100001) AND (id2 = 100001))
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 100050) AND (id2 = 100050))
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 104000) AND (id2 = 104000))
+(11 rows)
+
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+ count 
+-------
+     3
+(1 row)
+
+SET enable_bitmapscan = off;
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+ count 
+-------
+     3
+(1 row)
+
+SET enable_bitmapscan = on;
 CREATE SEQUENCE bitmap_test_multi_inval_id2_seq AS integer;
 -- Test multi column some not valid bitmap
 CREATE TABLE bitmap_test_multi_inval

--- a/test/expected/bitmap_scan_2.out
+++ b/test/expected/bitmap_scan_2.out
@@ -3997,6 +3997,42 @@ BEGIN
 END $$;
 DROP TABLE bitmap_jump_test;
 DROP TABLE bitmap_jump_ctest;
+-- Covering primary key (INCLUDE columns, incl. a by-ref type): the fixed-key
+-- bitmap must build the seek key from the ordering columns only and leave the
+-- INCLUDE columns out, or it would form a tuple over uninitialized values.
+-- Row-comparison range that indexes on the leading key columns.  Result must
+-- match a sequential scan.
+CREATE TABLE bitmap_cover_test (c1 int, c2 int, c3 int, c4 box,
+	CONSTRAINT bitmap_cover_pk PRIMARY KEY (c1, c2) INCLUDE (c3, c4))
+	USING orioledb;
+INSERT INTO bitmap_cover_test
+	SELECT 1, 2, 3 * x, box('4,4,4,4') FROM generate_series(1, 10) x
+	ON CONFLICT DO NOTHING;
+INSERT INTO bitmap_cover_test
+	SELECT x, 2 * x, NULL, NULL FROM generate_series(1, 300) x
+	ON CONFLICT DO NOTHING;
+ANALYZE bitmap_cover_test;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*) INTO bmp_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SET LOCAL enable_indexscan = off;
+	SELECT count(*) INTO seq_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	IF bmp_cnt <> seq_cnt THEN
+		RAISE EXCEPTION 'covering-pk bitmap mismatch: bmp=% seq=%',
+			bmp_cnt, seq_cnt;
+	END IF;
+END $$;
+DROP TABLE bitmap_cover_test;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to table bitmap_test

--- a/test/expected/bitmap_scan_2.out
+++ b/test/expected/bitmap_scan_2.out
@@ -3899,6 +3899,59 @@ SELECT * FROM bitmap_test_complex WHERE val < '13!';
  11 |   5 |   2 | 11!
 (2 rows)
 
+-- A bitmap scan skips internal pages that hold no wanted keys by descending
+-- straight to the next needed key.  Check it returns exactly the same rows as
+-- a plain scan for keys scattered across a table spanning several pages, for
+-- both a single-column and a composite primary key.  Raises on any mismatch.
+CREATE TABLE bitmap_jump_test (id int8 PRIMARY KEY, v int8) USING orioledb;
+INSERT INTO bitmap_jump_test
+	SELECT g, g * 7 % 100000 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_test;
+CREATE TABLE bitmap_jump_ctest (a int4, b int4, x int8, PRIMARY KEY (a, b))
+	USING orioledb;
+INSERT INTO bitmap_jump_ctest
+	SELECT g / 200, g % 200, g * 3 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_ctest;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+	bmp_sum		bigint;
+	seq_sum		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(v), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(v), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'single-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(x), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(x), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'composite-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+END $$;
+DROP TABLE bitmap_jump_test;
+DROP TABLE bitmap_jump_ctest;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to table bitmap_test

--- a/test/expected/bitmap_scan_2.out
+++ b/test/expected/bitmap_scan_2.out
@@ -2189,12 +2189,14 @@ INSERT INTO pkey_bitmap_test (i)
 	SELECT pseudo_random(5, v) * 20000 FROM generate_series(1,5000) v
 		ON CONFLICT DO NOTHING;
 EXPLAIN (COSTS OFF) SELECT * FROM pkey_bitmap_test WHERE i < 100;
-                     QUERY PLAN                      
------------------------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on pkey_bitmap_test
-   Forward index only scan of: pkey_bitmap_test_pkey
-   Conds: (i < 100)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (i < 100)
+   ->  Bitmap Index Scan on pkey_bitmap_test_pkey
+         Index Cond: (i < 100)
+(5 rows)
 
 -- Test ctid bitmap
 CREATE TABLE bitmap_test_ctid
@@ -3669,13 +3671,15 @@ INSERT INTO bitmap_test_multi (i)
 ANALYZE bitmap_test_multi;
 CREATE INDEX bitmap_test_multi_ix1 ON bitmap_test_multi (i);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                       QUERY PLAN                       
+--------------------------------------------------------
  Aggregate
-   ->  Index Only Scan using bitmap_test_multi_ix1 on bitmap_test_multi
-         Disabled: true
-         Index Cond: (i < 100)
-(4 rows)
+   ->  Custom Scan (o_scan) on bitmap_test_multi
+         Bitmap heap scan
+         Recheck Cond: (i < 100)
+         ->  Bitmap Index Scan on bitmap_test_multi_ix1
+               Index Cond: (i < 100)
+(6 rows)
 
 SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
  count 
@@ -3685,13 +3689,17 @@ SELECT count(*) FROM bitmap_test_multi WHERE i < 100;
 
 EXPLAIN (COSTS OFF)
 	SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                          QUERY PLAN                          
+--------------------------------------------------------------
  Limit
-   ->  Index Only Scan using bitmap_test_multi_ix1 on bitmap_test_multi
-         Disabled: true
-         Index Cond: (i < 100)
-(4 rows)
+   ->  Sort
+         Sort Key: i
+         ->  Custom Scan (o_scan) on bitmap_test_multi
+               Bitmap heap scan
+               Recheck Cond: (i < 100)
+               ->  Bitmap Index Scan on bitmap_test_multi_ix1
+                     Index Cond: (i < 100)
+(8 rows)
 
 SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
    id   |  id2   | i  
@@ -3710,14 +3718,51 @@ SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
  101672 | 101672 | 67
  100431 | 100431 | 72
  102448 | 102448 | 73
- 102088 | 102088 | 81
  104447 | 104447 | 81
+ 102088 | 102088 | 81
  102646 | 102646 | 85
  102805 | 102805 | 86
  101322 | 101322 | 87
  102688 | 102688 | 87
 (20 rows)
 
+-- Row-array IN() over a composite primary key: planned as a BitmapOr of
+-- per-tuple primary-index scans (the shape that was slow in TPCC delivery).
+-- The result must match a sequential scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM bitmap_test_multi
+		WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (o_scan) on bitmap_test_multi
+         Bitmap heap scan
+         Recheck Cond: (((id = 100001) AND (id2 = 100001)) OR ((id = 100050) AND (id2 = 100050)) OR ((id = 104000) AND (id2 = 104000)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 100001) AND (id2 = 100001))
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 100050) AND (id2 = 100050))
+               ->  Bitmap Index Scan on bitmap_test_multi_pkey
+                     Index Cond: ((id = 104000) AND (id2 = 104000))
+(11 rows)
+
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+ count 
+-------
+     3
+(1 row)
+
+SET enable_bitmapscan = off;
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+ count 
+-------
+     3
+(1 row)
+
+SET enable_bitmapscan = on;
 CREATE SEQUENCE bitmap_test_multi_inval_id2_seq AS integer;
 -- Test multi column some not valid bitmap
 CREATE TABLE bitmap_test_multi_inval

--- a/test/expected/explain.out
+++ b/test/expected/explain.out
@@ -1383,14 +1383,13 @@ SELECT regexp_replace(t, '[\d\.]+', 'x', 'g')
                ->  Bitmap Index Scan on test_the_geom_brin  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
                      Index Cond: (test_explain_bridged_indexxthe_geom && '(x,x),(x,x)'::box)
                      Buffers: shared hit=x
-               Primary pages: read=x
                Other pages: read=x, lock=x, load=x
                Buffers: shared hit=x
  Planning:
    Buffers: shared hit=x
  Planning Time: x ms
  Execution Time: x ms
-(22 rows)
+(21 rows)
 
 COMMIT;
 DROP EXTENSION orioledb CASCADE;

--- a/test/expected/getsomeattrs_1.out
+++ b/test/expected/getsomeattrs_1.out
@@ -733,11 +733,12 @@ BEGIN;
 SET LOCAL enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_pkey_include_same_field;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                           QUERY PLAN                           
+----------------------------------------------------------------
  Custom Scan (o_scan) on o_test_pkey_include_same_field
-   Forward index only scan of: o_test_pkey_include_same_field_pkey
-(2 rows)
+   Bitmap heap scan
+   ->  Bitmap Index Scan on o_test_pkey_include_same_field_pkey
+(3 rows)
 
 SELECT * FROM o_test_pkey_include_same_field;
  val_1 

--- a/test/expected/getsomeattrs_2.out
+++ b/test/expected/getsomeattrs_2.out
@@ -734,12 +734,11 @@ BEGIN;
 SET LOCAL enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_pkey_include_same_field;
-                           QUERY PLAN                           
-----------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_pkey_include_same_field
-   Bitmap heap scan
-   ->  Bitmap Index Scan on o_test_pkey_include_same_field_pkey
-(3 rows)
+   Forward index only scan of: o_test_pkey_include_same_field_pkey
+(2 rows)
 
 SELECT * FROM o_test_pkey_include_same_field;
  val_1 

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -136,12 +136,14 @@ SELECT * FROM o_test51 WHERE key BETWEEN 100 and 110;
 (10 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test51 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test51
-   Forward index scan of: o_test51_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test51_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test51 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -191,12 +193,14 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                 QUERY PLAN                  
----------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -214,12 +218,14 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 (10 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -269,12 +275,14 @@ SELECT orioledb_tbl_indices('o_test53'::regclass);
 
 INSERT INTO o_test53 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test53 WHERE key BETWEEN 100 and 110;
-                QUERY PLAN                
-------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test53
-   Forward index scan of: o_test53_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test53_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test53 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -674,20 +682,26 @@ EXPLAIN (COSTS off) SELECT * FROM o_test58;
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE foo = 301;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test58_reg2 on o_test58
-   Index Cond: (foo = 301)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test58
+   Bitmap heap scan
+   Recheck Cond: (foo = 301)
+   ->  Bitmap Index Scan on o_test58_reg2
+         Index Cond: (foo = 301)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE foo > 300 and foo < 400 and
 												 bar = 300;
-                 QUERY PLAN                  
----------------------------------------------
- Index Scan using o_test58_reg2 on o_test58
-   Index Cond: ((foo > 300) AND (foo < 400))
+                    QUERY PLAN                     
+---------------------------------------------------
+ Custom Scan (o_scan) on o_test58
    Filter: (bar = 300)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((foo > 300) AND (foo < 400))
+   ->  Bitmap Index Scan on o_test58_reg2
+         Index Cond: ((foo > 300) AND (foo < 400))
+(6 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE bar = 200;
       QUERY PLAN       
@@ -699,12 +713,15 @@ EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE bar = 200;
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test58 SET foo = 100 WHERE foo > 102 AND
 														 foo < 400;');
-                   smart_explain                   
----------------------------------------------------
+                      smart_explain                      
+---------------------------------------------------------
  Update on o_test58
-   ->  Index Scan using o_test58_reg2 on o_test58
-         Index Cond: ((foo > 102) AND (foo < 400))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test58
+         Bitmap heap scan
+         Recheck Cond: ((foo > 102) AND (foo < 400))
+         ->  Bitmap Index Scan on o_test58_reg2
+               Index Cond: ((foo > 102) AND (foo < 400))
+(6 rows)
 
 UPDATE o_test58 SET foo = 100 WHERE foo > 102;
 --SELECT orioledb_tbl_structure('o_test58'::regclass);
@@ -723,50 +740,71 @@ CREATE TABLE o_test59
 CREATE INDEX o_test59_reg1 ON o_test59(sec1);
 CREATE INDEX o_test59_reg2 ON o_test59(sec2);
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: (sec1 = 100)
+   ->  Bitmap Index Scan on o_test59_reg1
+         Index Cond: (sec1 = 100)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100 and pri1 > 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
    Filter: (pri1 > 200)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (sec1 = 100)
+   ->  Bitmap Index Scan on o_test59_reg1
+         Index Cond: (sec1 = 100)
+(6 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100 and pri1 = 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
-   Filter: (pri1 = 200)
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: ((sec1 = 100) AND (pri1 = 200))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: (sec1 = 100)
+         ->  Bitmap Index Scan on o_test59_pkey
+               Index Cond: (pri1 = 200)
+(8 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE pri1 = 100;
-               QUERY PLAN               
-----------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Custom Scan (o_scan) on o_test59
-   Forward index scan of: o_test59_pkey
-   Conds: (pri1 = 100)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (pri1 = 100)
+   ->  Bitmap Index Scan on o_test59_pkey
+         Index Cond: (pri1 = 100)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec2 = 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg2 on o_test59
-   Index Cond: (sec2 = 200)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: (sec2 = 200)
+   ->  Bitmap Index Scan on o_test59_reg2
+         Index Cond: (sec2 = 200)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec2 = 200 and pri1 = 100;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg2 on o_test59
-   Index Cond: (sec2 = 200)
-   Filter: (pri1 = 100)
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: ((sec2 = 200) AND (pri1 = 100))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on o_test59_reg2
+               Index Cond: (sec2 = 200)
+         ->  Bitmap Index Scan on o_test59_pkey
+               Index Cond: (pri1 = 100)
+(8 rows)
 
 INSERT INTO o_test59 SELECT 100 + i, 200 + i, 300 + i, 400 + i, 500 + i FROM generate_series(1, 10) AS i;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
@@ -774,36 +812,45 @@ INSERT INTO o_test59 SELECT 100 + i, 200 + i, 300 + i, 400 + i, 500 + i FROM gen
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET foo = 0 WHERE sec1 > 105 AND
 													   sec1 < 200;');
-                    smart_explain                    
------------------------------------------------------
+                       smart_explain                       
+-----------------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg1 on o_test59
-         Index Cond: ((sec1 > 105) AND (sec1 < 200))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: ((sec1 > 105) AND (sec1 < 200))
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: ((sec1 > 105) AND (sec1 < 200))
+(6 rows)
 
 UPDATE o_test59 SET foo = 0 WHERE sec1 > 105;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
 -- update only sec1 index field
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET sec1 = 100 WHERE sec2 > 405 and sec2 < 408;');
-                    smart_explain                    
------------------------------------------------------
+                       smart_explain                       
+-----------------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg2 on o_test59
-         Index Cond: ((sec2 > 405) AND (sec2 < 408))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: ((sec2 > 405) AND (sec2 < 408))
+         ->  Bitmap Index Scan on o_test59_reg2
+               Index Cond: ((sec2 > 405) AND (sec2 < 408))
+(6 rows)
 
 UPDATE o_test59 SET sec1 = 100 WHERE sec2 > 405 and sec2 < 408;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
 -- update primary index field
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET pri1 = 50 WHERE sec1 = 100;');
-                  smart_explain                   
---------------------------------------------------
+                 smart_explain                  
+------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg1 on o_test59
-         Index Cond: (sec1 = 100)
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: (sec1 = 100)
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: (sec1 = 100)
+(6 rows)
 
 UPDATE o_test59 SET pri1 = 50 WHERE sec1 = 100;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
@@ -7930,12 +7977,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -7955,13 +8006,19 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(10 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -7981,12 +8038,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8007,13 +8068,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8034,12 +8102,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(3 rows)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8058,12 +8130,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  (val_1 > 1 OR (val_1 = 1 AND val_2 > 2))
 			ORDER BY val_1, val_2;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: (((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3))) AND ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-(3 rows)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2)))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_2 < 3)) OR (val_1 < 2))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 < 3))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8082,12 +8162,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(3 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8108,12 +8192,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 <= 3))) AND
 			  (val_1 > 1 OR (val_1 = 1 AND val_2 >= 2))
 			ORDER BY val_1, val_2;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: (((val_1 < 2) OR ((val_1 = 2) AND (val_2 <= 3))) AND ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-(3 rows)
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2)))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_2 <= 3)) OR (val_1 < 2))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 <= 3))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 <= 3))) AND
@@ -8160,12 +8252,14 @@ SELECT orioledb_tbl_structure('o_test_row_searchkey_pkey_include'::regclass,
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
-   Conds: (val_1 < 2)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (val_1 < 2)
+   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
+         Index Cond: (val_1 < 2)
+(5 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8524,13 +8618,17 @@ INSERT INTO o_test_saop
 	(SELECT i % 10, (i / 10) % 10, i / 100 FROM generate_series(1, 1000) i);
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: (i < ANY ('{3,4,5}'::integer[]))
-(4 rows)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+         Bitmap heap scan
+         Recheck Cond: (i < ANY ('{3,4,5}'::integer[]))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: (i < ANY ('{3,4,5}'::integer[]))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8610,13 +8708,17 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                   QUERY PLAN                   
-------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: (j = ANY ('{1,3}'::integer[]))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: (i < ANY ('{1,2}'::integer[]))
-(4 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: (j = ANY ('{1,3}'::integer[]))
+         Bitmap heap scan
+         Recheck Cond: (i < ANY ('{1,2}'::integer[]))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: (i < ANY ('{1,2}'::integer[]))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -136,12 +136,14 @@ SELECT * FROM o_test51 WHERE key BETWEEN 100 and 110;
 (10 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test51 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test51
-   Forward index scan of: o_test51_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test51_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test51 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -191,12 +193,14 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                 QUERY PLAN                  
----------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -214,12 +218,14 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 (10 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -269,12 +275,14 @@ SELECT orioledb_tbl_indices('o_test53'::regclass);
 
 INSERT INTO o_test53 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test53 WHERE key BETWEEN 100 and 110;
-                QUERY PLAN                
-------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test53
-   Forward index scan of: o_test53_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test53_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test53 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -674,20 +682,26 @@ EXPLAIN (COSTS off) SELECT * FROM o_test58;
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE foo = 301;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test58_reg2 on o_test58
-   Index Cond: (foo = 301)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test58
+   Bitmap heap scan
+   Recheck Cond: (foo = 301)
+   ->  Bitmap Index Scan on o_test58_reg2
+         Index Cond: (foo = 301)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE foo > 300 and foo < 400 and
 												 bar = 300;
-                 QUERY PLAN                  
----------------------------------------------
- Index Scan using o_test58_reg2 on o_test58
-   Index Cond: ((foo > 300) AND (foo < 400))
+                    QUERY PLAN                     
+---------------------------------------------------
+ Custom Scan (o_scan) on o_test58
    Filter: (bar = 300)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((foo > 300) AND (foo < 400))
+   ->  Bitmap Index Scan on o_test58_reg2
+         Index Cond: ((foo > 300) AND (foo < 400))
+(6 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE bar = 200;
       QUERY PLAN       
@@ -699,12 +713,15 @@ EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE bar = 200;
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test58 SET foo = 100 WHERE foo > 102 AND
 														 foo < 400;');
-                   smart_explain                   
----------------------------------------------------
+                      smart_explain                      
+---------------------------------------------------------
  Update on o_test58
-   ->  Index Scan using o_test58_reg2 on o_test58
-         Index Cond: ((foo > 102) AND (foo < 400))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test58
+         Bitmap heap scan
+         Recheck Cond: ((foo > 102) AND (foo < 400))
+         ->  Bitmap Index Scan on o_test58_reg2
+               Index Cond: ((foo > 102) AND (foo < 400))
+(6 rows)
 
 UPDATE o_test58 SET foo = 100 WHERE foo > 102;
 --SELECT orioledb_tbl_structure('o_test58'::regclass);
@@ -723,50 +740,71 @@ CREATE TABLE o_test59
 CREATE INDEX o_test59_reg1 ON o_test59(sec1);
 CREATE INDEX o_test59_reg2 ON o_test59(sec2);
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: (sec1 = 100)
+   ->  Bitmap Index Scan on o_test59_reg1
+         Index Cond: (sec1 = 100)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100 and pri1 > 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
    Filter: (pri1 > 200)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (sec1 = 100)
+   ->  Bitmap Index Scan on o_test59_reg1
+         Index Cond: (sec1 = 100)
+(6 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100 and pri1 = 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
-   Filter: (pri1 = 200)
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: ((sec1 = 100) AND (pri1 = 200))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: (sec1 = 100)
+         ->  Bitmap Index Scan on o_test59_pkey
+               Index Cond: (pri1 = 200)
+(8 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE pri1 = 100;
-               QUERY PLAN               
-----------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Custom Scan (o_scan) on o_test59
-   Forward index scan of: o_test59_pkey
-   Conds: (pri1 = 100)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (pri1 = 100)
+   ->  Bitmap Index Scan on o_test59_pkey
+         Index Cond: (pri1 = 100)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec2 = 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg2 on o_test59
-   Index Cond: (sec2 = 200)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: (sec2 = 200)
+   ->  Bitmap Index Scan on o_test59_reg2
+         Index Cond: (sec2 = 200)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec2 = 200 and pri1 = 100;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg2 on o_test59
-   Index Cond: (sec2 = 200)
-   Filter: (pri1 = 100)
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: ((sec2 = 200) AND (pri1 = 100))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on o_test59_reg2
+               Index Cond: (sec2 = 200)
+         ->  Bitmap Index Scan on o_test59_pkey
+               Index Cond: (pri1 = 100)
+(8 rows)
 
 INSERT INTO o_test59 SELECT 100 + i, 200 + i, 300 + i, 400 + i, 500 + i FROM generate_series(1, 10) AS i;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
@@ -774,36 +812,45 @@ INSERT INTO o_test59 SELECT 100 + i, 200 + i, 300 + i, 400 + i, 500 + i FROM gen
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET foo = 0 WHERE sec1 > 105 AND
 													   sec1 < 200;');
-                    smart_explain                    
------------------------------------------------------
+                       smart_explain                       
+-----------------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg1 on o_test59
-         Index Cond: ((sec1 > 105) AND (sec1 < 200))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: ((sec1 > 105) AND (sec1 < 200))
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: ((sec1 > 105) AND (sec1 < 200))
+(6 rows)
 
 UPDATE o_test59 SET foo = 0 WHERE sec1 > 105;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
 -- update only sec1 index field
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET sec1 = 100 WHERE sec2 > 405 and sec2 < 408;');
-                    smart_explain                    
------------------------------------------------------
+                       smart_explain                       
+-----------------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg2 on o_test59
-         Index Cond: ((sec2 > 405) AND (sec2 < 408))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: ((sec2 > 405) AND (sec2 < 408))
+         ->  Bitmap Index Scan on o_test59_reg2
+               Index Cond: ((sec2 > 405) AND (sec2 < 408))
+(6 rows)
 
 UPDATE o_test59 SET sec1 = 100 WHERE sec2 > 405 and sec2 < 408;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
 -- update primary index field
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET pri1 = 50 WHERE sec1 = 100;');
-                  smart_explain                   
---------------------------------------------------
+                 smart_explain                  
+------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg1 on o_test59
-         Index Cond: (sec1 = 100)
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: (sec1 = 100)
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: (sec1 = 100)
+(6 rows)
 
 UPDATE o_test59 SET pri1 = 50 WHERE sec1 = 100;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
@@ -7919,12 +7966,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -7944,13 +7995,19 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(10 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -7970,12 +8027,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -7996,13 +8057,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8023,12 +8091,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(3 rows)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8047,12 +8119,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  (val_1 > 1 OR (val_1 = 1 AND val_2 > 2))
 			ORDER BY val_1, val_2;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: (((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3))) AND ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-(3 rows)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2)))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_2 < 3)) OR (val_1 < 2))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 < 3))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8071,12 +8151,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(3 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8097,12 +8181,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 <= 3))) AND
 			  (val_1 > 1 OR (val_1 = 1 AND val_2 >= 2))
 			ORDER BY val_1, val_2;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: (((val_1 < 2) OR ((val_1 = 2) AND (val_2 <= 3))) AND ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-(3 rows)
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2)))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_2 <= 3)) OR (val_1 < 2))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 <= 3))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 <= 3))) AND
@@ -8149,12 +8241,14 @@ SELECT orioledb_tbl_structure('o_test_row_searchkey_pkey_include'::regclass,
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
-   Conds: (val_1 < 2)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (val_1 < 2)
+   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
+         Index Cond: (val_1 < 2)
+(5 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8513,13 +8607,17 @@ INSERT INTO o_test_saop
 	(SELECT i % 10, (i / 10) % 10, i / 100 FROM generate_series(1, 1000) i);
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: (k > ALL ('{7,8}'::integer[]))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-(4 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: (k > ALL ('{7,8}'::integer[]))
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8597,12 +8695,16 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-(3 rows)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+(7 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -136,12 +136,14 @@ SELECT * FROM o_test51 WHERE key BETWEEN 100 and 110;
 (10 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test51 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test51
-   Forward index scan of: o_test51_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test51_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test51 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -191,12 +193,14 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                 QUERY PLAN                  
----------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -214,12 +218,14 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 (10 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -269,12 +275,14 @@ SELECT orioledb_tbl_indices('o_test53'::regclass);
 
 INSERT INTO o_test53 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test53 WHERE key BETWEEN 100 and 110;
-                QUERY PLAN                
-------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test53
-   Forward index scan of: o_test53_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test53_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test53 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -674,20 +682,26 @@ EXPLAIN (COSTS off) SELECT * FROM o_test58;
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE foo = 301;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test58_reg2 on o_test58
-   Index Cond: (foo = 301)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test58
+   Bitmap heap scan
+   Recheck Cond: (foo = 301)
+   ->  Bitmap Index Scan on o_test58_reg2
+         Index Cond: (foo = 301)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE foo > 300 and foo < 400 and
 												 bar = 300;
-                 QUERY PLAN                  
----------------------------------------------
- Index Scan using o_test58_reg2 on o_test58
-   Index Cond: ((foo > 300) AND (foo < 400))
+                    QUERY PLAN                     
+---------------------------------------------------
+ Custom Scan (o_scan) on o_test58
    Filter: (bar = 300)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((foo > 300) AND (foo < 400))
+   ->  Bitmap Index Scan on o_test58_reg2
+         Index Cond: ((foo > 300) AND (foo < 400))
+(6 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE bar = 200;
       QUERY PLAN       
@@ -699,12 +713,15 @@ EXPLAIN (COSTS off) SELECT * FROM o_test58 WHERE bar = 200;
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test58 SET foo = 100 WHERE foo > 102 AND
 														 foo < 400;');
-                   smart_explain                   
----------------------------------------------------
+                      smart_explain                      
+---------------------------------------------------------
  Update on o_test58
-   ->  Index Scan using o_test58_reg2 on o_test58
-         Index Cond: ((foo > 102) AND (foo < 400))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test58
+         Bitmap heap scan
+         Recheck Cond: ((foo > 102) AND (foo < 400))
+         ->  Bitmap Index Scan on o_test58_reg2
+               Index Cond: ((foo > 102) AND (foo < 400))
+(6 rows)
 
 UPDATE o_test58 SET foo = 100 WHERE foo > 102;
 --SELECT orioledb_tbl_structure('o_test58'::regclass);
@@ -723,50 +740,71 @@ CREATE TABLE o_test59
 CREATE INDEX o_test59_reg1 ON o_test59(sec1);
 CREATE INDEX o_test59_reg2 ON o_test59(sec2);
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: (sec1 = 100)
+   ->  Bitmap Index Scan on o_test59_reg1
+         Index Cond: (sec1 = 100)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100 and pri1 > 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
    Filter: (pri1 > 200)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (sec1 = 100)
+   ->  Bitmap Index Scan on o_test59_reg1
+         Index Cond: (sec1 = 100)
+(6 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec1 = 100 and pri1 = 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg1 on o_test59
-   Index Cond: (sec1 = 100)
-   Filter: (pri1 = 200)
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: ((sec1 = 100) AND (pri1 = 200))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: (sec1 = 100)
+         ->  Bitmap Index Scan on o_test59_pkey
+               Index Cond: (pri1 = 200)
+(8 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE pri1 = 100;
-               QUERY PLAN               
-----------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Custom Scan (o_scan) on o_test59
-   Forward index scan of: o_test59_pkey
-   Conds: (pri1 = 100)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (pri1 = 100)
+   ->  Bitmap Index Scan on o_test59_pkey
+         Index Cond: (pri1 = 100)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec2 = 200;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg2 on o_test59
-   Index Cond: (sec2 = 200)
-(2 rows)
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: (sec2 = 200)
+   ->  Bitmap Index Scan on o_test59_reg2
+         Index Cond: (sec2 = 200)
+(5 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_test59 WHERE sec2 = 200 and pri1 = 100;
-                 QUERY PLAN                 
---------------------------------------------
- Index Scan using o_test59_reg2 on o_test59
-   Index Cond: (sec2 = 200)
-   Filter: (pri1 = 100)
-(3 rows)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Custom Scan (o_scan) on o_test59
+   Bitmap heap scan
+   Recheck Cond: ((sec2 = 200) AND (pri1 = 100))
+   ->  BitmapAnd
+         ->  Bitmap Index Scan on o_test59_reg2
+               Index Cond: (sec2 = 200)
+         ->  Bitmap Index Scan on o_test59_pkey
+               Index Cond: (pri1 = 100)
+(8 rows)
 
 INSERT INTO o_test59 SELECT 100 + i, 200 + i, 300 + i, 400 + i, 500 + i FROM generate_series(1, 10) AS i;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
@@ -774,36 +812,45 @@ INSERT INTO o_test59 SELECT 100 + i, 200 + i, 300 + i, 400 + i, 500 + i FROM gen
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET foo = 0 WHERE sec1 > 105 AND
 													   sec1 < 200;');
-                    smart_explain                    
------------------------------------------------------
+                       smart_explain                       
+-----------------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg1 on o_test59
-         Index Cond: ((sec1 > 105) AND (sec1 < 200))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: ((sec1 > 105) AND (sec1 < 200))
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: ((sec1 > 105) AND (sec1 < 200))
+(6 rows)
 
 UPDATE o_test59 SET foo = 0 WHERE sec1 > 105;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
 -- update only sec1 index field
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET sec1 = 100 WHERE sec2 > 405 and sec2 < 408;');
-                    smart_explain                    
------------------------------------------------------
+                       smart_explain                       
+-----------------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg2 on o_test59
-         Index Cond: ((sec2 > 405) AND (sec2 < 408))
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: ((sec2 > 405) AND (sec2 < 408))
+         ->  Bitmap Index Scan on o_test59_reg2
+               Index Cond: ((sec2 > 405) AND (sec2 < 408))
+(6 rows)
 
 UPDATE o_test59 SET sec1 = 100 WHERE sec2 > 405 and sec2 < 408;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
 -- update primary index field
 SELECT smart_explain(
 'EXPLAIN (COSTS off) UPDATE o_test59 SET pri1 = 50 WHERE sec1 = 100;');
-                  smart_explain                   
---------------------------------------------------
+                 smart_explain                  
+------------------------------------------------
  Update on o_test59
-   ->  Index Scan using o_test59_reg1 on o_test59
-         Index Cond: (sec1 = 100)
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test59
+         Bitmap heap scan
+         Recheck Cond: (sec1 = 100)
+         ->  Bitmap Index Scan on o_test59_reg1
+               Index Cond: (sec1 = 100)
+(6 rows)
 
 UPDATE o_test59 SET pri1 = 50 WHERE sec1 = 100;
 --SELECT orioledb_tbl_structure('o_test59'::regclass);
@@ -7975,12 +8022,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8000,13 +8051,19 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: (((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
+(10 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8026,12 +8083,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8052,13 +8113,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8079,12 +8147,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(3 rows)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8103,12 +8175,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  (val_1 > 1 OR (val_1 = 1 AND val_2 > 2))
 			ORDER BY val_1, val_2;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: (((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3))) AND ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-(3 rows)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2)))
+         Bitmap heap scan
+         Recheck Cond: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 < 3))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8127,12 +8207,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(3 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8153,12 +8237,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 <= 3))) AND
 			  (val_1 > 1 OR (val_1 = 1 AND val_2 >= 2))
 			ORDER BY val_1, val_2;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: (((val_1 < 2) OR ((val_1 = 2) AND (val_2 <= 3))) AND ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-(3 rows)
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2)))
+         Bitmap heap scan
+         Recheck Cond: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 <= 3)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 <= 3))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 <= 3))) AND
@@ -8205,12 +8297,14 @@ SELECT orioledb_tbl_structure('o_test_row_searchkey_pkey_include'::regclass,
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
-   Conds: (val_1 < 2)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (val_1 < 2)
+   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
+         Index Cond: (val_1 < 2)
+(5 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8571,13 +8665,17 @@ INSERT INTO o_test_saop
 	(SELECT i % 10, (i / 10) % 10, i / 100 FROM generate_series(1, 1000) i);
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: (k > ALL ('{7,8}'::integer[]))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-(4 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: (k > ALL ('{7,8}'::integer[]))
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8655,12 +8753,16 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-(3 rows)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+(7 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 

--- a/test/expected/inherits.out
+++ b/test/expected/inherits.out
@@ -1537,11 +1537,12 @@ explain (verbose, costs off) select min(1-id) from matest0;
                                    ->  Custom Scan (o_scan) on inherits.matest2 matest0_3
                                          Output: matest0_3.id
                                          Filter: ((1 - matest0_3.id) IS NOT NULL)
-                                         Forward index only scan of: matest2_pkey
+                                         Bitmap heap scan
+                                         ->  Bitmap Index Scan on matest2_pkey
                        ->  Index Only Scan using matest3i on inherits.matest3 matest0_4
                              Output: matest0_4.id, ((1 - matest0_4.id))
                              Index Cond: (((1 - matest0_4.id)) IS NOT NULL)
-(27 rows)
+(28 rows)
 
 select min(1-id) from matest0;
  min 

--- a/test/expected/inherits_1.out
+++ b/test/expected/inherits_1.out
@@ -1537,11 +1537,12 @@ explain (verbose, costs off) select min(1-id) from matest0;
                                    ->  Custom Scan (o_scan) on inherits.matest2 matest0_3
                                          Output: matest0_3.id
                                          Filter: ((1 - matest0_3.id) IS NOT NULL)
-                                         Forward index only scan of: matest2_pkey
+                                         Bitmap heap scan
+                                         ->  Bitmap Index Scan on matest2_pkey
                        ->  Index Only Scan using matest3i on inherits.matest3 matest0_4
                              Output: matest0_4.id, ((1 - matest0_4.id))
                              Index Cond: (((1 - matest0_4.id)) IS NOT NULL)
-(27 rows)
+(28 rows)
 
 select min(1-id) from matest0;
  min 

--- a/test/expected/inherits_2.out
+++ b/test/expected/inherits_2.out
@@ -1540,11 +1540,12 @@ explain (verbose, costs off) select min(1-id) from matest0;
                                    ->  Custom Scan (o_scan) on inherits.matest2 matest0_3
                                          Output: matest0_3.id
                                          Filter: ((1 - matest0_3.id) IS NOT NULL)
-                                         Forward index only scan of: matest2_pkey
+                                         Bitmap heap scan
+                                         ->  Bitmap Index Scan on matest2_pkey
                        ->  Index Only Scan using matest3i on inherits.matest3 matest0_4
                              Output: matest0_4.id, ((1 - matest0_4.id))
                              Index Cond: (((1 - matest0_4.id)) IS NOT NULL)
-(27 rows)
+(28 rows)
 
 select min(1-id) from matest0;
  min 

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -737,17 +737,17 @@ EXPLAIN (COSTS OFF)
 		INNER JOIN o_test_parallelscan_reinitialize2 ot2
 			ON ot1.val_1 = ot2.val_1
 				WHERE ot1.val_1 % 1000 = 1 AND ot2.val_1 = any(array[1]);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Gather
-   Workers Planned: 3
-   ->  Nested Loop
-         Join Filter: (ot1.val_1 = ot2.val_1)
-         ->  Parallel Seq Scan on o_test_parallelscan_reinitialize2 ot2
-               Filter: (val_1 = ANY ('{1}'::integer[]))
-         ->  Materialize
-               ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
-                     Filter: ((val_1 % 1000) = 1)
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Nested Loop
+   Join Filter: (ot1.val_1 = ot2.val_1)
+   ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
+         Filter: ((val_1 % 1000) = 1)
+   ->  Custom Scan (o_scan) on o_test_parallelscan_reinitialize2 ot2
+         Bitmap heap scan
+         Recheck Cond: (val_1 = ANY ('{1}'::integer[]))
+         ->  Bitmap Index Scan on o_test_parallelscan_reinitialize2_ix
+               Index Cond: (val_1 = ANY ('{1}'::integer[]))
 (9 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
@@ -758,14 +758,14 @@ SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
  val_1 | ot1v2 | ot2v2 
 -------+-------+-------
      1 |     1 |     1
-     1 |     2 |     1
-     1 |     3 |     1
-     1 |     4 |     1
-     1 |     5 |     1
      1 |     1 |     2
+     1 |     2 |     1
      1 |     2 |     2
+     1 |     3 |     1
      1 |     3 |     2
+     1 |     4 |     1
      1 |     4 |     2
+     1 |     5 |     1
      1 |     5 |     2
 (10 rows)
 

--- a/test/expected/partition_1.out
+++ b/test/expected/partition_1.out
@@ -456,7 +456,7 @@ EXPLAIN (COSTS OFF)
    ->  Custom Scan (o_scan) on o_test_partition_index_child1 o_test_partition_index
          Bitmap heap scan
          Recheck Cond: ((val_1 >= 2) AND (val_1 <= 3))
-         ->  Bitmap Index Scan on o_test_partition_index_child1_ix1
+         ->  Bitmap Index Scan on o_test_partition_index_child1_pkey
                Index Cond: ((val_1 >= 2) AND (val_1 <= 3))
 (7 rows)
 
@@ -471,12 +471,16 @@ SELECT * FROM o_test_partition_index
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_partition_index
 		WHERE val_1 BETWEEN 7 AND 9 ORDER BY val_1;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_partition_index_child2 o_test_partition_index
-   Forward index scan of: o_test_partition_index_child2_pkey
-   Conds: ((val_1 >= 7) AND (val_1 <= 9))
-(3 rows)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o_test_partition_index.val_1
+   ->  Custom Scan (o_scan) on o_test_partition_index_child2 o_test_partition_index
+         Bitmap heap scan
+         Recheck Cond: ((val_1 >= 7) AND (val_1 <= 9))
+         ->  Bitmap Index Scan on o_test_partition_index_child2_pkey
+               Index Cond: ((val_1 >= 7) AND (val_1 <= 9))
+(7 rows)
 
 SELECT * FROM o_test_partition_index WHERE val_1 BETWEEN 7 AND 9 ORDER BY val_1;
  val_1 | val_2 

--- a/test/expected/partition_2.out
+++ b/test/expected/partition_2.out
@@ -456,7 +456,7 @@ EXPLAIN (COSTS OFF)
    ->  Custom Scan (o_scan) on o_test_partition_index_child1 o_test_partition_index
          Bitmap heap scan
          Recheck Cond: ((val_1 >= 2) AND (val_1 <= 3))
-         ->  Bitmap Index Scan on o_test_partition_index_child1_pkey
+         ->  Bitmap Index Scan on o_test_partition_index_child1_ix1
                Index Cond: ((val_1 >= 2) AND (val_1 <= 3))
 (7 rows)
 
@@ -471,16 +471,12 @@ SELECT * FROM o_test_partition_index
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_partition_index
 		WHERE val_1 BETWEEN 7 AND 9 ORDER BY val_1;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Sort
-   Sort Key: o_test_partition_index.val_1
-   ->  Custom Scan (o_scan) on o_test_partition_index_child2 o_test_partition_index
-         Bitmap heap scan
-         Recheck Cond: ((val_1 >= 7) AND (val_1 <= 9))
-         ->  Bitmap Index Scan on o_test_partition_index_child2_pkey
-               Index Cond: ((val_1 >= 7) AND (val_1 <= 9))
-(7 rows)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_partition_index_child2 o_test_partition_index
+   Forward index scan of: o_test_partition_index_child2_pkey
+   Conds: ((val_1 >= 7) AND (val_1 <= 9))
+(3 rows)
 
 SELECT * FROM o_test_partition_index WHERE val_1 BETWEEN 7 AND 9 ORDER BY val_1;
  val_1 | val_2 

--- a/test/expected/primary_key.out
+++ b/test/expected/primary_key.out
@@ -98,12 +98,14 @@ SELECT payload FROM o_pk1 WHERE key = 19;
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{1,4,13,20}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
  key | payload 
@@ -114,12 +116,14 @@ SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
-                   QUERY PLAN                    
--------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{1,4,13,20}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key = 1) OR (key = 4) OR (key = 13) OR (key = 20))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
  key | payload 
@@ -130,12 +134,14 @@ SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
  key | payload 
@@ -156,12 +162,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
 (13 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
  key | payload 
@@ -182,12 +190,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
 (13 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
  key | payload 
@@ -209,12 +219,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
 (14 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
  key | payload 
@@ -236,12 +248,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
 (14 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
  key | payload 
@@ -251,12 +265,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
  key | payload 
@@ -267,12 +283,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
  key | payload 
@@ -283,12 +301,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
  key | payload 
@@ -300,12 +320,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
  key | payload 
@@ -313,12 +335,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
  key | payload 
@@ -326,12 +350,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
  key | payload 
@@ -339,12 +365,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
  key | payload 
@@ -352,12 +380,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
  key | payload 
@@ -368,12 +398,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
  key | payload 
@@ -385,12 +417,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
  key | payload 
@@ -401,12 +435,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key <= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key <= 19;
  key | payload 
@@ -843,12 +879,14 @@ SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4]);
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
-                 QUERY PLAN                 
---------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{4,10}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{4,10}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{4,10}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
  key | payload 
@@ -858,12 +896,14 @@ SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10, NULL]);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{4,10,NULL}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{4,10,NULL}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{4,10,NULL}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10, NULL]);
  key | payload 
@@ -910,12 +950,14 @@ SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10, NULL]);
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
-               QUERY PLAN                
------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
  key | payload 
@@ -924,12 +966,14 @@ SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
-                 QUERY PLAN                 
---------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4,10}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4,10}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4,10}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
  key | payload 
@@ -940,12 +984,14 @@ SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10, NULL]);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4,10,NULL}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4,10,NULL}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4,10,NULL}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10, NULL]);
  key | payload 

--- a/test/expected/primary_key_1.out
+++ b/test/expected/primary_key_1.out
@@ -98,12 +98,14 @@ SELECT payload FROM o_pk1 WHERE key = 19;
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{1,4,13,20}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
  key | payload 
@@ -114,12 +116,14 @@ SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
-                   QUERY PLAN                    
--------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{1,4,13,20}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key = 1) OR (key = 4) OR (key = 13) OR (key = 20))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
  key | payload 
@@ -130,12 +134,14 @@ SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
  key | payload 
@@ -156,12 +162,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
 (13 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
  key | payload 
@@ -182,12 +190,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
 (13 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
  key | payload 
@@ -209,12 +219,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
 (14 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
  key | payload 
@@ -236,12 +248,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
 (14 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
  key | payload 
@@ -251,12 +265,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
  key | payload 
@@ -267,12 +283,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
  key | payload 
@@ -283,12 +301,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
  key | payload 
@@ -300,12 +320,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
  key | payload 
@@ -313,12 +335,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
  key | payload 
@@ -326,12 +350,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
  key | payload 
@@ -339,12 +365,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
  key | payload 
@@ -352,12 +380,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
  key | payload 
@@ -368,12 +398,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
  key | payload 
@@ -385,12 +417,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
  key | payload 
@@ -401,12 +435,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key <= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key <= 19;
  key | payload 
@@ -843,12 +879,14 @@ SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4]);
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
-                 QUERY PLAN                 
---------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{4,10}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{4,10}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{4,10}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
  key | payload 
@@ -858,12 +896,14 @@ SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10, NULL]);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{4,10,NULL}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{4,10,NULL}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{4,10,NULL}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10, NULL]);
  key | payload 
@@ -910,12 +950,14 @@ SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10, NULL]);
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
-               QUERY PLAN                
------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
  key | payload 
@@ -924,12 +966,14 @@ SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
-                 QUERY PLAN                 
---------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4,10}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4,10}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4,10}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
  key | payload 
@@ -940,12 +984,14 @@ SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10, NULL]);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4,10,NULL}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4,10,NULL}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4,10,NULL}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10, NULL]);
  key | payload 

--- a/test/expected/primary_key_2.out
+++ b/test/expected/primary_key_2.out
@@ -98,12 +98,14 @@ SELECT payload FROM o_pk1 WHERE key = 19;
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{1,4,13,20}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
  key | payload 
@@ -114,12 +116,14 @@ SELECT * FROM o_pk1 WHERE key IN (1, 4, 13, 20);
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
-                   QUERY PLAN                    
--------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{1,4,13,20}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key = 1) OR (key = 4) OR (key = 13) OR (key = 20))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{1,4,13,20}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
  key | payload 
@@ -130,12 +134,14 @@ SELECT * FROM o_pk1 WHERE key = 1 OR key = 4 OR key = 13 OR key = 20;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
  key | payload 
@@ -156,12 +162,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key >  19;
 (13 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
  key | payload 
@@ -182,12 +190,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key >  19;
 (13 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
  key | payload 
@@ -209,12 +219,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key >= 19;
 (14 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
  key | payload 
@@ -236,12 +248,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key >= 19;
 (14 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
  key | payload 
@@ -251,12 +265,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key <  19;
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
  key | payload 
@@ -267,12 +283,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key <  19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key > 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key > 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
  key | payload 
@@ -283,12 +301,14 @@ SELECT * FROM o_pk1 WHERE key >  10 AND key <= 19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key >= 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key >= 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
  key | payload 
@@ -300,12 +320,14 @@ SELECT * FROM o_pk1 WHERE key >= 10 AND key <= 19;
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
  key | payload 
@@ -313,12 +335,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key >  19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key > 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key > 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key > 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
  key | payload 
@@ -326,12 +350,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key >  19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
  key | payload 
@@ -339,12 +365,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key >= 19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key >= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key >= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key >= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
  key | payload 
@@ -352,12 +380,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key >= 19;
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
-              QUERY PLAN              
---------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
  key | payload 
@@ -368,12 +398,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key <  19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key < 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key < 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key < 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
  key | payload 
@@ -385,12 +417,14 @@ SELECT * FROM o_pk1 WHERE key <= 10 AND key <  19;
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
-              QUERY PLAN               
----------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key < 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key < 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key < 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
  key | payload 
@@ -401,12 +435,14 @@ SELECT * FROM o_pk1 WHERE key <  10 AND key <= 19;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 AND key <= 19;
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: ((key <= 10) AND (key <= 19))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key <= 10) AND (key <= 19))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: ((key <= 10) AND (key <= 19))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 AND key <= 19;
  key | payload 
@@ -843,12 +879,14 @@ SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4]);
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
-                 QUERY PLAN                 
---------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{4,10}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{4,10}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{4,10}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
  key | payload 
@@ -858,12 +896,14 @@ SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10]);
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10, NULL]);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key = ANY ('{4,10,NULL}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key = ANY ('{4,10,NULL}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key = ANY ('{4,10,NULL}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key = ANY (ARRAY[4,10, NULL]);
  key | payload 
@@ -910,12 +950,14 @@ SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10, NULL]);
 (0 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
-               QUERY PLAN                
------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
  key | payload 
@@ -924,12 +966,14 @@ SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4]);
 (1 row)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
-                 QUERY PLAN                 
---------------------------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4,10}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4,10}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4,10}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
  key | payload 
@@ -940,12 +984,14 @@ SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10]);
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10, NULL]);
-                   QUERY PLAN                    
--------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
-   Forward index scan of: o_pk1_pkey
-   Conds: (key < ANY ('{4,10,NULL}'::integer[]))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (key < ANY ('{4,10,NULL}'::integer[]))
+   ->  Bitmap Index Scan on o_pk1_pkey
+         Index Cond: (key < ANY ('{4,10,NULL}'::integer[]))
+(5 rows)
 
 SELECT * FROM o_pk1 WHERE key < ANY (ARRAY[4,10, NULL]);
  key | payload 

--- a/test/expected/stats.out
+++ b/test/expected/stats.out
@@ -472,13 +472,15 @@ SET LOCAL enable_seqscan TO off;
 SET LOCAL enable_indexscan TO off;
 SET LOCAL enable_bitmapscan TO on;
 EXPLAIN (COSTS off) SELECT count(*) FROM test_last_scan WHERE idx_col = 1;
-                       QUERY PLAN                        
----------------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Aggregate
    ->  Custom Scan (o_scan) on test_last_scan
-         Forward index only scan of: test_last_scan_pkey
-         Conds: (idx_col = 1)
-(4 rows)
+         Bitmap heap scan
+         Recheck Cond: (idx_col = 1)
+         ->  Bitmap Index Scan on test_last_scan_pkey
+               Index Cond: (idx_col = 1)
+(6 rows)
 
 SELECT count(*) FROM test_last_scan WHERE idx_col = 1;
  count 
@@ -498,7 +500,7 @@ SELECT seq_scan, :'test_last_seq' = last_seq_scan AS seq_ok, idx_scan, :'test_la
 FROM pg_stat_all_tables WHERE relid = 'test_last_scan'::regclass;
  seq_scan | seq_ok | idx_scan | idx_ok 
 ----------+--------+----------+--------
-        2 | t      |        3 | t
+        2 | t      |        2 | f
 (1 row)
 
 -- pg_stat_have_stats returns true for committed index creation

--- a/test/expected/tableam.out
+++ b/test/expected/tableam.out
@@ -4954,8 +4954,55 @@ SELECT * FROM fktable;
 
 DROP TABLE fktable;
 DROP TABLE pktable;
+CREATE TABLE o_test_lockstep
+(
+	a int8 NOT NULL,
+	b int8 NOT NULL,
+	PRIMARY KEY(a,b)
+) USING orioledb;
+INSERT INTO o_test_lockstep SELECT t, t FROM generate_series(1, 1000) t;
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+ count 
+-------
+    16
+(1 row)
+
+SELECT * FROM o_test_lockstep WHERE a in (1000, 1);
+  a   |  b   
+------+------
+    1 |    1
+ 1000 | 1000
+(2 rows)
+
+SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+    1 |    1
+(2 rows)
+
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 17 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table o_tableam6
 drop cascades to table o_tableam_join1
 drop cascades to table o_tableam_cte_base
@@ -4971,6 +5018,7 @@ drop cascades to table o_ctid_test
 drop cascades to table o_test_split_rightmost
 drop cascades to table o_test_cursor_snapshot
 drop cascades to table size_test
+drop cascades to table o_test_lockstep
 drop cascades to view db_o_tables
 drop cascades to view db_o_indices
 DROP SCHEMA tableam CASCADE;

--- a/test/expected/tableam_1.out
+++ b/test/expected/tableam_1.out
@@ -4958,8 +4958,55 @@ SELECT * FROM fktable;
 
 DROP TABLE fktable;
 DROP TABLE pktable;
+CREATE TABLE o_test_lockstep
+(
+	a int8 NOT NULL,
+	b int8 NOT NULL,
+	PRIMARY KEY(a,b)
+) USING orioledb;
+INSERT INTO o_test_lockstep SELECT t, t FROM generate_series(1, 1000) t;
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+ count 
+-------
+    16
+(1 row)
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+ count 
+-------
+    16
+(1 row)
+
+SELECT * FROM o_test_lockstep WHERE a in (1000, 1);
+  a   |  b   
+------+------
+    1 |    1
+ 1000 | 1000
+(2 rows)
+
+SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+    1 |    1
+(2 rows)
+
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 17 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table o_tableam6
 drop cascades to table o_tableam_join1
 drop cascades to table o_tableam_cte_base
@@ -4975,6 +5022,7 @@ drop cascades to table o_ctid_test
 drop cascades to table o_test_split_rightmost
 drop cascades to table o_test_cursor_snapshot
 drop cascades to table size_test
+drop cascades to table o_test_lockstep
 drop cascades to view db_o_tables
 drop cascades to view db_o_indices
 DROP SCHEMA tableam CASCADE;

--- a/test/sql/bitmap_scan.sql
+++ b/test/sql/bitmap_scan.sql
@@ -1397,6 +1397,43 @@ END $$;
 DROP TABLE bitmap_jump_test;
 DROP TABLE bitmap_jump_ctest;
 
+-- Covering primary key (INCLUDE columns, incl. a by-ref type): the fixed-key
+-- bitmap must build the seek key from the ordering columns only and leave the
+-- INCLUDE columns out, or it would form a tuple over uninitialized values.
+-- Row-comparison range that indexes on the leading key columns.  Result must
+-- match a sequential scan.
+CREATE TABLE bitmap_cover_test (c1 int, c2 int, c3 int, c4 box,
+	CONSTRAINT bitmap_cover_pk PRIMARY KEY (c1, c2) INCLUDE (c3, c4))
+	USING orioledb;
+INSERT INTO bitmap_cover_test
+	SELECT 1, 2, 3 * x, box('4,4,4,4') FROM generate_series(1, 10) x
+	ON CONFLICT DO NOTHING;
+INSERT INTO bitmap_cover_test
+	SELECT x, 2 * x, NULL, NULL FROM generate_series(1, 300) x
+	ON CONFLICT DO NOTHING;
+ANALYZE bitmap_cover_test;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*) INTO bmp_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SET LOCAL enable_indexscan = off;
+	SELECT count(*) INTO seq_cnt FROM bitmap_cover_test
+		WHERE (c1, c2, c3) < (2, 5, 1);
+	IF bmp_cnt <> seq_cnt THEN
+		RAISE EXCEPTION 'covering-pk bitmap mismatch: bmp=% seq=%',
+			bmp_cnt, seq_cnt;
+	END IF;
+END $$;
+DROP TABLE bitmap_cover_test;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA bitmap_scan CASCADE;
 RESET search_path;

--- a/test/sql/bitmap_scan.sql
+++ b/test/sql/bitmap_scan.sql
@@ -1343,6 +1343,60 @@ SELECT * FROM bitmap_test_complex WHERE val IN ('13!', 'b');
 EXPLAIN (COSTS OFF) SELECT * FROM bitmap_test_complex WHERE val < '13!';
 SELECT * FROM bitmap_test_complex WHERE val < '13!';
 
+-- A bitmap scan skips internal pages that hold no wanted keys by descending
+-- straight to the next needed key.  Check it returns exactly the same rows as
+-- a plain scan for keys scattered across a table spanning several pages, for
+-- both a single-column and a composite primary key.  Raises on any mismatch.
+CREATE TABLE bitmap_jump_test (id int8 PRIMARY KEY, v int8) USING orioledb;
+INSERT INTO bitmap_jump_test
+	SELECT g, g * 7 % 100000 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_test;
+CREATE TABLE bitmap_jump_ctest (a int4, b int4, x int8, PRIMARY KEY (a, b))
+	USING orioledb;
+INSERT INTO bitmap_jump_ctest
+	SELECT g / 200, g % 200, g * 3 FROM generate_series(1, 20000) g;
+ANALYZE bitmap_jump_ctest;
+DO $$
+DECLARE
+	bmp_cnt		bigint;
+	seq_cnt		bigint;
+	bmp_sum		bigint;
+	seq_sum		bigint;
+BEGIN
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(v), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(v), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_test
+		WHERE id IN (1, 3000, 6000, 9000, 12000, 15000, 18000, 20000, 7777, 13131);
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'single-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+
+	SET LOCAL enable_seqscan = off;
+	SET LOCAL enable_bitmapscan = on;
+	SELECT count(*), coalesce(sum(x), 0) INTO bmp_cnt, bmp_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	SET LOCAL enable_seqscan = on;
+	SET LOCAL enable_bitmapscan = off;
+	SELECT count(*), coalesce(sum(x), 0) INTO seq_cnt, seq_sum
+		FROM bitmap_jump_ctest
+		WHERE (a, b) IN ((0, 5), (25, 100), (50, 199), (75, 1), (99, 199));
+	IF bmp_cnt <> seq_cnt OR bmp_sum <> seq_sum THEN
+		RAISE EXCEPTION 'composite-key bitmap jump mismatch: bmp=(%,%) seq=(%,%)',
+			bmp_cnt, bmp_sum, seq_cnt, seq_sum;
+	END IF;
+END $$;
+DROP TABLE bitmap_jump_test;
+DROP TABLE bitmap_jump_ctest;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA bitmap_scan CASCADE;
 RESET search_path;

--- a/test/sql/bitmap_scan.sql
+++ b/test/sql/bitmap_scan.sql
@@ -1236,6 +1236,19 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
 SELECT * FROM bitmap_test_multi WHERE i < 100 ORDER BY i LIMIT 20;
 
+-- Row-array IN() over a composite primary key: planned as a BitmapOr of
+-- per-tuple primary-index scans (the shape that was slow in TPCC delivery).
+-- The result must match a sequential scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM bitmap_test_multi
+		WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+SET enable_bitmapscan = off;
+SELECT count(*) FROM bitmap_test_multi
+	WHERE (id, id2) IN ((100001, 100001), (100050, 100050), (104000, 104000));
+SET enable_bitmapscan = on;
+
 CREATE SEQUENCE bitmap_test_multi_inval_id2_seq AS integer;
 
 -- Test multi column some not valid bitmap

--- a/test/sql/tableam.sql
+++ b/test/sql/tableam.sql
@@ -1047,6 +1047,23 @@ UPDATE pktable SET a = '0' WHERE a = '-0';
 SELECT * FROM fktable;
 DROP TABLE fktable;
 DROP TABLE pktable;
+CREATE TABLE o_test_lockstep
+(
+	a int8 NOT NULL,
+	b int8 NOT NULL,
+	PRIMARY KEY(a,b)
+) USING orioledb;
+
+INSERT INTO o_test_lockstep SELECT t, t FROM generate_series(1, 1000) t;
+
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+SELECT COUNT(*) FROM o_test_lockstep WHERE a in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17) AND
+										   b in (1,2,3,4,5,6,7,8,9,10,12,13,14,15,16,17);
+SELECT * FROM o_test_lockstep WHERE a in (1000, 1);
+SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
 
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA tableam CASCADE;


### PR DESCRIPTION
## Summary

Reimplements the orioledb bitmap-scan key set on top of PostgreSQL's
adaptive radix tree (instead of a bespoke red-black tree) and extends
bitmap scans to **composite primary keys** — including row-array `IN()`
on the primary key, the shape that degraded to whole-warehouse scans in
TPCC delivery.

## What's here

- **`include/lib/o_radixtree.h`** — vendored copy of PG's `lib/radixtree.h`
  extended with an optional `RT_KEY_SIZE`: when defined, the tree is keyed
  by a fixed-length big-endian byte string instead of a `uint64`, keeping
  the adaptive-node machinery untouched. Vendoring also supplies the
  template on PG16.
- **`key_bitmap.c`** — the densified uint64 chunk map now lives in a radix
  tree (behaviour-equivalent to the old rbtree); a second, fixed-key mode
  stores whole order-preserving encoded keys for composite PKs. Ordered
  seeks come from a sorted key array built lazily once the bitmap stops
  being mutated. Handle type is the opaque `OKeyBitmap`.
- **`bitmap_scan.c`** — order-preserving encode/decode of integer PK
  columns (int2/int4/int8, ascending, INCLUDE columns excluded);
  `o_keybitmap_pk_mode()` classifies a PK (uint64 / fixed / ineligible)
  and is shared by planner and executor. Bitmap index scans over the
  primary index itself are now supported, so `(a,b,…) IN (...)` on a
  composite PK is planned as a `BitmapOr` of per-tuple primary-index
  scans — on a large table ~20x faster than the common-prefix scan, while
  selective single-key quals still use an index scan on default costs.
- **`radix_selftest.c`** — dev-only SQL self-tests for the fixed-key radix
  tree, the encoding, and the fixed-key set.
- **`bitmap_scan`** regression test gains a composite-PK row-array `IN()`
  case checked against a sequential scan.

`make regresscheck` 46/46 and `make isolationcheck` 31/31 pass locally
(PG17). All 7 touched regression tests changed only *plans*, not results.

## Follow-ups (to polish via CI)

- Only the **PG17** expected variants were regenerated locally
  (`*_1.out` / `stats.out`); the PG16 and PG18 variants of the same 7
  tests will show the identical plan changes and should be updated from CI.
- **Cost refinement:** on very small / unanalyzed tables the bitmap-heap
  path can still be chosen over an index scan because core
  `cost_bitmap_heap_scan` models a random heap fetch rather than
  orioledb's primary-index scan. Making that exact needs a patched-PG
  cost change.

---

## Update — read efficiency & array-scan reuse

Further commits on this branch make the scan itself cheaper, not just the plan choice.

### Partial (FETCH-mode) page reads
- Bitmap scans read only the needed chunks of a leaf and skip empty internal
  pages via bitmap-driven descent, instead of copying whole page images into
  local memory. Includes a fix for partial-state leaking across leaves (which
  re-emitted rows), a crash fix for a composite seek key over a covering
  primary key, and unifying the seq-scan `getNextKey` / `getNextPageKey`
  callbacks.

### Array-scan iterator reuse (`btree/iterator.c`, `tableam/index_scan.c`, `tableam/key_range.c`)
- An ordered `col = ANY(array)` / `col IN (...)` scan now reuses a single
  iterator — and its already-loaded page — across array elements, instead of
  re-descending from the root for every element. Adds
  `o_btree_iterator_advance()` (range path) and
  `o_btree_find_tuples_start()` / `o_btree_find_tuples_continue()` (exact-key
  path). Inspired by #647.
- Caches the "not coercible" fact for bound values
  (`O_VALUE_BOUND_NON_COERCIBLE`) to avoid repeated `IsBinaryCoercible()`
  calls that `perf` showed were significant.
- **Optimistic next-item check:** when the next matching tuple is the item the
  scan is already positioned on (adjacent / dense arrays), skip the per-key
  binary search; sparse gaps, chunk crossings and backward scans fall through
  to the search unchanged.

### Streaming primary bitmap scans (`tableam/bitmap_scan.c`, `tableam/key_bitmap.c`)
- A single primary `BitmapIndexScan`, or a `BitmapOr` of only such scans (the
  composite-PK row-array `(a,b,c) IN (...)` shape TPCC delivery uses), is now
  executed by driving the primary index scan(s) directly and handing their
  **live** tuples to the output — instead of materializing a key bitmap and
  re-reading the primary tree. Full orioledb row identity (csn / hint / rowid)
  is preserved, so row locking, EPQ, foreign keys and toast behave exactly as
  the second-pass path, and the second pass over the primary tree is removed.
- A `BitmapOr`'s branches can yield the same pk (overlapping / duplicate
  row-tuples, which the planner does not dedup), so a dedup key bitmap carries
  an "already-emitted" bit (`o_keybitmap_emit()` / `o_keybitmap_emit_key()`).
  Any other shape (`BitmapAnd`, a non-primary or bridged branch) falls back to
  the existing key-bitmap build.
- This also softens the cost follow-up above: for a primary bitmap scan the
  expensive second pass no longer happens, so choosing the bitmap-heap path is
  much closer to an index scan in practice.

### Benchmarks (VM, release build, sysbench / go-tpc)
- sysbench `id IN (50001..50100)` on 1M rows: **+14–19%** vs the key-bitmap
  path, reaching **~86–92% of heap** (was ~74–80%).
- Composite-PK row-array `IN` (TPCC delivery shape): **+14%**, reaching
  **~93–97% of heap** (was ~82–85%).
- go-tpc TPC-C tpm (w=22): **flat, no regression** — the row-array `IN`
  delivery `SELECT` is a small, non-bottleneck fraction of the transaction mix.

`make regresscheck` 46/46 and `make isolationcheck` 31/31 still pass (PG17),
verified against a sequential-scan baseline for overlapping / duplicate `OR`
branches and composite-PK row-array `IN`.
