### PR TITLE
Remove empty orioledb_data directory after DROP DATABASE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ OBJS = src/btree/btree.o \
 	   src/catalog/o_sys_cache.o \
 	   src/catalog/o_tables.o \
 	   src/catalog/o_type_cache.o \
-	   src/catalog/o_tablespace_cache.o \
+	   src/catalog/o_tablespaces.o \
 	   src/catalog/sys_trees.o \
 	   src/checkpoint/checkpoint.o \
 	   src/checkpoint/control.o \

--- a/include/catalog/o_sys_cache.h
+++ b/include/catalog/o_sys_cache.h
@@ -662,7 +662,4 @@ o_set_sys_cache_search_datoid(Oid datoid)
 	}
 }
 
-extern void o_get_prefixes_for_tablespace(Oid datoid, Oid tablespace,
-										  char **prefix, char **db_prefix);
-
 #endif							/* __O_SYS_CACHE_H__ */

--- a/include/catalog/o_tablespaces.h
+++ b/include/catalog/o_tablespaces.h
@@ -1,0 +1,20 @@
+/*-------------------------------------------------------------------------
+ *
+ * o_tablespaces.h
+ * 		Declarations for tablespace data directory routines.
+ *
+ * Copyright (c) 2021-2026, Oriole DB Inc.
+ * Copyright (c) 2025-2026, Supabase Inc.
+ *
+ * IDENTIFICATION
+ *	  contrib/orioledb/include/catalog/o_tablespaces.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef __O_TABLESPACES_H__
+#define __O_TABLESPACES_H__
+
+extern void o_get_prefixes_for_tablespace(Oid datoid, Oid tablespace,
+										  char **prefix, char **db_prefix);
+
+#endif							/* __O_TABLESPACES_H__ */

--- a/include/catalog/o_tablespaces.h
+++ b/include/catalog/o_tablespaces.h
@@ -17,4 +17,12 @@
 extern void o_get_prefixes_for_tablespace(Oid datoid, Oid tablespace,
 										  char **prefix, char **db_prefix);
 
+/* callback for o_tablespaces_foreach_prefix() */
+typedef void (*OTablespacesPrefixCallback) (Oid tablespace,
+											const char *prefix,
+											void *arg);
+
+extern void o_tablespaces_foreach_prefix(OTablespacesPrefixCallback callback,
+										 void *arg);
+
 #endif							/* __O_TABLESPACES_H__ */

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -578,6 +578,7 @@ extern bool o_in_add_column;
 
 extern void orioledb_setup_ddl_hooks(void);
 extern void o_ddl_cleanup(void);
+extern void orioledb_drop_database_xact_callback(XactEvent event, void *arg);
 
 /* scan.c */
 extern CustomScanMethods o_scan_methods;

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -29,7 +29,7 @@
 #include "btree/undo.h"
 #include "checkpoint/checkpoint.h"
 #include "catalog/free_extents.h"
-#include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "recovery/recovery.h"
 #include "s3/headers.h"
 #include "s3/worker.h"

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -3007,7 +3007,7 @@ drop_bridge_index(Relation tbl, OTable *o_table)
 }
 
 static void
-cleanup_tablespace_dir(char *tablespace_path)
+cleanup_tablespace_dir(const char *tablespace_path)
 {
 	DIR		   *dir;
 	struct dirent *file;
@@ -3054,6 +3054,15 @@ cleanup_tablespace_dir(char *tablespace_path)
 						errmsg("unable to clean up orioledb tablespace: %m")));
 	}
 	closedir(dir);
+}
+
+static void
+cleanup_tablespace_dir_cb(Oid tablespace, const char *prefix,
+						  void *arg)
+{
+	if (tablespace == DEFAULTTABLESPACE_OID)
+		return;
+	cleanup_tablespace_dir(prefix);
 }
 
 /*
@@ -4563,64 +4572,7 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 	}
 	else if (access == OAT_DROP && classId == TableSpaceRelationId)
 	{
-		DIR		   *dir;
-		char		path[MAXPGPATH];
-		char		targetpath[MAXPGPATH];
-		struct dirent *file;
-
-#define PG_TBLSPC "pg_tblspc"
-
-		dir = opendir(PG_TBLSPC);
-		while (errno = 0, (file = readdir(dir)) != NULL)
-		{
-			struct stat st;
-			int			rllen;
-
-			/* Skip special stuff */
-			if (strcmp(file->d_name, ".") == 0 || strcmp(file->d_name, "..") == 0)
-				continue;
-
-			path[0] = '\0';
-			pg_snprintf(path, MAXPGPATH,
-						PG_TBLSPC "/%s/" TABLESPACE_VERSION_DIRECTORY,
-						file->d_name);
-			if (lstat(path, &st) < 0)
-			{
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not stat file \"%s\": %m",
-								file->d_name)));
-			}
-
-			if (!S_ISLNK(st.st_mode))
-			{
-				strlcat(path, "/" ORIOLEDB_DATA_DIR, MAXPGPATH);
-				cleanup_tablespace_dir(path);
-			}
-			else
-			{
-				rllen = readlink(path, targetpath, sizeof(targetpath));
-				if (rllen < 0)
-					ereport(ERROR,
-							(errcode_for_file_access(),
-							 errmsg("could not read symbolic link \"%s\": %m",
-									path)));
-				if (rllen >= sizeof(targetpath))
-					ereport(ERROR,
-							(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-							 errmsg("symbolic link \"%s\" target is too long",
-									path)));
-				targetpath[rllen] = '\0';
-
-				path[0] = '\0';
-				pg_snprintf(path, MAXPGPATH,
-							"%s/" ORIOLEDB_DATA_DIR,
-							targetpath);
-				cleanup_tablespace_dir(path);
-			}
-		}
-		closedir(dir);
-#undef PG_TBLSPC
+		o_tablespaces_foreach_prefix(cleanup_tablespace_dir_cb, NULL);
 	}
 
 #if PG_VERSION_NUM >= 180000

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -141,6 +141,8 @@ static CreateStmt *create_stmt = NULL;
 static List *o_added_columns = NIL;
 static movedb_params o_movedb_data = {InvalidOid, InvalidOid, InvalidOid};
 
+static Oid	dropped_database_oid = InvalidOid;
+
 static void orioledb_utility_command(PlannedStmt *pstmt,
 									 const char *queryString,
 									 bool readOnlyTree,
@@ -3065,6 +3067,41 @@ cleanup_tablespace_dir_cb(Oid tablespace, const char *prefix,
 	cleanup_tablespace_dir(prefix);
 }
 
+static void
+rmdir_dropped_database_cb(Oid tablespace, const char *prefix, void *arg)
+{
+	Oid			dbOid = *((Oid *) arg);
+	char		path[MAXPGPATH];
+
+	pg_snprintf(path, MAXPGPATH, "%s/%u", prefix, dbOid);
+	if (rmdir(path) < 0 && errno != ENOENT && errno != ENOTEMPTY)
+		ereport(WARNING,
+				(errcode_for_file_access(),
+				 errmsg("could not remove orioledb database directory \"%s\": %m",
+						path)));
+}
+
+static void
+cleanup_dropped_database_dirs(void)
+{
+	Oid			dbOid = dropped_database_oid;
+
+	if (!OidIsValid(dbOid))
+		return;
+
+	o_tablespaces_foreach_prefix(rmdir_dropped_database_cb, &dbOid);
+	dropped_database_oid = InvalidOid;
+}
+
+void
+orioledb_drop_database_xact_callback(XactEvent event, void *arg)
+{
+	if (event == XACT_EVENT_COMMIT)
+		cleanup_dropped_database_dirs();
+	else if (event == XACT_EVENT_ABORT)
+		dropped_database_oid = InvalidOid;
+}
+
 /*
  * get_collation		- fetch qualified name of a collation
  *
@@ -3434,6 +3471,8 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 		o_tables_table_meta_lock(NULL);
 		o_tables_drop_all(oxid, oSnapshot.csn, objectId);
 		o_tables_table_meta_unlock(NULL, InvalidOid);
+
+		dropped_database_oid = objectId;
 	}
 	else if (access == OAT_DROP && classId == TypeRelationId &&
 			 ActiveSnapshotSet())

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -42,6 +42,7 @@
 #include "catalog/heap.h"
 #include "catalog/index.h"
 #include "catalog/namespace.h"
+#include "catalog/o_tablespaces.h"
 #include "catalog/objectaccess.h"
 #include "catalog/pg_attrdef.h"
 #include "catalog/pg_authid.h"

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -22,6 +22,7 @@
 #include "checkpoint/checkpoint.h"
 #include "catalog/indices.h"
 #include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "recovery/recovery.h"
 #include "recovery/internal.h"
 #include "recovery/wal.h"

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -22,6 +22,7 @@
 #include "catalog/o_indices.h"
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "catalog/pg_amop.h"
 #include "postgres_ext.h"
 #include "recovery/recovery.h"

--- a/src/catalog/o_tablespaces.c
+++ b/src/catalog/o_tablespaces.c
@@ -1,13 +1,13 @@
 /*-------------------------------------------------------------------------
  *
- * o_tablespace_cache.c
- * 		Routines to get tablespace path for relnode
+ * o_tablespaces.c
+ * 		Tablespace data directory routines
  *
  * Copyright (c) 2021-2026, Oriole DB Inc.
  * Copyright (c) 2025-2026, Supabase Inc.
  *
  * IDENTIFICATION
- *	  contrib/orioledb/src/catalog/o_tablespace_cache.c
+ *	  contrib/orioledb/src/catalog/o_tablespaces.c
  *
  *-------------------------------------------------------------------------
  */
@@ -17,7 +17,7 @@
 #include "orioledb.h"
 
 #include "btree/undo.h"
-#include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "tableam/descr.h"
 
 #include "catalog/pg_tablespace_d.h"

--- a/src/catalog/o_tablespaces.c
+++ b/src/catalog/o_tablespaces.c
@@ -25,9 +25,16 @@
 #include "recovery/recovery.h"
 #include "utils/syscache.h"
 
+#include <sys/stat.h>
+#include <unistd.h>
+
 /* Silent cppcheck */
 #ifndef TABLESPACE_VERSION_DIRECTORY
 #define TABLESPACE_VERSION_DIRECTORY
+#endif
+
+#ifndef PG_TBLSPC_DIR
+#define PG_TBLSPC_DIR "pg_tblspc"
 #endif
 
 void
@@ -59,4 +66,76 @@ o_get_prefixes_for_tablespace(Oid datoid, Oid tablespace,
 		*prefix = pathbuf;
 	if (db_prefix)
 		*db_prefix = psprintf("%s/%u", pathbuf, datoid);
+}
+
+void
+o_tablespaces_foreach_prefix(OTablespacesPrefixCallback callback, void *arg)
+{
+	DIR		   *dir;
+	char		path[MAXPGPATH];
+	char		targetpath[MAXPGPATH];
+	struct dirent *file;
+	struct stat st;
+	int			rllen;
+	Oid			tablespace;
+
+	path[0] = '\0';
+	strlcat(path, ORIOLEDB_DATA_DIR, MAXPGPATH);
+	callback(DEFAULTTABLESPACE_OID, path, arg);
+
+	dir = opendir(PG_TBLSPC_DIR);
+	if (dir == NULL)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open directory \"%s\": %m",
+						PG_TBLSPC_DIR)));
+
+	while (errno = 0, (file = readdir(dir)) != NULL)
+	{
+		if (strcmp(file->d_name, ".") == 0 ||
+			strcmp(file->d_name, "..") == 0)
+			continue;
+
+		tablespace = pg_strtoint64(file->d_name);
+		Assert(OidIsValid(tablespace));
+
+		path[0] = '\0';
+		pg_snprintf(path, MAXPGPATH,
+					PG_TBLSPC_DIR "/%s/" TABLESPACE_VERSION_DIRECTORY,
+					file->d_name);
+		if (lstat(path, &st) < 0)
+		{
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not stat file \"%s\": %m",
+							file->d_name)));
+		}
+
+		if (!S_ISLNK(st.st_mode))
+		{
+			strlcat(path, "/" ORIOLEDB_DATA_DIR, MAXPGPATH);
+		}
+		else
+		{
+			rllen = readlink(path, targetpath, sizeof(targetpath));
+			if (rllen < 0)
+				ereport(ERROR,
+						(errcode_for_file_access(),
+						 errmsg("could not read symbolic link \"%s\": %m",
+								path)));
+			if (rllen >= (int) sizeof(targetpath))
+				ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						 errmsg("symbolic link \"%s\" target is too long",
+								path)));
+			targetpath[rllen] = '\0';
+
+			path[0] = '\0';
+			pg_snprintf(path, MAXPGPATH,
+						"%s/" ORIOLEDB_DATA_DIR,
+						targetpath);
+		}
+		callback(tablespace, path, arg);
+	}
+	closedir(dir);
 }

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -33,6 +33,7 @@
 #include "catalog/o_indices.h"
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "catalog/sys_trees.h"
 #include "checkpoint/checkpoint.h"
 #include "checkpoint/control.h"

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -1262,6 +1262,7 @@ _PG_init(void)
 	AcceptInvalidationMessagesHook = orioledb_AcceptInvalidationMessagesHook;
 	set_rel_pathlist_hook = orioledb_set_rel_pathlist_hook;
 	set_plain_rel_pathlist_hook = orioledb_set_plain_rel_pathlist_hook;
+	RegisterXactCallback(orioledb_drop_database_xact_callback, NULL);
 	RegisterXactCallback(undo_xact_callback, NULL);
 	RegisterSubXactCallback(undo_subxact_callback, NULL);
 	get_xidless_commit_lsn_hook = orioledb_get_xidless_commit_lsn;

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -3307,7 +3307,8 @@ worker_wait_shutdown(RecoveryWorkerState *worker)
 }
 
 static void
-cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
+cleanup_tablespace_old_files(const char *path, uint32 chkp_num,
+							 bool before_recovery)
 {
 	DIR		   *dir,
 			   *dbDir;
@@ -3460,74 +3461,31 @@ cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
 	closedir(dir);
 }
 
+typedef struct CleanupOldFilesArg
+{
+	uint32		chkp_num;
+	bool		before_recovery;
+} CleanupOldFilesArg;
+
+static void
+cleanup_old_files_cb(Oid tablespace, const char *prefix, void *arg)
+{
+	CleanupOldFilesArg *c = (CleanupOldFilesArg *) arg;
+
+	cleanup_tablespace_old_files(prefix, c->chkp_num, c->before_recovery);
+}
+
 void
 recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 {
-	DIR		   *dir;
-	char		path[MAXPGPATH];
-	char		targetpath[MAXPGPATH];
-	struct dirent *file;
-
-#define PG_TBLSPC "pg_tblspc"
+	CleanupOldFilesArg arg;
 
 	if (!before_recovery && chkp_num == 0)
 		return;
 
-	path[0] = '\0';
-	strlcat(path, ORIOLEDB_DATA_DIR, MAXPGPATH);
-	cleanup_tablespace_old_files(path, chkp_num, before_recovery);
-
-	dir = opendir(PG_TBLSPC);
-	while (errno = 0, (file = readdir(dir)) != NULL)
-	{
-		struct stat st;
-		int			rllen;
-
-		/* Skip special stuff */
-		if (strcmp(file->d_name, ".") == 0 || strcmp(file->d_name, "..") == 0)
-			continue;
-
-		path[0] = '\0';
-		pg_snprintf(path, MAXPGPATH,
-					PG_TBLSPC "/%s/" TABLESPACE_VERSION_DIRECTORY,
-					file->d_name);
-		if (lstat(path, &st) < 0)
-		{
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not stat file \"%s\": %m",
-							file->d_name)));
-		}
-
-		if (!S_ISLNK(st.st_mode))
-		{
-			strlcat(path, "/" ORIOLEDB_DATA_DIR, MAXPGPATH);
-			cleanup_tablespace_old_files(path, chkp_num, before_recovery);
-		}
-		else
-		{
-			rllen = readlink(path, targetpath, sizeof(targetpath));
-			if (rllen < 0)
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not read symbolic link \"%s\": %m",
-								path)));
-			if (rllen >= sizeof(targetpath))
-				ereport(ERROR,
-						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-						 errmsg("symbolic link \"%s\" target is too long",
-								path)));
-			targetpath[rllen] = '\0';
-
-			path[0] = '\0';
-			pg_snprintf(path, MAXPGPATH,
-						"%s/" ORIOLEDB_DATA_DIR,
-						targetpath);
-			cleanup_tablespace_old_files(path, chkp_num, before_recovery);
-		}
-	}
-	closedir(dir);
-#undef PG_TBLSPC
+	arg.chkp_num = chkp_num;
+	arg.before_recovery = before_recovery;
+	o_tablespaces_foreach_prefix(cleanup_old_files_cb, &arg);
 }
 
 static OIndexKey *

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -24,6 +24,7 @@
 #include "catalog/indices.h"
 #include "catalog/o_indices.h"
 #include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "checkpoint/checkpoint.h"
 #include "recovery/recovery.h"
 #include "recovery/internal.h"

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -18,6 +18,7 @@
 #include "btree/modify.h"
 #include "catalog/indices.h"
 #include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "catalog/o_tables.h"
 #include "recovery/recovery.h"
 #include "recovery/internal.h"

--- a/src/s3/headers.c
+++ b/src/s3/headers.c
@@ -20,6 +20,7 @@
 
 #include "btree/btree.h"
 #include "btree/io.h"
+#include "catalog/o_tablespaces.h"
 #include "checkpoint/checkpoint.h"
 #include "s3/headers.h"
 #include "s3/worker.h"

--- a/src/s3/headers.c
+++ b/src/s3/headers.c
@@ -992,7 +992,8 @@ s3_headers_error_cleanup(void)
 typedef void (*IterateFilesCallback) (S3HeaderTag tag);
 
 static void
-iterate_tablespace_files(Oid tablespace, char *path, IterateFilesCallback callback)
+iterate_tablespace_files(Oid tablespace, const char *path,
+						 IterateFilesCallback callback)
 {
 	DIR		   *dir,
 			   *dbDir;
@@ -1059,77 +1060,15 @@ iterate_tablespace_files(Oid tablespace, char *path, IterateFilesCallback callba
 }
 
 static void
+iterate_files_cb(Oid tablespace, const char *prefix, void *arg)
+{
+	iterate_tablespace_files(tablespace, prefix, (IterateFilesCallback) arg);
+}
+
+static void
 iterate_files(IterateFilesCallback callback)
 {
-	DIR		   *dir;
-	char		path[MAXPGPATH];
-	char		targetpath[MAXPGPATH];
-	struct dirent *file;
-
-#define PG_TBLSPC "pg_tblspc"
-
-	path[0] = '\0';
-	strlcat(path, ORIOLEDB_DATA_DIR, MAXPGPATH);
-	iterate_tablespace_files(DEFAULTTABLESPACE_OID, path, callback);
-
-	dir = opendir(PG_TBLSPC);
-	if (dir == NULL)
-		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open directory \"%s\": %m", PG_TBLSPC)));
-	while (errno = 0, (file = readdir(dir)) != NULL)
-	{
-		struct stat st;
-		int			rllen;
-		Oid			tablespace;
-
-		/* Skip special stuff */
-		if (strcmp(file->d_name, ".") == 0 || strcmp(file->d_name, "..") == 0)
-			continue;
-
-		tablespace = pg_strtoint64(file->d_name);
-		Assert(OidIsValid(tablespace));
-		path[0] = '\0';
-		pg_snprintf(path, MAXPGPATH,
-					PG_TBLSPC "/%s/" TABLESPACE_VERSION_DIRECTORY,
-					file->d_name);
-		if (lstat(path, &st) < 0)
-		{
-			ereport(PANIC,
-					(errcode_for_file_access(),
-					 errmsg("could not stat file \"%s\": %m",
-							file->d_name)));
-		}
-
-		if (!S_ISLNK(st.st_mode))
-		{
-			strlcat(path, "/" ORIOLEDB_DATA_DIR, MAXPGPATH);
-			iterate_tablespace_files(tablespace, path, callback);
-		}
-		else
-		{
-			rllen = readlink(path, targetpath, sizeof(targetpath));
-			if (rllen < 0)
-				ereport(ERROR,
-						(errcode_for_file_access(),
-						 errmsg("could not read symbolic link \"%s\": %m",
-								path)));
-			if (rllen >= sizeof(targetpath))
-				ereport(ERROR,
-						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-						 errmsg("symbolic link \"%s\" target is too long",
-								path)));
-			targetpath[rllen] = '\0';
-
-			path[0] = '\0';
-			pg_snprintf(path, MAXPGPATH,
-						"%s/" ORIOLEDB_DATA_DIR,
-						targetpath);
-			iterate_tablespace_files(tablespace, path, callback);
-		}
-	}
-	closedir(dir);
-#undef PG_TBLSPC
+	o_tablespaces_foreach_prefix(iterate_files_cb, callback);
 }
 
 static off_t totalFilesSize;

--- a/src/s3/worker.c
+++ b/src/s3/worker.c
@@ -17,7 +17,7 @@
 #include "orioledb.h"
 
 #include "btree/io.h"
-#include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "s3/checksum.h"
 #include "s3/headers.h"
 #include "s3/queue.h"

--- a/src/utils/seq_buf.c
+++ b/src/utils/seq_buf.c
@@ -27,7 +27,7 @@
 #include "orioledb.h"
 
 #include "btree/io.h"
-#include "catalog/o_sys_cache.h"
+#include "catalog/o_tablespaces.h"
 #include "utils/seq_buf.h"
 
 #include "pgstat.h"

--- a/test/t/files_test.py
+++ b/test/t/files_test.py
@@ -443,6 +443,9 @@ class FilesTest(BaseTest):
 		reloids = node.execute('postgres',
 		                       "SELECT * FROM orioledb_table_oids();")
 		reloids = [item[1] for item in reloids if item[1] not in deleted]
+		t_db_oid = node.execute(
+		    'postgres',
+		    "SELECT oid FROM pg_database WHERE datname = 't';")[0][0]
 		node.safe_psql('postgres', "DROP DATABASE t;")
 		new_reloids = node.execute('postgres',
 		                           "SELECT * FROM orioledb_table_oids();")
@@ -463,6 +466,7 @@ class FilesTest(BaseTest):
 		self.assertFalse(bool(re.match(r".*\.tmp", all_files)))
 		self.assertFalse(bool(re.match(r".*evt", all_files)))
 		self.assertFalse(bool(re.match(r"[0-9]*_[0-9]*_[0-9]*", all_files)))
+		self.assertFalse(str(t_db_oid) in all_files)
 
 	def test_evt_cleanup(self):
 		node = self.node


### PR DESCRIPTION
`DROP DATABASE` removed table metadata and scheduled per-relation file cleanup via undo drop records, but left the per-database `orioledb_data/<dbOid>` directory behind.  Register a transaction callback that runs after undo processing (registered before `undo_xact_callback` so LIFO ordering places it last) to rmdir the empty directory from the default tablespace and all non-default tablespaces, under `pg_tblspc`.