### PR TITLE
Introduce pages checksums

### DIFF
--- a/doc/usage/configuration.mdx
+++ b/doc/usage/configuration.mdx
@@ -81,6 +81,14 @@ How OrioleDB handles a client request for SERIALIZABLE isolation. OrioleDB does 
 - `error`: reject SERIALIZABLE transactions with `ERRCODE_FEATURE_NOT_SUPPORTED` (the legacy behavior).
 - `repeatable_read`: treat SERIALIZABLE as `REPEATABLE READ` for OrioleDB tables only — no extra locks are taken, since OrioleDB's CSN-based snapshot already provides per-transaction stable reads. Heap tables in the same transaction continue to use PG's SSI as usual.
 
+### `orioledb.checksums_enabled`
+
+|             |    |
+| ----------- | -- |
+| **Default** | on |
+
+Read-only. Shows whether OrioleDB page checksums are enabled. OrioleDB always stores and verifies page checksums independently of the PostgreSQL `data_checksums` cluster setting.
+
 ## Advanced config options
 
 ### `orioledb.free_tree_buffers`

--- a/doc/usage/getting-started.mdx
+++ b/doc/usage/getting-started.mdx
@@ -240,7 +240,7 @@ OrioleDB automatically merges sparse pages. Therefore, when many rows are delete
 
 ### Checkpoints, WAL & recovery
 
-OrioleDB has its own recovery mechanism: copy-on-write checkpoints and row-level WAL. However, both OrioleDB's checkpoints and WAL are integrated into PostgreSQL. PostgreSQL checkpointer process handles OrioleDB's tables as well. PostgreSQL WAL stream contains both WAL-records of built-in PostgreSQL tables and row-level WAL-records of OrioleDB's tables.
+OrioleDB has its own recovery mechanism: copy-on-write checkpoints and row-level WAL. However, both OrioleDB's checkpoints and WAL are integrated into PostgreSQL. PostgreSQL checkpointer process handles OrioleDB's tables as well. PostgreSQL WAL stream contains both WAL-records of built-in PostgreSQL tables and row-level WAL-records of OrioleDB's tables. OrioleDB always stores and verifies page checksums, regardless of the PostgreSQL `data_checksums` cluster setting.
 
 Recovery using row-level WAL records might require significant CPU resources. Therefore parallel recovery of OrioleDB's tables is implemented. OrioleDB launches its own pool of recovery workers, each of them responsible for replaying a particular part of WAL records.
 
@@ -299,8 +299,7 @@ OrioleDB is currently in the development stage. Therefore it has the following t
     - `error`: reject SERIALIZABLE transactions with `ERRCODE_FEATURE_NOT_SUPPORTED` (the legacy behavior).
     - `repeatable_read`: treat SERIALIZABLE as `REPEATABLE READ` for OrioleDB tables only — no extra locks are taken, OrioleDB's CSN snapshot already provides per-transaction stable reads. Heap tables in the same transaction continue to use PG's SSI as usual.
 11. Backward fetches from a cursor is supported only when the cursor is declared with `SCROLL`.
-12. OrioleDB doesn't use checksums on data pages and initializing a database
-cluster with `-k` (`--data-checksums`) doesn't have effect on OrioleDB tables.
+12. OrioleDB always uses checksums on data pages and initializing a database cluster without data checksums doesn't have effect on OrioleDB tables.
 13. PostgreSQL sequences are backed by heap relations. Accessing them (e.g., via `nextval()`) forces full PostgreSQL Transaction ID (XID) allocation, bypassing OrioleDB's optimized transaction mechanics unless sequence caching is utilized.
 
 ## Links

--- a/include/btree/io.h
+++ b/include/btree/io.h
@@ -55,7 +55,17 @@ extern void btree_smgr_punch_hole(BTreeDescr *desc, uint32 chkpNum,
 extern void punch_fd_hole(int fd, off_t offset, off_t length,
 						  const char *fileName);
 extern void init_btree_io_lwlocks(void);
-extern bool read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink, FileExtent *extent);
+
+typedef enum
+{
+	OReadPageResultOk,
+	/* the page could not be read from the disk at all */
+	OReadPageResultIOError,
+	/* the page was read, but its checksum didn't match */
+	OReadPageResultChecksumFailed
+} OReadPageResult;
+
+extern OReadPageResult read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink, FileExtent *extent);
 extern void load_page(OBTreeFindPageContext *context);
 extern uint64 perform_page_io(BTreeDescr *desc, OInMemoryBlkno blkno,
 							  Page img, uint32 checkpoint_number,

--- a/include/checkpoint/control.h
+++ b/include/checkpoint/control.h
@@ -32,7 +32,7 @@ typedef struct
  * Also on-the-flight conversion routine should be added to
  * check_checkpoint_control()
  */
-#define ORIOLEDB_CHECKPOINT_CONTROL_VERSION	1
+#define ORIOLEDB_CHECKPOINT_CONTROL_VERSION	2
 
 /*
  * To ensure correct reading of controlFileVersion, changes in struct layout
@@ -58,6 +58,11 @@ typedef struct
 	OXid		checkpointRetainXmax;
 	uint32		binaryVersion;
 	bool		s3Mode;
+
+	/*
+	 * orioledb_checksums_enabled
+	 */
+	bool		checksums_enabled;
 	/* CRC of all fields above. It should be last */
 	pg_crc32c	crc;
 } CheckpointControl;

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -98,7 +98,7 @@
  * these values makes sense only within one ORIOLEDB_BINARY_VERSION value.
  */
 #define ORIOLEDB_VERSION "OrioleDB beta 16"
-#define ORIOLEDB_BINARY_VERSION 9
+#define ORIOLEDB_BINARY_VERSION 10
 #define ORIOLEDB_SYS_TREE_VERSION	1	/* Version of system catalog */
 #define ORIOLEDB_PAGE_VERSION		1	/* Version of binary page format */
 #define ORIOLEDB_COMPRESS_VERSION	1	/* Version of page compression (only
@@ -385,7 +385,8 @@ typedef struct
 	 * pages it should be used for conversion of uncompressed images
 	 */
 	uint8		page_version;
-	uint32		reserved1;
+	uint16		checkSum;
+	uint16		reserved1;
 	uint32		reserved2;
 } OrioleDBOndiskPageHeader;
 
@@ -470,6 +471,7 @@ extern bool orioledb_table_description_compress;
 extern char *max_bridge_ctid_string;
 extern BlockNumber max_bridge_ctid_blkno;
 extern bool orioledb_s3_mode;
+extern bool orioledb_checksums_enabled;
 extern int	s3_num_workers;
 extern int	s3_desired_size;
 extern int	s3_queue_size_guc;

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -47,6 +47,8 @@
 #include "access/relation.h"
 #include "pgstat.h"
 #include "storage/bufmgr.h"
+#include "storage/checksum.h"
+#include "storage/checksum_impl.h"
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "funcapi.h"
@@ -76,6 +78,21 @@ typedef struct IOWriteBack
 	int			extentsAllocated;
 	TreeOffset *extents;
 } IOWriteBack;
+
+typedef union
+{
+	OrioleDBOndiskPageHeader phdr;
+	uint32		data[ORIOLEDB_BLCKSZ / (sizeof(uint32) * N_SUMS)][N_SUMS];
+} OrioleDBChecksummablePage;
+
+
+StaticAssertDecl(sizeof(OrioleDBChecksummablePage) == ORIOLEDB_BLCKSZ,
+				 "OrioleDBChecksummablePage size doesn't match ORIOLEDB_BLCKSZ");
+
+StaticAssertDecl(ORIOLEDB_BLCKSZ % (sizeof(uint32) * N_SUMS) == 0,
+				 "ORIOLEDB_BLCKSZ is not a multiple of sizeof(uint32) * N_SUMS");
+StaticAssertDecl(ORIOLEDB_COMP_BLCKSZ % (sizeof(uint32) * N_SUMS) == 0,
+				 "ORIOLEDB_COMP_BLCKSZ is not a multiple of sizeof(uint32) * N_SUMS");
 
 static IOWriteBack io_writeback =
 {
@@ -1249,6 +1266,69 @@ convert_orioledb_page_version(Pointer img)
 	elog(FATAL, "Page version conversion is not implemented");
 }
 
+static inline uint32
+oriole_checksum_block_len(uint32 blk_size)
+{
+	return (uint32) (blk_size / (sizeof(uint32) * N_SUMS));
+}
+
+/*
+ * Block checksum algorithm.  The page must be adequately aligned
+ * (at least on 4-byte boundary).
+ */
+static inline uint32
+oriole_checksum_block(const OrioleDBChecksummablePage *page, uint32 len)
+{
+	uint32		sums[N_SUMS];
+	uint32		result = 0;
+	uint32		i,
+				j;
+
+	/* initialize partial checksums to their corresponding offsets */
+	memcpy(sums, checksumBaseOffsets, sizeof(checksumBaseOffsets));
+
+	/* main checksum calculation */
+	for (i = 0; i < len; i++)
+		for (j = 0; j < N_SUMS; j++)
+			CHECKSUM_COMP(sums[j], page->data[i][j]);
+
+	/* finally add in two rounds of zeroes for additional mixing */
+	for (i = 0; i < 2; i++)
+		for (j = 0; j < N_SUMS; j++)
+			CHECKSUM_COMP(sums[j], 0);
+
+	/* xor fold partial checksums together */
+	for (i = 0; i < N_SUMS; i++)
+		result ^= sums[i];
+
+	return result;
+}
+
+static bool
+check_orioledb_page_checksum(OrioleDBOndiskPageHeader ondisk_page_header,
+							 char *buf, const char *label, uint32 len)
+{
+	uint16		computedCheckSum = 0;
+
+	((OrioleDBOndiskPageHeader *) buf)->checkSum = 0;
+
+	computedCheckSum = (uint16) ((oriole_checksum_block((const OrioleDBChecksummablePage *) buf, len) % 65535) + 1);
+
+	elog(DEBUG1, "Read %s disk page: stored checksum %u, computed checksum %u",
+		 label, ondisk_page_header.checkSum, computedCheckSum);
+
+	if (computedCheckSum != ondisk_page_header.checkSum)
+	{
+		ereport(WARNING,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("%s page checksum mismatch: stored %u, computed %u",
+						label, ondisk_page_header.checkSum, computedCheckSum)));
+		/* TODO: maybe ereport(ERROR) here once caller cleanup is safe */
+		return false;
+	}
+	return true;
+}
+
 /*
  * Now we have only one compresss version (1). When we have
  * different versions we'll need to bump
@@ -1269,7 +1349,7 @@ check_orioledb_compress_version(OrioleDBOndiskPageHeader ondisk_page_header)
  * Reads a page from disk to the img from a valid downlink. It's fills an empty
  * array of offsets for the page.
  */
-bool
+OReadPageResult
 read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 					FileExtent *extent)
 {
@@ -1282,6 +1362,8 @@ read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 	OrioleDBOndiskPageHeader ondisk_page_header = {0};
 	bool		needs_page_version_convert;
 
+	/* for the checksum computation we need aligned buffer */
+	Assert(((uintptr_t) img % sizeof(uint32)) == 0);
 	Assert(FileExtentOffIsValid(offset));
 	Assert(FileExtentLenIsValid(len));
 
@@ -1307,16 +1389,22 @@ read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 
 		err = btree_smgr_read(desc, img, chkpNum, read_size, byte_offset) != read_size;
 		if (err)
-			return false;
+			return OReadPageResultIOError;
 
 		ondisk_page_header = *((OrioleDBOndiskPageHeader *) img);
 		needs_page_version_convert = check_orioledb_page_version(ondisk_page_header);
+
+		if (orioledb_checksums_enabled &&
+			!check_orioledb_page_checksum(ondisk_page_header, img, "plain", oriole_checksum_block_len(read_size)))
+			return OReadPageResultChecksumFailed;
 
 		elog(DEBUG1, "Read plain disk page: checkpoint %u", ondisk_page_header.checkpointNum);
 	}
 	else
 	{
-		char		buf[ORIOLEDB_BLCKSZ];
+		OrioleDBChecksummablePage cp;
+		char	   *buf = (char *) &cp;
+
 		bool		compressed = len != (ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ);
 
 		if (compressed)
@@ -1328,10 +1416,14 @@ read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 
 			err = btree_smgr_read(desc, buf, chkpNum, read_size, byte_offset) != read_size;
 			if (err)
-				return false;
+				return OReadPageResultIOError;
 
 			ondisk_page_header = *((OrioleDBOndiskPageHeader *) buf);
 			needs_page_version_convert = check_orioledb_page_version(ondisk_page_header);
+
+			if (orioledb_checksums_enabled &&
+				!check_orioledb_page_checksum(ondisk_page_header, buf, "compressed", oriole_checksum_block_len(read_size)))
+				return OReadPageResultChecksumFailed;
 
 			needs_compress_version_convert = check_orioledb_compress_version(ondisk_page_header);
 			Assert(!needs_compress_version_convert);
@@ -1355,14 +1447,29 @@ read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 			byte_offset += read_size;
 
 			if (err)
-				return false;
+				return OReadPageResultIOError;
 
 			read_size = ORIOLEDB_BLCKSZ - O_PAGE_HEADER_SIZE;
 			err = btree_smgr_read(desc, img + O_PAGE_HEADER_SIZE, chkpNum, read_size, byte_offset) != read_size;
 			if (err)
-				return false;
+				return OReadPageResultIOError;
 
 			needs_page_version_convert = check_orioledb_page_version(ondisk_page_header);
+
+			if (orioledb_checksums_enabled)
+			{
+				/*
+				 * The body is already in place at img + O_PAGE_HEADER_SIZE;
+				 * put the header back in front of it so img holds the whole
+				 * on-disk image, then verify.  img's header area is
+				 * overwritten below.
+				 */
+				memcpy(img, &ondisk_page_header, O_PAGE_HEADER_SIZE);
+
+				if (!check_orioledb_page_checksum(ondisk_page_header, img, "compressed (len=1)", oriole_checksum_block_len(ORIOLEDB_BLCKSZ)))
+					return OReadPageResultChecksumFailed;
+			}
+
 			elog(DEBUG1, "Read disk page: checkpoint %u size %d", ondisk_page_header.checkpointNum, ORIOLEDB_BLCKSZ);
 		}
 	}
@@ -1389,7 +1496,7 @@ read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 	store_read_page_checkpoint_stats(((BTreePageHeader *) img)->o_header.checkpointNum);
 #endif
 
-	return true;
+	return OReadPageResultOk;
 }
 
 /*
@@ -1404,7 +1511,8 @@ write_page_to_disk(BTreeDescr *desc, FileExtent *extent, uint32 curChkpNum,
 				write_size;
 	bool		err = false;
 	uint32		chkpNum = 0;
-	char		buf[ORIOLEDB_BLCKSZ];
+	OrioleDBChecksummablePage cp;
+	char	   *buf = (char *) &cp;
 
 	Assert(FileExtentOffIsValid(extent->off));
 
@@ -1438,6 +1546,9 @@ write_page_to_disk(BTreeDescr *desc, FileExtent *extent, uint32 curChkpNum,
 		ondisk_page_header->page_version = ORIOLEDB_PAGE_VERSION;
 		memcpy(&buf[O_PAGE_HEADER_SIZE], page + O_PAGE_HEADER_SIZE, ORIOLEDB_BLCKSZ - O_PAGE_HEADER_SIZE);
 
+		if (orioledb_checksums_enabled)
+			ondisk_page_header->checkSum = (uint16) ((oriole_checksum_block(&cp, oriole_checksum_block_len(write_size)) % 65535) + 1);
+
 		err = btree_smgr_write(desc, buf, chkpNum, write_size, byte_offset) != write_size;
 
 		elog(DEBUG1, "Wrote plain disk page: checkpoint %u", curChkpNum);
@@ -1459,6 +1570,31 @@ write_page_to_disk(BTreeDescr *desc, FileExtent *extent, uint32 curChkpNum,
 		ondisk_page_header.checkpointNum = curChkpNum;
 		ondisk_page_header.compress_version = ORIOLEDB_COMPRESS_VERSION;
 		ondisk_page_header.page_version = ORIOLEDB_PAGE_VERSION;
+
+		if (orioledb_checksums_enabled)
+		{
+			off_t		image_size;
+			char	   *body;
+
+			if (page_size != ORIOLEDB_BLCKSZ)
+			{
+				image_size = extent->len * ORIOLEDB_COMP_BLCKSZ;
+				body = page;
+			}
+			else
+			{
+				/*
+				 * Compression freed less than one ORIOLEDB_COMP_BLCKSZ, so
+				 * the page is stored full and its header is inline in page.
+				 */
+				image_size = ORIOLEDB_BLCKSZ;
+				body = page + O_PAGE_HEADER_SIZE;
+			}
+
+			memcpy(buf, &ondisk_page_header, O_PAGE_HEADER_SIZE);
+			memcpy(&buf[O_PAGE_HEADER_SIZE], body, image_size - O_PAGE_HEADER_SIZE);
+			ondisk_page_header.checkSum = (uint16) ((oriole_checksum_block(&cp, oriole_checksum_block_len(image_size)) % 65535) + 1);
+		}
 
 		write_size = O_PAGE_HEADER_SIZE;
 		err = btree_smgr_write(desc, (char *) &ondisk_page_header, chkpNum, write_size, byte_offset) != write_size;
@@ -1517,12 +1653,13 @@ load_page(OBTreeFindPageContext *context)
 	OFixedKey	target_hikey;
 	int			target_level;
 	Page		page;
-	char		buf[ORIOLEDB_BLCKSZ];
+	char		pg_attribute_aligned(sizeof(uint32)) buf[ORIOLEDB_BLCKSZ];
 	bool		was_modify;
 	bool		was_downlink_location;
 	bool		was_fetch = false;
 	bool		was_image = false;
 	bool		was_keep_lokey = false;
+	OReadPageResult read_result;
 	uint32		chkpNum = 0;
 
 	context_index = context->index;
@@ -1568,7 +1705,9 @@ load_page(OBTreeFindPageContext *context)
 	page_desc->flags = 0;
 
 	/* Read page data and put it to the page */
-	if (!read_page_from_disk(desc, buf, downlink, &page_desc->fileExtent))
+	read_result = read_page_from_disk(desc, buf, downlink,
+									  &page_desc->fileExtent);
+	if (read_result != OReadPageResultOk)
 	{
 		int_hdr->downlink = downlink;
 		PAGE_INC_N_ONDISK(parent_page);
@@ -1576,10 +1715,16 @@ load_page(OBTreeFindPageContext *context)
 		if (orioledb_s3_mode)
 			chkpNum = S3_GET_CHKP_NUM(page_desc->fileExtent.off);
 
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not read page with file offset " UINT64_FORMAT " from %s: %m",
-							   DOWNLINK_GET_DISK_OFF(downlink),
-							   btree_smgr_filename(desc, DOWNLINK_GET_DISK_OFF(downlink), chkpNum))));
+		if (read_result == OReadPageResultChecksumFailed)
+			ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
+							errmsg("invalid page with file offset " UINT64_FORMAT " in %s",
+								   DOWNLINK_GET_DISK_OFF(downlink),
+								   btree_smgr_filename(desc, DOWNLINK_GET_DISK_OFF(downlink), chkpNum))));
+		else
+			ereport(ERROR, (errcode_for_file_access(),
+							errmsg("could not read page with file offset " UINT64_FORMAT " from %s: %m",
+								   DOWNLINK_GET_DISK_OFF(downlink),
+								   btree_smgr_filename(desc, DOWNLINK_GET_DISK_OFF(downlink), chkpNum))));
 	}
 
 	put_page_image(blkno, buf);

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -82,7 +82,7 @@ struct BTreeSeqScan
 {
 	BTreeDescr *desc;
 
-	char		leafImg[ORIOLEDB_BLCKSZ];
+	char		pg_attribute_aligned(sizeof(uint32)) leafImg[ORIOLEDB_BLCKSZ];
 	char		histImg[ORIOLEDB_BLCKSZ];
 
 	/*
@@ -1538,7 +1538,7 @@ static bool
 load_next_disk_leaf_page(BTreeSeqScan *scan)
 {
 	FileExtent	extent;
-	bool		success;
+	OReadPageResult read_result;
 	BTreePageHeader *header;
 	BTreeSeqScanDiskDownlink downlink;
 	ParallelOScanDesc poscan = scan->poscan;
@@ -1566,10 +1566,10 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 		downlink = ((BTreeSeqScanDiskDownlink *) dsm_segment_address(scan->dsmSeg))[index];
 	}
 
-	success = read_page_from_disk(scan->desc,
-								  scan->leafImg,
-								  downlink.downlink,
-								  &extent);
+	read_result = read_page_from_disk(scan->desc,
+									  scan->leafImg,
+									  downlink.downlink,
+									  &extent);
 	header = (BTreePageHeader *) scan->leafImg;
 	if (header->csn >= downlink.csn)
 		read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
@@ -1579,8 +1579,16 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 			  btree_page_stopevent_params(scan->desc,
 										  scan->leafImg));
 
-	if (!success)
-		elog(ERROR, "can not read leaf page from disk");
+	if (read_result != OReadPageResultOk)
+	{
+		if (read_result == OReadPageResultChecksumFailed)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("invalid leaf page with file offset " UINT64_FORMAT " read from disk",
+							DOWNLINK_GET_DISK_OFF(downlink.downlink))));
+		else
+			elog(ERROR, "can not read leaf page from disk");
+	}
 
 	/*
 	 * A disk leaf is read whole into the private leafImg, so any partial-read

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -327,6 +327,8 @@ checkpoint_shmem_init(Pointer ptr, bool found)
 		if (!get_checkpoint_control_data(&control))
 			return;
 
+		orioledb_checksums_enabled = control.checksums_enabled;
+
 		checkpoint_state->controlIdentifier = control.controlIdentifier;
 		checkpoint_state->lastCheckpointNumber = control.lastCheckpointNumber;
 		checkpoint_state->controlToastConsistentPtr = control.toastConsistentPtr;
@@ -1539,6 +1541,7 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 	control.checkpointRetainXmax = checkpoint_xmax;
 	control.binaryVersion = ORIOLEDB_BINARY_VERSION;
 	control.s3Mode = orioledb_s3_mode;
+	control.checksums_enabled = orioledb_checksums_enabled;
 	control.controlFileVersion = ORIOLEDB_CHECKPOINT_CONTROL_VERSION;
 
 	write_checkpoint_control(&control);
@@ -5611,23 +5614,31 @@ evictable_tree_init_meta(BTreeDescr *desc, EvictedTreeData **evicted_data,
 	if (DiskDownlinkIsValid(file_header.rootDownlink))
 	{
 		OrioleDBPageDesc *root_desc;
-		char		buf[ORIOLEDB_BLCKSZ];
-		bool		rerror;
+		char		pg_attribute_aligned(sizeof(uint32)) buf[ORIOLEDB_BLCKSZ];
+		OReadPageResult read_result;
 
 		lock_page(desc->rootInfo.rootPageBlkno);
 		page_block_reads(desc->rootInfo.rootPageBlkno);
 		root_desc = O_GET_IN_MEMORY_PAGEDESC(desc->rootInfo.rootPageBlkno);
 
-		rerror = !read_page_from_disk(desc, buf, file_header.rootDownlink, &root_desc->fileExtent);
+		read_result = read_page_from_disk(desc, buf, file_header.rootDownlink,
+										  &root_desc->fileExtent);
 
-		if (rerror)
+		if (read_result != OReadPageResultOk)
 		{
 			unlock_page(desc->rootInfo.rootPageBlkno);
-			ereport(ERROR, (errcode_for_file_access(),
-							errmsg("could not read rootPageBlkno page from %s: %m",
-								   btree_smgr_filename(desc,
-													   DOWNLINK_GET_DISK_OFF(file_header.rootDownlink),
-													   chkp_num))));
+			if (read_result == OReadPageResultChecksumFailed)
+				ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
+								errmsg("invalid rootPageBlkno page in %s",
+									   btree_smgr_filename(desc,
+														   DOWNLINK_GET_DISK_OFF(file_header.rootDownlink),
+														   chkp_num))));
+			else
+				ereport(ERROR, (errcode_for_file_access(),
+								errmsg("could not read rootPageBlkno page from %s: %m",
+									   btree_smgr_filename(desc,
+														   DOWNLINK_GET_DISK_OFF(file_header.rootDownlink),
+														   chkp_num))));
 		}
 
 		put_page_image(desc->rootInfo.rootPageBlkno, buf);

--- a/src/checkpoint/control.c
+++ b/src/checkpoint/control.c
@@ -74,6 +74,7 @@ get_checkpoint_control_data(CheckpointControl *control)
 
 /*
  * Check checkpoint control data
+ *   - Check control version
  *   - Check CRC
  *   - Check control parameters
  */
@@ -82,13 +83,11 @@ check_checkpoint_control(CheckpointControl *control)
 {
 	pg_crc32c	crc;
 
-	INIT_CRC32C(crc);
-	COMP_CRC32C(crc, control, offsetof(CheckpointControl, crc));
-	FIN_CRC32C(crc);
-
-	if (crc != control->crc)
-		elog(ERROR, "Wrong CRC in control file");
-
+	/*
+	 * Check the version before the CRC: a version bump can move
+	 * offsetof(CheckpointControl, crc), which would otherwise fail as a
+	 * misleading "Wrong CRC" rather than a version mismatch.
+	 */
 	if (control->controlFileVersion != ORIOLEDB_CHECKPOINT_CONTROL_VERSION)
 	{
 		/*
@@ -103,6 +102,13 @@ check_checkpoint_control(CheckpointControl *control)
 						   " but the currently required version is %d.",
 						   control->controlFileVersion, ORIOLEDB_CHECKPOINT_CONTROL_VERSION)));
 	}
+
+	INIT_CRC32C(crc);
+	COMP_CRC32C(crc, control, offsetof(CheckpointControl, crc));
+	FIN_CRC32C(crc);
+
+	if (crc != control->crc)
+		elog(ERROR, "Wrong CRC in control file");
 
 	if (control->binaryVersion != ORIOLEDB_BINARY_VERSION)
 		ereport(FATAL,

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -135,6 +135,7 @@ bool		debug_disable_bgwriter = false;
 bool		use_mmap = false;
 bool		use_device = false;
 bool		orioledb_use_sparse_files = false;
+bool		orioledb_checksums_enabled = true;
 char	   *device_filename = NULL;
 Pointer		mmap_data = NULL;
 int			device_fd;
@@ -912,6 +913,20 @@ _PG_init(void)
 							 false,
 							 PGC_POSTMASTER,
 							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	/*
+	 * Read-only and currently always on.
+	 */
+	DefineCustomBoolVariable("orioledb.checksums_enabled",
+							 "Shows whether OrioleDB page checksums are enabled.",
+							 NULL,
+							 &orioledb_checksums_enabled,
+							 true,
+							 PGC_INTERNAL,
+							 GUC_NOT_IN_SAMPLE,
 							 NULL,
 							 NULL,
 							 NULL);

--- a/test/t/amcheck_test.py
+++ b/test/t/amcheck_test.py
@@ -228,6 +228,149 @@ class AmcheckTest(BaseTest):
 		self.assertTrue(any('check failed' in r[1] for r in rows),
 		                f"unexpected verify_orioledb output: {rows!r}")
 
+	def verify_orioledb_page_checksum_base(self, corrupt, compress=False):
+		"""
+		Shared helper for the page-checksum tests. OrioleDB page checksums are
+		always enabled, so we create + checkpoint a table, optionally corrupt a
+		page byte on disk, restart, and assert on the log: a corrupted page
+		must yield a 'page checksum mismatch' WARNING, a clean one must not.
+
+		With compress=True the table is created WITH (compress = 1) and filled
+		with both compressible and incompressible rows, so the on-disk image
+		exercises both the compressed-extent path and the full-block
+		(len == 1) path in read_page_from_disk / write_page_to_disk.
+		"""
+		import random
+		import struct
+
+		node = self.initNode(self.getBasePort(),
+		                     initdb_args=["--no-locale", "--encoding=UTF8"])
+		self.node = node
+
+		node.start()
+		if compress:
+			row_count = 1400
+			node.safe_psql(
+			    'postgres', """
+				CREATE EXTENSION IF NOT EXISTS orioledb;
+				CREATE TABLE o_corrupt (
+					k int PRIMARY KEY,
+					v bytea NOT NULL
+				) USING orioledb WITH (compress = 1);
+				INSERT INTO o_corrupt
+					SELECT i, decode(repeat('78', 200), 'hex')
+					FROM generate_series(1, 1000) i;
+			""")
+			# Incompressible rows so some leaf pages stay above the block size
+			# and get stored full-block (the len == 1 path). A fixed-seed PRNG
+			# keeps the run reproducible; the assertions don't depend on the
+			# actual bytes, only on the pages being incompressible.
+			rnd = random.Random(1234)
+			con = node.connect()
+			for i in range(1001, row_count + 1):
+				con.execute("INSERT INTO o_corrupt VALUES (%s, %s)", i,
+				            rnd.randbytes(2560))
+			con.commit()
+			con.close()
+			node.safe_psql('postgres', "CHECKPOINT;")
+		else:
+			row_count = 1000
+			node.safe_psql(
+			    'postgres', """
+				CREATE EXTENSION IF NOT EXISTS orioledb;
+				CREATE TABLE o_corrupt (
+					k int PRIMARY KEY,
+					v text NOT NULL
+				) USING orioledb;
+				INSERT INTO o_corrupt
+					SELECT i, repeat('x', 200) FROM generate_series(1, 1000) i;
+				CHECKPOINT;
+			""")
+
+		datoid, pkey_relnode = node.execute(
+		    'postgres', """
+			SELECT (SELECT oid FROM pg_database WHERE datname='postgres'),
+			       (SELECT relfilenode FROM pg_class
+			        WHERE relname='o_corrupt_pkey');
+		""")[0]
+
+		node.stop()
+
+		if corrupt:
+			# Pick the page file and write garbage somewhere. On restart we
+			# should get a checksum error (checksums are always on).
+			pattern = os.path.join(node.data_dir, 'orioledb_data', str(datoid),
+			                       f'{pkey_relnode}')
+			page_files = sorted(glob.glob(pattern))
+			self.assertTrue(page_files, f"no page files matched {pattern}")
+			with open(page_files[-1], 'r+b') as f:
+				if compress:
+					# Compressed extents are variably sized and the file is
+					# sparse, so a fixed offset can land in a hole. Flip the
+					# last non-zero byte instead: it is guaranteed to sit inside
+					# a written extent's checksummed region.
+					data = f.read()
+					pos = len(data)
+					while pos > 0 and data[pos - 1] == 0:
+						pos -= 1
+					self.assertGreater(pos, 0, "page file is all zeroes")
+					f.seek(pos - 1)
+					f.write(bytes([data[pos - 1] ^ 0xFF]))
+				else:
+					f.seek(16000)
+					f.write(struct.pack('<Q', 0xDEADBEEF))
+
+		node.start()
+		if corrupt:
+			# The checksum error is emitted as a WARNING inside
+			# read_page_from_disk because WARNING doesn't longjmp.
+			# After the cleanup, load_page raises the generic
+			# ereport(errcode_for_file_access, "could not read page ...: %m"),
+			# whose SQLSTATE comes from errcode_for_file_access() reading
+			# errno. The checksum path doesn't set errno, so whatever value
+			# happens to be there gets mapped (in practice ENOENT,
+			# surfaced as UndefinedFile).
+			#
+			# Assert on any Exception and grep the server log for the
+			# WARNING text to confirm the checksum path fired.
+			with self.assertRaises(Exception):
+				node.execute(
+				    'postgres',
+				    "SELECT * FROM verify_orioledb('o_corrupt'::regclass);")
+			with open(os.path.join(node.logs_dir, 'postgresql.log')) as f:
+				self.assertIn("page checksum mismatch", f.read())
+		else:
+			# Clean round-trip: reading every page back from cold cache must
+			# not report a checksum mismatch.
+			self.assertEqual(
+			    node.execute('postgres',
+			                 "SELECT count(*) FROM o_corrupt;")[0][0],
+			    row_count)
+			with open(os.path.join(node.logs_dir, 'postgresql.log')) as f:
+				self.assertNotIn("page checksum mismatch", f.read())
+
+	def test_verify_orioledb_page_corruption(self):
+		"""
+		Corrupting an on-disk page must produce a 'page checksum mismatch'
+		WARNING in the log.
+		"""
+		self.verify_orioledb_page_checksum_base(corrupt=True)
+
+	def test_verify_orioledb_page_corruption_compressed(self):
+		"""
+		Corrupting an on-disk page of a compressed table must produce a
+		'page checksum mismatch' WARNING, exercising the compressed read path
+		in read_page_from_disk.
+		"""
+		self.verify_orioledb_page_checksum_base(corrupt=True, compress=True)
+
+	def test_verify_orioledb_compressed_checksums_clean(self):
+		"""
+		A compressed table mixing compressed and full-block (len == 1) pages
+		must round-trip through disk with no checksum mismatch.
+		"""
+		self.verify_orioledb_page_checksum_base(corrupt=False, compress=True)
+
 	def test_verify_orioledb_during_checkpoint(self):
 		"""
 		With the checkpointer parked inside our pkey tree via a stopevent,


### PR DESCRIPTION
Uses FNV via pg_checksum_block, takes care of alignment. 
Skips validation for v1 pages. Zeroes compressed tails.
Doesn't do its own ERROR because load_page has some cleanup. 
Consequetly failed checksum validation can pick up strange errnos. 
^= blkno is deferred.

closes #956 