### PR TITLE
Add pgbackrest integration test

### DIFF
--- a/.github/workflows/pgbackrest.yml
+++ b/.github/workflows/pgbackrest.yml
@@ -1,0 +1,79 @@
+name: pgbackrest
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  pgbackrest-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      LLVM_VER: 18
+      CPU: amd64
+      CHECK_TYPE: normal
+      PG_VERSION: ${{ matrix.pg_version }}
+      COMPILER: gcc
+    steps:
+      - name: Checkout extension code into workspace directory
+        uses: actions/checkout@v6
+        with:
+          path: orioledb
+
+      - name: Get the required tag name
+        shell: bash
+        run: |
+          echo "PGTAG=$(grep '^${{ matrix.pg_version }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+
+      - name: Checkout PostgreSQL code into workspace directory
+        uses: actions/checkout@v6
+        with:
+          repository: orioledb/postgres
+          ref: ${{ env.PGTAG }}
+          path: postgresql
+
+      - name: Setup prerequisites
+        run: bash ./orioledb/ci/prerequisites.sh
+
+      - name: Install pgBackRest
+        run: |
+          # The Ubuntu universe package predates newer PostgreSQL majors
+          # (e.g. PG17) and rejects their catalog version, so pull
+          # pgbackrest from the PGDG apt repo instead, which tracks new
+          # PG majors promptly.
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update -qq
+          sudo apt-get -y install -qq pgbackrest
+
+      - name: Build
+        run: bash ./orioledb/ci/build.sh
+
+      - name: Install post build prerequisites
+        run: bash ./orioledb/ci/post_build_prerequisites.sh
+
+      - name: Run pgbackrest test
+        timeout-minutes: 100
+        run: |
+          export PATH="$GITHUB_WORKSPACE/pgsql/bin:$GITHUB_WORKSPACE/python3-venv/bin:$PATH"
+          cd orioledb
+          python3 -W ignore::DeprecationWarning -m unittest -v test.integration.pgbackrest_test
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: ${{ matrix.pg_version }}_pgbackrest_test.logs
+          path: |
+            ./orioledb/test/tmp_check_t/*/repo/logs/*.log
+            ./orioledb/test/tmp_check_t/*/logs/*log
+          retention-days: 2
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ make.flags
 
 # Local excludes in root directory
 /test/t/__pycache__/
+/test/integration/__pycache__/
 /test/__pycache__/
 /test/log/
 /log_docker_build/

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,30 @@
+# Integration tests
+
+This directory holds testgres-based tests that exercise OrioleDB against
+external tools, rather than PostgreSQL itself. Unlike `test/t`, these tests
+are not wired into the Makefile's `testgrescheck`/`installcheck`/`check`
+targets (or its `yapf` target), since they depend on external binaries not
+guaranteed to be present in every build environment. Run them manually,
+with the corresponding tool installed and on `PATH`.
+
+## Tests
+
+- `pgbackrest_test.py` - exercises the pgBackRest integration flow
+  (stanza creation, full/incremental backups, standby restore/promotion,
+  async archiving, and point-in-time recovery) against an OrioleDB table.
+  Requires `pgbackrest` on `PATH`.
+
+## Running a test
+
+Build and install OrioleDB first (see the top-level README), then run an
+individual test module from the repository root:
+
+```bash
+python3 -m unittest -v test.integration.pgbackrest_test
+```
+
+Or a single test case:
+
+```bash
+python3 -m unittest -v test.integration.pgbackrest_test.PgBackRestTest.test_integration
+```

--- a/test/integration/pgbackrest_test.py
+++ b/test/integration/pgbackrest_test.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+Python/testgres migration of pgBackRest's integration/allTest.c.
+
+This test exercises the core pgBackRest integration flow using orioledb as
+the default table access method: stanza creation, full/incremental backups,
+standby restore and promotion, async archiving, and point-in-time recovery
+by time and named restore point.
+"""
+
+import glob
+import inspect
+import json
+import os
+import shutil
+import subprocess
+import time
+
+from threading import Thread
+
+import testgres
+from testgres.node import PostgresNode
+from testgres.operations.os_ops import ConnectionParams
+
+from test.t.base_test import BaseTest, TestPortManager, wait_checkpointer_stopevent
+
+
+class PgBackRestTest(BaseTest):
+	STANZA = 'test'
+
+	# ------------------------------------------------------------------
+	# Setup / teardown
+	# ------------------------------------------------------------------
+
+	def setUp(self):
+		super().setUp()
+
+		# Derive paths from the directory that initNode chose
+		node_base = self.node.base_dir
+
+		self._repo_path = os.path.join(node_base, 'repo')
+		self._log_path = os.path.join(self._repo_path, 'logs')
+		self._conf_path = os.path.join(node_base, 'pgbackrest.conf')
+		self._standby_conf_path = os.path.join(node_base,
+		                                       'pgbackrest_standby.conf')
+
+		spool_path = os.path.join(node_base, 'spool')
+
+		os.makedirs(self._repo_path, exist_ok=True)
+		os.makedirs(self._log_path, exist_ok=True)
+		os.makedirs(spool_path, exist_ok=True)
+
+		self._write_pgbackrest_conf(self._conf_path, self.node.data_dir,
+		                            self.node.port, spool_path)
+
+		self.node.append_conf(
+		    'postgresql.conf', f"default_table_access_method = 'orioledb'\n"
+		    f"orioledb.enable_stopevents = true\n"
+		    f"wal_level = replica\n"
+		    f"archive_mode = on\n"
+		    f"archive_command = '{self._pgbackrest_bin()} --config=\"{self._conf_path}\""
+		    f" --stanza={self.STANZA} archive-push \"%p\"'\n"
+		    f"restore_command = '{self._pgbackrest_bin()} --config=\"{self._conf_path}\""
+		    f" --stanza={self.STANZA} archive-get \"%f\" \"%p\"'\n"
+		    f"max_wal_senders = 3\n"
+		    f"max_replication_slots = 3\n")
+
+	def tearDown(self):
+		# replica is set to the standby node when created; BaseTest.tearDown
+		# handles stopping and cleanup for self.node and self.replica.
+		super().tearDown()
+
+	# ------------------------------------------------------------------
+	# Helpers
+	# ------------------------------------------------------------------
+
+	@staticmethod
+	def _pgbackrest_bin():
+		return shutil.which('pgbackrest') or 'pgbackrest'
+
+	def _write_pgbackrest_conf(self, conf_path, pg_path, pg_port, spool_path):
+		conf = (f"[{self.STANZA}]\n"
+		        f"pg1-path={pg_path}\n"
+		        f"pg1-port={pg_port}\n"
+		        f"pg1-socket-path=/tmp\n"
+		        f"\n"
+		        f"[global]\n"
+		        f"repo1-path={self._repo_path}\n"
+		        f"archive-async=y\n"
+		        f"spool-path={spool_path}\n"
+		        f"log-level-console=warn\n"
+		        f"log-level-file=detail\n"
+		        f"log-path={self._log_path}\n")
+		with open(conf_path, 'w') as f:
+			f.write(conf)
+
+	def _pgbackrest(self, *args):
+		return self._pgbackrest_with_conf(self._conf_path, *args)
+
+	def _pgbackrest_with_conf(self, conf_path, *args):
+		cmd = [
+		    self._pgbackrest_bin(),
+		    f'--config={conf_path}',
+		    f'--stanza={self.STANZA}',
+		] + list(args)
+		result = subprocess.run(cmd, capture_output=True, text=True)
+		if result.returncode != 0:
+			raise AssertionError(
+			    f"pgbackrest {' '.join(args)} failed (exit {result.returncode}):\n"
+			    f"stdout: {result.stdout}\nstderr: {result.stderr}")
+		return result
+
+	def _backup_count(self):
+		result = self._pgbackrest('info', '--output=json')
+		info = json.loads(result.stdout)
+		return len(info[0]['backup']) if info and info[0].get('backup') else 0
+
+	def _restore_primary(self, *extra_opts):
+		"""Restore into the primary data dir (uses conf pg1-path)."""
+		self._pgbackrest('restore', '--delta', *extra_opts)
+
+	def _create_standby(self):
+		"""
+		Restore from pgbackrest into a fresh data dir and return a configured
+		testgres node ready to start.  Stored in self.replica so tearDown
+		cleans it up.
+		"""
+		(test_path,
+		 _) = os.path.split(os.path.dirname(inspect.getfile(self.__class__)))
+		base_dir = os.path.join(test_path, 'tmp_check_t',
+		                        self.myName + '_tgsb')
+		if os.path.exists(base_dir):
+			shutil.rmtree(base_dir)
+
+		port = self.getBasePort() + 1
+		pm = TestPortManager(PostgresNode._get_os_ops(ConnectionParams()),
+		                     port)
+		standby = testgres.get_new_node('standby',
+		                                base_dir=base_dir,
+		                                port_manager=pm)
+		os.makedirs(standby.data_dir, exist_ok=True)
+
+		standby_spool_path = os.path.join(standby.base_dir, 'spool')
+		os.makedirs(standby_spool_path, exist_ok=True)
+		self._write_pgbackrest_conf(self._standby_conf_path, standby.data_dir,
+		                            standby.port, standby_spool_path)
+
+		# pgbackrest restore writes standby.signal and restore_command into
+		# postgresql.auto.conf, so no manual signal file is needed.
+		self._pgbackrest_with_conf(self._standby_conf_path, 'restore',
+		                           f'--pg1-path={standby.data_dir}',
+		                           '--type=standby')
+
+		# The restored postgresql.conf has the primary's archive_command and
+		# port.  Override both so the standby uses its own pgbackrest config.
+		standby.append_conf(
+		    'postgresql.conf',
+		    f"archive_command = '{self._pgbackrest_bin()} --config=\"{self._standby_conf_path}\""
+		    f" --stanza={self.STANZA} archive-push \"%p\"'\n"
+		    f"port = {standby.port}\n")
+
+		self.replica = standby
+		return standby
+
+	def _repromote_standby(self, standby):
+		"""
+		Wipe the standby data dir and restore again.  Re-appends the port
+		override after restore (pgbackrest rewrites auto.conf).
+		"""
+		shutil.rmtree(standby.data_dir)
+		os.makedirs(standby.data_dir, exist_ok=True)
+
+		standby_spool_path = os.path.join(standby.base_dir, 'spool')
+		os.makedirs(standby_spool_path, exist_ok=True)
+		self._write_pgbackrest_conf(self._standby_conf_path, standby.data_dir,
+		                            standby.port, standby_spool_path)
+
+		self._pgbackrest_with_conf(self._standby_conf_path, 'restore',
+		                           f'--pg1-path={standby.data_dir}',
+		                           '--type=standby',
+		                           '--target-timeline=current')
+		standby.append_conf(
+		    'postgresql.conf',
+		    f"archive_command = '{self._pgbackrest_bin()} --config=\"{self._standby_conf_path}\""
+		    f" --stanza={self.STANZA} archive-push \"%p\"'\n"
+		    f"port = {standby.port}\n")
+
+	def _next_scratch_port(self):
+		"""Allocate a port beyond the primary (basePort) and standby
+		(basePort + 1) for one-off verification nodes."""
+		self._scratch_port_counter = getattr(self, '_scratch_port_counter',
+		                                     1) + 1
+		return self.getBasePort() + self._scratch_port_counter
+
+	def _restore_to_new_node(self, node_name, restore_opts, restore_count=1):
+		"""
+		Restore a backup into a fresh standalone data dir and return a
+		started testgres node.  Used to verify backup+restore integrity
+		independently of the primary's own in-place restore flow.
+
+		restore_count > 1 runs the same restore command that many times
+		in a row against the same (increasingly populated) directory
+		before starting Postgres -- e.g. to check that pgBackRest's
+		--delta comparison is idempotent.
+		"""
+		(test_path,
+		 _) = os.path.split(os.path.dirname(inspect.getfile(self.__class__)))
+		base_dir = os.path.join(test_path, 'tmp_check_t',
+		                        self.myName + '_' + node_name)
+		if os.path.exists(base_dir):
+			shutil.rmtree(base_dir)
+
+		port = self._next_scratch_port()
+		pm = TestPortManager(PostgresNode._get_os_ops(ConnectionParams()),
+		                     port)
+		scratch = testgres.get_new_node(node_name,
+		                                base_dir=base_dir,
+		                                port_manager=pm)
+		os.makedirs(scratch.data_dir, exist_ok=True)
+
+		conf_path = os.path.join(scratch.base_dir,
+		                         f'pgbackrest_{node_name}.conf')
+		spool_path = os.path.join(scratch.base_dir, 'spool')
+		os.makedirs(spool_path, exist_ok=True)
+		self._write_pgbackrest_conf(conf_path, scratch.data_dir, scratch.port,
+		                            spool_path)
+
+		for _ in range(restore_count):
+			self._pgbackrest_with_conf(conf_path, 'restore',
+			                           f'--pg1-path={scratch.data_dir}',
+			                           *restore_opts)
+
+		# The restored postgresql.conf carries the primary's archive
+		# settings; disable archiving on this scratch node since it is
+		# only used to verify already-archived data, not to produce more.
+		scratch.append_conf('postgresql.conf', f"archive_mode = off\n"
+		                    f"port = {scratch.port}\n")
+		scratch.start()
+		return scratch
+
+	def _wait_for_history_archive(self, standby, timeout=30):
+		wal_filename = standby.execute(
+		    'postgres', 'SELECT pg_walfile_name(pg_current_wal_lsn())')[0][0]
+		timeline = int(wal_filename[:8], 16)
+		pattern = os.path.join(self._repo_path, 'archive', self.STANZA, '*',
+		                       f'{timeline:08X}.history*')
+		deadline = time.time() + timeout
+		while time.time() < deadline:
+			if glob.glob(pattern):
+				return
+			time.sleep(0.5)
+		raise AssertionError(
+		    f"timeline history file {timeline:08X}.history was not archived")
+
+	# ------------------------------------------------------------------
+	# Test
+	# ------------------------------------------------------------------
+
+	def test_integration(self):
+		node = self.node
+		node.start()
+
+		# ------------------------------------------------------------------
+		# Stanza create and check
+		# ------------------------------------------------------------------
+		self._pgbackrest('stanza-create')
+		self._pgbackrest('check')
+
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql("CREATE TABLE status (message text NOT NULL);")
+		node.safe_psql("SELECT pg_switch_wal()")
+
+		# ------------------------------------------------------------------
+		# Primary full backup
+		# ------------------------------------------------------------------
+		node.safe_psql("INSERT INTO status VALUES ('full')")
+		node.safe_psql("SELECT pg_switch_wal()")
+
+		self._pgbackrest('backup', '--type=full')
+		self.assertEqual(self._backup_count(), 1)
+
+		# ------------------------------------------------------------------
+		# Standby restore
+		# ------------------------------------------------------------------
+		standby = self._create_standby()
+		standby.start()
+
+		# Poll until the standby has replayed WAL and caught up enough to
+		# see the status table.
+		standby.poll_query_until("SELECT pg_last_wal_replay_lsn() IS NOT NULL",
+		                         sleep_time=0.5,
+		                         max_attempts=60)
+
+		self.assertEqual(
+		    standby.execute('postgres', 'SELECT message FROM status')[0][0],
+		    'full')
+
+		# Update primary status; standby should receive it via streaming.
+		node.safe_psql("UPDATE status SET message = 'standby'")
+		node.safe_psql("SELECT pg_switch_wal()")
+		standby.poll_query_until("SELECT message = 'standby' FROM status",
+		                         sleep_time=0.5,
+		                         max_attempts=60)
+
+		# Promote the standby to create timeline 2, then restore it again on
+		# the current timeline so it tracks the primary.
+		standby.safe_psql('SELECT pg_promote()')
+		standby.safe_psql('SELECT pg_switch_wal()')
+		self._wait_for_history_archive(standby)
+		standby.stop()
+
+		self._repromote_standby(standby)
+		standby.start()
+		standby.poll_query_until("SELECT pg_last_wal_replay_lsn() IS NOT NULL",
+		                         sleep_time=0.5,
+		                         max_attempts=60)
+		standby.stop()
+
+		# ------------------------------------------------------------------
+		# Second full backup (from primary) + expire
+		# ------------------------------------------------------------------
+		self._pgbackrest('backup', '--type=full')
+		self.assertEqual(self._backup_count(), 2)
+
+		self._pgbackrest('expire', '--repo1-retention-full=1')
+		self.assertEqual(self._backup_count(), 1)
+
+		# ------------------------------------------------------------------
+		# Async archiving exercise
+		# ------------------------------------------------------------------
+		node.safe_psql("CREATE TABLE wal_activity (id int)")
+		for i in range(1, 6):
+			node.safe_psql(f"INSERT INTO wal_activity VALUES ({i})")
+			node.safe_psql("SELECT pg_switch_wal()")
+
+		# Verify the async archive-push log was created.
+		async_log = os.path.join(self._log_path,
+		                         f'{self.STANZA}-archive-push-async.log')
+		deadline = time.time() + 10
+		while time.time() < deadline:
+			if os.path.exists(async_log):
+				break
+			time.sleep(0.5)
+		self.assertTrue(os.path.exists(async_log),
+		                "async archive-push log was not created")
+
+		# ------------------------------------------------------------------
+		# Time target setup
+		# ------------------------------------------------------------------
+		time.sleep(1)  # Guarantee the timestamp is after the last backup
+		node.safe_psql("UPDATE status SET message = 'time'")
+		node.safe_psql("SELECT pg_switch_wal()")
+		target_time = node.execute('postgres',
+		                           'SELECT current_timestamp::text')[0][0]
+
+		# ------------------------------------------------------------------
+		# Incremental backup with real page churn + block-incremental
+		# ------------------------------------------------------------------
+		# Generate enough page churn that OrioleDB actually rewrites data
+		# during a checkpoint, rather than just a metadata-only change, so
+		# the backup below exercises pgBackRest's block-incremental
+		# diffing against real OrioleDB page rewrites.
+		node.safe_psql("CREATE DATABASE exclude_me")
+		node.safe_psql("UPDATE status SET message = 'incr'")
+
+		node.safe_psql("CREATE TABLE churn_tbl (id int PRIMARY KEY, "
+		               "val text)")
+		node.safe_psql("INSERT INTO churn_tbl "
+		               "SELECT i, repeat('x', 200) FROM "
+		               "generate_series(1, 5000) i")
+		node.safe_psql("UPDATE churn_tbl SET val = repeat('y', 200) "
+		               "WHERE id % 10 = 0")
+		node.safe_psql("CHECKPOINT")
+
+		churn_fingerprint_1 = node.execute(
+		    'postgres',
+		    "SELECT md5(string_agg(val, '' ORDER BY id)) FROM churn_tbl")[0][0]
+
+		self._pgbackrest('backup', '--type=incr', '--repo1-block',
+		                 '--repo1-bundle')
+
+		# Regression guard: pgBackRest must still report this as an
+		# incremental backup for OrioleDB data, not silently fall back to
+		# a full copy.
+		info = json.loads(self._pgbackrest('info', '--output=json').stdout)
+		incr_backup_1 = info[0]['backup'][-1]
+		self.assertEqual(incr_backup_1['type'], 'incr')
+
+		# Correctness check: restore this specific block-incremental
+		# backup into a standalone scratch node and confirm OrioleDB data
+		# survived the block-level diffing intact.
+		scratch = self._restore_to_new_node(
+		    'blkincr',
+		    [f'--set={incr_backup_1["label"]}', '--target-timeline=current'])
+		try:
+			churn_fingerprint_restored = scratch.execute(
+				'postgres', "SELECT md5(string_agg(val, '' ORDER BY id)) "
+				"FROM churn_tbl")[0][0]
+			self.assertEqual(churn_fingerprint_restored, churn_fingerprint_1)
+			scratch.stop()
+		finally:
+			scratch.cleanup()
+
+		# ------------------------------------------------------------------
+		# Second incremental backup: 2-deep chain (full -> incr -> incr)
+		# ------------------------------------------------------------------
+		node.safe_psql("UPDATE churn_tbl SET val = repeat('z', 200) "
+		               "WHERE id % 13 = 0")
+		node.safe_psql("UPDATE status SET message = 'incr2'")
+
+		churn_fingerprint_2 = node.execute(
+		    'postgres',
+		    "SELECT md5(string_agg(val, '' ORDER BY id)) FROM churn_tbl")[0][0]
+
+		self._pgbackrest('backup', '--type=incr', '--repo1-block',
+		                 '--repo1-bundle')
+
+		info = json.loads(self._pgbackrest('info', '--output=json').stdout)
+		incr_backup_2 = info[0]['backup'][-1]
+		self.assertEqual(incr_backup_2['type'], 'incr')
+
+		# Restoring the latest backup with no --set must resolve the full
+		# 2-deep incremental chain correctly against OrioleDB data.
+		scratch = self._restore_to_new_node('blkincr2',
+		                                    ['--target-timeline=current'])
+		try:
+			self.assertEqual(
+				scratch.execute('postgres', 'SELECT message FROM status')[0][0],
+				'incr2')
+			churn_fingerprint_chain = scratch.execute(
+				'postgres', "SELECT md5(string_agg(val, '' ORDER BY id)) "
+				"FROM churn_tbl")[0][0]
+			self.assertEqual(churn_fingerprint_chain, churn_fingerprint_2)
+			scratch.stop()
+		finally:
+			scratch.cleanup()
+
+		# ------------------------------------------------------------------
+		# Restore --delta applied twice onto the same populated directory
+		# ------------------------------------------------------------------
+		scratch_delta = self._restore_to_new_node('deltatwice', [
+		    '--delta', f'--set={incr_backup_2["label"]}', '--type=immediate',
+		    '--target-action=promote'
+		],
+		                                          restore_count=2)
+		try:
+			self.assertEqual(
+				scratch_delta.execute('postgres',
+									  'SELECT message FROM status')[0][0], 'incr2')
+			self.assertEqual(
+				scratch_delta.execute(
+					'postgres', "SELECT md5(string_agg(val, '' ORDER BY id)) "
+					"FROM churn_tbl")[0][0], churn_fingerprint_2)
+			scratch_delta.stop()
+		finally:
+			scratch_delta.cleanup()
+
+		# Known-good baseline: a single fresh restore of the same backup
+		# into a separate directory, to compare against the twice-applied
+		# delta restore above.
+		scratch_baseline = self._restore_to_new_node('deltabaseline', [
+		    f'--set={incr_backup_2["label"]}', '--type=immediate',
+		    '--target-action=promote'
+		])
+		try:
+			self.assertEqual(
+				scratch_baseline.execute(
+					'postgres', "SELECT md5(string_agg(val, '' ORDER BY id)) "
+					"FROM churn_tbl")[0][0], churn_fingerprint_2)
+			scratch_baseline.stop()
+		finally:
+			scratch_baseline.cleanup()
+
+		# ------------------------------------------------------------------
+		# Name target setup
+		# ------------------------------------------------------------------
+		node.safe_psql("UPDATE status SET message = 'name'")
+		node.safe_psql("SELECT pg_switch_wal()")
+		node.safe_psql("SELECT pg_create_restore_point('pgbackrest')")
+		node.safe_psql("SELECT pg_switch_wal()")
+
+		# ------------------------------------------------------------------
+		# Restore: default target (recovers to named restore point)
+		# ------------------------------------------------------------------
+		node.stop()
+		# Restore on the current timeline to avoid the timeline 2 mismatch
+		# created by the standby promotion above.
+		self._restore_primary('--target-timeline=current', '--force')
+		node.start()
+		node.poll_query_until("SELECT message = 'name' FROM status",
+		                      sleep_time=0.5,
+		                      max_attempts=60)
+
+		# ------------------------------------------------------------------
+		# Restore: immediate target (recovers to end of latest backup,
+		# which is now the second incremental backup added above)
+		# ------------------------------------------------------------------
+		node.stop()
+		self._restore_primary('--type=immediate', '--target-action=promote',
+		                      '--db-exclude=exclude_me')
+		node.start()
+		node.poll_query_until("SELECT message = 'incr2' FROM status",
+		                      sleep_time=0.5,
+		                      max_attempts=60)
+
+		# Wait for promotion to finish so the node is no longer read-only.
+		node.poll_query_until("SELECT pg_is_in_recovery()",
+		                      expected=False,
+		                      sleep_time=0.5,
+		                      max_attempts=60)
+
+		# The excluded database should be droppable even though it was not
+		# fully restored.
+		node.safe_psql("DROP DATABASE exclude_me")
+
+		# ------------------------------------------------------------------
+		# Restore: time target
+		# ------------------------------------------------------------------
+		node.stop()
+		self._restore_primary('--type=time', f'--target={target_time}',
+		                      '--target-timeline=current')
+		node.start()
+		node.poll_query_until("SELECT message = 'time' FROM status",
+		                      sleep_time=0.5,
+		                      max_attempts=60)
+
+		# ------------------------------------------------------------------
+		# Restore: name target
+		# ------------------------------------------------------------------
+		node.stop()
+		self._restore_primary('--type=name', '--target=pgbackrest',
+		                      '--target-action=promote',
+		                      '--target-timeline=current')
+		node.start()
+		node.poll_query_until("SELECT message = 'name' FROM status",
+		                      sleep_time=0.5,
+		                      max_attempts=60)
+		node.poll_query_until("SELECT pg_is_in_recovery()",
+		                      expected=False,
+		                      sleep_time=0.5,
+		                      max_attempts=60)
+
+		# ------------------------------------------------------------------
+		# Backup concurrent with an in-flight OrioleDB checkpoint
+		# ------------------------------------------------------------------
+		node.safe_psql("CREATE TABLE concurrent_tbl (id int PRIMARY KEY, "
+		               "val text)")
+		node.safe_psql("INSERT INTO concurrent_tbl "
+		               "SELECT i, repeat('z', 200) FROM "
+		               "generate_series(1, 5000) i")
+
+		con_ctrl = node.connect()
+		con_ctrl.execute(
+		    "SELECT pg_stopevent_set('checkpoint_writeback', 'true')")
+
+		backup_errors = []
+
+		def _run_backup():
+			try:
+				self._pgbackrest('backup', '--type=incr', '--start-fast')
+			except Exception as e:
+				backup_errors.append(e)
+
+		backup_thread = Thread(target=_run_backup)
+		backup_thread.start()
+
+		try:
+			# Wait for the backup's own startup checkpoint to be parked
+			# mid-writeback before mutating more data, so the mutation
+			# genuinely happens while the checkpoint that establishes
+			# this backup's consistency point is still in flight.
+			wait_checkpointer_stopevent(node)
+
+			node.safe_psql("UPDATE concurrent_tbl SET val = repeat('w', 200) "
+			               "WHERE id % 7 = 0")
+			concurrent_fingerprint = node.execute(
+			    'postgres', "SELECT md5(string_agg(val, '' ORDER BY id)) "
+			    "FROM concurrent_tbl")[0][0]
+		finally:
+			con_ctrl.execute(
+			    "SELECT pg_stopevent_reset('checkpoint_writeback')")
+			con_ctrl.close()
+
+		backup_thread.join()
+		if backup_errors:
+			raise backup_errors[0]
+
+		scratch = self._restore_to_new_node('chkptrace',
+		                                    ['--target-timeline=current'])
+		try:
+			restored_fingerprint = scratch.execute(
+			    'postgres', "SELECT md5(string_agg(val, '' ORDER BY id)) "
+			    "FROM concurrent_tbl")[0][0]
+			self.assertEqual(restored_fingerprint, concurrent_fingerprint)
+			scratch.stop()
+		finally:
+			scratch.cleanup()
+
+		# ------------------------------------------------------------------
+		# Stanza delete
+		# ------------------------------------------------------------------
+		node.stop()
+		self._pgbackrest('stop')
+		self._pgbackrest('stanza-delete', '--force')


### PR DESCRIPTION
- Add `test/integration/pgbackrest_test.py`, a testgres-based integration test that exercises pgBackRest against OrioleDB as the default table access method: stanza create/check, full and block-incremental backups, standby restore/promotion, async archiving, and PITR by time, name, and restore point.
- Add `.github/workflows/pgbackrest.yml` to run this test in CI — triggered manually (workflow_dispatch) or on GitHub release publish, across PG 17 and 18.