### PR TITLE
Support cross-major pg_upgrade of OrioleDB clusters

### DIFF
--- a/.github/workflows/pg_upgrade.yml
+++ b/.github/workflows/pg_upgrade.yml
@@ -1,0 +1,95 @@
+name: pg_upgrade
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pg_upgrade:
+    strategy:
+      fail-fast: false
+      matrix:
+        cpu: [amd64, arm64]
+        compiler: [clang, gcc]
+        # Which major version we migrate from -> to.
+        version:
+          - { old: 16, new: 17 }
+          - { old: 16, new: 18 }
+          - { old: 17, new: 18 }
+
+    runs-on: ${{ matrix.cpu == 'arm64' && 'blacksmith-8vcpu-ubuntu-2404-arm' || 'blacksmith-8vcpu-ubuntu-2404' }}
+
+    env:
+      LLVM_VER: 18
+      CPU: ${{ matrix.cpu }}
+      COMPILER: ${{ matrix.compiler }}
+      # prerequisites.sh / post_build_prerequisites.sh branch on these;
+      # 'normal' selects the standard package set with no extra tooling.
+      CHECK_TYPE: normal
+      PG_OLD_VERSION: ${{ matrix.version.old }}
+      PG_NEW_VERSION: ${{ matrix.version.new }}
+      # Needed by prerequisites.sh; PG_VERSION is otherwise unused here.
+      PG_VERSION: ${{ matrix.version.new }}
+
+    steps:
+      - name: Checkout extension code into workspace directory
+        uses: actions/checkout@v6
+        with:
+          path: orioledb
+
+      - name: Resolve required PG tags
+        shell: bash
+        run: |
+          echo "PG_OLD_TAG=$(grep "^${PG_OLD_VERSION}: " orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+          echo "PG_NEW_TAG=$(grep "^${PG_NEW_VERSION}: " orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+
+      - name: Checkout old PostgreSQL source
+        uses: actions/checkout@v6
+        with:
+          repository: orioledb/postgres
+          ref: ${{ env.PG_OLD_TAG }}
+          path: postgresql${{ matrix.version.old }}
+
+      - name: Checkout new PostgreSQL source
+        uses: actions/checkout@v6
+        with:
+          repository: orioledb/postgres
+          ref: ${{ env.PG_NEW_TAG }}
+          path: postgresql${{ matrix.version.new }}
+
+      - name: Setup prerequisites
+        run: bash ./orioledb/ci/prerequisites.sh
+
+      - name: Install Python prerequisites
+        run: bash ./orioledb/ci/post_build_prerequisites.sh
+
+      - name: Build old PostgreSQL + orioledb
+        run: bash ./orioledb/ci/pg_upgrade_build.sh "$PG_OLD_VERSION" "$GITHUB_WORKSPACE/postgresql$PG_OLD_VERSION" "$GITHUB_WORKSPACE/pgsql$PG_OLD_VERSION"
+
+      - name: Build new PostgreSQL + orioledb
+        run: bash ./orioledb/ci/pg_upgrade_build.sh "$PG_NEW_VERSION" "$GITHUB_WORKSPACE/postgresql$PG_NEW_VERSION" "$GITHUB_WORKSPACE/pgsql$PG_NEW_VERSION"
+
+      - name: Run pg_upgrade test
+        timeout-minutes: 30
+        run: bash ./orioledb/ci/pg_upgrade.sh
+
+      - name: Upload pg_upgrade logs
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: ${{ matrix.cpu }}_${{ matrix.compiler }}_${{ matrix.version.old }}_to_${{ matrix.version.new }}_pg_upgrade.logs
+          path: |
+            ./pg${{ matrix.version.old }}.log
+            ./pg${{ matrix.version.new }}.log
+            ./pgsql${{ matrix.version.old }}/pgdata/log/*.log
+            ./pgsql${{ matrix.version.new }}/pgdata/log/*.log
+            ./pgsql${{ matrix.version.new }}/pgdata/pg_upgrade_output.d/**/*.log
+            ./pgsql${{ matrix.version.new }}/pgdata/pg_upgrade_output.d/**/*.txt
+            ./pre_upgrade*.sql
+            ./post_upgrade*.sql
+            ./schema_diff.txt
+            ./data_diff.txt
+            ./data_diff_regression.txt
+            ./postgresql${{ matrix.version.new }}/src/test/regress/regression.diffs
+          retention-days: 2
+          if-no-files-found: ignore

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -386,12 +386,10 @@ fi
 	-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
 
 # ----------------------------------------------------------------------
-# 7a. Before anything triggers the automatic refresh, confirm that a
-#     plain read of an index whose expression trees were written by the old
-#     major raises a clean error instead of crashing.  A bare SELECT does not
-#     go through ProcessUtility, so it does not trip the automatic refresh
-#     (step 7b) and still exercises the read-time fallback guard.  Only
-#     meaningful across majors; same-version carries compatible trees.
+# 7a. Before refreshing, confirm that touching an index whose expression
+#     trees were written by the old major raises a clean error instead of
+#     crashing the backend.  Only meaningful across majors; same-version
+#     "upgrades" carry compatible trees and need no refresh.
 # ----------------------------------------------------------------------
 if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 	set +e
@@ -400,7 +398,7 @@ if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 	refresh_rc=$?
 	set -e
 	if [ $refresh_rc -eq 0 ]; then
-		echo "ERROR: expression-index table was readable before the automatic refresh"
+		echo "ERROR: expression-index table was readable before orioledb_upgrade_refresh()"
 		echo "$refresh_err"
 		exit 1
 	fi
@@ -417,33 +415,30 @@ if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 fi
 
 # ----------------------------------------------------------------------
-# 7b. Exercise the AUTOMATIC refresh.  A cross-major upgrade carries over
-#     expression/predicate/SQL-function node trees in the old major's
-#     nodeToString format, which the new server cannot read; OrioleDB rewrites
-#     them into the running server's format on the first utility command in
-#     each database (maybe_auto_upgrade_refresh), so no manual
-#     orioledb_upgrade_refresh() call is required.  Issue one trivial utility
-#     statement to trigger it, then confirm the expression-index table that
-#     erred in step 7a is now readable.
+# 7b. Refresh OrioleDB index expressions into the new server's node-tree
+#     format.  A cross-major upgrade carries over expression/predicate
+#     blobs in the old major's nodeToString format, which the new server
+#     skips on read (see o_deserialize_node); orioledb_upgrade_refresh()
+#     re-derives them from the catalog and rewrites them.  Run once per
+#     database that has the extension, before anything reads those tables.
 #
-#     $TEST_DB is fully controlled by this script, so a failure there is a real
-#     bug -- fail the job immediately.  The regression database can be left
-#     half-broken by a tolerated mid-suite failure (see step 2), so it stays
-#     best-effort, but we still surface the actual error.
+#     $TEST_DB is fully controlled by this script, so a refresh failure
+#     there is a real bug -- fail the job immediately rather than hoping
+#     the later dump diff catches it.  The regression database can be left
+#     half-broken by a tolerated mid-suite failure (see step 2), so its
+#     refresh stays best-effort, but we still surface the actual error.
 # ----------------------------------------------------------------------
 if db_exists $PORT_NEW "$TEST_DB"; then
-	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
-DISCARD ALL;					-- utility command: triggers the automatic refresh
-SELECT count(*) FROM numbers;	-- erred in step 7a; must succeed after the refresh
-SQL
-	echo "Auto-refreshed OrioleDB expressions in $TEST_DB"
+	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 \
+		-c "SELECT orioledb_upgrade_refresh();"
+	echo "Refreshed OrioleDB expressions in $TEST_DB"
 fi
 
 if db_exists $PORT_NEW regression; then
 	refresh_out=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d regression -v ON_ERROR_STOP=1 \
-		-c "DISCARD ALL;" 2>&1) \
-		&& echo "Auto-refresh triggered in regression" \
-		|| echo "[WARN] triggering auto-refresh in regression failed: $refresh_out"
+		-c "SELECT orioledb_upgrade_refresh();" 2>&1) \
+		&& echo "Refreshed OrioleDB expressions in regression" \
+		|| echo "[WARN] orioledb_upgrade_refresh() failed in regression: $refresh_out"
 fi
 
 # ----------------------------------------------------------------------

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -446,6 +446,47 @@ if db_exists $PORT_NEW regression; then
 fi
 
 # ----------------------------------------------------------------------
+# 7c. Exercise the catalog-free paths that actually crash if the cross-major
+#     cache handling regresses.  A foreground query alone would not: the
+#     checkpointer and crash recovery read OrioleDB's version-dependent caches
+#     (class cache tuple descriptors, database-cache locale) WITHOUT a catalog,
+#     via the syscache hook, and that is exactly where a carried-over
+#     old-major entry blows up.  So drive both explicitly on $TEST_DB (it has
+#     an expression + partial index, whose descriptor fill reads those caches):
+#
+#       1. CHECKPOINT   -> checkpointer fills index descriptors.
+#       2. INSERT into the expression-index table, then crash (-m immediate)
+#          and restart -> recovery must REPLAY that insert, rebuilding the
+#          expression-index tuple (reading the class + database caches) with no
+#          catalog of its own.  This is the scenario that asserted in
+#          o_class_cache_deserialize_entry / "default locale not initialized"
+#          before the fix.
+#
+#     Cross-major only; a same-version upgrade carries compatible caches.
+# ----------------------------------------------------------------------
+if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
+	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
+CHECKPOINT;
+INSERT INTO numbers SELECT i, 'v_' || i FROM generate_series(1000001, 1000050) i;
+SQL
+	# Crash without a clean shutdown so recovery has to replay the insert.
+	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" -m immediate stop
+	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" \
+		-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
+	if ! db_exists $PORT_NEW "$TEST_DB"; then
+		echo "ERROR: server did not come up after crash recovery of an expression-index insert"
+		exit 1
+	fi
+	rowcount=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -tAc \
+		"SELECT count(*) FROM numbers WHERE (val || '_x') = 'v_1000001_x'")
+	if [ "$rowcount" != "1" ]; then
+		echo "ERROR: expression index wrong after crash recovery (got '$rowcount', want 1)"
+		exit 1
+	fi
+	echo "OK: checkpoint + crash recovery of an expression-index insert survived"
+fi
+
+# ----------------------------------------------------------------------
 # 8. Dump the post-upgrade state.  This must happen before step 10's
 #    regression run, which drops and recreates the regression database.
 # ----------------------------------------------------------------------

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -408,14 +408,25 @@ fi
 #     skips on read (see o_deserialize_node); orioledb_upgrade_refresh()
 #     re-derives them from the catalog and rewrites them.  Run once per
 #     database that has the extension, before anything reads those tables.
+#
+#     $TEST_DB is fully controlled by this script, so a refresh failure
+#     there is a real bug -- fail the job immediately rather than hoping
+#     the later dump diff catches it.  The regression database can be left
+#     half-broken by a tolerated mid-suite failure (see step 2), so its
+#     refresh stays best-effort, but we still surface the actual error.
 # ----------------------------------------------------------------------
-for db in "$TEST_DB" regression; do
-	db_exists $PORT_NEW "$db" || continue
-	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$db" -v ON_ERROR_STOP=1 \
-		-c "SELECT orioledb_upgrade_refresh();" \
-		&& echo "Refreshed OrioleDB expressions in $db" \
-		|| echo "[WARN] orioledb_upgrade_refresh() failed in $db"
-done
+if db_exists $PORT_NEW "$TEST_DB"; then
+	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 \
+		-c "SELECT orioledb_upgrade_refresh();"
+	echo "Refreshed OrioleDB expressions in $TEST_DB"
+fi
+
+if db_exists $PORT_NEW regression; then
+	refresh_out=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d regression -v ON_ERROR_STOP=1 \
+		-c "SELECT orioledb_upgrade_refresh();" 2>&1) \
+		&& echo "Refreshed OrioleDB expressions in regression" \
+		|| echo "[WARN] orioledb_upgrade_refresh() failed in regression: $refresh_out"
+fi
 
 # ----------------------------------------------------------------------
 # 8. Dump the post-upgrade state.  This must happen before step 10's

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -64,6 +64,19 @@ collect_core_dumps() {
 	return $found
 }
 
+# Print core-dump backtraces on any exit -- including the `set -e` exit taken
+# when a backend crashes mid-test (which otherwise surfaces only as "server
+# closed the connection unexpectedly" with no cause).  This mirrors the check
+# workflow's post-run core inspection; the short sleep lets the kernel finish
+# writing the core before we read it.  The original exit code is preserved.
+dump_cores_on_exit() {
+	local rc=$?
+	sleep 2
+	collect_core_dumps || true
+	exit $rc
+}
+trap dump_cores_on_exit EXIT
+
 write_pg_conf() {
 	local data=$1
 	cat >> "$data/postgresql.conf" <<EOF

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -1,0 +1,494 @@
+#!/bin/bash
+#
+# pg_upgrade smoke test: populate a PG_OLD_VERSION cluster with orioledb
+# data, upgrade in-place to PG_NEW_VERSION (both set by the CI matrix;
+# default 16 -> 17), then verify that
+#
+#   1. pg_upgrade itself runs (with --check and the real run),
+#   2. a pg_dump of the upgraded $TEST_DB matches the pre-upgrade dump
+#      (schema and data),
+#   3. pg_upgrade preserves every row of the regression database too
+#      (data-only; see note in step 3),
+#   4. the orioledb regression suite still runs on the upgraded cluster.
+
+set -eux
+
+# Which major versions we migrate from/to (set by the CI matrix; default to
+# the original 16 -> 17 pair so the script still runs standalone).
+OLD_VERSION="${PG_OLD_VERSION:-16}"
+NEW_VERSION="${PG_NEW_VERSION:-17}"
+OLD_PREFIX="$GITHUB_WORKSPACE/pgsql${OLD_VERSION}"
+NEW_PREFIX="$GITHUB_WORKSPACE/pgsql${NEW_VERSION}"
+OLD_DATA="$OLD_PREFIX/pgdata"
+
+# PG18 turns data checksums on by default in initdb; PG16/17 default to off
+# and don't accept --no-data-checksums.  pg_upgrade requires the old and new
+# clusters to agree, so force checksums off wherever the flag is available
+# (>= 18) to match the older default on both ends.
+OLD_INITDB_CHECKSUMS=""
+NEW_INITDB_CHECKSUMS=""
+[ "$OLD_VERSION" -ge 18 ] && OLD_INITDB_CHECKSUMS="--no-data-checksums"
+[ "$NEW_VERSION" -ge 18 ] && NEW_INITDB_CHECKSUMS="--no-data-checksums"
+NEW_DATA="$NEW_PREFIX/pgdata"
+PORT_OLD=5432
+PORT_NEW=5433
+TEST_DB=upgrade_test
+SORT_DUMP="$GITHUB_WORKSPACE/orioledb/ci/sort_dump.py"
+
+# Capture core dumps produced by any backend during the test (mirrors
+# ci/check.sh), so a crash is diagnosable instead of just showing up as a
+# failed regression test.
+CORE_DIR="/tmp/cores-${GITHUB_SHA:-pg_upgrade}-${TIMESTAMP:-0}"
+ulimit -c unlimited -S || true
+mkdir -p "$CORE_DIR"
+sudo sh -c "echo '$CORE_DIR/%t_%p.core' > /proc/sys/kernel/core_pattern" || true
+
+# Dump backtraces for any postgres core left in CORE_DIR and return
+# non-zero if at least one postgres core was found.  Non-postgres cores
+# (shell/cp helpers killed during cleanup) are reported but ignored.
+collect_core_dumps() {
+	local cores corefile binary found=0
+	cores=$(find "$CORE_DIR" -name '*.core' 2>/dev/null)
+	[ -n "$cores" ] || return 0
+	for corefile in $cores; do
+		binary=$(gdb -quiet -core "$corefile" -batch -ex 'info auxv' 2>/dev/null \
+			| grep AT_EXECFN | perl -pe 's/^.*"(.*)"$/$1/g')
+		if [ "${binary##*/}" != "postgres" ]; then
+			echo "Skipping non-postgres core $corefile (binary: ${binary:-unknown})"
+			continue
+		fi
+		echo "======== core dump $corefile ($binary)"
+		gdb --batch --quiet -x "$GITHUB_WORKSPACE/orioledb/ci/cmds.gdb" "$binary" "$corefile" || true
+		found=1
+	done
+	return $found
+}
+
+write_pg_conf() {
+	local data=$1
+	cat >> "$data/postgresql.conf" <<EOF
+wal_level = logical
+shared_preload_libraries = 'orioledb'
+default_table_access_method = 'orioledb'
+EOF
+}
+
+# Does a database exist and accept connections?  Always uses PG17's psql
+# (forward-compatible to the PG16 server) so callers don't have to care
+# which cluster is up.
+db_exists() {		# port db
+	"$NEW_PREFIX/bin/psql" -p "$1" -tAc "SELECT 1" "$2" >/dev/null 2>&1
+}
+
+# pg_upgrade writes the per-database dump/restore failures into
+# pg_upgrade_output.d/<ts>/log/*.log and prints only the path.  Echo
+# those logs to stdout so the cause is visible directly in CI output.
+dump_pg_upgrade_logs() {
+	echo "=== pg_upgrade failed; dumping pg_upgrade_output.d logs ==="
+	find "$NEW_DATA/pg_upgrade_output.d" -type f \( -name '*.log' -o -name '*.txt' \) 2>/dev/null \
+		| sort | while read -r f; do
+			echo "----- $f -----"
+			cat "$f"
+		done
+}
+
+# Dump one database's schema to a normalized .sql file.  PG17's pg_dump
+# is used for every dump (pre and post) so the format is identical; the
+# leading \restrict / \unrestrict psql meta-commands carry a per-dump
+# nonce, and the "Dumped from database version" header reflects the
+# source server (16 pre-upgrade vs 17 post-upgrade), so strip both before
+# comparing.
+dump_schema() {		# port db outfile
+	"$NEW_PREFIX/bin/pg_dump" -s -p "$1" "$2" \
+		| grep -v '^\\\(un\)\{0,1\}restrict' \
+		| grep -v '^-- Dumped from database version ' > "$3"
+}
+
+# Dump one database's data as a row-sorted directory tree for a
+# deterministic diff (mirrors the primary/replica comparison in
+# check.sh).  Unlogged table contents are not preserved across
+# pg_upgrade, so exclude them.  Returns non-zero if either dump step
+# fails so best-effort callers can skip a broken database.
+dump_data() {		# port db out_sorted_dir
+	local port=$1 db=$2 out=$3 raw="$3.raw" exclude="" tbl
+	rm -rf "$raw" "$out"
+	for tbl in $("$NEW_PREFIX/bin/psql" -p "$port" -tAc \
+		"SELECT schemaname || '.' || tablename FROM pg_tables WHERE tablename IN (SELECT relname FROM pg_class WHERE relpersistence = 'u')" \
+		"$db" 2>/dev/null); do
+		exclude="$exclude --exclude-table=$tbl"
+	done
+	"$NEW_PREFIX/bin/pg_dump" -a -Fd --compress=0 -p "$port" $exclude -f "$raw" "$db" || return 1
+	PATH="$NEW_PREFIX/bin:$PATH" python3 "$SORT_DUMP" "$raw" "$out" || return 1
+}
+
+# ----------------------------------------------------------------------
+# 1. Initialize and start the PG16 cluster with orioledb preloaded.
+# ----------------------------------------------------------------------
+"$OLD_PREFIX/bin/initdb" -N --encoding=UTF-8 --locale=C $OLD_INITDB_CHECKSUMS -D "$OLD_DATA"
+write_pg_conf "$OLD_DATA"
+"$OLD_PREFIX/bin/pg_ctl" -D "$OLD_DATA" \
+	-o "-p $PORT_OLD" -l "$GITHUB_WORKSPACE/pg${OLD_VERSION}.log" -w start
+
+# ----------------------------------------------------------------------
+# 2. Populate the cluster.
+#
+#    First create a deterministic database with a few orioledb tables
+#    so the pre/post dump diff is meaningful even if the heavier
+#    regression suite is noisy.  Then run the orioledb-aware
+#    regression schedule from PG16's tree to add the "real" workload.
+#    Individual regression diffs are not fatal here -- we only care
+#    that the server stays alive and ends with the populated state.
+# ----------------------------------------------------------------------
+"$OLD_PREFIX/bin/psql" -p $PORT_OLD -d postgres -v ON_ERROR_STOP=1 <<EOF
+CREATE DATABASE $TEST_DB;
+EOF
+
+"$OLD_PREFIX/bin/psql" -p $PORT_OLD -d $TEST_DB -v ON_ERROR_STOP=1 <<'EOF'
+CREATE EXTENSION orioledb;
+
+CREATE TABLE numbers (id int PRIMARY KEY, val text) USING orioledb;
+INSERT INTO numbers SELECT i, 'v_' || i FROM generate_series(1, 10000) i;
+CREATE INDEX numbers_val_idx ON numbers (val);
+-- Expression + partial index: its node trees are version-specific, so a
+-- cross-major upgrade must rewrite them (see step 7a / 7b).
+CREATE INDEX numbers_expr_idx ON numbers ((val || '_x')) WHERE id > 5;
+
+CREATE TABLE composite (
+	a int,
+	b int,
+	c text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO composite SELECT i / 100, i % 100, md5(i::text)
+                      FROM generate_series(1, 10000) i;
+
+CHECKPOINT;
+EOF
+
+(
+	cd "$GITHUB_WORKSPACE/postgresql${OLD_VERSION}/src/test/regress"
+	PATH="$OLD_PREFIX/bin:$PATH" PGPORT=$PORT_OLD \
+		make installcheck-oriole \
+		EXTRA_REGRESS_OPTS="--load-extension=orioledb" \
+		-j "$(nproc)" || \
+		echo "[WARN] some installcheck-oriole tests failed in PG16; continuing"
+)
+
+# ----------------------------------------------------------------------
+# 2b. Move every user tablespace's contents back to pg_default and drop
+#     the tablespace before pg_upgrade --check.
+#
+#     pg_upgrade cannot migrate in-place tablespaces (LOCATION ''): for
+#     those pg_tablespace_location() returns a *relative* path such as
+#     "pg_tblspc/16577", which pg_upgrade stat()s against its own CWD
+#     rather than the data directory, so --check dies with "tablespace
+#     directory does not exist".  The regression suite leaves such
+#     tablespaces behind, especially when it aborts mid-way (which we
+#     tolerate above).
+#
+#     Relocating the objects to pg_default keeps their data -- so it is
+#     still upgraded and verified below -- and lets us drop the
+#     un-migratable tablespace.  A tablespace whose backing storage was
+#     already torn down can't be relocated; for those we fall back to
+#     recreating an empty stub directory so --check can still proceed
+#     (their data is already gone).
+# ----------------------------------------------------------------------
+ts_names=$("$OLD_PREFIX/bin/psql" -p $PORT_OLD -d postgres -tA -c \
+	"SELECT spcname FROM pg_tablespace WHERE spcname NOT IN ('pg_default','pg_global')")
+dbs=$("$OLD_PREFIX/bin/psql" -p $PORT_OLD -d postgres -tA -c \
+	"SELECT datname FROM pg_database WHERE datallowconn AND datname <> 'template0'")
+for ts in $ts_names; do
+	[ -n "$ts" ] || continue
+	for db in $dbs; do
+		"$OLD_PREFIX/bin/psql" -p $PORT_OLD -d "$db" -v ON_ERROR_STOP=0 -q <<EOF
+ALTER TABLE ALL IN TABLESPACE "$ts" SET TABLESPACE pg_default;
+ALTER INDEX ALL IN TABLESPACE "$ts" SET TABLESPACE pg_default;
+ALTER MATERIALIZED VIEW ALL IN TABLESPACE "$ts" SET TABLESPACE pg_default;
+EOF
+	done
+	if "$OLD_PREFIX/bin/psql" -p $PORT_OLD -d postgres -v ON_ERROR_STOP=1 \
+			-c "DROP TABLESPACE \"$ts\";"; then
+		echo "Relocated contents to pg_default and dropped tablespace: $ts"
+	else
+		echo "[WARN] could not drop tablespace $ts; will stub its directory"
+	fi
+done
+
+# Safety net: any tablespace we could not drop still needs a backing
+# directory or pg_upgrade --check refuses to run.
+ts_oids=$("$OLD_PREFIX/bin/psql" -p $PORT_OLD -d postgres -tA -c \
+	"SELECT oid FROM pg_tablespace WHERE spcname NOT IN ('pg_default','pg_global')")
+for oid in $ts_oids; do
+	[ -n "$oid" ] || continue
+	dir="$OLD_DATA/pg_tblspc/$oid"
+	if [ ! -e "$dir" ]; then
+		# Handles missing entry AND dangling symlink (-e is false for both).
+		rm -f "$dir"
+		mkdir -p "$dir"
+		echo "Recreated missing tablespace dir: pg_tblspc/$oid"
+	fi
+done
+
+# ----------------------------------------------------------------------
+# 2c. Strip references to test-only loadable libraries from the
+#     regression database before pg_upgrade --check.
+#
+#     The regression suite defines many C functions backed by build-tree
+#     test libraries (regress.so, refint, autoinc, ...).  pg_upgrade's
+#     "presence of required libraries" check tries to LOAD each library
+#     referenced by the old cluster on the new PG17 server; those
+#     PG16-ABI / not-installed libraries are not loadable there, so
+#     --check aborts.  They are pure PG-core test scaffolding, unrelated
+#     to orioledb, and cannot be migrated across versions.
+#
+#     Drop every user-defined C function that is not part of an extension
+#     (and whatever depends on it).  orioledb's own functions and any
+#     installed contrib are extension members, so they are kept -- their
+#     libraries load fine on the new cluster.  This runs before the
+#     pre-upgrade dump, so the pre/post data comparison is unaffected.
+# ----------------------------------------------------------------------
+if db_exists $PORT_OLD regression; then
+	"$OLD_PREFIX/bin/psql" -p $PORT_OLD -d regression -v ON_ERROR_STOP=1 <<'EOF'
+DO $$
+DECLARE
+	sigs text[];
+	sig text;
+BEGIN
+	-- Materialize all signatures up front, while every function still
+	-- exists: a lazily-fetched regprocedure renders as a bare OID once a
+	-- prior CASCADE has dropped it, which would make DROP ROUTINE a
+	-- syntax error rather than a catchable "does not exist".
+	SELECT array_agg(p.oid::regprocedure::text)
+	INTO sigs
+	FROM pg_proc p
+	JOIN pg_language l ON l.oid = p.prolang
+	WHERE l.lanname = 'c'
+	  AND p.oid >= 16384			-- FirstNormalObjectId: skip built-ins
+	  AND NOT EXISTS (SELECT 1 FROM pg_depend d
+					  WHERE d.classid = 'pg_proc'::regclass
+						AND d.objid = p.oid
+						AND d.deptype = 'e');
+
+	IF sigs IS NULL THEN
+		RETURN;
+	END IF;
+
+	FOREACH sig IN ARRAY sigs
+	LOOP
+		BEGIN
+			EXECUTE format('DROP ROUTINE %s CASCADE', sig);
+		EXCEPTION
+			WHEN undefined_function OR undefined_object THEN
+				-- already removed by an earlier CASCADE
+				NULL;
+		END;
+	END LOOP;
+END
+$$;
+EOF
+fi
+
+# ----------------------------------------------------------------------
+# 3. Dump the pre-upgrade state while PG16 is still up.
+#
+#    $TEST_DB is deterministic, so we compare both its schema and its
+#    data.  For the regression database we compare data only: a raw
+#    cross-version schema dump is not directly comparable (PG17's
+#    pg_dump renders a PG16 server differently from a PG17 server, which
+#    PG core reconciles with AdjustUpgrade -- machinery we don't
+#    replicate here), so instead we verify that pg_upgrade preserves
+#    every row.  The regression DB may also be left in a half-broken
+#    state by a tolerated mid-suite failure, so its comparison is
+#    best-effort: if a dump fails we skip it rather than fail the job.
+# ----------------------------------------------------------------------
+dump_schema $PORT_OLD "$TEST_DB" pre_upgrade_schema.sql
+dump_data   $PORT_OLD "$TEST_DB" pre_upgrade_data
+
+REGRESSION_CHECKED=0
+if db_exists $PORT_OLD regression; then
+	if dump_data $PORT_OLD regression pre_regression_data; then
+		REGRESSION_CHECKED=1
+	else
+		echo "[WARN] pre-upgrade data dump of regression failed; skipping its comparison"
+	fi
+fi
+
+# ----------------------------------------------------------------------
+# 4. Stop PG16.
+# ----------------------------------------------------------------------
+"$OLD_PREFIX/bin/pg_ctl" -D "$OLD_DATA" -m fast -w stop
+
+# ----------------------------------------------------------------------
+# 5. Initialize a fresh PG17 cluster with matching config.  pg_upgrade
+#    expects the new cluster to be initdb'd but not started.
+# ----------------------------------------------------------------------
+"$NEW_PREFIX/bin/initdb" -N --encoding=UTF-8 --locale=C $NEW_INITDB_CHECKSUMS -D "$NEW_DATA"
+write_pg_conf "$NEW_DATA"
+
+# ----------------------------------------------------------------------
+# 6. pg_upgrade --check first to surface incompatibilities cleanly,
+#    then the real upgrade.
+# ----------------------------------------------------------------------
+"$NEW_PREFIX/bin/pg_upgrade" --check \
+	-b "$OLD_PREFIX/bin" \
+	-B "$NEW_PREFIX/bin" \
+	-d "$OLD_DATA" \
+	-D "$NEW_DATA" \
+	-p $PORT_OLD \
+	-P $PORT_NEW || { dump_pg_upgrade_logs; exit 1; }
+
+"$NEW_PREFIX/bin/pg_upgrade" \
+	-b "$OLD_PREFIX/bin" \
+	-B "$NEW_PREFIX/bin" \
+	-d "$OLD_DATA" \
+	-D "$NEW_DATA" \
+	-p $PORT_OLD \
+	-P $PORT_NEW || { dump_pg_upgrade_logs; exit 1; }
+
+# ----------------------------------------------------------------------
+# 6b. Migrate OrioleDB storage.
+#
+#     pg_upgrade only transfers the per-relation heap files it knows about
+#     from pg_class.  OrioleDB keeps its table/index data in its own
+#     orioledb_data/ tree (plus undo logs in orioledb_undo/), which
+#     pg_upgrade never touches -- so without this the upgraded tables come
+#     up empty.
+#
+#     pg_upgrade preserves database OIDs, relation OIDs and relfilenodes,
+#     and OrioleDB names its files by (datoid, relnode), so the old
+#     cluster's files are valid as-is in the new cluster.  Both clusters
+#     are stopped here and the old one was shut down cleanly (fully
+#     checkpointed), so a wholesale copy needs no WAL replay.
+# ----------------------------------------------------------------------
+rm -rf "$NEW_DATA/orioledb_data" "$NEW_DATA/orioledb_undo"
+cp -R "$OLD_DATA/orioledb_data" "$NEW_DATA/orioledb_data"
+if [ -d "$OLD_DATA/orioledb_undo" ]; then
+	cp -R "$OLD_DATA/orioledb_undo" "$NEW_DATA/orioledb_undo"
+fi
+
+# ----------------------------------------------------------------------
+# 7. Start the upgraded PG17 cluster.
+# ----------------------------------------------------------------------
+"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" \
+	-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
+
+# ----------------------------------------------------------------------
+# 7a. Before refreshing, confirm that touching an index whose expression
+#     trees were written by the old major raises a clean error instead of
+#     crashing the backend.  Only meaningful across majors; same-version
+#     "upgrades" carry compatible trees and need no refresh.
+# ----------------------------------------------------------------------
+if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
+	set +e
+	refresh_err=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 \
+		-c "SELECT count(*) FROM numbers;" 2>&1)
+	refresh_rc=$?
+	set -e
+	if [ $refresh_rc -eq 0 ]; then
+		echo "ERROR: expression-index table was readable before orioledb_upgrade_refresh()"
+		echo "$refresh_err"
+		exit 1
+	fi
+	if ! printf '%s' "$refresh_err" | grep -q "orioledb_upgrade_refresh"; then
+		echo "ERROR: accessing an un-refreshed expression index did not raise the expected error:"
+		echo "$refresh_err"
+		exit 1
+	fi
+	if ! db_exists $PORT_NEW "$TEST_DB"; then
+		echo "ERROR: server is down after accessing an un-refreshed index (crash, not error)"
+		exit 1
+	fi
+	echo "OK: un-refreshed expression index raises a clean error and the server stays up"
+fi
+
+# ----------------------------------------------------------------------
+# 7b. Refresh OrioleDB index expressions into the new server's node-tree
+#     format.  A cross-major upgrade carries over expression/predicate
+#     blobs in the old major's nodeToString format, which the new server
+#     skips on read (see o_deserialize_node); orioledb_upgrade_refresh()
+#     re-derives them from the catalog and rewrites them.  Run once per
+#     database that has the extension, before anything reads those tables.
+# ----------------------------------------------------------------------
+for db in "$TEST_DB" regression; do
+	db_exists $PORT_NEW "$db" || continue
+	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$db" -v ON_ERROR_STOP=1 \
+		-c "SELECT orioledb_upgrade_refresh();" \
+		&& echo "Refreshed OrioleDB expressions in $db" \
+		|| echo "[WARN] orioledb_upgrade_refresh() failed in $db"
+done
+
+# ----------------------------------------------------------------------
+# 8. Dump the post-upgrade state.  This must happen before step 10's
+#    regression run, which drops and recreates the regression database.
+# ----------------------------------------------------------------------
+dump_schema $PORT_NEW "$TEST_DB" post_upgrade_schema.sql
+dump_data   $PORT_NEW "$TEST_DB" post_upgrade_data
+
+if [ "$REGRESSION_CHECKED" = 1 ]; then
+	if ! dump_data $PORT_NEW regression post_regression_data; then
+		echo "[WARN] post-upgrade data dump of regression failed; skipping its comparison"
+		REGRESSION_CHECKED=0
+	fi
+fi
+
+# ----------------------------------------------------------------------
+# 9. Diff pre vs post dumps.  Any difference is a failure.
+# ----------------------------------------------------------------------
+status=0
+if ! diff -u pre_upgrade_schema.sql post_upgrade_schema.sql > schema_diff.txt; then
+	echo "ERROR: $TEST_DB schema differs after pg_upgrade"
+	head -200 schema_diff.txt
+	status=1
+else
+	rm -f schema_diff.txt
+fi
+if ! diff -ru pre_upgrade_data post_upgrade_data > data_diff.txt; then
+	echo "ERROR: $TEST_DB data differs after pg_upgrade"
+	head -200 data_diff.txt
+	status=1
+else
+	rm -f data_diff.txt
+fi
+if [ "$REGRESSION_CHECKED" = 1 ]; then
+	if ! diff -ru pre_regression_data post_regression_data > data_diff_regression.txt; then
+		echo "ERROR: regression data differs after pg_upgrade"
+		head -200 data_diff_regression.txt
+		status=1
+	else
+		echo "regression data matches after pg_upgrade"
+		rm -f data_diff_regression.txt
+	fi
+fi
+
+# ----------------------------------------------------------------------
+# 10. Verify the upgraded cluster is functional by running PG17's
+#     orioledb-aware regression schedule.  This drops/recreates the
+#     `regression` database, which is fine -- $TEST_DB is left intact
+#     and the regression data comparison above already ran.
+#
+#     The schedule is run only as a smoke test that the upgraded binary
+#     stays alive.  Individual regression diffs are expected (the same
+#     orioledb-vs-heap drift the main CI filters, and which step 2
+#     tolerates on PG16), so they are not fatal here; an actual crash is
+#     caught by the core-dump check below instead.
+# ----------------------------------------------------------------------
+(
+	cd "$GITHUB_WORKSPACE/postgresql${NEW_VERSION}/src/test/regress"
+	PATH="$NEW_PREFIX/bin:$PATH" PGPORT=$PORT_NEW \
+		make installcheck-oriole \
+		EXTRA_REGRESS_OPTS="--load-extension=orioledb" \
+		-j "$(nproc)" || \
+		echo "[WARN] some installcheck-oriole tests failed on the upgraded cluster; continuing (diffs expected, crashes caught below)"
+)
+
+"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" -m fast -w stop
+
+# ----------------------------------------------------------------------
+# 11. Fail if any backend dumped core at any point during the test.
+# ----------------------------------------------------------------------
+if ! collect_core_dumps; then
+	echo "ERROR: a postgres backend dumped core during the pg_upgrade test"
+	status=1
+fi
+
+exit $status

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -175,6 +175,21 @@ CREATE TABLE composite (
 INSERT INTO composite SELECT i / 100, i % 100, md5(i::text)
                       FROM generate_series(1, 10000) i;
 
+-- SQL-language function used inside an index expression.  SECURITY DEFINER
+-- stops the planner from inlining it, so it is really invoked through the SQL
+-- function call manager.  In catalog-free contexts (recovery, checkpointer)
+-- that manager is OrioleDB's o_fmgr_sql, which reads the function's parse
+-- trees (jf_targetList/qtlists) from the OrioleDB proc cache.  Those trees are
+-- stored in this major's nodeToString format; a cross-major upgrade must
+-- rebuild the proc cache, or evaluating this index expression during recovery
+-- dereferences NULL trees and crashes (see step 9b).
+CREATE FUNCTION oriole_suffix(t text) RETURNS text
+	LANGUAGE sql IMMUTABLE SECURITY DEFINER AS $$ SELECT t || '_sql' $$;
+
+CREATE TABLE func_index (id int PRIMARY KEY, val text) USING orioledb;
+INSERT INTO func_index SELECT i, 'v_' || i FROM generate_series(1, 1000) i;
+CREATE INDEX func_index_expr ON func_index ((oriole_suffix(val)));
+
 CHECKPOINT;
 EOF
 
@@ -434,6 +449,11 @@ if db_exists $PORT_NEW "$TEST_DB"; then
 	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
 DISCARD ALL;					-- utility command: triggers the automatic refresh
 SELECT count(*) FROM numbers;	-- erred in step 7a; must succeed after the refresh
+-- Foreground read of the SQL-function index: this backend has a catalog, so
+-- the function is resolved through it (not the proc cache) and succeeds even
+-- if the proc cache is stale.  The proc-cache path is exercised catalog-free
+-- in step 9b.
+SELECT count(*) FROM func_index WHERE oriole_suffix(val) = 'v_1_sql';
 SQL
 	echo "Auto-refreshed OrioleDB expressions in $TEST_DB"
 fi
@@ -504,6 +524,12 @@ fi
 #          catalog of its own.  This is the scenario that asserted in
 #          o_class_cache_deserialize_entry / "default locale not initialized"
 #          before the fix.
+#       3. INSERT into func_index too: its index expression calls a SQL
+#          function, so recovery rebuilding that tuple evaluates the function
+#          via o_fmgr_sql, which reads the function's parse trees from the
+#          OrioleDB proc cache.  A cross-major upgrade leaves those trees NULL
+#          unless the proc cache is rebuilt, so recovery crashes here if the
+#          proc-cache handling regresses.
 #
 #     This runs AFTER the pre/post data comparison (step 9) on purpose: it
 #     mutates $TEST_DB (the INSERT below), so running it earlier would make the
@@ -516,8 +542,9 @@ if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
 CHECKPOINT;
 INSERT INTO numbers SELECT i, 'v_' || i FROM generate_series(1000001, 1000050) i;
+INSERT INTO func_index SELECT i, 'v_' || i FROM generate_series(100001, 100050) i;
 SQL
-	# Crash without a clean shutdown so recovery has to replay the insert.
+	# Crash without a clean shutdown so recovery has to replay the inserts.
 	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" -m immediate stop
 	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" \
 		-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
@@ -529,6 +556,13 @@ SQL
 		"SELECT count(*) FROM numbers WHERE (val || '_x') = 'v_1000001_x'")
 	if [ "$rowcount" != "1" ]; then
 		echo "ERROR: expression index wrong after crash recovery (got '$rowcount', want 1)"
+		exit 1
+	fi
+	# Probe the SQL-function index rebuilt by recovery via the proc cache.
+	rowcount=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -tAc \
+		"SELECT count(*) FROM func_index WHERE oriole_suffix(val) = 'v_100001_sql'")
+	if [ "$rowcount" != "1" ]; then
+		echo "ERROR: SQL-function index wrong after crash recovery (got '$rowcount', want 1)"
 		exit 1
 	fi
 	echo "OK: checkpoint + crash recovery of an expression-index insert survived"

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -446,47 +446,6 @@ if db_exists $PORT_NEW regression; then
 fi
 
 # ----------------------------------------------------------------------
-# 7c. Exercise the catalog-free paths that actually crash if the cross-major
-#     cache handling regresses.  A foreground query alone would not: the
-#     checkpointer and crash recovery read OrioleDB's version-dependent caches
-#     (class cache tuple descriptors, database-cache locale) WITHOUT a catalog,
-#     via the syscache hook, and that is exactly where a carried-over
-#     old-major entry blows up.  So drive both explicitly on $TEST_DB (it has
-#     an expression + partial index, whose descriptor fill reads those caches):
-#
-#       1. CHECKPOINT   -> checkpointer fills index descriptors.
-#       2. INSERT into the expression-index table, then crash (-m immediate)
-#          and restart -> recovery must REPLAY that insert, rebuilding the
-#          expression-index tuple (reading the class + database caches) with no
-#          catalog of its own.  This is the scenario that asserted in
-#          o_class_cache_deserialize_entry / "default locale not initialized"
-#          before the fix.
-#
-#     Cross-major only; a same-version upgrade carries compatible caches.
-# ----------------------------------------------------------------------
-if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
-	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
-CHECKPOINT;
-INSERT INTO numbers SELECT i, 'v_' || i FROM generate_series(1000001, 1000050) i;
-SQL
-	# Crash without a clean shutdown so recovery has to replay the insert.
-	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" -m immediate stop
-	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" \
-		-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
-	if ! db_exists $PORT_NEW "$TEST_DB"; then
-		echo "ERROR: server did not come up after crash recovery of an expression-index insert"
-		exit 1
-	fi
-	rowcount=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -tAc \
-		"SELECT count(*) FROM numbers WHERE (val || '_x') = 'v_1000001_x'")
-	if [ "$rowcount" != "1" ]; then
-		echo "ERROR: expression index wrong after crash recovery (got '$rowcount', want 1)"
-		exit 1
-	fi
-	echo "OK: checkpoint + crash recovery of an expression-index insert survived"
-fi
-
-# ----------------------------------------------------------------------
 # 8. Dump the post-upgrade state.  This must happen before step 10's
 #    regression run, which drops and recreates the regression database.
 # ----------------------------------------------------------------------
@@ -527,6 +486,52 @@ if [ "$REGRESSION_CHECKED" = 1 ]; then
 		echo "regression data matches after pg_upgrade"
 		rm -f data_diff_regression.txt
 	fi
+fi
+
+# ----------------------------------------------------------------------
+# 9b. Exercise the catalog-free paths that actually crash if the cross-major
+#     cache handling regresses.  A foreground query alone would not: the
+#     checkpointer and crash recovery read OrioleDB's version-dependent caches
+#     (class cache tuple descriptors, database-cache locale) WITHOUT a catalog,
+#     via the syscache hook, and that is exactly where a carried-over
+#     old-major entry blows up.  So drive both explicitly on $TEST_DB (it has
+#     an expression + partial index, whose descriptor fill reads those caches):
+#
+#       1. CHECKPOINT   -> checkpointer fills index descriptors.
+#       2. INSERT into the expression-index table, then crash (-m immediate)
+#          and restart -> recovery must REPLAY that insert, rebuilding the
+#          expression-index tuple (reading the class + database caches) with no
+#          catalog of its own.  This is the scenario that asserted in
+#          o_class_cache_deserialize_entry / "default locale not initialized"
+#          before the fix.
+#
+#     This runs AFTER the pre/post data comparison (step 9) on purpose: it
+#     mutates $TEST_DB (the INSERT below), so running it earlier would make the
+#     post-upgrade dump differ from the pre-upgrade baseline.  A crash here is
+#     still caught by the core-dump check in step 11.
+#
+#     Cross-major only; a same-version upgrade carries compatible caches.
+# ----------------------------------------------------------------------
+if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
+	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
+CHECKPOINT;
+INSERT INTO numbers SELECT i, 'v_' || i FROM generate_series(1000001, 1000050) i;
+SQL
+	# Crash without a clean shutdown so recovery has to replay the insert.
+	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" -m immediate stop
+	"$NEW_PREFIX/bin/pg_ctl" -D "$NEW_DATA" \
+		-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
+	if ! db_exists $PORT_NEW "$TEST_DB"; then
+		echo "ERROR: server did not come up after crash recovery of an expression-index insert"
+		exit 1
+	fi
+	rowcount=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -tAc \
+		"SELECT count(*) FROM numbers WHERE (val || '_x') = 'v_1000001_x'")
+	if [ "$rowcount" != "1" ]; then
+		echo "ERROR: expression index wrong after crash recovery (got '$rowcount', want 1)"
+		exit 1
+	fi
+	echo "OK: checkpoint + crash recovery of an expression-index insert survived"
 fi
 
 # ----------------------------------------------------------------------

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -386,10 +386,12 @@ fi
 	-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
 
 # ----------------------------------------------------------------------
-# 7a. Before refreshing, confirm that touching an index whose expression
-#     trees were written by the old major raises a clean error instead of
-#     crashing the backend.  Only meaningful across majors; same-version
-#     "upgrades" carry compatible trees and need no refresh.
+# 7a. Before anything triggers the automatic refresh, confirm that a
+#     plain read of an index whose expression trees were written by the old
+#     major raises a clean error instead of crashing.  A bare SELECT does not
+#     go through ProcessUtility, so it does not trip the automatic refresh
+#     (step 7b) and still exercises the read-time fallback guard.  Only
+#     meaningful across majors; same-version carries compatible trees.
 # ----------------------------------------------------------------------
 if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 	set +e
@@ -398,7 +400,7 @@ if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 	refresh_rc=$?
 	set -e
 	if [ $refresh_rc -eq 0 ]; then
-		echo "ERROR: expression-index table was readable before orioledb_upgrade_refresh()"
+		echo "ERROR: expression-index table was readable before the automatic refresh"
 		echo "$refresh_err"
 		exit 1
 	fi
@@ -415,30 +417,32 @@ if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 fi
 
 # ----------------------------------------------------------------------
-# 7b. Refresh OrioleDB index expressions into the new server's node-tree
-#     format.  A cross-major upgrade carries over expression/predicate
-#     blobs in the old major's nodeToString format, which the new server
-#     skips on read (see o_deserialize_node); orioledb_upgrade_refresh()
-#     re-derives them from the catalog and rewrites them.  Run once per
-#     database that has the extension, before anything reads those tables.
+# 7b. Exercise the AUTOMATIC refresh.  A cross-major upgrade carries over
+#     expression/predicate node trees in the old major's nodeToString format,
+#     which the new server cannot read; OrioleDB rewrites them into the running
+#     server's format on the first utility command in each database
+#     (maybe_auto_upgrade_refresh), so no manual orioledb_upgrade_refresh() call
+#     is required.  Issue one trivial utility statement to trigger it, then
+#     confirm the expression-index table that erred in step 7a is now readable.
 #
-#     $TEST_DB is fully controlled by this script, so a refresh failure
-#     there is a real bug -- fail the job immediately rather than hoping
-#     the later dump diff catches it.  The regression database can be left
-#     half-broken by a tolerated mid-suite failure (see step 2), so its
-#     refresh stays best-effort, but we still surface the actual error.
+#     $TEST_DB is fully controlled by this script, so a failure there is a real
+#     bug -- fail the job immediately.  The regression database can be left
+#     half-broken by a tolerated mid-suite failure (see step 2), so it stays
+#     best-effort, but we still surface the actual error.
 # ----------------------------------------------------------------------
 if db_exists $PORT_NEW "$TEST_DB"; then
-	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 \
-		-c "SELECT orioledb_upgrade_refresh();"
-	echo "Refreshed OrioleDB expressions in $TEST_DB"
+	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
+DISCARD ALL;					-- utility command: triggers the automatic refresh
+SELECT count(*) FROM numbers;	-- erred in step 7a; must succeed after the refresh
+SQL
+	echo "Auto-refreshed OrioleDB expressions in $TEST_DB"
 fi
 
 if db_exists $PORT_NEW regression; then
 	refresh_out=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d regression -v ON_ERROR_STOP=1 \
-		-c "SELECT orioledb_upgrade_refresh();" 2>&1) \
-		&& echo "Refreshed OrioleDB expressions in regression" \
-		|| echo "[WARN] orioledb_upgrade_refresh() failed in regression: $refresh_out"
+		-c "DISCARD ALL;" 2>&1) \
+		&& echo "Auto-refresh triggered in regression" \
+		|| echo "[WARN] triggering auto-refresh in regression failed: $refresh_out"
 fi
 
 # ----------------------------------------------------------------------

--- a/ci/pg_upgrade.sh
+++ b/ci/pg_upgrade.sh
@@ -373,10 +373,12 @@ fi
 	-o "-p $PORT_NEW" -l "$GITHUB_WORKSPACE/pg${NEW_VERSION}.log" -w start
 
 # ----------------------------------------------------------------------
-# 7a. Before refreshing, confirm that touching an index whose expression
-#     trees were written by the old major raises a clean error instead of
-#     crashing the backend.  Only meaningful across majors; same-version
-#     "upgrades" carry compatible trees and need no refresh.
+# 7a. Before anything triggers the automatic refresh, confirm that a
+#     plain read of an index whose expression trees were written by the old
+#     major raises a clean error instead of crashing.  A bare SELECT does not
+#     go through ProcessUtility, so it does not trip the automatic refresh
+#     (step 7b) and still exercises the read-time fallback guard.  Only
+#     meaningful across majors; same-version carries compatible trees.
 # ----------------------------------------------------------------------
 if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 	set +e
@@ -385,7 +387,7 @@ if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 	refresh_rc=$?
 	set -e
 	if [ $refresh_rc -eq 0 ]; then
-		echo "ERROR: expression-index table was readable before orioledb_upgrade_refresh()"
+		echo "ERROR: expression-index table was readable before the automatic refresh"
 		echo "$refresh_err"
 		exit 1
 	fi
@@ -402,30 +404,33 @@ if [ "$OLD_VERSION" != "$NEW_VERSION" ] && db_exists $PORT_NEW "$TEST_DB"; then
 fi
 
 # ----------------------------------------------------------------------
-# 7b. Refresh OrioleDB index expressions into the new server's node-tree
-#     format.  A cross-major upgrade carries over expression/predicate
-#     blobs in the old major's nodeToString format, which the new server
-#     skips on read (see o_deserialize_node); orioledb_upgrade_refresh()
-#     re-derives them from the catalog and rewrites them.  Run once per
-#     database that has the extension, before anything reads those tables.
+# 7b. Exercise the AUTOMATIC refresh.  A cross-major upgrade carries over
+#     expression/predicate/SQL-function node trees in the old major's
+#     nodeToString format, which the new server cannot read; OrioleDB rewrites
+#     them into the running server's format on the first utility command in
+#     each database (maybe_auto_upgrade_refresh), so no manual
+#     orioledb_upgrade_refresh() call is required.  Issue one trivial utility
+#     statement to trigger it, then confirm the expression-index table that
+#     erred in step 7a is now readable.
 #
-#     $TEST_DB is fully controlled by this script, so a refresh failure
-#     there is a real bug -- fail the job immediately rather than hoping
-#     the later dump diff catches it.  The regression database can be left
-#     half-broken by a tolerated mid-suite failure (see step 2), so its
-#     refresh stays best-effort, but we still surface the actual error.
+#     $TEST_DB is fully controlled by this script, so a failure there is a real
+#     bug -- fail the job immediately.  The regression database can be left
+#     half-broken by a tolerated mid-suite failure (see step 2), so it stays
+#     best-effort, but we still surface the actual error.
 # ----------------------------------------------------------------------
 if db_exists $PORT_NEW "$TEST_DB"; then
-	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 \
-		-c "SELECT orioledb_upgrade_refresh();"
-	echo "Refreshed OrioleDB expressions in $TEST_DB"
+	"$NEW_PREFIX/bin/psql" -p $PORT_NEW -d "$TEST_DB" -v ON_ERROR_STOP=1 <<'SQL'
+DISCARD ALL;					-- utility command: triggers the automatic refresh
+SELECT count(*) FROM numbers;	-- erred in step 7a; must succeed after the refresh
+SQL
+	echo "Auto-refreshed OrioleDB expressions in $TEST_DB"
 fi
 
 if db_exists $PORT_NEW regression; then
 	refresh_out=$("$NEW_PREFIX/bin/psql" -p $PORT_NEW -d regression -v ON_ERROR_STOP=1 \
-		-c "SELECT orioledb_upgrade_refresh();" 2>&1) \
-		&& echo "Refreshed OrioleDB expressions in regression" \
-		|| echo "[WARN] orioledb_upgrade_refresh() failed in regression: $refresh_out"
+		-c "DISCARD ALL;" 2>&1) \
+		&& echo "Auto-refresh triggered in regression" \
+		|| echo "[WARN] triggering auto-refresh in regression failed: $refresh_out"
 fi
 
 # ----------------------------------------------------------------------

--- a/ci/pg_upgrade_build.sh
+++ b/ci/pg_upgrade_build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Build a single PostgreSQL major version with orioledb against it.
+# Usage: pg_upgrade_build.sh <pg_major> <postgres_src_dir> <install_prefix>
+#
+# Expects CC selection driven by $COMPILER / $LLVM_VER from the workflow.
+
+set -eux
+
+PG_MAJOR=$1
+SRC_DIR=$2
+PREFIX=$3
+
+if [ "$COMPILER" = "clang" ]; then
+	export CC=clang-$LLVM_VER
+else
+	export CC=gcc
+fi
+
+# Look up the orioledb-patches tag for this PG major so the
+# ORIOLEDB_PATCHSET_VERSION imprint matches what ci/build.sh produces.
+PGTAG=$(grep "^${PG_MAJOR}: " "$GITHUB_WORKSPACE/orioledb/.pgtags" | cut -d' ' -f2-)
+export PGTAG
+
+# Configure and build PostgreSQL.  Mirrors ci/build.sh for a debug build
+# (asserts on), which is what we want for a pg_upgrade regression run.
+cd "$SRC_DIR"
+./configure --enable-debug --enable-cassert --enable-tap-tests --with-icu --prefix="$PREFIX"
+if printf "%s\n" "$PGTAG" | grep -v -Fqe "patches$(sed -n "/PACKAGE_VERSION='\(.*\)'/ s//\1/ p" configure | cut -d'.' -f1 )_"; then
+	echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global
+fi
+make -sj "$(nproc)"
+make -sj "$(nproc)" install
+make -C contrib -sj "$(nproc)"
+make -C contrib -sj "$(nproc)" install
+
+if [ "$PG_MAJOR" = "17" ]; then
+	make -C src/test/modules/injection_points -sj "$(nproc)" install
+fi
+
+# Build and install orioledb against this PG.  pg_config under $PREFIX
+# selects the right server headers / pkglibdir.  A clean is mandatory
+# between the two PG versions because the build artefacts are not
+# binary-compatible across PG major versions.
+cd "$GITHUB_WORKSPACE/orioledb"
+PATH="$PREFIX/bin:$PATH"
+export PATH
+
+make USE_PGXS=1 IS_DEV=1 clean
+make -j "$(nproc)" USE_PGXS=1 IS_DEV=1 \
+	CFLAGS_SL="$(pg_config --cflags_sl) -Werror"
+make -j "$(nproc)" USE_PGXS=1 IS_DEV=1 install

--- a/ci/post_build_prerequisites.sh
+++ b/ci/post_build_prerequisites.sh
@@ -18,7 +18,7 @@ else
 	sudo env "PATH=$PATH" pip3 install --upgrade -r orioledb/requirements.txt
 fi
 
-if [ $GITHUB_JOB != "run-benchmark" ] && [ $GITHUB_JOB != "pgindent" ]; then
+if [ $GITHUB_JOB != "run-benchmark" ] && [ $GITHUB_JOB != "pgindent" ] && [ $GITHUB_JOB != "pg_upgrade" ]; then
     wget https://codeload.github.com/eulerto/wal2json/tar.gz/refs/tags/wal2json_2_6
     tar -zxf wal2json_2_6
     rm wal2json_2_6

--- a/doc/usage/pg-upgrade.mdx
+++ b/doc/usage/pg-upgrade.mdx
@@ -52,13 +52,12 @@ shutdown means no WAL replay is required for the copied files).
 
 ## How the expression rewrite works
 
-OrioleDB stores index **expressions** and **partial-index predicates** (and the
-parse trees of any SQL functions they call) as serialized PostgreSQL node trees,
-so that recovery and background workers can evaluate them without access to the
-catalog.  That serialization format (`nodeToString`) is **not stable across
-major versions**.  After a cross-major upgrade the carried-over node trees were
-written by the old major and cannot be parsed by the new server, so they are
-dropped on read.
+OrioleDB stores index **expressions** and **partial-index predicates** as
+serialized PostgreSQL node trees, so that recovery and background workers can
+evaluate them without access to the catalog.  That serialization format
+(`nodeToString`) is **not stable across major versions**.  After a cross-major
+upgrade the carried-over node trees were written by the old major and cannot be
+parsed by the new server, so they are dropped on read.
 
 The rewrite re-derives those expressions and predicates from the catalog and
 stores them in the running server's format.  It runs automatically on first use

--- a/doc/usage/pg-upgrade.mdx
+++ b/doc/usage/pg-upgrade.mdx
@@ -38,34 +38,42 @@ shutdown means no WAL replay is required for the copied files).
        cp -R "$OLD_DATA/orioledb_undo" "$NEW_DATA/orioledb_undo"
    ```
 
-3. **Start the new cluster** and, **in every database that uses OrioleDB**,
-   rewrite the carried-over index expressions into the new server's format:
+3. **Start the new cluster.**  Nothing else is required: OrioleDB rewrites the
+   carried-over index expressions into the new server's format **automatically**,
+   the first time each database is used after the upgrade.
+
+   If you prefer to do it eagerly (for example in a migration script, before
+   opening the database to traffic), you can trigger the same work explicitly
+   **in every database that uses OrioleDB**:
 
    ```sql title="psql"
    SELECT orioledb_upgrade_refresh();
    ```
 
-   Do this before reading or writing the affected tables.
+## How the expression rewrite works
 
-## Why `orioledb_upgrade_refresh()` is required
+OrioleDB stores index **expressions** and **partial-index predicates** (and the
+parse trees of any SQL functions they call) as serialized PostgreSQL node trees,
+so that recovery and background workers can evaluate them without access to the
+catalog.  That serialization format (`nodeToString`) is **not stable across
+major versions**.  After a cross-major upgrade the carried-over node trees were
+written by the old major and cannot be parsed by the new server, so they are
+dropped on read.
 
-OrioleDB stores index **expressions** and **partial-index predicates** as
-serialized PostgreSQL node trees so that recovery and background workers can
-evaluate them without access to the catalog.  That serialization format
-(`nodeToString`) is **not stable across major versions**.  After a cross-major
-upgrade the carried-over node trees were written by the old major and cannot be
-parsed by the new server, so they are dropped on read.
+The rewrite re-derives those expressions and predicates from the catalog and
+stores them in the running server's format.  It runs automatically on first use
+of each database, and `orioledb_upgrade_refresh()` performs exactly the same
+work on demand.  Either way it only touches indexes that actually carry node
+trees (expression and partial indexes); plain indexes need no rewriting.  It is
+safe to run more than once and is a no-op when there is nothing to rewrite.
 
-`orioledb_upgrade_refresh()` re-derives those expressions and predicates from
-the catalog and rewrites them in the running server's format.  It only touches
-indexes that actually carry node trees (expression and partial indexes); plain
-indexes need no rewriting and are unaffected.  The function is safe to run more
-than once and is a no-op when there is nothing to rewrite.
-
-:::warning
-Until `orioledb_upgrade_refresh()` has been run, accessing an **expression** or
-**partial** index whose trees came from the old major raises a clear error
-rather than crashing the backend:
+:::note
+The automatic rewrite is triggered by the first statement in a database that
+goes through utility processing (which the tools that connect after an upgrade,
+including `pg_dump`, do at session start).  A session that issues only a bare
+`SELECT` against a not-yet-rewritten **expression** or **partial** index before
+that happens gets a clear error rather than a crash, and can proceed after
+running `orioledb_upgrade_refresh()`:
 
 ```
 ERROR:  OrioleDB index "..." has expressions stored by another PostgreSQL major version

--- a/doc/usage/pg-upgrade.mdx
+++ b/doc/usage/pg-upgrade.mdx
@@ -1,0 +1,77 @@
+---
+id: pg-upgrade
+sidebar_label: Major upgrades (pg_upgrade)
+---
+
+# Major upgrades with `pg_upgrade`
+
+`pg_upgrade` migrates a PostgreSQL cluster to a new major version in place by
+copying the catalog and the heap relation files it knows about.  OrioleDB,
+however, keeps its table and index data in its own `orioledb_data/` directory
+(plus undo logs in `orioledb_undo/`), which `pg_upgrade` does not touch, and it
+persists some version-specific metadata in its system trees.  Upgrading an
+OrioleDB cluster therefore needs two extra manual steps that the stock
+`pg_upgrade` flow does not perform.
+
+:::note
+Always take a backup before upgrading, and run the steps below against a copy
+first.  Both clusters must be **stopped** during the file copy, and the old
+cluster must have been shut down cleanly (a final checkpoint on a clean
+shutdown means no WAL replay is required for the copied files).
+:::
+
+## Procedure
+
+1. **Stop the old cluster cleanly** and run `pg_upgrade` as usual (including
+   `pg_upgrade --check`).  OrioleDB tables are restored as empty shells at this
+   point — their data still lives in the old cluster's `orioledb_data/`.
+
+2. **Copy the OrioleDB storage** from the old data directory to the new one.
+   `pg_upgrade` preserves database OIDs, relation OIDs and relfilenodes, and
+   OrioleDB names its files by `(datoid, relnode)`, so the old cluster's files
+   are valid as-is in the new cluster:
+
+   ```bash title="bash"
+   rm -rf "$NEW_DATA/orioledb_data" "$NEW_DATA/orioledb_undo"
+   cp -R "$OLD_DATA/orioledb_data" "$NEW_DATA/orioledb_data"
+   [ -d "$OLD_DATA/orioledb_undo" ] && \
+       cp -R "$OLD_DATA/orioledb_undo" "$NEW_DATA/orioledb_undo"
+   ```
+
+3. **Start the new cluster** and, **in every database that uses OrioleDB**,
+   rewrite the carried-over index expressions into the new server's format:
+
+   ```sql title="psql"
+   SELECT orioledb_upgrade_refresh();
+   ```
+
+   Do this before reading or writing the affected tables.
+
+## Why `orioledb_upgrade_refresh()` is required
+
+OrioleDB stores index **expressions** and **partial-index predicates** as
+serialized PostgreSQL node trees so that recovery and background workers can
+evaluate them without access to the catalog.  That serialization format
+(`nodeToString`) is **not stable across major versions**.  After a cross-major
+upgrade the carried-over node trees were written by the old major and cannot be
+parsed by the new server, so they are dropped on read.
+
+`orioledb_upgrade_refresh()` re-derives those expressions and predicates from
+the catalog and rewrites them in the running server's format.  It only touches
+indexes that actually carry node trees (expression and partial indexes); plain
+indexes need no rewriting and are unaffected.  The function is safe to run more
+than once and is a no-op when there is nothing to rewrite.
+
+:::warning
+Until `orioledb_upgrade_refresh()` has been run, accessing an **expression** or
+**partial** index whose trees came from the old major raises a clear error
+rather than crashing the backend:
+
+```
+ERROR:  OrioleDB index "..." has expressions stored by another PostgreSQL major version
+HINT:   Run "SELECT orioledb_upgrade_refresh();" in this database before using the index.
+```
+
+Tables without such indexes are unaffected and remain usable immediately after
+the upgrade.
+:::

--- a/doc/usage/pg-upgrade.mdx
+++ b/doc/usage/pg-upgrade.mdx
@@ -38,34 +38,43 @@ shutdown means no WAL replay is required for the copied files).
        cp -R "$OLD_DATA/orioledb_undo" "$NEW_DATA/orioledb_undo"
    ```
 
-3. **Start the new cluster** and, **in every database that uses OrioleDB**,
-   rewrite the carried-over index expressions into the new server's format:
+3. **Start the new cluster.**  Nothing else is required: OrioleDB rewrites the
+   carried-over index expressions into the new server's format **automatically**,
+   the first time each database is used after the upgrade.
+
+   If you prefer to do it eagerly (for example in a migration script, before
+   opening the database to traffic), you can trigger the same work explicitly
+   **in every database that uses OrioleDB**:
 
    ```sql title="psql"
    SELECT orioledb_upgrade_refresh();
    ```
 
-   Do this before reading or writing the affected tables.
-
-## Why `orioledb_upgrade_refresh()` is required
+## How the expression rewrite works
 
 OrioleDB stores index **expressions** and **partial-index predicates** as
-serialized PostgreSQL node trees so that recovery and background workers can
-evaluate them without access to the catalog.  That serialization format
-(`nodeToString`) is **not stable across major versions**.  After a cross-major
+serialized PostgreSQL node trees, and caches version-dependent catalog data
+(such as tuple descriptors and the database locale) in its own system trees, so
+that recovery and background workers can work without access to the catalog.
+Those formats are **not stable across major versions**.  After a cross-major
 upgrade the carried-over node trees were written by the old major and cannot be
-parsed by the new server, so they are dropped on read.
+parsed by the new server, and the affected caches are dropped and rebuilt.
 
-`orioledb_upgrade_refresh()` re-derives those expressions and predicates from
-the catalog and rewrites them in the running server's format.  It only touches
-indexes that actually carry node trees (expression and partial indexes); plain
-indexes need no rewriting and are unaffected.  The function is safe to run more
-than once and is a no-op when there is nothing to rewrite.
+The rewrite re-derives the index expressions and predicates from the catalog,
+stores them in the running server's format, and repopulates the caches it
+depends on.  It runs automatically on first use of each database, and
+`orioledb_upgrade_refresh()` performs exactly the same work on demand.  Either
+way it only touches indexes that actually carry node trees (expression and
+partial indexes); plain indexes need no rewriting.  It is safe to run more than
+once and is a no-op when there is nothing to rewrite.
 
-:::warning
-Until `orioledb_upgrade_refresh()` has been run, accessing an **expression** or
-**partial** index whose trees came from the old major raises a clear error
-rather than crashing the backend:
+:::note
+The automatic rewrite is triggered by the first statement in a database that
+goes through utility processing (which the tools that connect after an upgrade,
+including `pg_dump`, do at session start).  A session that issues only a bare
+`SELECT` against a not-yet-rewritten **expression** or **partial** index before
+that happens gets a clear error rather than a crash, and can proceed after
+running `orioledb_upgrade_refresh()`:
 
 ```
 ERROR:  OrioleDB index "..." has expressions stored by another PostgreSQL major version

--- a/doc/usage/pg-upgrade.mdx
+++ b/doc/usage/pg-upgrade.mdx
@@ -38,41 +38,34 @@ shutdown means no WAL replay is required for the copied files).
        cp -R "$OLD_DATA/orioledb_undo" "$NEW_DATA/orioledb_undo"
    ```
 
-3. **Start the new cluster.**  Nothing else is required: OrioleDB rewrites the
-   carried-over index expressions into the new server's format **automatically**,
-   the first time each database is used after the upgrade.
-
-   If you prefer to do it eagerly (for example in a migration script, before
-   opening the database to traffic), you can trigger the same work explicitly
-   **in every database that uses OrioleDB**:
+3. **Start the new cluster** and, **in every database that uses OrioleDB**,
+   rewrite the carried-over index expressions into the new server's format:
 
    ```sql title="psql"
    SELECT orioledb_upgrade_refresh();
    ```
 
-## How the expression rewrite works
+   Do this before reading or writing the affected tables.
+
+## Why `orioledb_upgrade_refresh()` is required
 
 OrioleDB stores index **expressions** and **partial-index predicates** as
-serialized PostgreSQL node trees, so that recovery and background workers can
+serialized PostgreSQL node trees so that recovery and background workers can
 evaluate them without access to the catalog.  That serialization format
 (`nodeToString`) is **not stable across major versions**.  After a cross-major
 upgrade the carried-over node trees were written by the old major and cannot be
 parsed by the new server, so they are dropped on read.
 
-The rewrite re-derives those expressions and predicates from the catalog and
-stores them in the running server's format.  It runs automatically on first use
-of each database, and `orioledb_upgrade_refresh()` performs exactly the same
-work on demand.  Either way it only touches indexes that actually carry node
-trees (expression and partial indexes); plain indexes need no rewriting.  It is
-safe to run more than once and is a no-op when there is nothing to rewrite.
+`orioledb_upgrade_refresh()` re-derives those expressions and predicates from
+the catalog and rewrites them in the running server's format.  It only touches
+indexes that actually carry node trees (expression and partial indexes); plain
+indexes need no rewriting and are unaffected.  The function is safe to run more
+than once and is a no-op when there is nothing to rewrite.
 
-:::note
-The automatic rewrite is triggered by the first statement in a database that
-goes through utility processing (which the tools that connect after an upgrade,
-including `pg_dump`, do at session start).  A session that issues only a bare
-`SELECT` against a not-yet-rewritten **expression** or **partial** index before
-that happens gets a clear error rather than a crash, and can proceed after
-running `orioledb_upgrade_refresh()`:
+:::warning
+Until `orioledb_upgrade_refresh()` has been run, accessing an **expression** or
+**partial** index whose trees came from the old major raises a clear error
+rather than crashing the backend:
 
 ```
 ERROR:  OrioleDB index "..." has expressions stored by another PostgreSQL major version

--- a/doc/usage/pg-upgrade.mdx
+++ b/doc/usage/pg-upgrade.mdx
@@ -52,13 +52,14 @@ shutdown means no WAL replay is required for the copied files).
 
 ## How the expression rewrite works
 
-OrioleDB stores index **expressions** and **partial-index predicates** as
-serialized PostgreSQL node trees, and caches version-dependent catalog data
-(such as tuple descriptors and the database locale) in its own system trees, so
-that recovery and background workers can work without access to the catalog.
-Those formats are **not stable across major versions**.  After a cross-major
-upgrade the carried-over node trees were written by the old major and cannot be
-parsed by the new server, and the affected caches are dropped and rebuilt.
+OrioleDB stores index **expressions** and **partial-index predicates** (and the
+parse trees of any SQL functions they call) as serialized PostgreSQL node trees,
+and caches version-dependent catalog data (such as tuple descriptors and the
+database locale) in its own system trees, so that recovery and background workers
+can work without access to the catalog.  Those formats are **not stable across
+major versions**.  After a cross-major upgrade the carried-over node trees were
+written by the old major and cannot be parsed by the new server, and the affected
+caches are dropped and rebuilt.
 
 The rewrite re-derives the index expressions and predicates from the catalog,
 stores them in the running server's format, and repopulates the caches it

--- a/include/catalog/o_indices.h
+++ b/include/catalog/o_indices.h
@@ -81,6 +81,15 @@ typedef struct
 	Oid		   *exclops;
 	bool		immediate;
 	MemoryContext index_mctx;
+
+	/*
+	 * Set (not serialized) when deserialization skipped a node tree
+	 * (expression/predicate) written by a different PG major after a
+	 * cross-major pg_upgrade.  The index cannot be used until
+	 * orioledb_upgrade_refresh() rewrites it; o_define_index_descr() raises
+	 * an error rather than letting access crash on the missing trees.
+	 */
+	bool		refresh_exprs;
 } OIndex;
 
 /* callback for o_indices_foreach_oids() */

--- a/include/catalog/o_sys_cache.h
+++ b/include/catalog/o_sys_cache.h
@@ -524,6 +524,7 @@ extern void o_proc_cache_validate_add(Oid datoid, Oid procoid, Oid fncollation,
 									  List **processed);
 extern void o_proc_cache_fill_finfo(FmgrInfo *finfo, Oid procoid, Oid datoid);
 extern HeapTuple o_proc_cache_search_htup(TupleDesc tupdesc, Oid procoid);
+extern bool o_proc_cache_delete_if_stale(Oid datoid, Oid procoid);
 
 /* o_type_cache.c */
 typedef struct OType

--- a/include/catalog/o_tables.h
+++ b/include/catalog/o_tables.h
@@ -137,6 +137,14 @@ typedef struct
 	Oid			tablespace;
 	uint32		version;		/* not serialized in serialize_o_table */
 	MemoryContext tbl_mctx;		/* not serialized in serialize_o_table */
+
+	/*
+	 * Set (not serialized) when deserialization skipped index expressions
+	 * written by a different PG major version; they must be re-derived from
+	 * the catalog and rewritten before use.  See
+	 * o_table_refresh_expressions().
+	 */
+	bool		refresh_exprs;
 } OTable;
 
 #define OGetTableContext(table) \
@@ -158,6 +166,8 @@ typedef struct
 
 extern void o_table_fill_index(OTable *o_table, OIndexNumber ix_num,
 							   Relation index_rel);
+extern bool o_table_refresh_index_exprs(OTable *o_table, OIndexNumber ix_num,
+										Relation index_rel);
 
 /* Creates and fills OTable. */
 extern OTable *o_table_tableam_create(ORelOids oids, TupleDesc tupdesc,
@@ -249,6 +259,7 @@ extern void o_tables_rel_lock_exclusive_no_inval_no_log(ORelOids *oids);
 extern void o_tables_rel_unlock_extended(ORelOids *oids, int lockmode, bool checkpoint);
 
 /* Deserialize OTable stored in O_TABLES sys tree */
+extern bool o_node_deserialize_format_changed;
 extern void o_serialize_node(Node *node, StringInfo str);
 extern Node *o_deserialize_node(Pointer *ptr);
 extern bool o_deserialize_node_safe(Pointer *ptr, Pointer data, Size length, Node **out);

--- a/include/checkpoint/checkpoint.h
+++ b/include/checkpoint/checkpoint.h
@@ -218,6 +218,14 @@ typedef struct
 	int			punchHolesTrancheId;
 	pg_atomic_uint64 xidRecLastPos;
 	pg_atomic_uint64 xidRecFlushPos;
+
+	/*
+	 * Set at startup when the control file was written by a different PG
+	 * major version: the version-dependent OSysCache trees must be rebuilt
+	 * rather than read with a mismatching on-disk layout.  Consumed when the
+	 * cache sys-trees are first initialized.
+	 */
+	bool		resetSysCaches;
 	XidFileRec	xidRecQueue[FLEXIBLE_ARRAY_MEMBER];
 } CheckpointState;
 

--- a/include/checkpoint/control.h
+++ b/include/checkpoint/control.h
@@ -63,6 +63,14 @@ typedef struct
 	 * orioledb_checksums_enabled
 	 */
 	bool		checksums_enabled;
+
+	/*
+	 * PG_VERSION_NUM of the server that wrote this control file.  A change of
+	 * the major version means the version-dependent system caches (the
+	 * OSysCache trees) were serialized by a different PG and must be rebuilt
+	 * -- see reset of rebuildable sys-cache trees at startup.
+	 */
+	uint32		pgVersion;
 	/* CRC of all fields above. It should be last */
 	pg_crc32c	crc;
 } CheckpointControl;

--- a/include/tableam/index_scan.h
+++ b/include/tableam/index_scan.h
@@ -25,6 +25,12 @@ typedef struct OScanState
 	IndexScanDescData scandesc;
 	OIndexNumber ixNum;
 	MemoryContext cxt;
+
+	/*
+	 * set by orioledb_ambeginscan when the descriptor is absent under
+	 * IsBinaryUpgrade: the scan yields no rows (see orioledb_amgettuple)
+	 */
+	bool		emptyScan;
 	ScanDirection scanDir;
 	bool		addJunk;
 	/* is only current index can be used in scan */

--- a/include/utils/planner.h
+++ b/include/utils/planner.h
@@ -18,6 +18,7 @@ extern void o_validate_funcexpr(Node *node, char *hint_msg);
 extern void o_validate_function_by_oid(Oid procoid, char *hint_msg);
 
 extern void o_collect_funcexpr(Node *node);
+extern void o_collect_funcexpr_refresh(Node *node);
 extern void o_collect_op_by_oid(Oid opoid);
 
 extern void o_collect_function_by_oid(Oid procoid, Oid inputcollid,

--- a/include/utils/planner.h
+++ b/include/utils/planner.h
@@ -18,7 +18,6 @@ extern void o_validate_funcexpr(Node *node, char *hint_msg);
 extern void o_validate_function_by_oid(Oid procoid, char *hint_msg);
 
 extern void o_collect_funcexpr(Node *node);
-extern void o_collect_funcexpr_refresh(Node *node);
 extern void o_collect_op_by_oid(Oid opoid);
 
 extern void o_collect_function_by_oid(Oid procoid, Oid inputcollid,

--- a/sql/orioledb--1.7--1.8_prod.sql
+++ b/sql/orioledb--1.7--1.8_prod.sql
@@ -14,3 +14,13 @@ AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
 
 REVOKE ALL ON FUNCTION verify_orioledb(regclass, boolean) FROM PUBLIC;
+
+-- Refresh persisted index expressions of every OrioleDB table in the current
+-- database into the running server's node-tree format.  Run once per database
+-- after a cross-major pg_upgrade.
+CREATE FUNCTION orioledb_upgrade_refresh()
+RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+REVOKE ALL ON FUNCTION orioledb_upgrade_refresh() FROM PUBLIC;

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -21,6 +21,7 @@
 #include "catalog/o_indices.h"
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
+#include "checkpoint/checkpoint.h"
 #include "storage/lockdefs.h"
 #include "tableam/descr.h"
 #include "storage/copydir.h"
@@ -40,6 +41,7 @@
 #include "access/tableam.h"
 #include "access/toast_compression.h"
 #include "access/transam.h"
+#include "access/xlog.h"
 #include "catalog/catalog.h"
 #include "catalog/heap.h"
 #include "catalog/index.h"
@@ -153,6 +155,7 @@ static void orioledb_utility_command(PlannedStmt *pstmt,
 									 struct QueryCompletion *qc);
 static void orioledb_object_access_hook(ObjectAccessType access, Oid classId,
 										Oid objectId, int subId, void *arg);
+static void maybe_auto_upgrade_refresh(void);
 
 static void o_alter_column_type(AlterTableCmd *cmd, const char *queryString,
 								Relation rel);
@@ -930,6 +933,14 @@ orioledb_utility_command(PlannedStmt *pstmt,
 	bool		isTopLevel = (context == PROCESS_UTILITY_TOPLEVEL);
 	ParseState *pstate;
 	bool		call_next = true;
+
+	/*
+	 * First use of this database after a cross-major restart: rewrite the
+	 * carried-over index expressions into this server's format, so
+	 * orioledb_upgrade_refresh() need not be called by hand.  A no-op unless
+	 * a cross-major upgrade actually happened (see the guards inside).
+	 */
+	maybe_auto_upgrade_refresh();
 
 	/* copied from standard_ProcessUtility */
 	if (readOnlyTree)
@@ -5285,6 +5296,33 @@ o_refresh_table_expressions(Oid reloid)
 	OSnapshot	oSnapshot;
 	int			ix_num;
 
+	/*
+	 * Cheap pre-check under a share lock: a table whose persisted expressions
+	 * are already in this server's node-tree format has refresh_exprs unset
+	 * and needs no rewrite.  Skipping it here avoids taking an exclusive lock
+	 * on every table -- important for the automatic per-database refresh,
+	 * where repeated calls (from later backends, once the first has done the
+	 * work) must not serialize the whole database behind exclusive locks.
+	 */
+	rel = table_open(reloid, AccessShareLock);
+	if (!is_orioledb_rel(rel))
+	{
+		table_close(rel, AccessShareLock);
+		return;
+	}
+	ORelOidsSetFromRel(oids, rel);
+	o_table = o_tables_get(oids);
+	if (o_table == NULL || !o_table->refresh_exprs)
+	{
+		if (o_table)
+			o_table_free(o_table);
+		table_close(rel, AccessShareLock);
+		return;
+	}
+	o_table_free(o_table);
+	table_close(rel, AccessShareLock);
+
+	/* Stale: rewrite the node trees under an exclusive lock. */
 	rel = table_open(reloid, AccessExclusiveLock);
 	if (!is_orioledb_rel(rel))
 	{
@@ -5294,8 +5332,11 @@ o_refresh_table_expressions(Oid reloid)
 
 	ORelOidsSetFromRel(oids, rel);
 	o_table = o_tables_get(oids);
-	if (o_table == NULL)
+	/* Recheck: another backend may have refreshed it since the share lock. */
+	if (o_table == NULL || !o_table->refresh_exprs)
 	{
+		if (o_table)
+			o_table_free(o_table);
 		table_close(rel, AccessExclusiveLock);
 		return;
 	}
@@ -5333,15 +5374,15 @@ o_refresh_table_expressions(Oid reloid)
 	table_close(rel, AccessExclusiveLock);
 }
 
-PG_FUNCTION_INFO_V1(orioledb_upgrade_refresh);
-
 /*
- * SQL-callable: refresh every OrioleDB table in the current database.  Meant
- * to be run once per database after a cross-major pg_upgrade so the persisted
- * index expressions are rewritten in the running server's node-tree format.
+ * Rewrite the persisted index expressions/predicates of every OrioleDB table
+ * in the current database into the running server's node-tree format, and
+ * repopulate the sys caches (class, database, ...) they depend on.  Tables
+ * already in the current format are skipped cheaply (see
+ * o_refresh_table_expressions).  Idempotent.
  */
-Datum
-orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
+static void
+o_upgrade_refresh_database(void)
 {
 	Oid			orioledb_am = get_am_oid("orioledb", false);
 	Relation	pgclass;
@@ -5385,6 +5426,62 @@ orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
 
 	foreach(lc, reloids)
 		o_refresh_table_expressions(lfirst_oid(lc));
+}
+
+/*
+ * Automatically refresh the current database once, the first time it is used
+ * after the cluster started from on-disk state written by a different PG major
+ * (e.g. carried over by pg_upgrade), so the manual orioledb_upgrade_refresh()
+ * call is not required.
+ *
+ * Guards -- this must NOT run:
+ *  - unless the cross-major reset actually happened (resetSysCaches);
+ *  - during pg_upgrade's own binary-upgrade restore (IsBinaryUpgrade): the
+ *    catalog is not yet populated and orioledb_data/ is not yet in place, so a
+ *    refresh then would see no tables and wrongly stamp the database as done;
+ *  - on a standby / during recovery (cannot write);
+ *  - outside a normal, fully-initialized backend bound to a real database.
+ *
+ * It runs at most once per backend (a cheap boolean short-circuits afterwards).
+ * The persisted per-table refresh_exprs flag is the shared "already done"
+ * marker: once the first backend rewrites a table, later backends find nothing
+ * stale and o_refresh_table_expressions returns cheaply, so no cross-backend
+ * lock or extra bookkeeping is needed.  The read-time errors on stale index
+ * entries remain as a fallback for a backend that touches a stale object before
+ * this runs (e.g. a SELECT-only session issuing no utility command).
+ */
+static void
+maybe_auto_upgrade_refresh(void)
+{
+	static bool attempted = false;
+
+	if (attempted)
+		return;
+
+	if (checkpoint_state == NULL || !checkpoint_state->resetSysCaches)
+		return;
+	if (IsBinaryUpgrade ||
+		RecoveryInProgress() ||
+		!IsNormalProcessingMode() ||
+		!IsTransactionState() ||
+		!OidIsValid(MyDatabaseId))
+		return;
+
+	attempted = true;
+	o_upgrade_refresh_database();
+}
+
+PG_FUNCTION_INFO_V1(orioledb_upgrade_refresh);
+
+/*
+ * SQL-callable wrapper for o_upgrade_refresh_database().  Normally unnecessary
+ * -- maybe_auto_upgrade_refresh() does the same work automatically on first use
+ * -- but kept for explicit/eager invocation and backward compatibility.
+ */
+Datum
+orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
+{
+	o_upgrade_refresh_database();
 
 	PG_RETURN_VOID();
 }

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -5350,6 +5350,24 @@ orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
 	List	   *reloids = NIL;
 	ListCell   *lc;
 
+	/*
+	 * The database cache was dropped by the cross-major reset (its locale
+	 * fields have a version-dependent on-disk layout).  Repopulate it now, in
+	 * this normal transaction, so recovery and the checkpointer can set up
+	 * the default collation from it
+	 * (o_database_cache_set_default_locale_provider) -- they have no catalog
+	 * of their own and cannot rebuild it.
+	 */
+#if PG_VERSION_NUM >= 170000
+	{
+		XLogRecPtr	cur_lsn;
+
+		o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
+		o_database_cache_add_if_needed(Template1DbOid, Template1DbOid, cur_lsn,
+									   NULL);
+	}
+#endif
+
 	/* Collect the orioledb table OIDs first; refresh outside the scan. */
 	pgclass = table_open(RelationRelationId, AccessShareLock);
 	scan = systable_beginscan(pgclass, InvalidOid, false, NULL, 0, NULL);

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -21,7 +21,6 @@
 #include "catalog/o_indices.h"
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
-#include "checkpoint/checkpoint.h"
 #include "storage/lockdefs.h"
 #include "tableam/descr.h"
 #include "storage/copydir.h"
@@ -41,7 +40,6 @@
 #include "access/tableam.h"
 #include "access/toast_compression.h"
 #include "access/transam.h"
-#include "access/xlog.h"
 #include "catalog/catalog.h"
 #include "catalog/heap.h"
 #include "catalog/index.h"
@@ -155,7 +153,6 @@ static void orioledb_utility_command(PlannedStmt *pstmt,
 									 struct QueryCompletion *qc);
 static void orioledb_object_access_hook(ObjectAccessType access, Oid classId,
 										Oid objectId, int subId, void *arg);
-static void maybe_auto_upgrade_refresh(void);
 
 static void o_alter_column_type(AlterTableCmd *cmd, const char *queryString,
 								Relation rel);
@@ -933,14 +930,6 @@ orioledb_utility_command(PlannedStmt *pstmt,
 	bool		isTopLevel = (context == PROCESS_UTILITY_TOPLEVEL);
 	ParseState *pstate;
 	bool		call_next = true;
-
-	/*
-	 * First use of this database after a cross-major restart: rewrite the
-	 * carried-over index expressions / proc trees into this server's format,
-	 * so orioledb_upgrade_refresh() need not be called by hand.  A no-op
-	 * unless a cross-major upgrade actually happened (see the guards inside).
-	 */
-	maybe_auto_upgrade_refresh();
 
 	/* copied from standard_ProcessUtility */
 	if (readOnlyTree)
@@ -5296,33 +5285,6 @@ o_refresh_table_expressions(Oid reloid)
 	OSnapshot	oSnapshot;
 	int			ix_num;
 
-	/*
-	 * Cheap pre-check under a share lock: a table whose persisted expressions
-	 * are already in this server's node-tree format has refresh_exprs unset
-	 * and needs no rewrite.  Skipping it here avoids taking an exclusive lock
-	 * on every table -- important for the automatic per-database refresh,
-	 * where repeated calls (from later backends, once the first has done the
-	 * work) must not serialize the whole database behind exclusive locks.
-	 */
-	rel = table_open(reloid, AccessShareLock);
-	if (!is_orioledb_rel(rel))
-	{
-		table_close(rel, AccessShareLock);
-		return;
-	}
-	ORelOidsSetFromRel(oids, rel);
-	o_table = o_tables_get(oids);
-	if (o_table == NULL || !o_table->refresh_exprs)
-	{
-		if (o_table)
-			o_table_free(o_table);
-		table_close(rel, AccessShareLock);
-		return;
-	}
-	o_table_free(o_table);
-	table_close(rel, AccessShareLock);
-
-	/* Stale: rewrite the node trees under an exclusive lock. */
 	rel = table_open(reloid, AccessExclusiveLock);
 	if (!is_orioledb_rel(rel))
 	{
@@ -5332,11 +5294,8 @@ o_refresh_table_expressions(Oid reloid)
 
 	ORelOidsSetFromRel(oids, rel);
 	o_table = o_tables_get(oids);
-	/* Recheck: another backend may have refreshed it since the share lock. */
-	if (o_table == NULL || !o_table->refresh_exprs)
+	if (o_table == NULL)
 	{
-		if (o_table)
-			o_table_free(o_table);
 		table_close(rel, AccessExclusiveLock);
 		return;
 	}
@@ -5374,14 +5333,15 @@ o_refresh_table_expressions(Oid reloid)
 	table_close(rel, AccessExclusiveLock);
 }
 
+PG_FUNCTION_INFO_V1(orioledb_upgrade_refresh);
+
 /*
- * Rewrite the persisted index expressions/predicates of every OrioleDB table in
- * the current database into the running server's node-tree format (and rebuild
- * the referenced proc-cache entries).  Tables already in the current format are
- * skipped cheaply (see o_refresh_table_expressions).  Idempotent.
+ * SQL-callable: refresh every OrioleDB table in the current database.  Meant
+ * to be run once per database after a cross-major pg_upgrade so the persisted
+ * index expressions are rewritten in the running server's node-tree format.
  */
-static void
-o_upgrade_refresh_database(void)
+Datum
+orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
 {
 	Oid			orioledb_am = get_am_oid("orioledb", false);
 	Relation	pgclass;
@@ -5407,65 +5367,6 @@ o_upgrade_refresh_database(void)
 
 	foreach(lc, reloids)
 		o_refresh_table_expressions(lfirst_oid(lc));
-}
-
-/*
- * Automatically refresh the current database once, the first time it is used
- * after the cluster started from on-disk state written by a different PG major
- * (e.g. carried over by pg_upgrade), so the manual orioledb_upgrade_refresh()
- * call is not required.
- *
- * Guards -- this must NOT run:
- *  - unless the cross-major reset actually happened (resetSysCaches);
- *  - during pg_upgrade's own binary-upgrade restore (IsBinaryUpgrade): the
- *    catalog is not yet populated and orioledb_data/ is not yet in place, so a
- *    refresh then would see no tables and wrongly stamp the database as done;
- *  - on a standby / during recovery (cannot write);
- *  - outside a normal, fully-initialized backend bound to a real database.
- *
- * It runs at most once per backend (a cheap boolean short-circuits afterwards).
- * The persisted per-table refresh_exprs flag is the shared "already done"
- * marker: once the first backend rewrites a table, later backends find nothing
- * stale and o_refresh_table_expressions returns cheaply, so no cross-backend
- * lock or extra bookkeeping is needed.  The read-time errors on stale
- * index/proc entries remain as a fallback for a backend that touches a stale
- * object before this runs (e.g. a SELECT-only session issuing no utility
- * command).
- */
-static void
-maybe_auto_upgrade_refresh(void)
-{
-	static bool attempted = false;
-
-	if (attempted)
-		return;
-
-	if (checkpoint_state == NULL || !checkpoint_state->resetSysCaches)
-		return;
-	if (IsBinaryUpgrade ||
-		RecoveryInProgress() ||
-		!IsNormalProcessingMode() ||
-		!IsTransactionState() ||
-		!OidIsValid(MyDatabaseId))
-		return;
-
-	attempted = true;
-	o_upgrade_refresh_database();
-}
-
-PG_FUNCTION_INFO_V1(orioledb_upgrade_refresh);
-
-/*
- * SQL-callable: refresh every OrioleDB table in the current database.  Meant
- * to be run once per database after a cross-major pg_upgrade so the persisted
- * index expressions are rewritten in the running server's node-tree format.
- * Normally unnecessary -- maybe_auto_upgrade_refresh() does this automatically
- * on first use -- but kept for manual invocation and backward compatibility.
- */
-Datum
-orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
-{
-	o_upgrade_refresh_database();
 
 	PG_RETURN_VOID();
 }

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -21,6 +21,7 @@
 #include "catalog/o_indices.h"
 #include "catalog/o_tables.h"
 #include "catalog/o_sys_cache.h"
+#include "checkpoint/checkpoint.h"
 #include "storage/lockdefs.h"
 #include "tableam/descr.h"
 #include "storage/copydir.h"
@@ -40,6 +41,7 @@
 #include "access/tableam.h"
 #include "access/toast_compression.h"
 #include "access/transam.h"
+#include "access/xlog.h"
 #include "catalog/catalog.h"
 #include "catalog/heap.h"
 #include "catalog/index.h"
@@ -153,6 +155,7 @@ static void orioledb_utility_command(PlannedStmt *pstmt,
 									 struct QueryCompletion *qc);
 static void orioledb_object_access_hook(ObjectAccessType access, Oid classId,
 										Oid objectId, int subId, void *arg);
+static void maybe_auto_upgrade_refresh(void);
 
 static void o_alter_column_type(AlterTableCmd *cmd, const char *queryString,
 								Relation rel);
@@ -930,6 +933,14 @@ orioledb_utility_command(PlannedStmt *pstmt,
 	bool		isTopLevel = (context == PROCESS_UTILITY_TOPLEVEL);
 	ParseState *pstate;
 	bool		call_next = true;
+
+	/*
+	 * First use of this database after a cross-major restart: rewrite the
+	 * carried-over index expressions / proc trees into this server's format,
+	 * so orioledb_upgrade_refresh() need not be called by hand.  A no-op
+	 * unless a cross-major upgrade actually happened (see the guards inside).
+	 */
+	maybe_auto_upgrade_refresh();
 
 	/* copied from standard_ProcessUtility */
 	if (readOnlyTree)
@@ -5285,6 +5296,33 @@ o_refresh_table_expressions(Oid reloid)
 	OSnapshot	oSnapshot;
 	int			ix_num;
 
+	/*
+	 * Cheap pre-check under a share lock: a table whose persisted expressions
+	 * are already in this server's node-tree format has refresh_exprs unset
+	 * and needs no rewrite.  Skipping it here avoids taking an exclusive lock
+	 * on every table -- important for the automatic per-database refresh,
+	 * where repeated calls (from later backends, once the first has done the
+	 * work) must not serialize the whole database behind exclusive locks.
+	 */
+	rel = table_open(reloid, AccessShareLock);
+	if (!is_orioledb_rel(rel))
+	{
+		table_close(rel, AccessShareLock);
+		return;
+	}
+	ORelOidsSetFromRel(oids, rel);
+	o_table = o_tables_get(oids);
+	if (o_table == NULL || !o_table->refresh_exprs)
+	{
+		if (o_table)
+			o_table_free(o_table);
+		table_close(rel, AccessShareLock);
+		return;
+	}
+	o_table_free(o_table);
+	table_close(rel, AccessShareLock);
+
+	/* Stale: rewrite the node trees under an exclusive lock. */
 	rel = table_open(reloid, AccessExclusiveLock);
 	if (!is_orioledb_rel(rel))
 	{
@@ -5294,8 +5332,11 @@ o_refresh_table_expressions(Oid reloid)
 
 	ORelOidsSetFromRel(oids, rel);
 	o_table = o_tables_get(oids);
-	if (o_table == NULL)
+	/* Recheck: another backend may have refreshed it since the share lock. */
+	if (o_table == NULL || !o_table->refresh_exprs)
 	{
+		if (o_table)
+			o_table_free(o_table);
 		table_close(rel, AccessExclusiveLock);
 		return;
 	}
@@ -5333,15 +5374,14 @@ o_refresh_table_expressions(Oid reloid)
 	table_close(rel, AccessExclusiveLock);
 }
 
-PG_FUNCTION_INFO_V1(orioledb_upgrade_refresh);
-
 /*
- * SQL-callable: refresh every OrioleDB table in the current database.  Meant
- * to be run once per database after a cross-major pg_upgrade so the persisted
- * index expressions are rewritten in the running server's node-tree format.
+ * Rewrite the persisted index expressions/predicates of every OrioleDB table in
+ * the current database into the running server's node-tree format (and rebuild
+ * the referenced proc-cache entries).  Tables already in the current format are
+ * skipped cheaply (see o_refresh_table_expressions).  Idempotent.
  */
-Datum
-orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
+static void
+o_upgrade_refresh_database(void)
 {
 	Oid			orioledb_am = get_am_oid("orioledb", false);
 	Relation	pgclass;
@@ -5367,6 +5407,65 @@ orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
 
 	foreach(lc, reloids)
 		o_refresh_table_expressions(lfirst_oid(lc));
+}
+
+/*
+ * Automatically refresh the current database once, the first time it is used
+ * after the cluster started from on-disk state written by a different PG major
+ * (e.g. carried over by pg_upgrade), so the manual orioledb_upgrade_refresh()
+ * call is not required.
+ *
+ * Guards -- this must NOT run:
+ *  - unless the cross-major reset actually happened (resetSysCaches);
+ *  - during pg_upgrade's own binary-upgrade restore (IsBinaryUpgrade): the
+ *    catalog is not yet populated and orioledb_data/ is not yet in place, so a
+ *    refresh then would see no tables and wrongly stamp the database as done;
+ *  - on a standby / during recovery (cannot write);
+ *  - outside a normal, fully-initialized backend bound to a real database.
+ *
+ * It runs at most once per backend (a cheap boolean short-circuits afterwards).
+ * The persisted per-table refresh_exprs flag is the shared "already done"
+ * marker: once the first backend rewrites a table, later backends find nothing
+ * stale and o_refresh_table_expressions returns cheaply, so no cross-backend
+ * lock or extra bookkeeping is needed.  The read-time errors on stale
+ * index/proc entries remain as a fallback for a backend that touches a stale
+ * object before this runs (e.g. a SELECT-only session issuing no utility
+ * command).
+ */
+static void
+maybe_auto_upgrade_refresh(void)
+{
+	static bool attempted = false;
+
+	if (attempted)
+		return;
+
+	if (checkpoint_state == NULL || !checkpoint_state->resetSysCaches)
+		return;
+	if (IsBinaryUpgrade ||
+		RecoveryInProgress() ||
+		!IsNormalProcessingMode() ||
+		!IsTransactionState() ||
+		!OidIsValid(MyDatabaseId))
+		return;
+
+	attempted = true;
+	o_upgrade_refresh_database();
+}
+
+PG_FUNCTION_INFO_V1(orioledb_upgrade_refresh);
+
+/*
+ * SQL-callable: refresh every OrioleDB table in the current database.  Meant
+ * to be run once per database after a cross-major pg_upgrade so the persisted
+ * index expressions are rewritten in the running server's node-tree format.
+ * Normally unnecessary -- maybe_auto_upgrade_refresh() does this automatically
+ * on first use -- but kept for manual invocation and backward compatibility.
+ */
+Datum
+orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
+{
+	o_upgrade_refresh_database();
 
 	PG_RETURN_VOID();
 }

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -33,8 +33,10 @@
 #include "utils/compress.h"
 #include "recovery/wal.h"
 
+#include "access/genam.h"
 #include "access/heapam.h"
 #include "access/reloptions.h"
+#include "access/table.h"
 #include "access/tableam.h"
 #include "access/toast_compression.h"
 #include "access/transam.h"
@@ -2144,8 +2146,15 @@ set_toast_oids_and_options(Relation rel, Relation toast_rel, bool only_fillfacto
 		if (index_bridging)
 		{
 			o_table->bridge_oids.datoid = MyDatabaseId;
-			o_table->bridge_oids.relnode = GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
-															   rel->rd_rel->relpersistence);
+
+			/*
+			 * Under pg_upgrade fresh relfilenumber allocation is forbidden
+			 * and the real bridge is carried over with the data; this OTable
+			 * is discarded after the schema restore, so leave it invalid.
+			 */
+			o_table->bridge_oids.relnode = IsBinaryUpgrade ? InvalidOid :
+				GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
+									rel->rd_rel->relpersistence);
 			o_table->bridge_oids.reloid = o_table->bridge_oids.relnode;
 		}
 	}
@@ -4411,6 +4420,14 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 		Form_pg_database dbform;
 		int32		cluster_encoding;
 
+		/*
+		 * Make the just-created pg_database row visible before touching the
+		 * database cache.  pg_upgrade restores template1 itself with an
+		 * explicit OID (CREATE DATABASE "template1" ... OID = 1); in that
+		 * case the template1 cache refresh below looks up the very row being
+		 * created, which is not yet visible without this increment.
+		 */
+		CommandCounterIncrement();
 
 		if (IsTransactionState())
 		{
@@ -4420,7 +4437,6 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 			o_database_cache_add_if_needed(Template1DbOid, Template1DbOid, cur_lsn, NULL);
 		}
 
-		CommandCounterIncrement();
 		dbTuple = SearchSysCache1(DATABASEOID, ObjectIdGetDatum(objectId));
 
 		if (!HeapTupleIsValid(dbTuple))
@@ -5244,4 +5260,113 @@ o_process_added_column(AlterTableCmd *cmd)
 	o_added_columns = lappend(o_added_columns,
 	/* cppcheck-suppress unknownEvaluationOrder */
 							  list_make2(makeInteger(typeid), makeString(def->colname)));
+}
+
+/*
+ * Re-derive one OrioleDB table's index expressions/predicates from the
+ * catalog and re-persist OTable/OIndex in the current node-tree format.
+ *
+ * After a cross-major pg_upgrade the carried-over expression blobs were
+ * written by another PostgreSQL major and are skipped on read (their
+ * nodeToString format is not portable; see o_deserialize_node).  This
+ * re-derives them from RelationGetIndexExpressions/Predicate via
+ * o_table_refresh_index_exprs, then saves -- so subsequent reads (including
+ * catalog-free recovery) get current-format blobs.  Only the node trees are
+ * touched; the fixed-layout index metadata is left as deserialized, so we
+ * avoid the type/class-cache machinery that o_table_fill_index would run.
+ */
+static void
+o_refresh_table_expressions(Oid reloid)
+{
+	Relation	rel;
+	ORelOids	oids;
+	OTable	   *o_table;
+	OXid		oxid;
+	OSnapshot	oSnapshot;
+	int			ix_num;
+
+	rel = table_open(reloid, AccessExclusiveLock);
+	if (!is_orioledb_rel(rel))
+	{
+		table_close(rel, AccessExclusiveLock);
+		return;
+	}
+
+	ORelOidsSetFromRel(oids, rel);
+	o_table = o_tables_get(oids);
+	if (o_table == NULL)
+	{
+		table_close(rel, AccessExclusiveLock);
+		return;
+	}
+
+	for (ix_num = 0; ix_num < o_table->nindices; ix_num++)
+	{
+		OTableIndex *index = &o_table->indices[ix_num];
+		Relation	index_rel;
+
+		/* ctid pseudo-index has no catalog relation */
+		if (!OidIsValid(index->oids.reloid))
+			continue;
+		index_rel = index_open(index->oids.reloid, AccessShareLock);
+		o_table_refresh_index_exprs(o_table, ix_num, index_rel);
+		index_close(index_rel, AccessShareLock);
+	}
+
+	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
+	o_tables_rel_meta_lock(rel);
+	for (ix_num = 0; ix_num < o_table->nindices; ix_num++)
+	{
+		int			ctid_idx_off = o_table->has_primary ? 0 : 1;
+		OTableIndex *index = &o_table->indices[ix_num];
+
+		o_indices_update(o_table, ix_num + ctid_idx_off, oxid, oSnapshot.csn);
+		o_invalidate_oids(index->oids);
+		o_add_invalidate_undo_item(index->oids, O_INVALIDATE_OIDS_ON_ABORT);
+	}
+	o_tables_update(o_table, oxid, oSnapshot.csn);
+	o_tables_rel_meta_unlock(rel, InvalidOid);
+	o_invalidate_oids(oids);
+	o_add_invalidate_undo_item(oids, O_INVALIDATE_OIDS_ON_ABORT);
+
+	o_table_free(o_table);
+	table_close(rel, AccessExclusiveLock);
+}
+
+PG_FUNCTION_INFO_V1(orioledb_upgrade_refresh);
+
+/*
+ * SQL-callable: refresh every OrioleDB table in the current database.  Meant
+ * to be run once per database after a cross-major pg_upgrade so the persisted
+ * index expressions are rewritten in the running server's node-tree format.
+ */
+Datum
+orioledb_upgrade_refresh(PG_FUNCTION_ARGS)
+{
+	Oid			orioledb_am = get_am_oid("orioledb", false);
+	Relation	pgclass;
+	SysScanDesc scan;
+	HeapTuple	tup;
+	List	   *reloids = NIL;
+	ListCell   *lc;
+
+	/* Collect the orioledb table OIDs first; refresh outside the scan. */
+	pgclass = table_open(RelationRelationId, AccessShareLock);
+	scan = systable_beginscan(pgclass, InvalidOid, false, NULL, 0, NULL);
+	while (HeapTupleIsValid(tup = systable_getnext(scan)))
+	{
+		Form_pg_class cf = (Form_pg_class) GETSTRUCT(tup);
+
+		if ((cf->relkind == RELKIND_RELATION ||
+			 cf->relkind == RELKIND_MATVIEW) &&
+			cf->relam == orioledb_am)
+			reloids = lappend_oid(reloids, cf->oid);
+	}
+	systable_endscan(scan);
+	table_close(pgclass, AccessShareLock);
+
+	foreach(lc, reloids)
+		o_refresh_table_expressions(lfirst_oid(lc));
+
+	PG_RETURN_VOID();
 }

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -177,6 +177,21 @@ assign_new_oids(OTable *oTable, Relation rel, bool drop_pkey)
 
 	CheckTableForSerializableConflictIn(rel);
 
+	/*
+	 * Under pg_upgrade (binary upgrade) every relation's relfilenode is
+	 * preserved from the old cluster, and the on-disk OrioleDB trees are
+	 * carried over as-is.  Reassigning relfilenodes here would both ask the
+	 * core for a fresh relfilenumber -- which is forbidden in binary upgrade
+	 * mode -- and orphan the migrated data.  Keep the preserved relnodes and
+	 * just refresh the OTable oids from the (unchanged) relation.
+	 */
+	if (IsBinaryUpgrade)
+	{
+		o_table_fill_oids(oTable, rel, &RelGetNode(rel), drop_pkey);
+		orioledb_free_rd_amcache(rel);
+		return;
+	}
+
 	/* If toast relation exists, set new filenode for it */
 	toast_relid = rel->rd_rel->reltoastrelid;
 	if (OidIsValid(toast_relid))

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -806,17 +806,53 @@ o_deserialize_string_safe(Pointer *ptr, Pointer data, Size length, char **out)
 	return true;
 }
 
+/*
+ * Set while deserializing an OTable/OIndex whose persisted node trees were
+ * written by a different PostgreSQL major version: PostgreSQL's nodeToString
+ * format is not stable across majors, so we can't (and must not, e.g. in a
+ * catalog-free recovery worker) stringToNode such a blob.  We skip it and
+ * record that the expressions need to be re-derived from the catalog and
+ * rewritten -- see o_table_refresh_expressions().
+ */
+bool		o_node_deserialize_format_changed = false;
+
+/*
+ * Each serialized node blob is prefixed with the PG_VERSION_NUM that wrote it,
+ * so a reader on a different major version can detect the incompatible
+ * nodeToString format instead of parsing garbage.
+ */
 void
 o_serialize_node(Node *node, StringInfo str)
 {
 	char	   *node_str;
 	size_t		node_str_len;
+	int32		pg_version = PG_VERSION_NUM;
 
 	node_str = nodeToString(node);
 	node_str_len = strlen(node_str) + 1;
+	appendBinaryStringInfo(str, (Pointer) &pg_version, sizeof(pg_version));
 	appendBinaryStringInfo(str, (Pointer) &node_str_len, sizeof(size_t));
 	appendBinaryStringInfo(str, node_str, node_str_len);
 	pfree(node_str);
+}
+
+/* True if a node blob written by pg_version can be parsed by this binary. */
+static inline bool
+o_node_version_compatible(int32 pg_version)
+{
+	return pg_version / 10000 == PG_VERSION_NUM / 10000;
+}
+
+/*
+ * True if a serialized node string carries no actual node.  nodeToString()
+ * renders an empty/NULL list as "<>", so such a blob loses nothing when it
+ * cannot be parsed across majors -- only a non-empty tree marks the owning
+ * index as needing orioledb_upgrade_refresh().
+ */
+static inline bool
+o_node_str_is_empty(const char *node_str)
+{
+	return node_str[0] == '\0' || strcmp(node_str, "<>") == 0;
 }
 
 Node *
@@ -824,15 +860,22 @@ o_deserialize_node(Pointer *ptr)
 {
 	Node	   *result;
 	size_t		node_str_len;
-	int			len;
+	int32		pg_version;
 
-	len = sizeof(size_t);
-	memcpy(&node_str_len, *ptr, len);
-	*ptr += len;
+	memcpy(&pg_version, *ptr, sizeof(pg_version));
+	*ptr += sizeof(pg_version);
+	memcpy(&node_str_len, *ptr, sizeof(size_t));
+	*ptr += sizeof(size_t);
 
-	len = node_str_len;
-	result = stringToNode(*ptr);
-	*ptr += len;
+	if (o_node_version_compatible(pg_version))
+		result = stringToNode(*ptr);
+	else
+	{
+		if (!o_node_str_is_empty(*ptr))
+			o_node_deserialize_format_changed = true;
+		result = NULL;
+	}
+	*ptr += node_str_len;
 	return result;
 }
 
@@ -844,15 +887,25 @@ bool
 o_deserialize_node_safe(Pointer *ptr, Pointer data, Size length, Node **out)
 {
 	size_t		node_str_len;
+	int32		pg_version;
 
-	if ((*ptr - data) + (int) sizeof(size_t) > length)
+	if ((*ptr - data) + (int) (sizeof(pg_version) + sizeof(size_t)) > length)
 		return false;
+	memcpy(&pg_version, *ptr, sizeof(pg_version));
+	*ptr += sizeof(pg_version);
 	memcpy(&node_str_len, *ptr, sizeof(size_t));
 	*ptr += sizeof(size_t);
 
 	if ((*ptr - data) + (Size) node_str_len > length)
 		return false;
-	*out = stringToNode(*ptr);
+	if (o_node_version_compatible(pg_version))
+		*out = stringToNode(*ptr);
+	else
+	{
+		if (!o_node_str_is_empty(*ptr))
+			o_node_deserialize_format_changed = true;
+		*out = NULL;
+	}
 	*ptr += node_str_len;
 	return true;
 }
@@ -877,8 +930,8 @@ serialize_o_index(OIndex *o_index, int *size)
 	appendBinaryStringInfo(&str, (Pointer) o_index->leafFields,
 						   o_index->nLeafFields * sizeof(o_index->leafFields[0]));
 	o_serialize_node((Node *) o_index->predicate, &str);
-	if (o_index->predicate)
-		o_serialize_string(o_index->predicate_str, &str);
+	/* always present, see serialize_o_table_index for the rationale */
+	o_serialize_string(o_index->predicate_str, &str);
 	o_serialize_node((Node *) o_index->expressions, &str);
 	o_serialize_node((Node *) o_index->duplicates, &str);
 
@@ -935,20 +988,19 @@ deserialize_o_index(OIndexChunkKey *key, Pointer data, Size length)
 	mcxt = OGetIndexContext(oIndex);
 	old_mcxt = MemoryContextSwitchTo(mcxt);
 
+	o_node_deserialize_format_changed = false;
 	if (!o_deserialize_node_safe(&ptr, data, length,
 								 (Node **) &oIndex->predicate))
 	{
 		MemoryContextSwitchTo(old_mcxt);
 		goto truncated;
 	}
-	if (oIndex->predicate)
+	/* predicate_str is always present (see serialize_o_index) */
+	if (!o_deserialize_string_safe(&ptr, data, length,
+								   &oIndex->predicate_str))
 	{
-		if (!o_deserialize_string_safe(&ptr, data, length,
-									   &oIndex->predicate_str))
-		{
-			MemoryContextSwitchTo(old_mcxt);
-			goto truncated;
-		}
+		MemoryContextSwitchTo(old_mcxt);
+		goto truncated;
 	}
 	if (!o_deserialize_node_safe(&ptr, data, length,
 								 (Node **) &oIndex->expressions))
@@ -963,6 +1015,14 @@ deserialize_o_index(OIndexChunkKey *key, Pointer data, Size length)
 		goto truncated;
 	}
 	MemoryContextSwitchTo(old_mcxt);
+
+	/*
+	 * If any of the node trees above was written by a different PG major it
+	 * was skipped (its nodeToString format is unreadable here), leaving the
+	 * list NULL.  Flag the index so o_define_index_descr() refuses to use it
+	 * until orioledb_upgrade_refresh() rewrites the trees.
+	 */
+	oIndex->refresh_exprs = o_node_deserialize_format_changed;
 
 	if (oIndex->indexType == oIndexExclusion)
 	{
@@ -1044,6 +1104,15 @@ make_o_index(OTable *table, OIndexNumber ixNum, OIndexVersionMode ixVerMode)
 	}
 
 	index->data_version = ORIOLEDB_SYS_TREE_VERSION;
+
+	/*
+	 * Carry the table's "expressions written by another PG major" flag onto
+	 * the index built from it.  The normal table-access path builds index
+	 * descriptors from the OTable (not from the SYS_TREES_O_INDICES copy), so
+	 * without this o_index_fill_descr() would not know to refuse the index
+	 * after a cross-major pg_upgrade.  See OTable.refresh_exprs.
+	 */
+	index->refresh_exprs = table->refresh_exprs;
 	return index;
 }
 
@@ -1185,6 +1254,21 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, void *o_table_source, OTa
 	bool		was_saving;
 
 	Assert(oIndex != NULL);
+
+	/*
+	 * The index's expression/predicate node trees were carried over from a
+	 * different PostgreSQL major by a cross-major pg_upgrade and dropped on
+	 * read (their nodeToString format is not portable).  Using the index now
+	 * would evaluate against missing trees and crash, so refuse until
+	 * orioledb_upgrade_refresh() rewrites them in this server's format.
+	 */
+	if (oIndex->refresh_exprs)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("OrioleDB index \"%s\" has expressions stored by another PostgreSQL major version",
+						oIndex->name.data),
+				 errdetail("This happens after a cross-major pg_upgrade, before the carried-over index expressions have been rewritten."),
+				 errhint("Run \"SELECT orioledb_upgrade_refresh();\" in this database before using the index.")));
 
 	/*
 	 * Defer invalidation messages while filling the index descriptor. Catalog

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -31,6 +31,8 @@
 #include "access/genam.h"
 #include "access/relation.h"
 #include "access/table.h"
+#include "executor/execExpr.h"
+#include "executor/functions.h"
 #include "catalog/pg_opclass_d.h"
 #include "catalog/pg_tablespace_d.h"
 #include "catalog/pg_type_d.h"
@@ -1221,6 +1223,68 @@ cache_scan_tupdesc_and_slot(OIndexDescr *index_descr, OIndex *oIndex)
 }
 
 /*
+ * Redirect SQL-function calls in a compiled index expression/predicate to
+ * o_fmgr_sql.
+ *
+ * ExecInitExpr/ExecInitQual give a SQL function PostgreSQL's native fmgr_sql,
+ * which parses and executes the function body against the catalog.  In a
+ * catalog-free context (recovery, checkpointer) there is no catalog, so such a
+ * call crashes (native fmgr_sql segfaults in the executor).  o_fmgr_sql instead
+ * evaluates the function from the parse trees cached in the OrioleDB proc
+ * cache.  This mirrors the comparator fixup in descr.c; only relevant when the
+ * syscache hooks are active (installed only outside a transaction), so the
+ * caller gates on o_is_syscache_hooks_set().  fn_extra is cleared because the
+ * SQLFunctionCache layout differs between fmgr_sql and o_fmgr_sql.
+ */
+static void
+o_index_expr_redirect_sql_funcs(ExprState *state)
+{
+	int			i;
+
+	if (state == NULL || !o_is_syscache_hooks_set())
+		return;
+
+	for (i = 0; i < state->steps_len; i++)
+	{
+		ExprEvalStep *step = &state->steps[i];
+		FmgrInfo   *finfo = NULL;
+
+		switch (ExecEvalStepOp(state, step))
+		{
+			case EEOP_FUNCEXPR:
+			case EEOP_FUNCEXPR_STRICT:
+			case EEOP_FUNCEXPR_FUSAGE:
+			case EEOP_FUNCEXPR_STRICT_FUSAGE:
+#if PG_VERSION_NUM >= 180000
+			case EEOP_FUNCEXPR_STRICT_1:
+			case EEOP_FUNCEXPR_STRICT_2:
+#endif
+			case EEOP_DISTINCT:
+			case EEOP_NOT_DISTINCT:
+			case EEOP_NULLIF:
+				finfo = step->d.func.finfo;
+				break;
+			default:
+				break;
+		}
+
+		if (finfo != NULL && step->d.func.fn_addr == fmgr_sql)
+		{
+			/*
+			 * ExecInterpExpr calls the cached step->d.func.fn_addr directly
+			 * (the finfo indirection is bypassed for speed), so redirect that
+			 * copy; keep finfo consistent too.  fn_extra is cleared because
+			 * the SQLFunctionCache layout differs between fmgr_sql and
+			 * o_fmgr_sql.
+			 */
+			step->d.func.fn_addr = o_fmgr_sql;
+			finfo->fn_addr = o_fmgr_sql;
+			finfo->fn_extra = NULL;
+		}
+	}
+}
+
+/*
  * o_index_fill_descr()
  *
  * Initialize *descr from the catalog OIndex entry.
@@ -1473,6 +1537,7 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, void *o_table_source, OTa
 
 	o_set_syscache_hooks();
 	descr->predicate_state = ExecInitQual(descr->predicate, NULL);
+	o_index_expr_redirect_sql_funcs(descr->predicate_state);
 	descr->expressions_state = NIL;
 	foreach(lc, descr->expressions)
 	{
@@ -1480,6 +1545,7 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, void *o_table_source, OTa
 		ExprState  *expr_state;
 
 		expr_state = ExecInitExpr(node, NULL);
+		o_index_expr_redirect_sql_funcs(expr_state);
 
 		descr->expressions_state = lappend(descr->expressions_state,
 										   expr_state);

--- a/src/catalog/o_proc_cache.c
+++ b/src/catalog/o_proc_cache.c
@@ -89,6 +89,18 @@ struct OProc
 	Oid		   *argtypes;
 	sql_func_data *sql_func;
 
+	/*
+	 * True when this entry's SQL-function parse trees were serialized by a
+	 * different PG major version and could not be deserialized (their
+	 * nodeToString format is not portable; o_deserialize_node returned NULL).
+	 * The scalar metadata above is still valid, but the parse trees are
+	 * missing, so executing the function would crash.  Set on read after a
+	 * cross-major pg_upgrade; cleared once orioledb_upgrade_refresh()
+	 * rebuilds the entry in this server's format.  In-memory only (never
+	 * serialized).
+	 */
+	bool		node_format_stale;
+
 	MemoryContext cxt;
 };
 
@@ -409,6 +421,13 @@ o_proc_cache_deserialize_entry(MemoryContext mcxt, Pointer data, Size length)
 		sql_func = (sql_func_data *) palloc0(sizeof(sql_func_data));
 		o_proc->sql_func = sql_func;
 
+		/*
+		 * Track whether any parse tree below was written by a different PG
+		 * major and dropped on read (o_deserialize_node sets the global
+		 * flag). Reset it first so it reflects only this entry.
+		 */
+		o_node_deserialize_format_changed = false;
+
 		sql_func->src = o_deserialize_string(&ptr);
 
 		len = offsetof(sql_func_data, jf_targetList) -
@@ -451,6 +470,8 @@ o_proc_cache_deserialize_entry(MemoryContext mcxt, Pointer data, Size length)
 				sql_func->qtlists[i][j] = o_deserialize_node(&ptr);
 			}
 		}
+
+		o_proc->node_format_stale = o_node_deserialize_format_changed;
 	}
 
 	MemoryContextSwitchTo(old_mcxt);
@@ -816,7 +837,25 @@ init_sql_fcache(FunctionCallInfo fcinfo, Oid collation, bool lazyEvalOK,
 	o_proc = o_proc_cache_search(datoid, fcinfo->flinfo->fn_oid, cur_lsn,
 								 proc_cache->nkeys);
 	if (o_proc)
+	{
+		/*
+		 * The cached parse trees were written by a different PG major version
+		 * and dropped on read (see o_proc_cache_deserialize_entry); executing
+		 * the function now would dereference missing trees.  Refuse cleanly
+		 * until orioledb_upgrade_refresh() rebuilds the entry in this
+		 * server's node-tree format.  We cannot fall back to the catalog
+		 * here: this path also runs in background workers (recovery,
+		 * checkpointer) that have no database catalog to consult.
+		 */
+		if (o_proc->node_format_stale)
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("OrioleDB SQL function \"%s\" was stored by another PostgreSQL major version",
+							o_proc->proname),
+					 errdetail("This happens after a cross-major pg_upgrade, before the carried-over function parse trees have been rebuilt."),
+					 errhint("Run \"SELECT orioledb_upgrade_refresh();\" in this database before using it.")));
 		sql_func = o_proc->sql_func;
+	}
 
 	/*
 	 * Create memory context that holds all the SQLFunctionCache data.  It

--- a/src/catalog/o_proc_cache.c
+++ b/src/catalog/o_proc_cache.c
@@ -89,18 +89,6 @@ struct OProc
 	Oid		   *argtypes;
 	sql_func_data *sql_func;
 
-	/*
-	 * True when this entry's SQL-function parse trees were serialized by a
-	 * different PG major version and could not be deserialized (their
-	 * nodeToString format is not portable; o_deserialize_node returned NULL).
-	 * The scalar metadata above is still valid, but the parse trees are
-	 * missing, so executing the function would crash.  Set on read after a
-	 * cross-major pg_upgrade; cleared once orioledb_upgrade_refresh()
-	 * rebuilds the entry in this server's format.  In-memory only (never
-	 * serialized).
-	 */
-	bool		node_format_stale;
-
 	MemoryContext cxt;
 };
 
@@ -421,13 +409,6 @@ o_proc_cache_deserialize_entry(MemoryContext mcxt, Pointer data, Size length)
 		sql_func = (sql_func_data *) palloc0(sizeof(sql_func_data));
 		o_proc->sql_func = sql_func;
 
-		/*
-		 * Track whether any parse tree below was written by a different PG
-		 * major and dropped on read (o_deserialize_node sets the global
-		 * flag). Reset it first so it reflects only this entry.
-		 */
-		o_node_deserialize_format_changed = false;
-
 		sql_func->src = o_deserialize_string(&ptr);
 
 		len = offsetof(sql_func_data, jf_targetList) -
@@ -470,8 +451,6 @@ o_proc_cache_deserialize_entry(MemoryContext mcxt, Pointer data, Size length)
 				sql_func->qtlists[i][j] = o_deserialize_node(&ptr);
 			}
 		}
-
-		o_proc->node_format_stale = o_node_deserialize_format_changed;
 	}
 
 	MemoryContextSwitchTo(old_mcxt);
@@ -837,25 +816,7 @@ init_sql_fcache(FunctionCallInfo fcinfo, Oid collation, bool lazyEvalOK,
 	o_proc = o_proc_cache_search(datoid, fcinfo->flinfo->fn_oid, cur_lsn,
 								 proc_cache->nkeys);
 	if (o_proc)
-	{
-		/*
-		 * The cached parse trees were written by a different PG major version
-		 * and dropped on read (see o_proc_cache_deserialize_entry); executing
-		 * the function now would dereference missing trees.  Refuse cleanly
-		 * until orioledb_upgrade_refresh() rebuilds the entry in this
-		 * server's node-tree format.  We cannot fall back to the catalog
-		 * here: this path also runs in background workers (recovery,
-		 * checkpointer) that have no database catalog to consult.
-		 */
-		if (o_proc->node_format_stale)
-			ereport(ERROR,
-					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-					 errmsg("OrioleDB SQL function \"%s\" was stored by another PostgreSQL major version",
-							o_proc->proname),
-					 errdetail("This happens after a cross-major pg_upgrade, before the carried-over function parse trees have been rebuilt."),
-					 errhint("Run \"SELECT orioledb_upgrade_refresh();\" in this database before using it.")));
 		sql_func = o_proc->sql_func;
-	}
 
 	/*
 	 * Create memory context that holds all the SQLFunctionCache data.  It

--- a/src/catalog/o_proc_cache.c
+++ b/src/catalog/o_proc_cache.c
@@ -2197,7 +2197,23 @@ o_proc_cache_search_htup(TupleDesc tupdesc, Oid procoid)
 		values[Anum_pg_proc_proname - 1] = NameGetDatum(&procname);
 		values[Anum_pg_proc_proowner - 1] = ObjectIdGetDatum(o_proc->proowner);
 		values[Anum_pg_proc_prolang - 1] = ObjectIdGetDatum(o_proc->prolang);
-		if (o_proc->prosrc)
+
+		/*
+		 * For a SQL function fmgr_symbol() stored the language-handler symbol
+		 * in o_proc->prosrc ("fmgr_sql", or "fmgr_security_definer" for a
+		 * SECURITY DEFINER / SET-clause function) -- not the function body. A
+		 * catalog-free caller that re-parses the body from this synthetic
+		 * tuple (PostgreSQL's native fmgr_sql, reached in recovery when the
+		 * FmgrInfo is built outside o_proc_cache_fill_finfo) would then choke
+		 * on that symbol.  Hand back the real body text (sql_func->src)
+		 * instead; the synthetic tuple advertises prosecdef = false, so no
+		 * wrapper is involved and the plain SQL body is what must be parsed.
+		 */
+		if (o_proc->prolang == SQLlanguageId && o_proc->sql_func &&
+			o_proc->sql_func->src)
+			values[Anum_pg_proc_prosrc - 1] =
+				CStringGetTextDatum(o_proc->sql_func->src);
+		else if (o_proc->prosrc)
 			values[Anum_pg_proc_prosrc - 1] =
 				CStringGetTextDatum(o_proc->prosrc);
 		else

--- a/src/catalog/o_proc_cache.c
+++ b/src/catalog/o_proc_cache.c
@@ -2064,6 +2064,36 @@ o_proc_cache_validate_add(Oid datoid, Oid procoid, Oid fncollation,
 }
 
 /*
+ * For the cross-major upgrade refresh (o_collect_funcexpr_refresh): drop a
+ * proc-cache entry ONLY if its SQL-function parse trees were carried over from
+ * another PG major and dropped on read (node_format_stale), so the caller can
+ * re-add it from the catalog in this server's node-tree format.
+ *
+ * A non-stale entry must be left in place.  In particular an INTERNAL opclass
+ * support proc (comparator, hash, sort support) has no node trees, deserializes
+ * fine across majors, and is relied on by index-descriptor fills -- dropping
+ * one (as an unconditional delete did) leaves it missing and trips
+ * o_proc_cache_fill_finfo's Assert(o_proc).  The refresh walker visits such
+ * procs transitively (operator support functions), so the guard is essential.
+ *
+ * Returns true if a stale entry was dropped.
+ */
+bool
+o_proc_cache_delete_if_stale(Oid datoid, Oid procoid)
+{
+	XLogRecPtr	cur_lsn;
+	OProc	   *o_proc;
+
+	o_sys_cache_set_datoid_lsn(&cur_lsn, datoid == InvalidOid ? &datoid : NULL);
+	o_proc = o_proc_cache_search(datoid, procoid, cur_lsn, proc_cache->nkeys);
+	if (o_proc == NULL || !o_proc->node_format_stale)
+		return false;
+
+	o_proc_cache_delete(datoid, procoid);
+	return true;
+}
+
+/*
  * o_proc_cache_fill_finfo
  *
  * Fill FmgrInfo for procoid in the provided database context.

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -684,9 +684,19 @@ o_table_refresh_index_exprs(OTable *o_table, OIndexNumber ix_num,
 	 * and the checkpointer later read these entries via the syscache hook
 	 * without a catalog of their own, so they must be present and
 	 * current-format before then.
+	 *
+	 * Use the refresh variant: a referenced SQL function's proc-cache entry
+	 * may already exist but hold parse trees in the old major's node-tree
+	 * format (unreadable here), and the proc cache forbids in-place updates,
+	 * so the stale entry is dropped and re-created from the current catalog
+	 * in this server's format.  This is safe now that the class cache is
+	 * reset first: rebuilding a proc entry collects its referenced types into
+	 * an empty class-cache tree, which refills from the relcache instead of
+	 * deserializing a stale old-major entry -- the deserialize that crashed
+	 * the earlier walker-based rebuild before the class cache was reset.
 	 */
-	o_collect_funcexpr((Node *) index->predicate);
-	o_collect_funcexpr((Node *) index->expressions);
+	o_collect_funcexpr_refresh((Node *) index->predicate);
+	o_collect_funcexpr_refresh((Node *) index->expressions);
 
 	MemoryContextSwitchTo(old_mcxt);
 	return true;

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -675,6 +675,19 @@ o_table_refresh_index_exprs(OTable *o_table, OIndexNumber ix_num,
 									 expression_planner(e));
 	}
 
+	/*
+	 * Repopulate the sys caches these expressions/predicates reference
+	 * (types, operators, procedures, ...).  This runs in a normal
+	 * transaction, so the class cache -- dropped by the cross-major reset
+	 * because its FormData_pg_attribute layout is version-dependent -- is
+	 * refilled from the relcache in the running server's format.  Recovery
+	 * and the checkpointer later read these entries via the syscache hook
+	 * without a catalog of their own, so they must be present and
+	 * current-format before then.
+	 */
+	o_collect_funcexpr((Node *) index->predicate);
+	o_collect_funcexpr((Node *) index->expressions);
+
 	MemoryContextSwitchTo(old_mcxt);
 	return true;
 }

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -675,17 +675,6 @@ o_table_refresh_index_exprs(OTable *o_table, OIndexNumber ix_num,
 									 expression_planner(e));
 	}
 
-	/*
-	 * Rebuild the proc cache for any SQL function referenced by these
-	 * expressions.  Its entries may hold parse trees in the old major's
-	 * node-tree format (unreadable here); force them to be re-serialized in
-	 * this server's format so evaluating the just-rewritten expressions -- in
-	 * foreground backends and in background workers alike -- finds valid
-	 * trees.
-	 */
-	o_collect_funcexpr_refresh((Node *) index->predicate);
-	o_collect_funcexpr_refresh((Node *) index->expressions);
-
 	MemoryContextSwitchTo(old_mcxt);
 	return true;
 }

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -675,6 +675,17 @@ o_table_refresh_index_exprs(OTable *o_table, OIndexNumber ix_num,
 									 expression_planner(e));
 	}
 
+	/*
+	 * Rebuild the proc cache for any SQL function referenced by these
+	 * expressions.  Its entries may hold parse trees in the old major's
+	 * node-tree format (unreadable here); force them to be re-serialized in
+	 * this server's format so evaluating the just-rewritten expressions -- in
+	 * foreground backends and in background workers alike -- finds valid
+	 * trees.
+	 */
+	o_collect_funcexpr_refresh((Node *) index->predicate);
+	o_collect_funcexpr_refresh((Node *) index->expressions);
+
 	MemoryContextSwitchTo(old_mcxt);
 	return true;
 }

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -622,6 +622,63 @@ o_table_fill_index(OTable *o_table, OIndexNumber ix_num, Relation index_rel)
 	}
 }
 
+/*
+ * Re-derive only the node-tree members (expressions and predicate) of an
+ * index from the catalog and replant them into the index's memory context.
+ *
+ * Used by orioledb_upgrade_refresh() after a cross-major pg_upgrade: the
+ * carried-over node trees were written in another PostgreSQL major's
+ * nodeToString format and are dropped on read (see o_deserialize_node),
+ * leaving these lists NULL.  Everything else in the OTableIndex (fields,
+ * exprfields, opclasses, collations, ...) deserializes unchanged because it
+ * has a fixed binary layout, so -- unlike o_table_fill_index -- we
+ * deliberately do *not* re-run the type/opclass/hash machinery.  That work is
+ * both unnecessary here (those fields are already correct) and unsafe to run
+ * against carried-over data, as it consults the version-specific class cache
+ * which may not be readable in the running major.
+ *
+ * Returns true if the index actually carries node trees (and was thus
+ * rewritten), false if it has none.
+ */
+bool
+o_table_refresh_index_exprs(OTable *o_table, OIndexNumber ix_num,
+							Relation index_rel)
+{
+	OTableIndex *index = &o_table->indices[ix_num];
+	MemoryContext mcxt,
+				old_mcxt;
+	ListCell   *lc;
+
+	RelationGetIndexExpressions(index_rel);
+	RelationGetIndexPredicate(index_rel);
+
+	/* No node trees were persisted for this index: nothing to rewrite. */
+	if (index_rel->rd_indexprs == NIL && index_rel->rd_indpred == NIL)
+		return false;
+
+	mcxt = OGetIndexContext(index);
+	old_mcxt = MemoryContextSwitchTo(mcxt);
+
+	index->predicate = (List *)
+		expression_planner((Expr *) index_rel->rd_indpred);
+	if (index->predicate)
+		index->predicate_str =
+			o_deparse_expression(nodeToString(index->predicate),
+								 o_table->oids.reloid);
+
+	index->expressions = NIL;
+	foreach(lc, index_rel->rd_indexprs)
+	{
+		Expr	   *e = (Expr *) lfirst(lc);
+
+		index->expressions = lappend(index->expressions,
+									 expression_planner(e));
+	}
+
+	MemoryContextSwitchTo(old_mcxt);
+	return true;
+}
+
 void
 o_table_resize_constr(OTable *o_table)
 {
@@ -1995,8 +2052,14 @@ serialize_o_table_index(OTableIndex *o_table_index, StringInfo str)
 	appendBinaryStringInfo(str, (Pointer) o_table_index->exprfields,
 						   o_table_index->nexprfields * sizeof(OTableField));
 	o_serialize_node((Node *) o_table_index->predicate, str);
-	if (o_table_index->predicate)
-		o_serialize_string(o_table_index->predicate_str, str);
+
+	/*
+	 * Always serialize predicate_str (even when NULL) so the record layout is
+	 * fixed: a reader on a different PG major skips the predicate node
+	 * without being able to tell whether predicate_str follows, so it must
+	 * always be there to keep the stream aligned.
+	 */
+	o_serialize_string(o_table_index->predicate_str, str);
 	o_serialize_node((Node *) o_table_index->expressions, str);
 	appendBinaryStringInfo(str, (Pointer) &o_table_index->tablespace, sizeof(Oid));
 	if (o_table_index->type == oIndexExclusion)
@@ -2090,14 +2153,12 @@ deserialize_o_table_index(OTableIndex *o_table_index, Pointer *ptr,
 		MemoryContextSwitchTo(old_mcxt);
 		return false;
 	}
-	if (o_table_index->predicate)
+	/* predicate_str is always present (see serialize_o_table_index) */
+	if (!o_deserialize_string_safe(ptr, data, length,
+								   &o_table_index->predicate_str))
 	{
-		if (!o_deserialize_string_safe(ptr, data, length,
-									   &o_table_index->predicate_str))
-		{
-			MemoryContextSwitchTo(old_mcxt);
-			return false;
-		}
+		MemoryContextSwitchTo(old_mcxt);
+		return false;
 	}
 	if (!o_deserialize_node_safe(ptr, data, length,
 								 (Node **) &o_table_index->expressions))
@@ -2229,6 +2290,7 @@ deserialize_o_table(Pointer data, Size length)
 
 	len = o_table->nindices * sizeof(OTableIndex);
 	o_table->indices = (OTableIndex *) palloc0(len);
+	o_node_deserialize_format_changed = false;
 	for (i = 0; i < o_table->nindices; i++)
 	{
 		if (!deserialize_o_table_index(&o_table->indices[i], &ptr,
@@ -2239,6 +2301,14 @@ deserialize_o_table(Pointer data, Size length)
 			return NULL;
 		}
 	}
+
+	/*
+	 * If any index expression/predicate was written by a different PG major
+	 * version it was skipped above (its nodeToString format is unreadable
+	 * here); flag the table so the expressions get re-derived from the
+	 * catalog and rewritten before use.
+	 */
+	o_table->refresh_exprs = o_node_deserialize_format_changed;
 	if ((ptr - data) > length)
 	{
 		MemoryContextSwitchTo(oldcxt);
@@ -2381,8 +2451,15 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 	if (oTable->index_bridging)
 	{
 		oTable->bridge_oids.datoid = MyDatabaseId;
-		oTable->bridge_oids.relnode = GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
-														  rel->rd_rel->relpersistence);
+
+		/*
+		 * Under pg_upgrade fresh relfilenumber allocation is forbidden and
+		 * the real bridge is carried over with the data; this OTable is
+		 * discarded after the schema restore, so leave it invalid.
+		 */
+		oTable->bridge_oids.relnode = IsBinaryUpgrade ? InvalidOid :
+			GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
+								rel->rd_rel->relpersistence);
 		oTable->bridge_oids.reloid = oTable->bridge_oids.relnode;
 	}
 

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -762,20 +762,9 @@ sys_tree_init_if_needed(int i)
  * across PG majors in practice (it gained datlocale/daticurules/datctype),
  * which is what crashed deserialization after pg_upgrade.
  *
- * Per-object caches are handled without dropping the tree, because emptying
- * them would break the reads described above:
- *
- *  - class and collation caches version-gate their layout by appending fields,
- *    so an old-major entry still deserializes correctly and needs nothing.
- *
- *  - the proc cache stores SQL-function parse trees whose nodeToString format
- *    is NOT portable across majors, so an old-major entry deserializes with
- *    missing trees.  That cannot be papered over by a gate, but neither can the
- *    tree be reset (per-object, LSN-pinned, and consulted from background
- *    workers that have no catalog to fall back to).  Instead such an entry is
- *    marked stale and refused at use (o_proc_cache's node_format_stale guard),
- *    and orioledb_upgrade_refresh() rebuilds it in this server's format
- *    alongside the index expressions that reference it.
+ * Per-object caches with version-gated layouts (class, proc, collation) are
+ * intentionally left alone: their gated fields are appended, so old data
+ * still reads back, and resetting them would break existing reads.
  */
 static bool
 sys_tree_reset_on_major_upgrade(int tree_num)

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -762,9 +762,20 @@ sys_tree_init_if_needed(int i)
  * across PG majors in practice (it gained datlocale/daticurules/datctype),
  * which is what crashed deserialization after pg_upgrade.
  *
- * Per-object caches with version-gated layouts (class, proc, collation) are
- * intentionally left alone: their gated fields are appended, so old data
- * still reads back, and resetting them would break existing reads.
+ * Per-object caches are handled without dropping the tree, because emptying
+ * them would break the reads described above:
+ *
+ *  - class and collation caches version-gate their layout by appending fields,
+ *    so an old-major entry still deserializes correctly and needs nothing.
+ *
+ *  - the proc cache stores SQL-function parse trees whose nodeToString format
+ *    is NOT portable across majors, so an old-major entry deserializes with
+ *    missing trees.  That cannot be papered over by a gate, but neither can the
+ *    tree be reset (per-object, LSN-pinned, and consulted from background
+ *    workers that have no catalog to fall back to).  Instead such an entry is
+ *    marked stale and refused at use (o_proc_cache's node_format_stale guard),
+ *    and orioledb_upgrade_refresh() rebuilds it in this server's format
+ *    alongside the index expressions that reference it.
  */
 static bool
 sys_tree_reset_on_major_upgrade(int tree_num)

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -17,6 +17,7 @@
 #include "orioledb.h"
 
 #include "btree/check.h"
+#include "btree/io.h"
 #include "btree/iterator.h"
 #include "catalog/sys_trees.h"
 #include "catalog/o_sys_cache.h"
@@ -747,6 +748,31 @@ sys_tree_init_if_needed(int i)
 }
 
 /*
+ * Should this system tree be discarded and rebuilt when the on-disk state was
+ * written by a different PG major version?
+ *
+ * The OSysCache trees cache PostgreSQL catalog data and some serialize with a
+ * PG-version-dependent layout, so a cross-major restart (e.g. via pg_upgrade)
+ * would read them with a mismatching layout.  But most of these caches are
+ * keyed by object OID and pinned to the object's creation LSN; emptying them
+ * breaks reads of pre-existing objects (the entry can no longer be resolved
+ * at the reading snapshot).  Only the database cache is safe to drop: it is
+ * keyed by database OID, re-resolved on demand, and not consulted while
+ * reading user relations.  It is also the cache whose layout actually changed
+ * across PG majors in practice (it gained datlocale/daticurules/datctype),
+ * which is what crashed deserialization after pg_upgrade.
+ *
+ * Per-object caches with version-gated layouts (class, proc, collation) are
+ * intentionally left alone: their gated fields are appended, so old data
+ * still reads back, and resetting them would break existing reads.
+ */
+static bool
+sys_tree_reset_on_major_upgrade(int tree_num)
+{
+	return tree_num == SYS_TREES_DATABASE_CACHE;
+}
+
+/*
  * Initializes the system B-tree.
  *
  * We can not initialize system BTree on shmem startup because it uses
@@ -803,6 +829,23 @@ sys_tree_init(int i, bool init_shmem)
 
 	if (descr->storageType == BTreeStoragePersistence)
 	{
+		/*
+		 * When the on-disk state came from a different PG major version, the
+		 * rebuildable cache trees were serialized with an incompatible
+		 * layout. Delete their files before init so the tree comes up empty
+		 * (as on a fresh cluster) and is repopulated on demand, instead of
+		 * reading stale-layout entries.  Only the process that initializes
+		 * shared memory does this, and only for the rebuildable caches.
+		 */
+		if (init_shmem && checkpoint_state->resetSysCaches &&
+			sys_tree_reset_on_major_upgrade(i + 1))
+		{
+			OIndexKey	key;
+
+			key.oids = descr->oids;
+			key.tablespace = descr->tablespace;
+			cleanup_btree_files(key, false);
+		}
 		checkpointable_tree_init(descr, init_shmem, NULL);
 	}
 	else if (descr->storageType == BTreeStorageTemporary)

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -769,7 +769,17 @@ sys_tree_init_if_needed(int i)
 static bool
 sys_tree_reset_on_major_upgrade(int tree_num)
 {
-	return tree_num == SYS_TREES_DATABASE_CACHE;
+	/*
+	 * The class cache stores tuple descriptors as raw FormData_pg_attribute
+	 * arrays, whose element size changes across PG majors, so a carried-over
+	 * entry fails o_class_cache_deserialize_entry's length check.  It is only
+	 * ever read in catalog-free contexts (recovery, checkpointer) via the
+	 * syscache hook, and always for system catalogs, so dropping it lets
+	 * o_class_cache_fill_entry rebuild each entry from the relcache in the
+	 * running server's format -- safe in every backend.
+	 */
+	return tree_num == SYS_TREES_DATABASE_CACHE ||
+		tree_num == SYS_TREES_CLASS_CACHE;
 }
 
 /*

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -329,6 +329,15 @@ checkpoint_shmem_init(Pointer ptr, bool found)
 
 		orioledb_checksums_enabled = control.checksums_enabled;
 
+		/*
+		 * If the on-disk state was written by a different PG major version
+		 * (e.g. carried over by pg_upgrade), the version-dependent OSysCache
+		 * trees were serialized with a layout this binary can't read, so they
+		 * must be rebuilt.
+		 */
+		checkpoint_state->resetSysCaches =
+			(control.pgVersion / 10000 != PG_VERSION_NUM / 10000);
+
 		checkpoint_state->controlIdentifier = control.controlIdentifier;
 		checkpoint_state->lastCheckpointNumber = control.lastCheckpointNumber;
 		checkpoint_state->controlToastConsistentPtr = control.toastConsistentPtr;

--- a/src/checkpoint/control.c
+++ b/src/checkpoint/control.c
@@ -24,6 +24,24 @@
 #include "utils/wait_event.h"
 
 /*
+ * The v1 -> v2 conversion in check_checkpoint_control() reads a version-1
+ * control file's CRC from the byte offset that pgVersion now occupies: v1 had
+ * no pgVersion field, so its trailing crc sat immediately after s3Mode, exactly
+ * where pgVersion was inserted in v2.  Enforce that invariant statically so a
+ * future reorder of CheckpointControl (moving pgVersion away from just-before
+ * crc, or changing its width) can't silently break reading pre-v2 files -- the
+ * offending change trips these asserts and must revisit the conversion instead.
+ * New fields must be appended right before crc (bumping the control version and
+ * adding a conversion), never inserted earlier.
+ */
+StaticAssertDecl(offsetof(CheckpointControl, crc) ==
+				 offsetof(CheckpointControl, pgVersion) +
+				 sizeof(((CheckpointControl *) 0)->pgVersion),
+				 "pgVersion must sit immediately before crc so a v1 file's crc aligns with pgVersion");
+StaticAssertDecl(sizeof(((CheckpointControl *) 0)->pgVersion) == sizeof(pg_crc32c),
+				 "pgVersion must be the same width as the v1 crc it overlays");
+
+/*
  * Read checkpoint control file data from the disk.
  *
  * Returns false if the control file doesn't exist.

--- a/src/checkpoint/control.c
+++ b/src/checkpoint/control.c
@@ -24,24 +24,6 @@
 #include "utils/wait_event.h"
 
 /*
- * The v1 -> v2 conversion in check_checkpoint_control() reads a version-1
- * control file's CRC from the byte offset that pgVersion now occupies: v1 had
- * no pgVersion field, so its trailing crc sat immediately after s3Mode, exactly
- * where pgVersion was inserted in v2.  Enforce that invariant statically so a
- * future reorder of CheckpointControl (moving pgVersion away from just-before
- * crc, or changing its width) can't silently break reading pre-v2 files -- the
- * offending change trips these asserts and must revisit the conversion instead.
- * New fields must be appended right before crc (bumping the control version and
- * adding a conversion), never inserted earlier.
- */
-StaticAssertDecl(offsetof(CheckpointControl, crc) ==
-				 offsetof(CheckpointControl, pgVersion) +
-				 sizeof(((CheckpointControl *) 0)->pgVersion),
-				 "pgVersion must sit immediately before crc so a v1 file's crc aligns with pgVersion");
-StaticAssertDecl(sizeof(((CheckpointControl *) 0)->pgVersion) == sizeof(pg_crc32c),
-				 "pgVersion must be the same width as the v1 crc it overlays");
-
-/*
  * Read checkpoint control file data from the disk.
  *
  * Returns false if the control file doesn't exist.

--- a/src/checkpoint/control.c
+++ b/src/checkpoint/control.c
@@ -136,6 +136,9 @@ write_checkpoint_control(CheckpointControl *control)
 	File		controlFile;
 	char		buffer[CHECKPOINT_CONTROL_FILE_SIZE];
 
+	/* Stamp the writing server's PG version (see CheckpointControl). */
+	control->pgVersion = PG_VERSION_NUM;
+
 	INIT_CRC32C(control->crc);
 	COMP_CRC32C(control->crc, control, offsetof(CheckpointControl, crc));
 	FIN_CRC32C(control->crc);

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -36,6 +36,7 @@
 #include "access/relation.h"
 #include "commands/progress.h"
 #include "commands/vacuum.h"
+#include "miscadmin.h"
 #include "nodes/pathnodes.h"
 #include "optimizer/optimizer.h"
 #include "parser/parsetree.h"
@@ -275,6 +276,17 @@ orioledb_ambuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	IndexBuildResult *result;
 	String	   *relname;
 	OBTOptions *options = (OBTOptions *) index->rd_options;
+
+	/*
+	 * Under pg_upgrade the index data is carried over with the rest of the
+	 * storage -- orioledb_data/ for native indexes, the transferred
+	 * relfilenode for bridged ones -- so build nothing here.  Reorganizing
+	 * the table (e.g. ADD PRIMARY KEY) or re-inserting shared-root
+	 * placeholders for the preserved relnodes would corrupt or duplicate the
+	 * carried-over state.
+	 */
+	if (IsBinaryUpgrade)
+		return (IndexBuildResult *) palloc0(sizeof(IndexBuildResult));
 
 	if (options && !options->orioledb_index)
 	{

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -1570,6 +1570,27 @@ orioledb_ambeginscan(Relation rel, int nkeys, int norderbys)
 	ORelOidsSetFromRel(oids, rel);
 	ix_type = o_index_rel_get_ix_type(rel);
 	index_descr = o_fetch_index_descr(oids, ix_type, false, NULL);
+
+	/*
+	 * Under pg_upgrade's binary-upgrade restore the carried-over OrioleDB
+	 * trees are migrated only after pg_upgrade finishes, so a relation
+	 * created during the restore has no descriptor yet and holds no live
+	 * data.  A scan over it must behave like the empty relation it currently
+	 * is -- this is how a heap FK re-validation (RI_Initial_Check for ALTER
+	 * TABLE ... ADD CONSTRAINT ... FOREIGN KEY) works against the
+	 * not-yet-swapped files too. Return a scan that yields nothing instead of
+	 * dereferencing a NULL descriptor.  Outside binary upgrade a missing
+	 * descriptor is a real bug.
+	 */
+	if (index_descr == NULL && IsBinaryUpgrade)
+	{
+		o_scan->emptyScan = true;
+		o_scan->cxt = AllocSetContextCreate(CurrentMemoryContext,
+											"orioledb_cs plan data",
+											ALLOCSET_DEFAULT_SIZES);
+		return scan;
+	}
+
 	Assert(index_descr != NULL);
 	descr = o_fetch_table_descr(index_descr->tableOids);
 	Assert(descr != NULL);
@@ -2021,6 +2042,10 @@ orioledb_amgettuple(IndexScanDesc scan, ScanDirection dir)
 	{
 		return btgettuple(scan, dir);
 	}
+
+	/* Binary-upgrade restore: carried-over relation has no data yet. */
+	if (o_scan->emptyScan)
+		return false;
 
 	o_scan->scanDir = dir;
 

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -2117,14 +2117,29 @@ orioledb_get_relation_info_hook(PlannerInfo *root,
 
 					index_close(index, AccessShareLock);
 
+					index_descr = NULL;
 					for (ix_num = 0; ix_num < descr->nIndices; ix_num++)
 					{
-						index_descr = descr->indices[ix_num];
-						if (index_descr->oids.reloid == info->indexoid)
+						if (descr->indices[ix_num]->oids.reloid == info->indexoid)
+						{
+							index_descr = descr->indices[ix_num];
 							break;
+						}
 					}
-					Assert(ix_num < descr->nIndices);
-					Assert(index_descr);
+
+					/*
+					 * During a binary upgrade the OrioleDB descr is not yet
+					 * populated -- the storage and its system trees are
+					 * carried over from the old cluster afterwards -- so an
+					 * index present in the catalog may be missing here.
+					 * Planner estimates are irrelevant during the upgrade, so
+					 * just skip it.
+					 */
+					if (index_descr == NULL)
+					{
+						Assert(IsBinaryUpgrade);
+						continue;
+					}
 					o_btree_load_shmem(&index_descr->desc);
 					rootPageBlkno = index_descr->desc.rootInfo.rootPageBlkno;
 					root_page = O_GET_IN_MEMORY_PAGE(rootPageBlkno);

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -934,8 +934,15 @@ orioledb_relation_set_new_filenode(Relation rel,
 		{
 			new_o_table->index_bridging = true;
 			new_o_table->bridge_oids.datoid = MyDatabaseId;
-			new_o_table->bridge_oids.relnode = GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
-																   rel->rd_rel->relpersistence);
+
+			/*
+			 * Under pg_upgrade fresh relfilenumber allocation is forbidden
+			 * and the real bridge is carried over with the data; this OTable
+			 * is discarded after the schema restore, so leave it invalid.
+			 */
+			new_o_table->bridge_oids.relnode = IsBinaryUpgrade ? InvalidOid :
+				GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
+									rel->rd_rel->relpersistence);
 			new_o_table->bridge_oids.reloid = new_o_table->bridge_oids.relnode;
 		}
 		else

--- a/src/utils/planner.c
+++ b/src/utils/planner.c
@@ -843,13 +843,6 @@ o_collect_function(Node *node, void *context)
 	return false;
 }
 
-/*
- * When true, o_collect_function_walker() force-rebuilds existing proc-cache
- * entries instead of leaving them as-is.  Set only around
- * o_collect_funcexpr_refresh().
- */
-static bool o_collect_funcs_refresh = false;
-
 void
 o_collect_funcexpr(Node *node)
 {
@@ -860,35 +853,6 @@ o_collect_funcexpr(Node *node)
 
 	expression_tree_walker(o_wrap_top_funcexpr(node), o_collect_function,
 						   &processed);
-	list_free_deep(processed);
-}
-
-/*
- * Like o_collect_funcexpr(), but rebuilds every proc-cache entry it visits
- * from the current catalog even if one already exists.  Used by
- * orioledb_upgrade_refresh() so SQL-function parse trees carried over from a
- * different PG major (and unreadable in this server's format) are re-serialized
- * in the running server's format, matching the just-rewritten index expressions.
- */
-void
-o_collect_funcexpr_refresh(Node *node)
-{
-	List	   *processed = NIL;
-
-	if (!node)
-		return;
-
-	o_collect_funcs_refresh = true;
-	PG_TRY();
-	{
-		expression_tree_walker(o_wrap_top_funcexpr(node), o_collect_function,
-							   &processed);
-	}
-	PG_FINALLY();
-	{
-		o_collect_funcs_refresh = false;
-	}
-	PG_END_TRY();
 	list_free_deep(processed);
 }
 
@@ -908,17 +872,6 @@ o_collect_function_walker(Oid functionId, Oid inputcollid, List *args,
 	procedureStruct = (Form_pg_proc) GETSTRUCT(procedureTuple);
 	o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
 	o_class_cache_add_if_needed(datoid, TypeRelationId, cur_lsn, NULL);
-
-	/*
-	 * In refresh mode (orioledb_upgrade_refresh, after a cross-major upgrade)
-	 * an entry may already exist but hold parse trees in the old major's
-	 * node-tree format; add_if_needed would leave it untouched, and the proc
-	 * cache forbids in-place updates.  Drop the stale entry first so the add
-	 * below re-creates it from the current catalog in this server's format --
-	 * see o_proc_cache's node_format_stale guard.
-	 */
-	if (o_collect_funcs_refresh)
-		o_proc_cache_delete(datoid, functionId);
 	o_proc_cache_add_if_needed(datoid, functionId, cur_lsn, (Pointer) &arg);
 	o_class_cache_add_if_needed(datoid, AuthIdRelationId, cur_lsn, NULL);
 	for (i = 0; i < procedureStruct->pronargs; i++)

--- a/src/utils/planner.c
+++ b/src/utils/planner.c
@@ -843,6 +843,13 @@ o_collect_function(Node *node, void *context)
 	return false;
 }
 
+/*
+ * When true, o_collect_function_walker() force-rebuilds existing proc-cache
+ * entries instead of leaving them as-is.  Set only around
+ * o_collect_funcexpr_refresh().
+ */
+static bool o_collect_funcs_refresh = false;
+
 void
 o_collect_funcexpr(Node *node)
 {
@@ -853,6 +860,35 @@ o_collect_funcexpr(Node *node)
 
 	expression_tree_walker(o_wrap_top_funcexpr(node), o_collect_function,
 						   &processed);
+	list_free_deep(processed);
+}
+
+/*
+ * Like o_collect_funcexpr(), but rebuilds every proc-cache entry it visits
+ * from the current catalog even if one already exists.  Used by
+ * orioledb_upgrade_refresh() so SQL-function parse trees carried over from a
+ * different PG major (and unreadable in this server's format) are re-serialized
+ * in the running server's format, matching the just-rewritten index expressions.
+ */
+void
+o_collect_funcexpr_refresh(Node *node)
+{
+	List	   *processed = NIL;
+
+	if (!node)
+		return;
+
+	o_collect_funcs_refresh = true;
+	PG_TRY();
+	{
+		expression_tree_walker(o_wrap_top_funcexpr(node), o_collect_function,
+							   &processed);
+	}
+	PG_FINALLY();
+	{
+		o_collect_funcs_refresh = false;
+	}
+	PG_END_TRY();
 	list_free_deep(processed);
 }
 
@@ -872,6 +908,17 @@ o_collect_function_walker(Oid functionId, Oid inputcollid, List *args,
 	procedureStruct = (Form_pg_proc) GETSTRUCT(procedureTuple);
 	o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
 	o_class_cache_add_if_needed(datoid, TypeRelationId, cur_lsn, NULL);
+
+	/*
+	 * In refresh mode (orioledb_upgrade_refresh, after a cross-major upgrade)
+	 * an entry may already exist but hold parse trees in the old major's
+	 * node-tree format; add_if_needed would leave it untouched, and the proc
+	 * cache forbids in-place updates.  Drop the stale entry first so the add
+	 * below re-creates it from the current catalog in this server's format --
+	 * see o_proc_cache's node_format_stale guard.
+	 */
+	if (o_collect_funcs_refresh)
+		o_proc_cache_delete(datoid, functionId);
 	o_proc_cache_add_if_needed(datoid, functionId, cur_lsn, (Pointer) &arg);
 	o_class_cache_add_if_needed(datoid, AuthIdRelationId, cur_lsn, NULL);
 	for (i = 0; i < procedureStruct->pronargs; i++)

--- a/src/utils/planner.c
+++ b/src/utils/planner.c
@@ -913,12 +913,16 @@ o_collect_function_walker(Oid functionId, Oid inputcollid, List *args,
 	 * In refresh mode (orioledb_upgrade_refresh, after a cross-major upgrade)
 	 * an entry may already exist but hold parse trees in the old major's
 	 * node-tree format; add_if_needed would leave it untouched, and the proc
-	 * cache forbids in-place updates.  Drop the stale entry first so the add
-	 * below re-creates it from the current catalog in this server's format --
-	 * see o_proc_cache's node_format_stale guard.
+	 * cache forbids in-place updates.  Drop only such a stale entry so the
+	 * add below re-creates it from the current catalog in this server's
+	 * format. The walker also visits INTERNAL opclass support procs
+	 * (comparators, hash) transitively; those have no node trees, are fine
+	 * across majors, and are relied on by index-descriptor fills, so
+	 * o_proc_cache_delete_if_stale leaves them in place (dropping one crashes
+	 * o_proc_cache_fill_finfo).
 	 */
 	if (o_collect_funcs_refresh)
-		o_proc_cache_delete(datoid, functionId);
+		o_proc_cache_delete_if_stale(datoid, functionId);
 	o_proc_cache_add_if_needed(datoid, functionId, cur_lsn, (Pointer) &arg);
 	o_class_cache_add_if_needed(datoid, AuthIdRelationId, cur_lsn, NULL);
 	for (i = 0; i < procedureStruct->pronargs; i++)

--- a/test/expected/btree_sys_check.out
+++ b/test/expected/btree_sys_check.out
@@ -106,22 +106,22 @@ SELECT regexp_replace(
 		'g');
                                              regexp_replace                                              
 ---------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6504                                                +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6568                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                    +
      Leftmost, Rightmost                                                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ((NNN, NNN, NNN), 0, 1)            +
      Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294)  +
    Chunk 1: offset = 1, location = 600, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
-     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2076) +
-   Chunk 2: offset = 2, location = 2728, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 2: deleted, offset = 2736, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
-     Item 3: deleted, offset = 3072, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1185)+
-   Chunk 3: offset = 4, location = 4304, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 4: deleted, offset = 4312, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
-   Chunk 4: offset = 5, location = 4840, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 5: deleted, offset = 4848, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1379)+
-   Chunk 5: offset = 6, location = 6272, hikey location = 200                                           +
-     Item 6: deleted, offset = 6280, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
+     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2108) +
+   Chunk 2: offset = 2, location = 2760, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 2: deleted, offset = 2768, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
+     Item 3: deleted, offset = 3104, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1201)+
+   Chunk 3: offset = 4, location = 4352, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 4: deleted, offset = 4360, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
+   Chunk 4: offset = 5, location = 4888, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 5: deleted, offset = 4896, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1395)+
+   Chunk 5: offset = 6, location = 6336, hikey location = 200                                           +
+     Item 6: deleted, offset = 6344, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
                                                                                                         +
  
 (1 row)
@@ -134,19 +134,19 @@ SELECT regexp_replace(
 		'g');
                                         regexp_replace                                         
 -----------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 4936                                      +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 5056                                      +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                          +
      Leftmost, Rightmost                                                                      +
    Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 0)  +
-     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 678)                    +
-   Chunk 1: offset = 1, location = 992, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0)  +
-     Item 1: deleted, offset = 1000, tuple = ((1, (NNN, NNN, NNN), 0), 1026)                  +
-     Item 2: deleted, offset = 2072, tuple = ((1, (NNN, NNN, NNN), 0), 678)                   +
-   Chunk 2: offset = 3, location = 2800, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
-     Item 3: deleted, offset = 2808, tuple = ((3, (NNN, NNN, NNN), 0), 794)                   +
-   Chunk 3: offset = 4, location = 3648, hikey location = 144                                 +
-     Item 4: deleted, offset = 3656, tuple = ((3, (NNN, NNN, NNN), 0), 678)                   +
-     Item 5: deleted, offset = 4384, tuple = ((3, (NNN, NNN, NNN), 0), 794)                   +
+     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 698)                    +
+   Chunk 1: offset = 1, location = 1008, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0) +
+     Item 1: deleted, offset = 1016, tuple = ((1, (NNN, NNN, NNN), 0), 1046)                  +
+     Item 2: deleted, offset = 2112, tuple = ((1, (NNN, NNN, NNN), 0), 698)                   +
+   Chunk 2: offset = 3, location = 2856, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
+     Item 3: deleted, offset = 2864, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
+   Chunk 3: offset = 4, location = 3728, hikey location = 144                                 +
+     Item 4: deleted, offset = 3736, tuple = ((3, (NNN, NNN, NNN), 0), 698)                   +
+     Item 5: deleted, offset = 4480, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
                                                                                               +
  
 (1 row)

--- a/test/expected/btree_sys_check_1.out
+++ b/test/expected/btree_sys_check_1.out
@@ -106,22 +106,22 @@ SELECT regexp_replace(
 		'g');
                                              regexp_replace                                              
 ---------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6504                                                +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6568                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                    +
      Leftmost, Rightmost                                                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ((NNN, NNN, NNN), 0, 1)            +
      Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294)  +
    Chunk 1: offset = 1, location = 600, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
-     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2076) +
-   Chunk 2: offset = 2, location = 2728, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 2: deleted, offset = 2736, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
-     Item 3: deleted, offset = 3072, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1185)+
-   Chunk 3: offset = 4, location = 4304, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 4: deleted, offset = 4312, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
-   Chunk 4: offset = 5, location = 4840, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 5: deleted, offset = 4848, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1379)+
-   Chunk 5: offset = 6, location = 6272, hikey location = 200                                           +
-     Item 6: deleted, offset = 6280, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
+     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2108) +
+   Chunk 2: offset = 2, location = 2760, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 2: deleted, offset = 2768, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
+     Item 3: deleted, offset = 3104, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1201)+
+   Chunk 3: offset = 4, location = 4352, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 4: deleted, offset = 4360, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
+   Chunk 4: offset = 5, location = 4888, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 5: deleted, offset = 4896, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1395)+
+   Chunk 5: offset = 6, location = 6336, hikey location = 200                                           +
+     Item 6: deleted, offset = 6344, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
                                                                                                         +
  
 (1 row)
@@ -134,19 +134,19 @@ SELECT regexp_replace(
 		'g');
                                         regexp_replace                                         
 -----------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 4936                                      +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 5056                                      +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                          +
      Leftmost, Rightmost                                                                      +
    Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 0)  +
-     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 678)                    +
-   Chunk 1: offset = 1, location = 992, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0)  +
-     Item 1: deleted, offset = 1000, tuple = ((1, (NNN, NNN, NNN), 0), 1026)                  +
-     Item 2: deleted, offset = 2072, tuple = ((1, (NNN, NNN, NNN), 0), 678)                   +
-   Chunk 2: offset = 3, location = 2800, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
-     Item 3: deleted, offset = 2808, tuple = ((3, (NNN, NNN, NNN), 0), 794)                   +
-   Chunk 3: offset = 4, location = 3648, hikey location = 144                                 +
-     Item 4: deleted, offset = 3656, tuple = ((3, (NNN, NNN, NNN), 0), 678)                   +
-     Item 5: deleted, offset = 4384, tuple = ((3, (NNN, NNN, NNN), 0), 794)                   +
+     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 698)                    +
+   Chunk 1: offset = 1, location = 1008, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0) +
+     Item 1: deleted, offset = 1016, tuple = ((1, (NNN, NNN, NNN), 0), 1046)                  +
+     Item 2: deleted, offset = 2112, tuple = ((1, (NNN, NNN, NNN), 0), 698)                   +
+   Chunk 2: offset = 3, location = 2856, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
+     Item 3: deleted, offset = 2864, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
+   Chunk 3: offset = 4, location = 3728, hikey location = 144                                 +
+     Item 4: deleted, offset = 3736, tuple = ((3, (NNN, NNN, NNN), 0), 698)                   +
+     Item 5: deleted, offset = 4480, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
                                                                                               +
  
 (1 row)

--- a/test/expected/btree_sys_check_2.out
+++ b/test/expected/btree_sys_check_2.out
@@ -106,22 +106,22 @@ SELECT regexp_replace(
 		'g');
                                              regexp_replace                                              
 ---------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6504                                                +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6568                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                    +
      Leftmost, Rightmost                                                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ((NNN, NNN, NNN), 0, 1)            +
      Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294)  +
    Chunk 1: offset = 1, location = 600, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
-     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2076) +
-   Chunk 2: offset = 2, location = 2728, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 2: deleted, offset = 2736, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
-     Item 3: deleted, offset = 3072, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1185)+
-   Chunk 3: offset = 4, location = 4304, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 4: deleted, offset = 4312, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
-   Chunk 4: offset = 5, location = 4840, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 5: deleted, offset = 4848, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1379)+
-   Chunk 5: offset = 6, location = 6272, hikey location = 200                                           +
-     Item 6: deleted, offset = 6280, tuple = (((NNN, NNN, NNN), chunknum 0, version 2), dataLength 488) +
+     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2108) +
+   Chunk 2: offset = 2, location = 2760, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 2: deleted, offset = 2768, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
+     Item 3: deleted, offset = 3104, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1201)+
+   Chunk 3: offset = 4, location = 4352, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 4: deleted, offset = 4360, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
+   Chunk 4: offset = 5, location = 4888, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 5: deleted, offset = 4896, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1395)+
+   Chunk 5: offset = 6, location = 6336, hikey location = 200                                           +
+     Item 6: deleted, offset = 6344, tuple = (((NNN, NNN, NNN), chunknum 0, version 2), dataLength 488) +
                                                                                                         +
  
 (1 row)
@@ -134,19 +134,19 @@ SELECT regexp_replace(
 		'g');
                                         regexp_replace                                         
 -----------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 4936                                      +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 5056                                      +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                          +
      Leftmost, Rightmost                                                                      +
    Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 0)  +
-     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 678)                    +
-   Chunk 1: offset = 1, location = 992, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0)  +
-     Item 1: deleted, offset = 1000, tuple = ((1, (NNN, NNN, NNN), 0), 1026)                  +
-     Item 2: deleted, offset = 2072, tuple = ((1, (NNN, NNN, NNN), 0), 678)                   +
-   Chunk 2: offset = 3, location = 2800, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
-     Item 3: deleted, offset = 2808, tuple = ((3, (NNN, NNN, NNN), 0), 794)                   +
-   Chunk 3: offset = 4, location = 3648, hikey location = 144                                 +
-     Item 4: deleted, offset = 3656, tuple = ((3, (NNN, NNN, NNN), 0), 678)                   +
-     Item 5: deleted, offset = 4384, tuple = ((3, (NNN, NNN, NNN), 0), 794)                   +
+     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 698)                    +
+   Chunk 1: offset = 1, location = 1008, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0) +
+     Item 1: deleted, offset = 1016, tuple = ((1, (NNN, NNN, NNN), 0), 1046)                  +
+     Item 2: deleted, offset = 2112, tuple = ((1, (NNN, NNN, NNN), 0), 698)                   +
+   Chunk 2: offset = 3, location = 2856, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
+     Item 3: deleted, offset = 2864, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
+   Chunk 3: offset = 4, location = 3728, hikey location = 144                                 +
+     Item 4: deleted, offset = 3736, tuple = ((3, (NNN, NNN, NNN), 0), 698)                   +
+     Item 5: deleted, offset = 4480, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
                                                                                               +
  
 (1 row)

--- a/test/t/page_fit_items_test.py
+++ b/test/t/page_fit_items_test.py
@@ -37,8 +37,8 @@ class PageFitItemsTest(BaseTest):
 	# MAGIC NUMBERS RELATIVE TO TUPLES STRUCTURES
 	RELATION_SINGLE_FIELD_TUPLE_SIZE = 197
 	RELATION_EXTRA_FIELD_TUPLE_SIZE = 97
-	INDEX_EXTRA_TUPLE_SIZE = 891
-	PER_TUPLE_EXTRA_SIZE = 52
+	INDEX_EXTRA_TUPLE_SIZE = 907
+	PER_TUPLE_EXTRA_SIZE = 55
 
 	def setUp(self):
 		super().setUp()
@@ -336,12 +336,14 @@ class PageFitItemsTest(BaseTest):
 
 		node = self.node
 
-		self.startup_page_filling(8192 - self.estimateTupleSize(4, 0) + 100)
+		relDescr = self.startup_page_filling(8192 -
+		                                     self.estimateTupleSize(4, 0) +
+		                                     100)
 		self.assertSysTreePagesCount(1)
 
 		node.safe_psql(
 		    'postgres',
-		    "CREATE TABLE o_table4(t1 text, t2 text, t3 text, t4 text, t5 text, t6 text, t7 text, t8 text) USING orioledb;\n"
+		    f"CREATE TABLE o_test{len(relDescr) + 1}(t1 text, t2 text, t3 text, t4 text, t5 text, t6 text, t7 text, t8 text) USING orioledb;\n"
 		)
 
 		self.assertSysTreePagesCount(3)
@@ -403,10 +405,19 @@ class PageFitItemsTest(BaseTest):
 
 		self.assertSysTreePagesCount(1)
 
+		# The new tuple must not fit even in (free space + the space vacated
+		# by the drop), so the page is forced to split.  Size it from the
+		# test's own estimate -- the free space left by startup plus the
+		# vacated tuple -- so the bound holds regardless of the per-tuple
+		# sizes of the running PostgreSQL major.
+		freeAndVacated = self.estimateTupleSize(1, 0) + smalestTupSize
+		fields = 4
+		while self.estimateTupleSize(fields, 0) <= freeAndVacated + 256:
+			fields += 1
+		cols = ", ".join(f"t{i} text" for i in range(fields))
 		node.safe_psql(
 		    'postgres',
-		    f"CREATE TABLE o_test{len(relDescr) + 1}(t1 text, t2 text, t3 text, t4 text, t5 text, t6 text, t7 text) USING orioledb;"
-		)
+		    f"CREATE TABLE o_test{len(relDescr) + 1}({cols}) USING orioledb;")
 
 		self.assertSysTreePagesCount(3)
 		node.stop()


### PR DESCRIPTION
Make `pg_upgrade` work end to end across PostgreSQL major versions
(16→17, 16→18, 17→18) for OrioleDB clusters, plus a CI matrix that
exercises it.

## Why
`pg_upgrade` migrates the catalog and the heap relfiles it knows about,
but OrioleDB keeps its table/index data in its own `orioledb_data/` tree
and persists version-specific metadata (PostgreSQL node trees and
`FormData_pg_attribute`) in its system trees. A naive upgrade therefore
came up empty or crashed on the foreign on-disk format.

## What the support commit does
**Binary-upgrade restore**
- Keep preserved relfilenodes in `assign_new_oids` and skip the physical
  DDL OrioleDB would normally perform, so the schema restore neither
  allocates new storage nor rejects preserved relnodes.
- `orioledb_ambuild` builds nothing under `IsBinaryUpgrade`; data is
  carried over wholesale from the old cluster.
- Fix "cache lookup failed for database" when restoring `template1` by
  advancing the command counter before refreshing the database cache.

**Foreign on-disk metadata**
- Stamp the checkpoint control file with the writing PostgreSQL major
  (`ORIOLEDB_CHECKPOINT_CONTROL_VERSION 2`, with v1 conversion) and a
  `resetSysCaches` flag when the running major differs.
- Rebuild the version-specific database sys-cache after a cross-major
  upgrade instead of reading the foreign-format entry.
- Version-stamp persisted node trees (index expressions/predicates): on
  read, trees written by another major are tolerated and dropped rather
  than crashing `stringToNode`.
- `orioledb_upgrade_refresh()` rewrites index expressions into the new
  server's node-tree format.

## CI
A `pg_upgrade` workflow builds OrioleDB against both the old and new
majors, populates an old-version cluster (incl. expression + partial
indexes) with the regression schema, runs `pg_upgrade --check` and the
real upgrade, copies the `orioledb_data/`/`orioledb_undo/` trees, checks
that touching an expression index before `orioledb_upgrade_refresh()`
errors cleanly (no crash), refreshes, then verifies via pre/post
schema+data dumps and a re-run of the regression schedule. Matrix:
{16→17,16→18,17→18} × {amd64,arm64} × {gcc,clang}.

Rebased onto current main; the `btree_sys_check` expected output is
regenerated across all three PG-major variants for the slightly larger
catalog records this adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)