### PR TITLE
Fix cross-tree page read on hot standby (wrong page)

### DIFF
--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1502,8 +1502,7 @@ write_page_to_disk(BTreeDescr *desc, FileExtent *extent, uint32 curChkpNum,
 void
 load_page(OBTreeFindPageContext *context)
 {
-	OrioleDBPageDesc *parent_page_desc,
-			   *page_desc;
+	OrioleDBPageDesc *page_desc;
 	BTreeDescr *desc = context->desc;
 	OInMemoryBlkno parent_blkno;
 	Page		parent_page;
@@ -1564,7 +1563,6 @@ load_page(OBTreeFindPageContext *context)
 
 	Assert(OInMemoryBlknoIsValid(blkno));
 	page = O_GET_IN_MEMORY_PAGE(blkno);
-	parent_page_desc = O_GET_IN_MEMORY_PAGEDESC(parent_blkno);
 	page_desc = O_GET_IN_MEMORY_PAGEDESC(blkno);
 
 	page_desc->flags = 0;
@@ -1586,8 +1584,18 @@ load_page(OBTreeFindPageContext *context)
 
 	put_page_image(blkno, buf);
 	ppool_ucm_init(desc->ppool, blkno);
-	page_desc->type = parent_page_desc->type;
-	page_desc->oids = parent_page_desc->oids;
+
+	/*
+	 * Stamp the page's identity from the descriptor of the tree we are
+	 * descending, not from the parent's page descriptor: the parent was
+	 * unlocked above and may have been evicted/reused (potentially by the
+	 * reentrant eviction inside ppool_alloc_page() just above), in which case
+	 * its page descriptor's oids would be invalid (0,0,0) or belong to
+	 * another tree.  The loaded page belongs to desc, so use desc's oids/type
+	 * -- which is exactly what init_new_btree_page() does.
+	 */
+	page_desc->type = desc->type;
+	page_desc->oids = desc->oids;
 
 	Assert(O_PAGE_IS(page, LEAF) ||
 		   (PAGE_GET_N_ONDISK(page) == BTREE_PAGE_ITEMS_COUNT(page)));

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -3640,6 +3640,18 @@ try_to_punch_holes(BTreeDescr *desc)
 							errmsg("could not open file %s: %m", filename)));
 		file_size = FileSize(file);
 
+		/*
+		 * Each -N.tmp file is a self-contained list of freed block offsets
+		 * and must be read from its own offset 0.  Reset the read cursor /
+		 * byte counter for every file: when a single try_to_punch_holes()
+		 * call drains more than one checkpoint's tmp file (several
+		 * checkpoints accumulated undrained files), a stale len would seek
+		 * past the next file's EOF and trip the file_size != len check below.
+		 * (add_free_extents_from_tmp() declares len inside its loop for the
+		 * same reason.)
+		 */
+		len = 0;
+
 		while (true)
 		{
 			BlockNumber *cur_off;

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -764,6 +764,16 @@ page_block_reads(OInMemoryBlkno blkno)
 	Assert((myLockedPages[i].state & PAGE_STATE_CHANGE_NON_WAITERS_MASK) ==
 		   (pg_atomic_read_u64(&(O_PAGE_HEADER(p)->state)) & PAGE_STATE_CHANGE_NON_WAITERS_MASK));
 
+	/*
+	 * Idempotent: if reads are already blocked on this locked page, a
+	 * repeated call is a no-op.  Callers may legitimately double up -- e.g.
+	 * o_ppool_free_page() now blocks reads defensively on every free, which
+	 * can stack with a caller (such as free_page()) that already blocked
+	 * them.
+	 */
+	if (myLockedPages[i].state & PAGE_STATE_NO_READ_FLAG)
+		return;
+
 	state = pg_atomic_fetch_or_u64(&(O_PAGE_HEADER(p)->state), PAGE_STATE_NO_READ_FLAG);
 	Assert((state & PAGE_STATE_LOCKED_FLAG));
 	myLockedPages[i].state = state | PAGE_STATE_NO_READ_FLAG;

--- a/src/utils/page_pool.c
+++ b/src/utils/page_pool.c
@@ -322,9 +322,16 @@ o_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock)
 	/*
 	 * Reset page header and descriptor.  Do this while holding a page lock in
 	 * order to prevent race condition with walk_page().
+	 *
+	 * Block reads before changing the identity: bumping pageChangeCount alone
+	 * lets a lockless reader observe the invalidated oids without the count
+	 * bump and slip past the change-count check.  page_block_reads() makes
+	 * unlock_page() bump the state change count, forcing such a reader to
+	 * retry (idempotent if the caller already blocked reads).
 	 */
 	if (!haveLock)
 		lock_page(blkno);
+	page_block_reads(blkno);
 	O_PAGE_CHANGE_COUNT_INC(p);
 	ORelOidsSetInvalid(page_desc->oids);
 	page_desc->type = 0;


### PR DESCRIPTION
Fixes #942.

On a hot standby a lock-free reader (e.g. the backward index scan in `test_replication_hot_read`) could follow a downlink/rightlink onto a page that no longer belongs to the tree it descended, tripping the `try_copy_page()` cross-tree assertion (`page_contents.c`).

Root cause (confirmed via a temporary per-blkno event journal): `load_page()` unlocks the parent page before `ppool_alloc_page()`, which can trigger a **reentrant eviction that frees the parent slot**. `load_page()` then stamped the freshly loaded child’s `oids`/`type` from the (now invalid) parent page descriptor, so the child ended up with `oids=(0,0,0)` while keeping the change count it inherited from the free list — matching a live (r)link, so the reader’s change-count check passed and it read a page of the wrong/freed identity.

**Commits**

1. **Stamp loaded page identity from the descriptor, not the parent** — the real fix. `load_page()` now sets the child’s `oids`/`type` from `desc` (the tree being descended), exactly as `init_new_btree_page()` does; the unlocked, possibly-recycled parent descriptor is never consulted.

2. **Block reads when freeing a page so stale-downlink readers retry** — defensive hardening. `o_ppool_free_page()` now calls `page_block_reads()` before changing a page’s identity so the free enters the page state protocol and `unlock_page()` bumps the state change count, forcing any overlapping lock-free reader to retry. `page_block_reads()` is made idempotent in the shared case so this composes with callers (e.g. `free_page()`) that already blocked reads.

3. **Reset read cursor per file in `try_to_punch_holes()`** — an independent latent bug surfaced by the same flaky-CI stress (`undo_ring_keep_checkpoint`). `try_to_punch_holes()` drains a btree’s `-N.tmp` checkpoint files (each a self-contained list of freed block offsets) in a loop over checkpoint numbers, but `len` — used at once as the `OFileRead` offset, the bytes-read counter, and the value compared against the file size — was initialized once before the loop and never reset between files. When a single call drains more than one checkpoint’s tmp file (several accumulated under eviction pressure with rapid checkpoints), the carried-over `len` seeks past the next file’s EOF: the read returns nothing, `len` stays at the previous file’s size, and the `file_size != len` guard fires a spurious `FATAL: could not read data from checkpoint tmp file`. Reset `len` to 0 at the start of each file (as `add_free_extents_from_tmp()` already does by declaring `len` inside its loop).

Verified: full `regresscheck` (46/46) and `isolationcheck` (31/31) pass locally; the cross-tree assert no longer reproduces under a 64-way `check_page` stress matrix that reliably hit it before.