### PR TITLE
Stabilize pg_constraint ordering in AT_AddIndexConstraint test

### DIFF
--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -8705,7 +8705,8 @@ CREATE UNIQUE INDEX o_test_idx_id ON o_test_add_index_constraint(id);
 -- Check initial state (index exists but no constraint)
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
  conname | contype | conindid 
 ---------+---------+----------
 (0 rows)
@@ -8718,7 +8719,8 @@ WARNING:  We cannot just reuse index for primary key in orioledb, because second
 -- Verify constraint was added
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
   conname  | contype | conindid  
 -----------+---------+-----------
  o_test_pk | p       | o_test_pk
@@ -8734,7 +8736,8 @@ CREATE UNIQUE INDEX o_test_idx_val ON o_test_add_index_constraint(val);
 -- Check state before adding UNIQUE constraint
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
   conname  | contype | conindid  
 -----------+---------+-----------
  o_test_pk | p       | o_test_pk
@@ -8747,7 +8750,8 @@ NOTICE:  ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "o_test_idx_
 -- Verify both constraints exist
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
   conname  | contype | conindid  
 -----------+---------+-----------
  o_test_pk | p       | o_test_pk

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -8691,7 +8691,8 @@ CREATE UNIQUE INDEX o_test_idx_id ON o_test_add_index_constraint(id);
 -- Check initial state (index exists but no constraint)
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
  conname | contype | conindid 
 ---------+---------+----------
 (0 rows)
@@ -8704,7 +8705,8 @@ WARNING:  We cannot just reuse index for primary key in orioledb, because second
 -- Verify constraint was added
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
   conname  | contype | conindid  
 -----------+---------+-----------
  o_test_pk | p       | o_test_pk
@@ -8720,7 +8722,8 @@ CREATE UNIQUE INDEX o_test_idx_val ON o_test_add_index_constraint(val);
 -- Check state before adding UNIQUE constraint
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
   conname  | contype | conindid  
 -----------+---------+-----------
  o_test_pk | p       | o_test_pk
@@ -8733,7 +8736,8 @@ NOTICE:  ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "o_test_idx_
 -- Verify both constraints exist
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
   conname  | contype | conindid  
 -----------+---------+-----------
  o_test_pk | p       | o_test_pk

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -8749,7 +8749,8 @@ CREATE UNIQUE INDEX o_test_idx_id ON o_test_add_index_constraint(id);
 -- Check initial state (index exists but no constraint)
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
  conname | contype | conindid 
 ---------+---------+----------
 (0 rows)
@@ -8762,7 +8763,8 @@ WARNING:  We cannot just reuse index for primary key in orioledb, because second
 -- Verify constraint was added
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
                  conname                 | contype | conindid  
 -----------------------------------------+---------+-----------
  o_test_add_index_constraint_id_not_null | n       | -
@@ -8779,7 +8781,8 @@ CREATE UNIQUE INDEX o_test_idx_val ON o_test_add_index_constraint(val);
 -- Check state before adding UNIQUE constraint
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
                  conname                 | contype | conindid  
 -----------------------------------------+---------+-----------
  o_test_add_index_constraint_id_not_null | n       | -
@@ -8793,7 +8796,8 @@ NOTICE:  ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "o_test_idx_
 -- Verify both constraints exist
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
                  conname                 | contype | conindid  
 -----------------------------------------+---------+-----------
  o_test_add_index_constraint_id_not_null | n       | -

--- a/test/sql/indices.sql
+++ b/test/sql/indices.sql
@@ -2009,7 +2009,8 @@ CREATE UNIQUE INDEX o_test_idx_id ON o_test_add_index_constraint(id);
 -- Check initial state (index exists but no constraint)
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
 
 -- Test AT_AddIndexConstraint: Add PRIMARY KEY using existing index
 ALTER TABLE o_test_add_index_constraint
@@ -2018,7 +2019,8 @@ ALTER TABLE o_test_add_index_constraint
 -- Verify constraint was added
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
 
 -- Test constraint enforcement
 INSERT INTO o_test_add_index_constraint VALUES (4, 'four');  -- Should succeed
@@ -2030,7 +2032,8 @@ CREATE UNIQUE INDEX o_test_idx_val ON o_test_add_index_constraint(val);
 -- Check state before adding UNIQUE constraint
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
 
 -- Test AT_AddIndexConstraint: Add UNIQUE constraint using existing index
 ALTER TABLE o_test_add_index_constraint
@@ -2039,7 +2042,8 @@ ALTER TABLE o_test_add_index_constraint
 -- Verify both constraints exist
 SELECT conname, contype, conindid::regclass
 FROM pg_constraint
-WHERE conrelid = 'o_test_add_index_constraint'::regclass;
+WHERE conrelid = 'o_test_add_index_constraint'::regclass
+ORDER BY conname;
 
 -- Test UNIQUE constraint enforcement
 INSERT INTO o_test_add_index_constraint VALUES (5, 'five');  -- Should succeed


### PR DESCRIPTION
Fix for test introduced in 1b8fde392: the SELECT queries lacked ORDER BY, so pg_constraint scan order was unstable and caused flaky row ordering in CI.