### PR TITLE
Parallel bitmap heap scan support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  merge \
 				  parallel_idx_scan \
 				  parallel_ordered_scan \
+				  parallel_bitmap_scan \
 				  partition_move \
 				  rightlink \
 				  rll \

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \
 						test/t/parallel_ordered_scan_test.py \
+						test/t/parallel_bitmap_scan_test.py \
 						test/t/reindex_test.py \
 						test/t/s3_test.py \
 						test/t/schema_test.py \

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  merge \
 				  parallel_idx_scan \
 				  parallel_ordered_scan \
+				  parallel_bitmap_scan \
 				  partition_move \
 				  rightlink \
 				  rll \
@@ -238,6 +239,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \
 						test/t/parallel_ordered_scan_test.py \
+						test/t/parallel_bitmap_scan_test.py \
 						test/t/recovery_heap_verdict_test.py \
 						test/t/recovery_heap_xid_binding_test.py \
 						test/t/recovery_item_rollback_test.py \

--- a/ci/filter_regression_diff.py
+++ b/ci/filter_regression_diff.py
@@ -417,7 +417,11 @@ def compare_trees(src_tree: list, target_tree: list, test_name: str):
 				src_up = True
 				target_up = True
 		elif src_cur_value.startswith('Bitmap Heap Scan'):
-			if target_cur[1].startswith('Custom Scan'):
+			# normalize_src_value() has already stripped a leading "Parallel "
+			# from the source, so a parallel bitmap heap scan on the heap side
+			# matches orioledb's "Parallel Custom Scan (o_scan)" too.
+			if (target_cur[1].startswith('Custom Scan')
+					or target_cur[1].startswith('Parallel Custom Scan')):
 				# EXPLAIN VERBOSE inserts "Output: ..." (and an optional
 				# "Filter: ..." in subplans that reference scan-level filters)
 				# ahead of the marker we look for, pushing it down the

--- a/ci/filter_regression_diff.py
+++ b/ci/filter_regression_diff.py
@@ -528,7 +528,11 @@ def compare_trees(src_tree: list, target_tree: list, test_name: str):
 				src_up = True
 				target_up = True
 		elif src_cur_value.startswith('Bitmap Heap Scan'):
-			if target_cur[1].startswith('Custom Scan'):
+			# normalize_src_value() has already stripped a leading "Parallel "
+			# from the source, so a parallel bitmap heap scan on the heap side
+			# matches orioledb's "Parallel Custom Scan (o_scan)" too.
+			if (target_cur[1].startswith('Custom Scan')
+					or target_cur[1].startswith('Parallel Custom Scan')):
 				# EXPLAIN VERBOSE inserts "Output: ..." (and an optional
 				# "Filter: ..." in subplans that reference scan-level filters)
 				# ahead of the marker we look for, pushing it down the

--- a/include/btree/scan.h
+++ b/include/btree/scan.h
@@ -64,6 +64,11 @@ extern BTreeSeqScan *make_btree_seq_scan_cb(BTreeDescr *desc,
 											OSnapshot *oSnapshot,
 											BTreeSeqScanCallbacks *cb,
 											void *arg);
+extern BTreeSeqScan *make_btree_seq_scan_cb_parallel(BTreeDescr *desc,
+													 OSnapshot *oSnapshot,
+													 BTreeSeqScanCallbacks *cb,
+													 void *arg,
+													 void *poscan);
 extern BTreeSeqScan *make_btree_sampling_scan(BTreeDescr *desc,
 											  BlockSampler sampler);
 extern OTuple btree_seq_scan_getnext(BTreeSeqScan *scan, MemoryContext mctx,

--- a/include/tableam/bitmap_scan.h
+++ b/include/tableam/bitmap_scan.h
@@ -102,4 +102,12 @@ extern bool o_keybitmap_range_is_valid_key(OKeyBitmap *bm, const uint8 *low,
 extern bool o_keybitmap_get_next_key(OKeyBitmap *bm, const uint8 *prev,
 									 uint8 *result);
 
+/*
+ * Serialize a finalized bitmap into a flat, pointerless buffer (for sharing
+ * across parallel workers), and attach a read-only wrapper over such a buffer.
+ */
+extern Size o_keybitmap_serialized_size(OKeyBitmap *bm);
+extern void o_keybitmap_serialize(OKeyBitmap *bm, void *buf);
+extern OKeyBitmap *o_keybitmap_attach(void *buf, MemoryContext cxt);
+
 #endif							/* __TABLEAM_BITMAP_SCAN_H__ */

--- a/include/tableam/bitmap_scan.h
+++ b/include/tableam/bitmap_scan.h
@@ -19,6 +19,9 @@
 #include "tableam/scan.h"
 
 #include "executor/executor.h"
+#include "storage/condition_variable.h"
+#include "storage/spin.h"
+#include "utils/dsa.h"
 
 /*
  * Opaque set of uint64 keys backing the orioledb bitmap scan.  Implemented in
@@ -27,6 +30,32 @@
 typedef struct OKeyBitmap OKeyBitmap;
 
 typedef struct OBitmapScan OBitmapScan;
+
+/*
+ * Shared (DSM) state coordinating a parallel bitmap heap scan.  The bitmap is
+ * built once by the first worker to arrive and serialized into es_query_dsa;
+ * the others wait on `cv` and then attach the same buffer read-only.  The
+ * primary tree is then fetched cooperatively through `poscan`.
+ */
+typedef enum OBitmapParallelStage
+{
+	OBITMAP_PARALLEL_NEW = 0,	/* nobody has started building yet */
+	OBITMAP_PARALLEL_BUILDING,	/* one worker is building the bitmap */
+	OBITMAP_PARALLEL_READY,		/* bitmap serialized (or empty); fetch may run */
+} OBitmapParallelStage;
+
+typedef struct ParallelOBitmapScanDesc
+{
+	ParallelOScanDescData poscan;	/* cooperative primary fetch scan */
+	slock_t		mutex;			/* protects the fields below */
+	ConditionVariable cv;		/* waited on until stage == READY */
+	OBitmapParallelStage stage;
+	bool		empty;			/* built bitmap has no keys (skip fetch) */
+	dsa_pointer bitmap_dsa;		/* serialized bitmap in es_query_dsa */
+	Size		bitmap_size;
+} ParallelOBitmapScanDesc;
+
+typedef ParallelOBitmapScanDesc *ParallelOBitmapScan;
 
 typedef struct OBitmapHeapPlanState
 {
@@ -42,6 +71,9 @@ typedef struct OBitmapHeapPlanState
 	MemoryContext cxt;
 	OBitmapScan *scan;
 	OEACallsCounters *eaCounters;
+	/* parallel scan: DSM coordination state + the query DSA (NULL if serial) */
+	ParallelOBitmapScan pbitmap;
+	dsa_area   *dsa;
 } OBitmapHeapPlanState;
 
 extern OBitmapScan *o_make_bitmap_scan(OBitmapHeapPlanState *bitmap_state,

--- a/include/tableam/bitmap_scan.h
+++ b/include/tableam/bitmap_scan.h
@@ -51,8 +51,10 @@ typedef struct ParallelOBitmapScanDesc
 	ConditionVariable cv;		/* waited on until stage == READY */
 	OBitmapParallelStage stage;
 	bool		empty;			/* built bitmap has no keys (skip fetch) */
-	dsa_pointer bitmap_dsa;		/* serialized bitmap in es_query_dsa */
+	bool		is_bridge;		/* built a bridge TIDBitmap, not a key bitmap */
+	dsa_pointer bitmap_dsa;		/* serialized key bitmap in es_query_dsa */
 	Size		bitmap_size;
+	dsa_pointer tbm_iter;		/* bridge: shared TIDBitmap iterator */
 } ParallelOBitmapScanDesc;
 
 typedef ParallelOBitmapScanDesc *ParallelOBitmapScan;

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -2494,6 +2494,21 @@ make_btree_seq_scan_cb(BTreeDescr *desc, OSnapshot *oSnapshot,
 	return make_btree_seq_scan_internal(desc, oSnapshot, cb, arg, NULL, NULL);
 }
 
+/*
+ * Parallel variant of make_btree_seq_scan_cb(): the callback-pruned scan runs
+ * cooperatively across workers via `poscan`.  The bitmap-directed partial-leaf
+ * "fetch" optimization is disabled in this mode (see BTreeSeqScan.fetch); the
+ * scan still skips whole downlinks/pages via the isRangeValid callback, and
+ * each worker independently tests the tuples of its share.
+ */
+BTreeSeqScan *
+make_btree_seq_scan_cb_parallel(BTreeDescr *desc, OSnapshot *oSnapshot,
+								BTreeSeqScanCallbacks *cb, void *arg,
+								void *poscan)
+{
+	return make_btree_seq_scan_internal(desc, oSnapshot, cb, arg, NULL, poscan);
+}
+
 BTreeSeqScan *
 make_btree_sampling_scan(BTreeDescr *desc, BlockSampler sampler)
 {

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -2587,6 +2587,21 @@ make_btree_seq_scan_cb(BTreeDescr *desc, OSnapshot *oSnapshot,
 	return make_btree_seq_scan_internal(desc, oSnapshot, cb, arg, NULL, NULL);
 }
 
+/*
+ * Parallel variant of make_btree_seq_scan_cb(): the callback-pruned scan runs
+ * cooperatively across workers via `poscan`.  The bitmap-directed partial-leaf
+ * "fetch" optimization is disabled in this mode (see BTreeSeqScan.fetch); the
+ * scan still skips whole downlinks/pages via the isRangeValid callback, and
+ * each worker independently tests the tuples of its share.
+ */
+BTreeSeqScan *
+make_btree_seq_scan_cb_parallel(BTreeDescr *desc, OSnapshot *oSnapshot,
+								BTreeSeqScanCallbacks *cb, void *arg,
+								void *poscan)
+{
+	return make_btree_seq_scan_internal(desc, oSnapshot, cb, arg, NULL, poscan);
+}
+
 BTreeSeqScan *
 make_btree_sampling_scan(BTreeDescr *desc, BlockSampler sampler)
 {

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -43,6 +43,13 @@ typedef struct BridgeIterator
 {
 	TIDBitmap  *tidbitmap;
 
+	/*
+	 * For a parallel bridged scan the TIDBitmap lives in es_query_dsa and is
+	 * consumed cooperatively through this shared iterator (NULL for a serial
+	 * scan, which uses the private tbmiterator below).
+	 */
+	TBMSharedIterator *shared_iterator;
+
 #if PG_VERSION_NUM >= 180000
 	TBMPrivateIterator *tbmiterator;
 	TBMIterateResult tbmres;
@@ -964,8 +971,13 @@ exec_bitmap_index_state(OBitmapHeapPlanState *bitmap_state, PlanState *planstate
 		bool		doscan;
 		IndexScanDesc scandesc;
 
+		/*
+		 * A parallel bridged scan builds the TIDBitmap in es_query_dsa so it
+		 * can be iterated cooperatively; bitmap_state->dsa is NULL for a
+		 * serial scan (backend-local bitmap), unchanged.
+		 */
 		if (*tbm_result == NULL)
-			*tbm_result = tbm_create(work_mem * 1024L, NULL);
+			*tbm_result = tbm_create(work_mem * 1024L, bitmap_state->dsa);
 
 		/*
 		 * extract necessary information from index scan node
@@ -1535,13 +1547,18 @@ o_bitmap_stream_fetch(OBitmapScan *scan, CustomScanState *node)
 
 /*
  * Parallel build coordination: the first worker to arrive builds the whole
- * key bitmap (running the bitmap qual), serializes it into es_query_dsa and
- * publishes it; the others wait on the condition variable and then attach the
- * same buffer read-only.  Returns the attached (shared) bitmap, or NULL when
- * the built bitmap is empty.  The cooperative primary fetch then runs through
- * pbitmap->poscan.
+ * bitmap (running the bitmap qual) and publishes it in es_query_dsa; the others
+ * wait on the condition variable and then attach the same shared state.  Sets
+ * up `scan` for the cooperative fetch: for a native key bitmap, attaches it
+ * read-only and creates the cooperative primary seq scan; for a bridge
+ * TIDBitmap, attaches the shared TID iterator.  Leaves the scan empty (no
+ * seq_scan, no iterator) when the built bitmap is empty.
+ *
+ * The bridge TIDBitmap is intentionally NOT freed by the building worker: it
+ * lives in es_query_dsa and is reclaimed when that area is destroyed at query
+ * end, so a worker finishing early can never free it out from under the others.
  */
-static OKeyBitmap *
+static void
 o_bitmap_parallel_prepare(OBitmapHeapPlanState *bitmap_state, OBitmapScan *scan,
 						  PlanState *bitmapqualplanstate)
 {
@@ -1560,14 +1577,22 @@ o_bitmap_parallel_prepare(OBitmapHeapPlanState *bitmap_state, OBitmapScan *scan,
 		OKeyBitmap *local = NULL;
 		TIDBitmap  *tbm = NULL;
 		dsa_pointer dp = InvalidDsaPointer;
+		dsa_pointer tbm_iter = InvalidDsaPointer;
 		Size		sz = 0;
 		bool		empty = true;
+		bool		is_bridge = false;
 
 		o_exec_bitmapqual(bitmap_state, bitmapqualplanstate, &local, &tbm);
-		/* The planner only offers a parallel path for native-index quals. */
-		Assert(tbm == NULL);
 
-		if (local != NULL && !o_keybitmap_is_empty(local))
+		if (tbm != NULL)
+		{
+			/* Bridged qual: share the DSA TIDBitmap's iterator. */
+			is_bridge = true;
+			empty = false;
+			tbm_iter = tbm_prepare_shared_iterate(tbm);
+			/* Do not free tbm: es_query_dsa owns its pages until query end. */
+		}
+		else if (local != NULL && !o_keybitmap_is_empty(local))
 		{
 			sz = o_keybitmap_serialized_size(local);
 			dp = dsa_allocate(dsa, sz);
@@ -1578,8 +1603,10 @@ o_bitmap_parallel_prepare(OBitmapHeapPlanState *bitmap_state, OBitmapScan *scan,
 			o_keybitmap_free(local);
 
 		SpinLockAcquire(&pbitmap->mutex);
+		pbitmap->is_bridge = is_bridge;
 		pbitmap->bitmap_dsa = dp;
 		pbitmap->bitmap_size = sz;
+		pbitmap->tbm_iter = tbm_iter;
 		pbitmap->empty = empty;
 		pbitmap->stage = OBITMAP_PARALLEL_READY;
 		SpinLockRelease(&pbitmap->mutex);
@@ -1604,10 +1631,31 @@ o_bitmap_parallel_prepare(OBitmapHeapPlanState *bitmap_state, OBitmapScan *scan,
 	}
 
 	if (pbitmap->empty)
-		return NULL;
+		return;
 
-	return o_keybitmap_attach(dsa_get_address(dsa, pbitmap->bitmap_dsa),
-							  scan->cxt);
+	if (pbitmap->is_bridge)
+	{
+		scan->bridge_iter.shared_iterator =
+			tbm_attach_shared_iterate(dsa, pbitmap->tbm_iter);
+		scan->bridge_iter.tidbitmap = NULL;
+#if PG_VERSION_NUM >= 180000
+		scan->bridge_iter.tbmres.blockno = InvalidBlockNumber;
+#else
+		scan->bridge_iter.tbmres = NULL;
+#endif
+	}
+	else
+	{
+		scan->arg.bitmap =
+			o_keybitmap_attach(dsa_get_address(dsa, pbitmap->bitmap_dsa),
+							   scan->cxt);
+		scan->seq_scan =
+			make_btree_seq_scan_cb_parallel(&GET_PRIMARY(scan->arg.tbl_desc)->desc,
+											&scan->oSnapshot,
+											&bitmap_seq_scan_callbacks,
+											&scan->arg,
+											&pbitmap->poscan);
+	}
 }
 
 OBitmapScan *
@@ -1632,15 +1680,7 @@ o_make_bitmap_scan(OBitmapHeapPlanState *bitmap_state, ScanState *ss,
 	 */
 	if (bitmap_state->pbitmap != NULL)
 	{
-		scan->arg.bitmap = o_bitmap_parallel_prepare(bitmap_state, scan,
-													 bitmapqualplanstate);
-		if (scan->arg.bitmap != NULL)
-			scan->seq_scan =
-				make_btree_seq_scan_cb_parallel(&GET_PRIMARY(scan->arg.tbl_desc)->desc,
-												&scan->oSnapshot,
-												&bitmap_seq_scan_callbacks,
-												&scan->arg,
-												&bitmap_state->pbitmap->poscan);
+		o_bitmap_parallel_prepare(bitmap_state, scan, bitmapqualplanstate);
 		return scan;
 	}
 
@@ -1687,7 +1727,8 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 		return o_bitmap_stream_fetch(scan, node);
 
 	/* An empty (parallel) bitmap has no primary scan and no bridge iterator. */
-	if (scan->seq_scan == NULL && bridge_iter->tbmiterator == NULL)
+	if (scan->seq_scan == NULL && bridge_iter->tbmiterator == NULL &&
+		bridge_iter->shared_iterator == NULL)
 		return ExecClearTuple(node->ss.ss_ScanTupleSlot);
 
 	do
@@ -1717,8 +1758,9 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 		 */
 		ResetExprContext(node->ss.ps.ps_ExprContext);
 
-		/* Path 1: Iterate using bridge bitmap */
-		if (bridge_iter->tbmiterator != NULL && page_exhausted)
+		/* Path 1: Iterate using bridge bitmap (private or shared iterator) */
+		if ((bridge_iter->tbmiterator != NULL ||
+			 bridge_iter->shared_iterator != NULL) && page_exhausted)
 		{
 			if (!bridge_iterate(bridge_iter))
 			{
@@ -1749,7 +1791,8 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 				 * BRIDGE_NEXT_TUPLE never marks the page exhausted on its
 				 * own.  Force the advance here and continue the outer loop.
 				 */
-				if (bridge_iter->tbmiterator != NULL)
+				if (bridge_iter->tbmiterator != NULL ||
+					bridge_iter->shared_iterator != NULL)
 				{
 #if PG_VERSION_NUM >= 180000
 					bridge_iter->tbmres.blockno = InvalidBlockNumber;
@@ -1895,6 +1938,15 @@ o_free_bitmap_scan(OBitmapScan *scan)
 #else
 		tbm_end_iterate(scan->bridge_iter.tbmiterator);
 #endif
+
+	/*
+	 * A parallel bridged scan uses a shared iterator over a DSA TIDBitmap:
+	 * end the per-worker iterator, but do NOT tbm_free the bitmap --
+	 * es_query_dsa owns it and reclaims it at query end (freeing it here
+	 * would corrupt the other workers' iterators).
+	 */
+	if (scan->bridge_iter.shared_iterator)
+		tbm_end_shared_iterate(scan->bridge_iter.shared_iterator);
 	if (scan->bridge_iter.tidbitmap)
 		tbm_free(scan->bridge_iter.tidbitmap);
 	pfree(scan);
@@ -2065,7 +2117,13 @@ bridge_iterate(BridgeIterator *iter)
 #if PG_VERSION_NUM >= 180000
 	if (!BlockNumberIsValid(iter->tbmres.blockno))
 	{
-		if (!tbm_private_iterate(iter->tbmiterator, &iter->tbmres))
+		bool		ok;
+
+		if (iter->shared_iterator != NULL)
+			ok = tbm_shared_iterate(iter->shared_iterator, &iter->tbmres);
+		else
+			ok = tbm_private_iterate(iter->tbmiterator, &iter->tbmres);
+		if (!ok)
 			return false;
 		if (!iter->tbmres.lossy)
 			iter->iter_ntuples = tbm_extract_page_tuple(&iter->tbmres,
@@ -2075,7 +2133,12 @@ bridge_iterate(BridgeIterator *iter)
 	return BlockNumberIsValid(iter->tbmres.blockno);
 #else
 	if (iter->tbmres == NULL)
-		iter->tbmres = tbm_iterate(iter->tbmiterator);
+	{
+		if (iter->shared_iterator != NULL)
+			iter->tbmres = tbm_shared_iterate(iter->shared_iterator);
+		else
+			iter->tbmres = tbm_iterate(iter->tbmiterator);
+	}
 	return iter->tbmres != NULL;
 #endif
 }
@@ -2086,7 +2149,8 @@ bridge_next_page(OBitmapScan *scan, OBitmapHeapPlanState *bitmap_state)
 	OIndexDescr *bridge = scan->arg.tbl_desc->bridge;
 	BridgeIterator *iter;
 
-	Assert(scan->bridge_iter.tbmiterator != NULL);
+	Assert(scan->bridge_iter.tbmiterator != NULL ||
+		   scan->bridge_iter.shared_iterator != NULL);
 #if PG_VERSION_NUM >= 180000
 	Assert(BlockNumberIsValid(scan->bridge_iter.tbmres.blockno));
 #else

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -28,6 +28,7 @@
 #include "executor/nodeIndexscan.h"
 #include "nodes/execnodes.h"
 #include "utils/memutils.h"
+#include "utils/wait_event.h"
 
 #include <math.h>
 
@@ -1532,6 +1533,83 @@ o_bitmap_stream_fetch(OBitmapScan *scan, CustomScanState *node)
 	return ExecClearTuple(ss->ss_ScanTupleSlot);
 }
 
+/*
+ * Parallel build coordination: the first worker to arrive builds the whole
+ * key bitmap (running the bitmap qual), serializes it into es_query_dsa and
+ * publishes it; the others wait on the condition variable and then attach the
+ * same buffer read-only.  Returns the attached (shared) bitmap, or NULL when
+ * the built bitmap is empty.  The cooperative primary fetch then runs through
+ * pbitmap->poscan.
+ */
+static OKeyBitmap *
+o_bitmap_parallel_prepare(OBitmapHeapPlanState *bitmap_state, OBitmapScan *scan,
+						  PlanState *bitmapqualplanstate)
+{
+	ParallelOBitmapScan pbitmap = bitmap_state->pbitmap;
+	dsa_area   *dsa = bitmap_state->dsa;
+	bool		build;
+
+	SpinLockAcquire(&pbitmap->mutex);
+	build = (pbitmap->stage == OBITMAP_PARALLEL_NEW);
+	if (build)
+		pbitmap->stage = OBITMAP_PARALLEL_BUILDING;
+	SpinLockRelease(&pbitmap->mutex);
+
+	if (build)
+	{
+		OKeyBitmap *local = NULL;
+		TIDBitmap  *tbm = NULL;
+		dsa_pointer dp = InvalidDsaPointer;
+		Size		sz = 0;
+		bool		empty = true;
+
+		o_exec_bitmapqual(bitmap_state, bitmapqualplanstate, &local, &tbm);
+		/* The planner only offers a parallel path for native-index quals. */
+		Assert(tbm == NULL);
+
+		if (local != NULL && !o_keybitmap_is_empty(local))
+		{
+			sz = o_keybitmap_serialized_size(local);
+			dp = dsa_allocate(dsa, sz);
+			o_keybitmap_serialize(local, dsa_get_address(dsa, dp));
+			empty = false;
+		}
+		if (local != NULL)
+			o_keybitmap_free(local);
+
+		SpinLockAcquire(&pbitmap->mutex);
+		pbitmap->bitmap_dsa = dp;
+		pbitmap->bitmap_size = sz;
+		pbitmap->empty = empty;
+		pbitmap->stage = OBITMAP_PARALLEL_READY;
+		SpinLockRelease(&pbitmap->mutex);
+		ConditionVariableBroadcast(&pbitmap->cv);
+	}
+	else
+	{
+		ConditionVariablePrepareToSleep(&pbitmap->cv);
+		for (;;)
+		{
+			OBitmapParallelStage stage;
+
+			SpinLockAcquire(&pbitmap->mutex);
+			stage = pbitmap->stage;
+			SpinLockRelease(&pbitmap->mutex);
+			if (stage == OBITMAP_PARALLEL_READY)
+				break;
+			ConditionVariableSleep(&pbitmap->cv,
+								   WAIT_EVENT_PARALLEL_BITMAP_SCAN);
+		}
+		ConditionVariableCancelSleep();
+	}
+
+	if (pbitmap->empty)
+		return NULL;
+
+	return o_keybitmap_attach(dsa_get_address(dsa, pbitmap->bitmap_dsa),
+							  scan->cxt);
+}
+
 OBitmapScan *
 o_make_bitmap_scan(OBitmapHeapPlanState *bitmap_state, ScanState *ss,
 				   PlanState *bitmapqualplanstate, Relation rel,
@@ -1546,6 +1624,25 @@ o_make_bitmap_scan(OBitmapHeapPlanState *bitmap_state, ScanState *ss,
 	scan->ss = ss;
 	scan->arg.tbl_desc = relation_get_descr(rel);
 	bitmap_state->scan = scan;
+
+	/*
+	 * Parallel bitmap heap scan: build the key bitmap once (cooperatively),
+	 * attach it read-only, and fetch the primary tree cooperatively through
+	 * the shared poscan.  The streaming/bridge fast paths are not used here.
+	 */
+	if (bitmap_state->pbitmap != NULL)
+	{
+		scan->arg.bitmap = o_bitmap_parallel_prepare(bitmap_state, scan,
+													 bitmapqualplanstate);
+		if (scan->arg.bitmap != NULL)
+			scan->seq_scan =
+				make_btree_seq_scan_cb_parallel(&GET_PRIMARY(scan->arg.tbl_desc)->desc,
+												&scan->oSnapshot,
+												&bitmap_seq_scan_callbacks,
+												&scan->arg,
+												&bitmap_state->pbitmap->poscan);
+		return scan;
+	}
 
 	/*
 	 * Fast path: a single primary BitmapIndexScan, or a BitmapOr of only such
@@ -1588,6 +1685,10 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 
 	if (scan->stream_primary)
 		return o_bitmap_stream_fetch(scan, node);
+
+	/* An empty (parallel) bitmap has no primary scan and no bridge iterator. */
+	if (scan->seq_scan == NULL && bridge_iter->tbmiterator == NULL)
+		return ExecClearTuple(node->ss.ss_ScanTupleSlot);
 
 	do
 	{

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -245,7 +245,18 @@ orioledb_index_fetch_tuple(struct IndexFetchTableData *scan,
 												   (Pointer) &bridge_bound, BTreeKeyBound,
 												   &o_non_deleted_snapshot, &tupleCsn,
 												   slot->tts_mcxt, NULL);
-			O_LOAD_SNAPSHOT(&oSnapshot, snapshot);
+
+			/*
+			 * A non-MVCC snapshot (e.g. SnapshotNonVacuumable, used by the
+			 * planner's get_actual_variable_range() index-endpoint probe) has
+			 * no csnSnapshotData, so O_LOAD_SNAPSHOT() would read an
+			 * uninitialised csn.  Map it the same way orioledb_amgettuple()
+			 * does instead of feeding garbage into the primary-index lookup.
+			 */
+			if (snapshot->snapshot_type == SNAPSHOT_NON_VACUUMABLE)
+				oSnapshot = o_non_deleted_snapshot;
+			else
+				O_LOAD_SNAPSHOT(&oSnapshot, snapshot);
 		}
 		if (O_TUPLE_IS_NULL(bridge_tup))
 			return false;

--- a/src/tableam/key_bitmap.c
+++ b/src/tableam/key_bitmap.c
@@ -756,3 +756,97 @@ o_keybitmap_get_next_key(OKeyBitmap *bm, const uint8 *prev, uint8 *result)
 	memcpy(result, bm->fkeys + (Size) idx * OKBM_FIXED_BYTES, OKBM_FIXED_BYTES);
 	return true;
 }
+
+/* --- serialization (for sharing a finalized bitmap across workers) --- */
+
+/*
+ * On-buffer header.  The flat arrays follow at MAXALIGN(sizeof(header)):
+ *   uint64 mode: uint64 chunks[nchunks]; OKeyBitmapChunk payloads[nchunks];
+ *   fixed mode:  uint8  fkeys[nchunks * OKBM_FIXED_BYTES];
+ * The layout contains no pointers, so it can be copied into shared memory and
+ * attached (o_keybitmap_attach) at a different mapping address per worker.
+ */
+typedef struct OKeyBitmapSerialHeader
+{
+	int32		nchunks;
+	bool		fixed;
+} OKeyBitmapSerialHeader;
+
+#define OKBM_SERIAL_BODY_OFFSET MAXALIGN(sizeof(OKeyBitmapSerialHeader))
+
+Size
+o_keybitmap_serialized_size(OKeyBitmap *bm)
+{
+	Size		sz = OKBM_SERIAL_BODY_OFFSET;
+
+	okbm_finalize(bm);
+
+	if (bm->fixed)
+		sz += (Size) bm->nchunks * OKBM_FIXED_BYTES;
+	else
+		sz += (Size) bm->nchunks * (sizeof(uint64) + sizeof(OKeyBitmapChunk));
+	return sz;
+}
+
+void
+o_keybitmap_serialize(OKeyBitmap *bm, void *buf)
+{
+	OKeyBitmapSerialHeader *hdr = (OKeyBitmapSerialHeader *) buf;
+	char	   *body = (char *) buf + OKBM_SERIAL_BODY_OFFSET;
+
+	okbm_finalize(bm);
+
+	hdr->nchunks = bm->nchunks;
+	hdr->fixed = bm->fixed;
+
+	if (bm->fixed)
+	{
+		if (bm->nchunks > 0)
+			memcpy(body, bm->fkeys, (Size) bm->nchunks * OKBM_FIXED_BYTES);
+	}
+	else if (bm->nchunks > 0)
+	{
+		memcpy(body, bm->chunks, (Size) bm->nchunks * sizeof(uint64));
+		memcpy(body + (Size) bm->nchunks * sizeof(uint64), bm->payloads,
+			   (Size) bm->nchunks * sizeof(OKeyBitmapChunk));
+	}
+}
+
+/*
+ * Attach a read-only bitmap over a buffer produced by o_keybitmap_serialize().
+ * The wrapper is allocated in `cxt` and holds pointers into `buf` (valid for
+ * the caller's mapping of the shared segment); o_keybitmap_free() drops only
+ * the wrapper.
+ */
+OKeyBitmap *
+o_keybitmap_attach(void *buf, MemoryContext cxt)
+{
+	OKeyBitmapSerialHeader *hdr = (OKeyBitmapSerialHeader *) buf;
+	char	   *body = (char *) buf + OKBM_SERIAL_BODY_OFFSET;
+	OKeyBitmap *bm = MemoryContextAllocZero(cxt, sizeof(OKeyBitmap));
+
+	bm->cxt = cxt;
+	bm->treeCxt = NULL;
+	bm->tree = NULL;
+	bm->ftree = NULL;
+	bm->fixed = hdr->fixed;
+	bm->nchunks = hdr->nchunks;
+	bm->chunksCapacity = 0;
+	bm->finalized = true;
+	bm->shared = true;
+
+	if (bm->fixed)
+	{
+		bm->chunks = NULL;
+		bm->payloads = NULL;
+		bm->fkeys = (uint8 *) body;
+	}
+	else
+	{
+		bm->chunks = (uint64 *) body;
+		bm->payloads = (OKeyBitmapChunk *)
+			(body + (Size) bm->nchunks * sizeof(uint64));
+		bm->fkeys = NULL;
+	}
+	return bm;
+}

--- a/src/tableam/key_bitmap.c
+++ b/src/tableam/key_bitmap.c
@@ -82,15 +82,31 @@ struct OKeyBitmap
 	/*
 	 * Sorted key arrays, built lazily by okbm_finalize() to serve ordered
 	 * seeks.  Invalidated (finalized = false) on every mutation.  uint64 mode
-	 * stores chunk keys in chunks[]; fixed mode stores whole keys, each
+	 * stores chunk keys in chunks[] and the matching per-chunk bitmaps in
+	 * payloads[] (so the read path is self-contained -- no radix-tree lookup
+	 * -- and the finalized form is a set of flat POD arrays that can be
+	 * shared across parallel workers); fixed mode stores whole keys, each
 	 * OKBM_FIXED_BYTES bytes, in fkeys[].
 	 */
 	uint64	   *chunks;
+	OKeyBitmapChunk *payloads;
 	uint8	   *fkeys;
 	int			nchunks;
 	int			chunksCapacity;
 	bool		finalized;
+
+	/*
+	 * A shared (read-only) bitmap attached over a serialized buffer: chunks/
+	 * payloads/fkeys point into that buffer, tree/ftree are NULL and
+	 * finalized is true.  o_keybitmap_free() must not free the buffer-backed
+	 * arrays.
+	 */
+	bool		shared;
 };
+
+static void okbm_finalize(OKeyBitmap *bm);
+static int	okbm_lower_bound(OKeyBitmap *bm, uint64 target);
+static int	okbmf_lower_bound(OKeyBitmap *bm, const uint8 *target);
 
 /*
  * Return the first set bit offset >= minOffset within a chunk bitmap, or -1.
@@ -146,10 +162,12 @@ o_keybitmap_create(void)
 	bm->tree = okbm_create(bm->treeCxt);
 	bm->ftree = NULL;
 	bm->chunks = NULL;
+	bm->payloads = NULL;
 	bm->fkeys = NULL;
 	bm->nchunks = 0;
 	bm->chunksCapacity = 0;
 	bm->finalized = false;
+	bm->shared = false;
 	return bm;
 }
 
@@ -168,16 +186,25 @@ o_keybitmap_create_fixed(void)
 	bm->tree = NULL;
 	bm->ftree = okbmf_create(bm->treeCxt);
 	bm->chunks = NULL;
+	bm->payloads = NULL;
 	bm->fkeys = NULL;
 	bm->nchunks = 0;
 	bm->chunksCapacity = 0;
 	bm->finalized = false;
+	bm->shared = false;
 	return bm;
 }
 
 void
 o_keybitmap_free(OKeyBitmap *bm)
 {
+	if (bm->shared)
+	{
+		/* Arrays live in the shared buffer; only the wrapper is ours. */
+		pfree(bm);
+		return;
+	}
+
 	if (bm->fixed)
 		okbmf_free(bm->ftree);
 	else
@@ -185,6 +212,8 @@ o_keybitmap_free(OKeyBitmap *bm)
 	MemoryContextDelete(bm->treeCxt);
 	if (bm->chunks)
 		pfree(bm->chunks);
+	if (bm->payloads)
+		pfree(bm->payloads);
 	if (bm->fkeys)
 		pfree(bm->fkeys);
 	pfree(bm);
@@ -219,10 +248,15 @@ o_keybitmap_insert_key(OKeyBitmap *bm, const uint8 *key)
 bool
 o_keybitmap_test_key(OKeyBitmap *bm, const uint8 *key)
 {
-	okbmf_key	k = okbmf_mkkey(key);
+	int			idx;
 
 	Assert(bm->fixed);
-	return okbmf_find(bm->ftree, k) != NULL;
+	okbm_finalize(bm);
+
+	idx = okbmf_lower_bound(bm, key);
+	return idx < bm->nchunks &&
+		memcmp(bm->fkeys + (Size) idx * OKBM_FIXED_BYTES, key,
+			   OKBM_FIXED_BYTES) == 0;
 }
 
 /*
@@ -271,12 +305,15 @@ o_keybitmap_test(OKeyBitmap *bm, uint64 value)
 {
 	uint64		chunk = value >> OKBM_CHUNK_BITS;
 	int			offset = value & OKBM_LOW_MASK;
-	OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
+	int			idx;
 
-	if (entry == NULL)
+	okbm_finalize(bm);
+
+	idx = okbm_lower_bound(bm, chunk);
+	if (idx >= bm->nchunks || bm->chunks[idx] != chunk)
 		return false;
 
-	return (entry->bitmap[offset >> 3] & (1 << (offset & 7))) != 0;
+	return (bm->payloads[idx].bitmap[offset >> 3] & (1 << (offset & 7))) != 0;
 }
 
 /* uint64 variant of o_keybitmap_emit_key(): insert, return true if newly added. */
@@ -514,19 +551,33 @@ okbm_finalize(OKeyBitmap *bm)
 	}
 
 	iter = okbm_begin_iterate(bm->tree);
-	while (okbm_iterate_next(iter, &chunk) != NULL)
 	{
-		if (bm->nchunks >= bm->chunksCapacity)
+		OKeyBitmapChunk *entry;
+
+		while ((entry = okbm_iterate_next(iter, &chunk)) != NULL)
 		{
-			bm->chunksCapacity = bm->chunksCapacity ? bm->chunksCapacity * 2 : 64;
-			if (bm->chunks == NULL)
-				bm->chunks = MemoryContextAlloc(bm->cxt,
-												sizeof(uint64) * bm->chunksCapacity);
-			else
-				bm->chunks = repalloc(bm->chunks,
-									  sizeof(uint64) * bm->chunksCapacity);
+			if (bm->nchunks >= bm->chunksCapacity)
+			{
+				bm->chunksCapacity = bm->chunksCapacity ? bm->chunksCapacity * 2 : 64;
+				if (bm->chunks == NULL)
+				{
+					bm->chunks = MemoryContextAlloc(bm->cxt,
+													sizeof(uint64) * bm->chunksCapacity);
+					bm->payloads = MemoryContextAlloc(bm->cxt,
+													  sizeof(OKeyBitmapChunk) * bm->chunksCapacity);
+				}
+				else
+				{
+					bm->chunks = repalloc(bm->chunks,
+										  sizeof(uint64) * bm->chunksCapacity);
+					bm->payloads = repalloc(bm->payloads,
+											sizeof(OKeyBitmapChunk) * bm->chunksCapacity);
+				}
+			}
+			bm->chunks[bm->nchunks] = chunk;
+			memcpy(&bm->payloads[bm->nchunks], entry, sizeof(OKeyBitmapChunk));
+			bm->nchunks++;
 		}
-		bm->chunks[bm->nchunks++] = chunk;
 	}
 	okbm_end_iterate(iter);
 
@@ -580,7 +631,7 @@ o_keybitmap_range_is_valid(OKeyBitmap *bm, uint64 low, uint64 high)
 		if (chunk > chunkHigh)
 			break;
 
-		entry = okbm_find(bm->tree, chunk);
+		entry = &bm->payloads[idx];
 
 		if (chunk == chunkLow)
 		{
@@ -631,12 +682,10 @@ o_keybitmap_get_next(OKeyBitmap *bm, uint64 prev, bool *found)
 	for (idx = okbm_lower_bound(bm, chunkPrev); idx < bm->nchunks; idx++)
 	{
 		uint64		chunk = bm->chunks[idx];
-		OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
+		OKeyBitmapChunk *entry = &bm->payloads[idx];
 		int			startOff = (chunk == chunkPrev) ? offPrev : 0;
 		int			nextOff;
 
-		/* chunk came from bm->chunks[], so the tree always has it */
-		Assert(entry != NULL);
 		nextOff = find_next_offset(entry->bitmap, startOff);
 
 		if (nextOff >= 0)

--- a/src/tableam/key_bitmap.c
+++ b/src/tableam/key_bitmap.c
@@ -82,15 +82,31 @@ struct OKeyBitmap
 	/*
 	 * Sorted key arrays, built lazily by okbm_finalize() to serve ordered
 	 * seeks.  Invalidated (finalized = false) on every mutation.  uint64 mode
-	 * stores chunk keys in chunks[]; fixed mode stores whole keys, each
+	 * stores chunk keys in chunks[] and the matching per-chunk bitmaps in
+	 * payloads[] (so the read path is self-contained -- no radix-tree lookup
+	 * -- and the finalized form is a set of flat POD arrays that can be
+	 * shared across parallel workers); fixed mode stores whole keys, each
 	 * OKBM_FIXED_BYTES bytes, in fkeys[].
 	 */
 	uint64	   *chunks;
+	OKeyBitmapChunk *payloads;
 	uint8	   *fkeys;
 	int			nchunks;
 	int			chunksCapacity;
 	bool		finalized;
+
+	/*
+	 * A shared (read-only) bitmap attached over a serialized buffer: chunks/
+	 * payloads/fkeys point into that buffer, tree/ftree are NULL and
+	 * finalized is true.  o_keybitmap_free() must not free the buffer-backed
+	 * arrays.
+	 */
+	bool		shared;
 };
+
+static void okbm_finalize(OKeyBitmap *bm);
+static int	okbm_lower_bound(OKeyBitmap *bm, uint64 target);
+static int	okbmf_lower_bound(OKeyBitmap *bm, const uint8 *target);
 
 /*
  * Return the first set bit offset >= minOffset within a chunk bitmap, or -1.
@@ -146,10 +162,12 @@ o_keybitmap_create(void)
 	bm->tree = okbm_create(bm->treeCxt);
 	bm->ftree = NULL;
 	bm->chunks = NULL;
+	bm->payloads = NULL;
 	bm->fkeys = NULL;
 	bm->nchunks = 0;
 	bm->chunksCapacity = 0;
 	bm->finalized = false;
+	bm->shared = false;
 	return bm;
 }
 
@@ -168,16 +186,25 @@ o_keybitmap_create_fixed(void)
 	bm->tree = NULL;
 	bm->ftree = okbmf_create(bm->treeCxt);
 	bm->chunks = NULL;
+	bm->payloads = NULL;
 	bm->fkeys = NULL;
 	bm->nchunks = 0;
 	bm->chunksCapacity = 0;
 	bm->finalized = false;
+	bm->shared = false;
 	return bm;
 }
 
 void
 o_keybitmap_free(OKeyBitmap *bm)
 {
+	if (bm->shared)
+	{
+		/* Arrays live in the shared buffer; only the wrapper is ours. */
+		pfree(bm);
+		return;
+	}
+
 	if (bm->fixed)
 		okbmf_free(bm->ftree);
 	else
@@ -185,6 +212,8 @@ o_keybitmap_free(OKeyBitmap *bm)
 	MemoryContextDelete(bm->treeCxt);
 	if (bm->chunks)
 		pfree(bm->chunks);
+	if (bm->payloads)
+		pfree(bm->payloads);
 	if (bm->fkeys)
 		pfree(bm->fkeys);
 	pfree(bm);
@@ -219,10 +248,15 @@ o_keybitmap_insert_key(OKeyBitmap *bm, const uint8 *key)
 bool
 o_keybitmap_test_key(OKeyBitmap *bm, const uint8 *key)
 {
-	okbmf_key	k = okbmf_mkkey(key);
+	int			idx;
 
 	Assert(bm->fixed);
-	return okbmf_find(bm->ftree, k) != NULL;
+	okbm_finalize(bm);
+
+	idx = okbmf_lower_bound(bm, key);
+	return idx < bm->nchunks &&
+		memcmp(bm->fkeys + (Size) idx * OKBM_FIXED_BYTES, key,
+			   OKBM_FIXED_BYTES) == 0;
 }
 
 /*
@@ -271,12 +305,15 @@ o_keybitmap_test(OKeyBitmap *bm, uint64 value)
 {
 	uint64		chunk = value >> OKBM_CHUNK_BITS;
 	int			offset = value & OKBM_LOW_MASK;
-	OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
+	int			idx;
 
-	if (entry == NULL)
+	okbm_finalize(bm);
+
+	idx = okbm_lower_bound(bm, chunk);
+	if (idx >= bm->nchunks || bm->chunks[idx] != chunk)
 		return false;
 
-	return (entry->bitmap[offset >> 3] & (1 << (offset & 7))) != 0;
+	return (bm->payloads[idx].bitmap[offset >> 3] & (1 << (offset & 7))) != 0;
 }
 
 /* uint64 variant of o_keybitmap_emit_key(): insert, return true if newly added. */
@@ -514,19 +551,33 @@ okbm_finalize(OKeyBitmap *bm)
 	}
 
 	iter = okbm_begin_iterate(bm->tree);
-	while (okbm_iterate_next(iter, &chunk) != NULL)
 	{
-		if (bm->nchunks >= bm->chunksCapacity)
+		OKeyBitmapChunk *entry;
+
+		while ((entry = okbm_iterate_next(iter, &chunk)) != NULL)
 		{
-			bm->chunksCapacity = bm->chunksCapacity ? bm->chunksCapacity * 2 : 64;
-			if (bm->chunks == NULL)
-				bm->chunks = MemoryContextAlloc(bm->cxt,
-												sizeof(uint64) * bm->chunksCapacity);
-			else
-				bm->chunks = repalloc(bm->chunks,
-									  sizeof(uint64) * bm->chunksCapacity);
+			if (bm->nchunks >= bm->chunksCapacity)
+			{
+				bm->chunksCapacity = bm->chunksCapacity ? bm->chunksCapacity * 2 : 64;
+				if (bm->chunks == NULL)
+				{
+					bm->chunks = MemoryContextAlloc(bm->cxt,
+													sizeof(uint64) * bm->chunksCapacity);
+					bm->payloads = MemoryContextAlloc(bm->cxt,
+													  sizeof(OKeyBitmapChunk) * bm->chunksCapacity);
+				}
+				else
+				{
+					bm->chunks = repalloc(bm->chunks,
+										  sizeof(uint64) * bm->chunksCapacity);
+					bm->payloads = repalloc(bm->payloads,
+											sizeof(OKeyBitmapChunk) * bm->chunksCapacity);
+				}
+			}
+			bm->chunks[bm->nchunks] = chunk;
+			memcpy(&bm->payloads[bm->nchunks], entry, sizeof(OKeyBitmapChunk));
+			bm->nchunks++;
 		}
-		bm->chunks[bm->nchunks++] = chunk;
 	}
 	okbm_end_iterate(iter);
 
@@ -580,7 +631,7 @@ o_keybitmap_range_is_valid(OKeyBitmap *bm, uint64 low, uint64 high)
 		if (chunk > chunkHigh)
 			break;
 
-		entry = okbm_find(bm->tree, chunk);
+		entry = &bm->payloads[idx];
 
 		if (chunk == chunkLow)
 		{
@@ -631,12 +682,10 @@ o_keybitmap_get_next(OKeyBitmap *bm, uint64 prev, bool *found)
 	for (idx = okbm_lower_bound(bm, chunkPrev); idx < bm->nchunks; idx++)
 	{
 		uint64		chunk = bm->chunks[idx];
-		OKeyBitmapChunk *entry = okbm_find(bm->tree, chunk);
+		OKeyBitmapChunk *entry = &bm->payloads[idx];
 		int			startOff = (chunk == chunkPrev) ? offPrev : 0;
 		int			nextOff;
 
-		/* chunk came from bm->chunks[], so the tree always has it */
-		Assert(entry != NULL);
 		nextOff = find_next_offset(entry->bitmap, startOff);
 
 		if (nextOff >= 0)
@@ -706,4 +755,98 @@ o_keybitmap_get_next_key(OKeyBitmap *bm, const uint8 *prev, uint8 *result)
 
 	memcpy(result, bm->fkeys + (Size) idx * OKBM_FIXED_BYTES, OKBM_FIXED_BYTES);
 	return true;
+}
+
+/* --- serialization (for sharing a finalized bitmap across workers) --- */
+
+/*
+ * On-buffer header.  The flat arrays follow at MAXALIGN(sizeof(header)):
+ *   uint64 mode: uint64 chunks[nchunks]; OKeyBitmapChunk payloads[nchunks];
+ *   fixed mode:  uint8  fkeys[nchunks * OKBM_FIXED_BYTES];
+ * The layout contains no pointers, so it can be copied into shared memory and
+ * attached (o_keybitmap_attach) at a different mapping address per worker.
+ */
+typedef struct OKeyBitmapSerialHeader
+{
+	int32		nchunks;
+	bool		fixed;
+} OKeyBitmapSerialHeader;
+
+#define OKBM_SERIAL_BODY_OFFSET MAXALIGN(sizeof(OKeyBitmapSerialHeader))
+
+Size
+o_keybitmap_serialized_size(OKeyBitmap *bm)
+{
+	Size		sz = OKBM_SERIAL_BODY_OFFSET;
+
+	okbm_finalize(bm);
+
+	if (bm->fixed)
+		sz += (Size) bm->nchunks * OKBM_FIXED_BYTES;
+	else
+		sz += (Size) bm->nchunks * (sizeof(uint64) + sizeof(OKeyBitmapChunk));
+	return sz;
+}
+
+void
+o_keybitmap_serialize(OKeyBitmap *bm, void *buf)
+{
+	OKeyBitmapSerialHeader *hdr = (OKeyBitmapSerialHeader *) buf;
+	char	   *body = (char *) buf + OKBM_SERIAL_BODY_OFFSET;
+
+	okbm_finalize(bm);
+
+	hdr->nchunks = bm->nchunks;
+	hdr->fixed = bm->fixed;
+
+	if (bm->fixed)
+	{
+		if (bm->nchunks > 0)
+			memcpy(body, bm->fkeys, (Size) bm->nchunks * OKBM_FIXED_BYTES);
+	}
+	else if (bm->nchunks > 0)
+	{
+		memcpy(body, bm->chunks, (Size) bm->nchunks * sizeof(uint64));
+		memcpy(body + (Size) bm->nchunks * sizeof(uint64), bm->payloads,
+			   (Size) bm->nchunks * sizeof(OKeyBitmapChunk));
+	}
+}
+
+/*
+ * Attach a read-only bitmap over a buffer produced by o_keybitmap_serialize().
+ * The wrapper is allocated in `cxt` and holds pointers into `buf` (valid for
+ * the caller's mapping of the shared segment); o_keybitmap_free() drops only
+ * the wrapper.
+ */
+OKeyBitmap *
+o_keybitmap_attach(void *buf, MemoryContext cxt)
+{
+	OKeyBitmapSerialHeader *hdr = (OKeyBitmapSerialHeader *) buf;
+	char	   *body = (char *) buf + OKBM_SERIAL_BODY_OFFSET;
+	OKeyBitmap *bm = MemoryContextAllocZero(cxt, sizeof(OKeyBitmap));
+
+	bm->cxt = cxt;
+	bm->treeCxt = NULL;
+	bm->tree = NULL;
+	bm->ftree = NULL;
+	bm->fixed = hdr->fixed;
+	bm->nchunks = hdr->nchunks;
+	bm->chunksCapacity = 0;
+	bm->finalized = true;
+	bm->shared = true;
+
+	if (bm->fixed)
+	{
+		bm->chunks = NULL;
+		bm->payloads = NULL;
+		bm->fkeys = (uint8 *) body;
+	}
+	else
+	{
+		bm->chunks = (uint64 *) body;
+		bm->payloads = (OKeyBitmapChunk *)
+			(body + (Size) bm->nchunks * sizeof(uint64));
+		bm->fkeys = NULL;
+	}
+	return bm;
 }

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -644,8 +644,10 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 					 * cooperatively. Only the native key-bitmap path is
 					 * parallelized, so the qual must reference only OrioleDB
 					 * indexes and the primary key must be bitmap-eligible.
+					 * Parallel scans are not supported during recovery.
 					 */
-					if (o_keybitmap_pk_mode(GET_PRIMARY(descr), NULL) !=
+					if (!RecoveryInProgress() &&
+						o_keybitmap_pk_mode(GET_PRIMARY(descr), NULL) !=
 						O_KEYBITMAP_NONE &&
 						bitmap_qual_all_native(bh_path->bitmapqual, descr))
 					{

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -244,6 +244,19 @@ bitmap_qual_all_native(Path *bitmapqual, OTableDescr *descr)
 }
 
 /*
+ * Whether a bitmap qual is a single bridged-index scan -- one IndexPath whose
+ * index is not a native OrioleDB index (so the scan builds a bridge TIDBitmap).
+ * The parallel bitmap scan supports this via a shared DSA TIDBitmap; And/Or
+ * combinations of bridged indexes are not parallelized (they stay serial).
+ */
+static bool
+bitmap_qual_single_bridged(Path *bitmapqual, OTableDescr *descr)
+{
+	return IsA(bitmapqual, IndexPath) &&
+		o_find_ix_num((IndexPath *) bitmapqual, descr) < 0;
+}
+
+/*
  * Estimate the number of parallel workers for a parallel index scan.
  */
 static int
@@ -640,16 +653,17 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 					/*
 					 * Transform a partial BitmapHeapPath into a
 					 * parallel-aware custom bitmap scan: the first worker
-					 * builds the key bitmap and the primary tree is fetched
-					 * cooperatively. Only the native key-bitmap path is
-					 * parallelized, so the qual must reference only OrioleDB
-					 * indexes and the primary key must be bitmap-eligible.
-					 * Parallel scans are not supported during recovery.
+					 * builds the bitmap and the primary tree is fetched
+					 * cooperatively.  Supported when the primary key is
+					 * bitmap-eligible and the qual is either all native
+					 * OrioleDB indexes (key bitmap) or a single bridged index
+					 * (shared DSA TIDBitmap).  Not supported during recovery.
 					 */
 					if (!RecoveryInProgress() &&
 						o_keybitmap_pk_mode(GET_PRIMARY(descr), NULL) !=
 						O_KEYBITMAP_NONE &&
-						bitmap_qual_all_native(bh_path->bitmapqual, descr))
+						(bitmap_qual_all_native(bh_path->bitmapqual, descr) ||
+						 bitmap_qual_single_bridged(bh_path->bitmapqual, descr)))
 					{
 						Path	   *custom_path = transform_path(path, descr,
 																 false);
@@ -1577,6 +1591,8 @@ o_bitmap_scan_init_dsm(CustomScanState *node, ParallelContext *pcxt,
 	pbitmap->empty = false;
 	pbitmap->bitmap_dsa = InvalidDsaPointer;
 	pbitmap->bitmap_size = 0;
+	pbitmap->is_bridge = false;
+	pbitmap->tbm_iter = InvalidDsaPointer;
 
 	bitmap_state->pbitmap = pbitmap;
 	bitmap_state->dsa = node->ss.ps.state->es_query_dsa;
@@ -1614,4 +1630,6 @@ o_bitmap_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
 	pbitmap->empty = false;
 	pbitmap->bitmap_dsa = InvalidDsaPointer;
 	pbitmap->bitmap_size = 0;
+	pbitmap->is_bridge = false;
+	pbitmap->tbm_iter = InvalidDsaPointer;
 }

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -105,6 +105,15 @@ static void o_idx_scan_init_worker(CustomScanState *node,
 static void o_idx_scan_reinit_dsm(CustomScanState *node,
 								  ParallelContext *pcxt, void *coordinate);
 
+static Size o_bitmap_scan_estimate_dsm(CustomScanState *node,
+									   ParallelContext *pcxt);
+static void o_bitmap_scan_init_dsm(CustomScanState *node,
+								   ParallelContext *pcxt, void *coordinate);
+static void o_bitmap_scan_init_worker(CustomScanState *node,
+									  shm_toc *toc, void *coordinate);
+static void o_bitmap_scan_reinit_dsm(CustomScanState *node,
+									 ParallelContext *pcxt, void *coordinate);
+
 static CustomPathMethods o_path_methods =
 {
 	.CustomName = "o_path",
@@ -151,6 +160,23 @@ static CustomExecMethods o_parallel_idx_scan_exec_methods =
 	o_explain_custom_scan
 };
 
+static CustomExecMethods o_parallel_bitmap_scan_exec_methods =
+{
+	"o_exec_parallel_bitmap_scan",
+	o_begin_custom_scan,
+	o_exec_custom_scan,
+	o_end_custom_scan,
+	o_rescan_custom_scan,
+	NULL,
+	NULL,
+	o_bitmap_scan_estimate_dsm,
+	o_bitmap_scan_init_dsm,
+	o_bitmap_scan_reinit_dsm,
+	o_bitmap_scan_init_worker,
+	NULL,
+	o_explain_custom_scan
+};
+
 /* No existing callers */
 bool
 is_o_custom_scan(CustomScan *scan)
@@ -163,7 +189,8 @@ bool
 is_o_custom_scan_state(CustomScanState *scan)
 {
 	return scan->methods == &o_scan_exec_methods ||
-		scan->methods == &o_parallel_idx_scan_exec_methods;
+		scan->methods == &o_parallel_idx_scan_exec_methods ||
+		scan->methods == &o_parallel_bitmap_scan_exec_methods;
 }
 
 /*
@@ -181,6 +208,39 @@ o_find_ix_num(IndexPath *ix_path, OTableDescr *descr)
 			return ix_num;
 	}
 	return -1;
+}
+
+/*
+ * Whether every leaf of a bitmap qual path is a native OrioleDB index (so the
+ * bitmap scan builds a key bitmap rather than a bridge TIDBitmap).  The
+ * parallel bitmap heap scan only supports the native key-bitmap path.
+ */
+static bool
+bitmap_qual_all_native(Path *bitmapqual, OTableDescr *descr)
+{
+	ListCell   *lc;
+
+	if (IsA(bitmapqual, IndexPath))
+		return o_find_ix_num((IndexPath *) bitmapqual, descr) >= 0;
+	else if (IsA(bitmapqual, BitmapAndPath))
+	{
+		foreach(lc, ((BitmapAndPath *) bitmapqual)->bitmapquals)
+		{
+			if (!bitmap_qual_all_native((Path *) lfirst(lc), descr))
+				return false;
+		}
+		return true;
+	}
+	else if (IsA(bitmapqual, BitmapOrPath))
+	{
+		foreach(lc, ((BitmapOrPath *) bitmapqual)->bitmapquals)
+		{
+			if (!bitmap_qual_all_native((Path *) lfirst(lc), descr))
+				return false;
+		}
+		return true;
+	}
+	return false;
 }
 
 /*
@@ -573,12 +633,45 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 							list_delete_nth_cell(rel->partial_pathlist, i);
 					}
 				}
+				else if (IsA(path, BitmapHeapPath))
+				{
+					BitmapHeapPath *bh_path = (BitmapHeapPath *) path;
+
+					/*
+					 * Transform a partial BitmapHeapPath into a
+					 * parallel-aware custom bitmap scan: the first worker
+					 * builds the key bitmap and the primary tree is fetched
+					 * cooperatively. Only the native key-bitmap path is
+					 * parallelized, so the qual must reference only OrioleDB
+					 * indexes and the primary key must be bitmap-eligible.
+					 */
+					if (o_keybitmap_pk_mode(GET_PRIMARY(descr), NULL) !=
+						O_KEYBITMAP_NONE &&
+						bitmap_qual_all_native(bh_path->bitmapqual, descr))
+					{
+						Path	   *custom_path = transform_path(path, descr,
+																 false);
+
+						custom_path->parallel_aware = true;
+						if (custom_path->parallel_workers < 1)
+							custom_path->parallel_workers = 1;
+
+						rel->partial_pathlist =
+							list_delete_nth_cell(rel->partial_pathlist, i);
+						rel->partial_pathlist =
+							list_insert_nth(rel->partial_pathlist, i,
+											custom_path);
+						i++;
+					}
+					else
+					{
+						rel->partial_pathlist =
+							list_delete_nth_cell(rel->partial_pathlist, i);
+					}
+				}
 				else if (!IsA(path, Path))
 				{
-					/*
-					 * TODO: Remove when parallel bitmap heap scan will be
-					 * implemented
-					 */
+					/* Other partial paths are not supported yet. */
 					rel->partial_pathlist =
 						list_delete_nth_cell(rel->partial_pathlist, i);
 				}
@@ -782,6 +875,9 @@ o_create_custom_scan_state(CustomScan *cscan)
 		bitmap_state->bitmapqualplan = copyObject(bh_scan->scan.plan.lefttree);
 		bitmap_state->bitmapqualorig = copyObject(bh_scan->bitmapqualorig);
 		ocstate->o_plan_state = (OPlanState *) bitmap_state;
+
+		if (cscan->scan.plan.parallel_aware)
+			ocstate->css.methods = &o_parallel_bitmap_scan_exec_methods;
 	}
 	else
 	{
@@ -1455,4 +1551,65 @@ o_idx_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
 	orioledb_parallelscan_initialize_inner(&poscan->phs_base);
 
 	ix_plan_state->ostate.seqScan = NULL;
+}
+
+static Size
+o_bitmap_scan_estimate_dsm(CustomScanState *node, ParallelContext *pcxt)
+{
+	return MAXALIGN(sizeof(ParallelOBitmapScanDesc));
+}
+
+static void
+o_bitmap_scan_init_dsm(CustomScanState *node, ParallelContext *pcxt,
+					   void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OBitmapHeapPlanState *bitmap_state =
+		(OBitmapHeapPlanState *) ocstate->o_plan_state;
+	ParallelOBitmapScan pbitmap = (ParallelOBitmapScan) coordinate;
+
+	orioledb_parallelscan_initialize_inner(&pbitmap->poscan.phs_base);
+	SpinLockInit(&pbitmap->mutex);
+	ConditionVariableInit(&pbitmap->cv);
+	pbitmap->stage = OBITMAP_PARALLEL_NEW;
+	pbitmap->empty = false;
+	pbitmap->bitmap_dsa = InvalidDsaPointer;
+	pbitmap->bitmap_size = 0;
+
+	bitmap_state->pbitmap = pbitmap;
+	bitmap_state->dsa = node->ss.ps.state->es_query_dsa;
+	node->pscan_len = sizeof(ParallelOBitmapScanDesc);
+}
+
+static void
+o_bitmap_scan_init_worker(CustomScanState *node, shm_toc *toc,
+						  void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OBitmapHeapPlanState *bitmap_state =
+		(OBitmapHeapPlanState *) ocstate->o_plan_state;
+	ParallelOBitmapScan pbitmap = (ParallelOBitmapScan) coordinate;
+
+	bitmap_state->pbitmap = pbitmap;
+	bitmap_state->dsa = node->ss.ps.state->es_query_dsa;
+}
+
+static void
+o_bitmap_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
+						 void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OBitmapHeapPlanState *bitmap_state =
+		(OBitmapHeapPlanState *) ocstate->o_plan_state;
+	ParallelOBitmapScan pbitmap = (ParallelOBitmapScan) coordinate;
+
+	/* Drop a bitmap built by the previous scan iteration (rescan). */
+	if (DsaPointerIsValid(pbitmap->bitmap_dsa) && bitmap_state->dsa != NULL)
+		dsa_free(bitmap_state->dsa, pbitmap->bitmap_dsa);
+
+	orioledb_parallelscan_initialize_inner(&pbitmap->poscan.phs_base);
+	pbitmap->stage = OBITMAP_PARALLEL_NEW;
+	pbitmap->empty = false;
+	pbitmap->bitmap_dsa = InvalidDsaPointer;
+	pbitmap->bitmap_size = 0;
 }

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -260,6 +260,19 @@ bitmap_qual_all_native(Path *bitmapqual, OTableDescr *descr)
 }
 
 /*
+ * Whether a bitmap qual is a single bridged-index scan -- one IndexPath whose
+ * index is not a native OrioleDB index (so the scan builds a bridge TIDBitmap).
+ * The parallel bitmap scan supports this via a shared DSA TIDBitmap; And/Or
+ * combinations of bridged indexes are not parallelized (they stay serial).
+ */
+static bool
+bitmap_qual_single_bridged(Path *bitmapqual, OTableDescr *descr)
+{
+	return IsA(bitmapqual, IndexPath) &&
+		o_find_ix_num((IndexPath *) bitmapqual, descr) < 0;
+}
+
+/*
  * Estimate the number of parallel workers for a parallel index scan.
  */
 static int
@@ -673,16 +686,17 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 					/*
 					 * Transform a partial BitmapHeapPath into a
 					 * parallel-aware custom bitmap scan: the first worker
-					 * builds the key bitmap and the primary tree is fetched
-					 * cooperatively. Only the native key-bitmap path is
-					 * parallelized, so the qual must reference only OrioleDB
-					 * indexes and the primary key must be bitmap-eligible.
-					 * Parallel scans are not supported during recovery.
+					 * builds the bitmap and the primary tree is fetched
+					 * cooperatively.  Supported when the primary key is
+					 * bitmap-eligible and the qual is either all native
+					 * OrioleDB indexes (key bitmap) or a single bridged index
+					 * (shared DSA TIDBitmap).  Not supported during recovery.
 					 */
 					if (!RecoveryInProgress() &&
 						o_keybitmap_pk_mode(GET_PRIMARY(descr), NULL) !=
 						O_KEYBITMAP_NONE &&
-						bitmap_qual_all_native(bh_path->bitmapqual, descr))
+						(bitmap_qual_all_native(bh_path->bitmapqual, descr) ||
+						 bitmap_qual_single_bridged(bh_path->bitmapqual, descr)))
 					{
 						Path	   *custom_path = transform_path(path, descr,
 																 false);
@@ -1620,6 +1634,8 @@ o_bitmap_scan_init_dsm(CustomScanState *node, ParallelContext *pcxt,
 	pbitmap->empty = false;
 	pbitmap->bitmap_dsa = InvalidDsaPointer;
 	pbitmap->bitmap_size = 0;
+	pbitmap->is_bridge = false;
+	pbitmap->tbm_iter = InvalidDsaPointer;
 
 	bitmap_state->pbitmap = pbitmap;
 	bitmap_state->dsa = node->ss.ps.state->es_query_dsa;
@@ -1657,4 +1673,6 @@ o_bitmap_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
 	pbitmap->empty = false;
 	pbitmap->bitmap_dsa = InvalidDsaPointer;
 	pbitmap->bitmap_size = 0;
+	pbitmap->is_bridge = false;
+	pbitmap->tbm_iter = InvalidDsaPointer;
 }

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -105,6 +105,15 @@ static void o_idx_scan_init_worker(CustomScanState *node,
 static void o_idx_scan_reinit_dsm(CustomScanState *node,
 								  ParallelContext *pcxt, void *coordinate);
 
+static Size o_bitmap_scan_estimate_dsm(CustomScanState *node,
+									   ParallelContext *pcxt);
+static void o_bitmap_scan_init_dsm(CustomScanState *node,
+								   ParallelContext *pcxt, void *coordinate);
+static void o_bitmap_scan_init_worker(CustomScanState *node,
+									  shm_toc *toc, void *coordinate);
+static void o_bitmap_scan_reinit_dsm(CustomScanState *node,
+									 ParallelContext *pcxt, void *coordinate);
+
 static CustomPathMethods o_path_methods =
 {
 	.CustomName = "o_path",
@@ -151,6 +160,23 @@ static CustomExecMethods o_parallel_idx_scan_exec_methods =
 	o_explain_custom_scan
 };
 
+static CustomExecMethods o_parallel_bitmap_scan_exec_methods =
+{
+	"o_exec_parallel_bitmap_scan",
+	o_begin_custom_scan,
+	o_exec_custom_scan,
+	o_end_custom_scan,
+	o_rescan_custom_scan,
+	NULL,
+	NULL,
+	o_bitmap_scan_estimate_dsm,
+	o_bitmap_scan_init_dsm,
+	o_bitmap_scan_reinit_dsm,
+	o_bitmap_scan_init_worker,
+	NULL,
+	o_explain_custom_scan
+};
+
 /* No existing callers */
 bool
 is_o_custom_scan(CustomScan *scan)
@@ -163,7 +189,8 @@ bool
 is_o_custom_scan_state(CustomScanState *scan)
 {
 	return scan->methods == &o_scan_exec_methods ||
-		scan->methods == &o_parallel_idx_scan_exec_methods;
+		scan->methods == &o_parallel_idx_scan_exec_methods ||
+		scan->methods == &o_parallel_bitmap_scan_exec_methods;
 }
 
 /*
@@ -197,6 +224,39 @@ static inline double
 o_index_path_pages(IndexPath *ipath)
 {
 	return (double) ipath->indexinfo->pages * ipath->indexselectivity;
+}
+
+/*
+ * Whether every leaf of a bitmap qual path is a native OrioleDB index (so the
+ * bitmap scan builds a key bitmap rather than a bridge TIDBitmap).  The
+ * parallel bitmap heap scan only supports the native key-bitmap path.
+ */
+static bool
+bitmap_qual_all_native(Path *bitmapqual, OTableDescr *descr)
+{
+	ListCell   *lc;
+
+	if (IsA(bitmapqual, IndexPath))
+		return o_find_ix_num((IndexPath *) bitmapqual, descr) >= 0;
+	else if (IsA(bitmapqual, BitmapAndPath))
+	{
+		foreach(lc, ((BitmapAndPath *) bitmapqual)->bitmapquals)
+		{
+			if (!bitmap_qual_all_native((Path *) lfirst(lc), descr))
+				return false;
+		}
+		return true;
+	}
+	else if (IsA(bitmapqual, BitmapOrPath))
+	{
+		foreach(lc, ((BitmapOrPath *) bitmapqual)->bitmapquals)
+		{
+			if (!bitmap_qual_all_native((Path *) lfirst(lc), descr))
+				return false;
+		}
+		return true;
+	}
+	return false;
 }
 
 /*
@@ -606,12 +666,47 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 							list_delete_nth_cell(rel->partial_pathlist, i);
 					}
 				}
+				else if (IsA(path, BitmapHeapPath))
+				{
+					BitmapHeapPath *bh_path = (BitmapHeapPath *) path;
+
+					/*
+					 * Transform a partial BitmapHeapPath into a
+					 * parallel-aware custom bitmap scan: the first worker
+					 * builds the key bitmap and the primary tree is fetched
+					 * cooperatively. Only the native key-bitmap path is
+					 * parallelized, so the qual must reference only OrioleDB
+					 * indexes and the primary key must be bitmap-eligible.
+					 * Parallel scans are not supported during recovery.
+					 */
+					if (!RecoveryInProgress() &&
+						o_keybitmap_pk_mode(GET_PRIMARY(descr), NULL) !=
+						O_KEYBITMAP_NONE &&
+						bitmap_qual_all_native(bh_path->bitmapqual, descr))
+					{
+						Path	   *custom_path = transform_path(path, descr,
+																 false);
+
+						custom_path->parallel_aware = true;
+						if (custom_path->parallel_workers < 1)
+							custom_path->parallel_workers = 1;
+
+						rel->partial_pathlist =
+							list_delete_nth_cell(rel->partial_pathlist, i);
+						rel->partial_pathlist =
+							list_insert_nth(rel->partial_pathlist, i,
+											custom_path);
+						i++;
+					}
+					else
+					{
+						rel->partial_pathlist =
+							list_delete_nth_cell(rel->partial_pathlist, i);
+					}
+				}
 				else if (!IsA(path, Path))
 				{
-					/*
-					 * TODO: Remove when parallel bitmap heap scan will be
-					 * implemented
-					 */
+					/* Other partial paths are not supported yet. */
 					rel->partial_pathlist =
 						list_delete_nth_cell(rel->partial_pathlist, i);
 				}
@@ -815,6 +910,9 @@ o_create_custom_scan_state(CustomScan *cscan)
 		bitmap_state->bitmapqualplan = copyObject(bh_scan->scan.plan.lefttree);
 		bitmap_state->bitmapqualorig = copyObject(bh_scan->bitmapqualorig);
 		ocstate->o_plan_state = (OPlanState *) bitmap_state;
+
+		if (cscan->scan.plan.parallel_aware)
+			ocstate->css.methods = &o_parallel_bitmap_scan_exec_methods;
 	}
 	else
 	{
@@ -1498,4 +1596,65 @@ o_idx_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
 	orioledb_parallelscan_initialize_inner(&poscan->phs_base);
 
 	ix_plan_state->ostate.seqScan = NULL;
+}
+
+static Size
+o_bitmap_scan_estimate_dsm(CustomScanState *node, ParallelContext *pcxt)
+{
+	return MAXALIGN(sizeof(ParallelOBitmapScanDesc));
+}
+
+static void
+o_bitmap_scan_init_dsm(CustomScanState *node, ParallelContext *pcxt,
+					   void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OBitmapHeapPlanState *bitmap_state =
+		(OBitmapHeapPlanState *) ocstate->o_plan_state;
+	ParallelOBitmapScan pbitmap = (ParallelOBitmapScan) coordinate;
+
+	orioledb_parallelscan_initialize_inner(&pbitmap->poscan.phs_base);
+	SpinLockInit(&pbitmap->mutex);
+	ConditionVariableInit(&pbitmap->cv);
+	pbitmap->stage = OBITMAP_PARALLEL_NEW;
+	pbitmap->empty = false;
+	pbitmap->bitmap_dsa = InvalidDsaPointer;
+	pbitmap->bitmap_size = 0;
+
+	bitmap_state->pbitmap = pbitmap;
+	bitmap_state->dsa = node->ss.ps.state->es_query_dsa;
+	node->pscan_len = sizeof(ParallelOBitmapScanDesc);
+}
+
+static void
+o_bitmap_scan_init_worker(CustomScanState *node, shm_toc *toc,
+						  void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OBitmapHeapPlanState *bitmap_state =
+		(OBitmapHeapPlanState *) ocstate->o_plan_state;
+	ParallelOBitmapScan pbitmap = (ParallelOBitmapScan) coordinate;
+
+	bitmap_state->pbitmap = pbitmap;
+	bitmap_state->dsa = node->ss.ps.state->es_query_dsa;
+}
+
+static void
+o_bitmap_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
+						 void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OBitmapHeapPlanState *bitmap_state =
+		(OBitmapHeapPlanState *) ocstate->o_plan_state;
+	ParallelOBitmapScan pbitmap = (ParallelOBitmapScan) coordinate;
+
+	/* Drop a bitmap built by the previous scan iteration (rescan). */
+	if (DsaPointerIsValid(pbitmap->bitmap_dsa) && bitmap_state->dsa != NULL)
+		dsa_free(bitmap_state->dsa, pbitmap->bitmap_dsa);
+
+	orioledb_parallelscan_initialize_inner(&pbitmap->poscan.phs_base);
+	pbitmap->stage = OBITMAP_PARALLEL_NEW;
+	pbitmap->empty = false;
+	pbitmap->bitmap_dsa = InvalidDsaPointer;
+	pbitmap->bitmap_size = 0;
 }

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -34,6 +34,7 @@
 #include "access/xlog.h"
 #include "common/hashfn.h"
 #include "executor/executor.h"
+#include "nodes/tidbitmap.h"
 #include "executor/nodeIndexscan.h"
 #include "executor/nodeModifyTable.h"
 #if PG_VERSION_NUM >= 180000
@@ -1664,9 +1665,22 @@ o_bitmap_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
 		(OBitmapHeapPlanState *) ocstate->o_plan_state;
 	ParallelOBitmapScan pbitmap = (ParallelOBitmapScan) coordinate;
 
-	/* Drop a bitmap built by the previous scan iteration (rescan). */
-	if (DsaPointerIsValid(pbitmap->bitmap_dsa) && bitmap_state->dsa != NULL)
-		dsa_free(bitmap_state->dsa, pbitmap->bitmap_dsa);
+	/* Drop what the previous scan iteration built (rescan). */
+	if (bitmap_state->dsa != NULL)
+	{
+		if (DsaPointerIsValid(pbitmap->bitmap_dsa))
+			dsa_free(bitmap_state->dsa, pbitmap->bitmap_dsa);
+
+		/*
+		 * The bridged path publishes a shared TIDBitmap iterator for the
+		 * workers to attach to (tbm_prepare_shared_iterate()).  It is a DSA
+		 * allocation of its own, so clearing the pointer below would leak it
+		 * once per rescan; ExecBitmapHeapReInitializeDSM() frees its
+		 * equivalent here for the same reason.
+		 */
+		if (DsaPointerIsValid(pbitmap->tbm_iter))
+			tbm_free_shared_area(bitmap_state->dsa, pbitmap->tbm_iter);
+	}
 
 	orioledb_parallelscan_initialize_inner(&pbitmap->poscan.phs_base);
 	pbitmap->stage = OBITMAP_PARALLEL_NEW;

--- a/test/expected/parallel_bitmap_scan.out
+++ b/test/expected/parallel_bitmap_scan.out
@@ -1,0 +1,278 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan s2_insert s2_checkpoint s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_indexscan = off;
+	SET enable_indexonlyscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan: 
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE val < 50 AND sqrt(id::float8) >= 0; <waiting ...>
+step s2_insert: 
+	INSERT INTO o_bm SELECT i, i % 1000
+		FROM generate_series(1000000, 1030000) i;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan: <... completed>
+count|min|  max|     sum
+-----+---+-----+--------
+ 2000|  1|40000|39089000
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan s2_delete s2_checkpoint s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_indexscan = off;
+	SET enable_indexonlyscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan: 
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE val < 50 AND sqrt(id::float8) >= 0; <waiting ...>
+step s2_delete: 
+	DELETE FROM o_bm WHERE id BETWEEN 3000 AND 12000;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan: <... completed>
+count|min|  max|     sum
+-----+---+-----+--------
+ 2000|  1|40000|39089000
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan s2_update s2_evict s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_indexscan = off;
+	SET enable_indexonlyscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan: 
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE val < 50 AND sqrt(id::float8) >= 0; <waiting ...>
+step s2_update: 
+	UPDATE o_bm SET val = val + 1 WHERE id BETWEEN 5000 AND 8000;
+step s2_evict: 
+	SELECT orioledb_evict_pages('o_bm'::regclass::oid, 0);
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan: <... completed>
+count|min|  max|     sum
+-----+---+-----+--------
+ 2000|  1|40000|39089000
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan_or s2_insert s2_delete s2_checkpoint s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_indexscan = off;
+	SET enable_indexonlyscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan_or: 
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0; <waiting ...>
+step s2_insert: 
+	INSERT INTO o_bm SELECT i, i % 1000
+		FROM generate_series(1000000, 1030000) i;
+step s2_delete: 
+	DELETE FROM o_bm WHERE id BETWEEN 3000 AND 12000;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan_or: <... completed>
+count|min|  max|     sum
+-----+---+-----+--------
+ 2360|  1|40000|47220000
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rc s1_scan s2_delete s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_indexscan = off;
+	SET enable_indexonlyscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rc: BEGIN ISOLATION LEVEL READ COMMITTED;
+step s1_scan: 
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE val < 50 AND sqrt(id::float8) >= 0; <waiting ...>
+step s2_delete: 
+	DELETE FROM o_bm WHERE id BETWEEN 3000 AND 12000;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan: <... completed>
+count|min|  max|     sum
+-----+---+-----+--------
+ 2000|  1|40000|39089000
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_scan s2_update s2_checkpoint s2_reset
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_indexscan = off;
+	SET enable_indexonlyscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_scan: 
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE val < 50 AND sqrt(id::float8) >= 0; <waiting ...>
+step s2_update: 
+	UPDATE o_bm SET val = val + 1 WHERE id BETWEEN 5000 AND 8000;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan: <... completed>
+count|min|  max|     sum
+-----+---+-----+--------
+ 2000|  1|40000|39089000
+(1 row)
+

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1384,8 +1384,118 @@ SELECT count(*), min(id), max(id) FROM (
 (1 row)
 
 COMMIT;
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1405,6 +1515,8 @@ drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
+drop cascades to table o_test_parallel_bitmap
+drop cascades to table o_test_parallel_bitmap_fixed
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1494,8 +1494,75 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 (1 row)
 
 COMMIT;
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+ANALYZE o_test_parallel_bitmap_bridged;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1517,6 +1584,7 @@ drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
+drop cascades to table o_test_parallel_bitmap_bridged
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1646,6 +1646,56 @@ SELECT count(*) FROM o_test_parallel_bitmap_bridged
      0
 (1 row)
 
+-- Rescan of the bridged path.  Putting the Gather on the inner side of a
+-- nested loop (enable_material = off keeps it from being materialized away)
+-- shuts it down and relaunches it once per outer row, so o_bitmap_scan_reinit_
+-- dsm() runs between iterations on a scan that published a shared TIDBitmap
+-- iterator -- the one path where it has a tbm_iter to release, and one no
+-- other test reaches.
+--
+-- What this checks is that reinitializing does not disturb a live scan: a
+-- misplaced free of the shared iterator surfaces here as a crash or a wrong
+-- count.  It cannot check that the shared state was reset at all, because the
+-- bound is the same on every iteration, so a bitmap carried over from the
+-- previous one would still give the right answer.  A correlated bound would
+-- distinguish the two, but the planner does not put a Gather under a
+-- parameterized nested loop, so that plan shape is not reachable from SQL.
+SET LOCAL enable_material = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM
+		(SELECT count(*) AS cnt, sum(id) AS total
+			FROM o_test_parallel_bitmap_bridged
+			WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+		RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Values Scan on "*VALUES*"
+   ->  Finalize Aggregate
+         ->  Gather
+               Workers Planned: 3
+               ->  Partial Aggregate
+                     ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                           Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                           Bitmap heap scan
+                           Recheck Cond: (val < 50)
+                           ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                                 Index Cond: (val < 50)
+(12 rows)
+
+SELECT * FROM
+	(SELECT count(*) AS cnt, sum(id) AS total
+		FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+	RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+  cnt  |   total   | x 
+-------+-----------+---
+ 10000 | 995445000 | 1
+ 10000 | 995445000 | 2
+ 10000 | 995445000 | 3
+(3 rows)
+
+RESET enable_material;
 COMMIT;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 22 other objects

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1470,8 +1470,118 @@ SELECT count(*), min(id), max(id) FROM (
 (1 row)
 
 COMMIT;
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1491,6 +1601,8 @@ drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
+drop cascades to table o_test_parallel_bitmap
+drop cascades to table o_test_parallel_bitmap_fixed
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1580,8 +1580,75 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 (1 row)
 
 COMMIT;
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+ANALYZE o_test_parallel_bitmap_bridged;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1603,6 +1670,7 @@ drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
+drop cascades to table o_test_parallel_bitmap_bridged
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1384,8 +1384,118 @@ SELECT count(*), min(id), max(id) FROM (
 (1 row)
 
 COMMIT;
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1405,6 +1515,8 @@ drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
+drop cascades to table o_test_parallel_bitmap
+drop cascades to table o_test_parallel_bitmap_fixed
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1494,8 +1494,75 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 (1 row)
 
 COMMIT;
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+ANALYZE o_test_parallel_bitmap_bridged;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1517,6 +1584,7 @@ drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
+drop cascades to table o_test_parallel_bitmap_bridged
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1577,8 +1577,75 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 (1 row)
 
 COMMIT;
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+ANALYZE o_test_parallel_bitmap_bridged;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1600,6 +1667,7 @@ drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
+drop cascades to table o_test_parallel_bitmap_bridged
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1467,8 +1467,118 @@ SELECT count(*), min(id), max(id) FROM (
 (1 row)
 
 COMMIT;
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1488,6 +1598,8 @@ drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
+drop cascades to table o_test_parallel_bitmap
+drop cascades to table o_test_parallel_bitmap_fixed
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1643,6 +1643,56 @@ SELECT count(*) FROM o_test_parallel_bitmap_bridged
      0
 (1 row)
 
+-- Rescan of the bridged path.  Putting the Gather on the inner side of a
+-- nested loop (enable_material = off keeps it from being materialized away)
+-- shuts it down and relaunches it once per outer row, so o_bitmap_scan_reinit_
+-- dsm() runs between iterations on a scan that published a shared TIDBitmap
+-- iterator -- the one path where it has a tbm_iter to release, and one no
+-- other test reaches.
+--
+-- What this checks is that reinitializing does not disturb a live scan: a
+-- misplaced free of the shared iterator surfaces here as a crash or a wrong
+-- count.  It cannot check that the shared state was reset at all, because the
+-- bound is the same on every iteration, so a bitmap carried over from the
+-- previous one would still give the right answer.  A correlated bound would
+-- distinguish the two, but the planner does not put a Gather under a
+-- parameterized nested loop, so that plan shape is not reachable from SQL.
+SET LOCAL enable_material = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM
+		(SELECT count(*) AS cnt, sum(id) AS total
+			FROM o_test_parallel_bitmap_bridged
+			WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+		RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Values Scan on "*VALUES*"
+   ->  Finalize Aggregate
+         ->  Gather
+               Workers Planned: 3
+               ->  Partial Aggregate
+                     ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                           Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                           Bitmap heap scan
+                           Recheck Cond: (val < 50)
+                           ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                                 Index Cond: (val < 50)
+(12 rows)
+
+SELECT * FROM
+	(SELECT count(*) AS cnt, sum(id) AS total
+		FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+	RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+  cnt  |   total   | x 
+-------+-----------+---
+ 10000 | 995445000 | 1
+ 10000 | 995445000 | 2
+ 10000 | 995445000 | 3
+(3 rows)
+
+RESET enable_material;
 COMMIT;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 22 other objects

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -1495,8 +1495,75 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 (1 row)
 
 COMMIT;
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+ANALYZE o_test_parallel_bitmap_bridged;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1518,6 +1585,7 @@ drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
+drop cascades to table o_test_parallel_bitmap_bridged
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -1385,8 +1385,118 @@ SELECT count(*), min(id), max(id) FROM (
 (1 row)
 
 COMMIT;
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1406,6 +1516,8 @@ drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
+drop cascades to table o_test_parallel_bitmap
+drop cascades to table o_test_parallel_bitmap_fixed
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -1577,8 +1577,75 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 (1 row)
 
 COMMIT;
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+ANALYZE o_test_parallel_bitmap_bridged;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1600,6 +1667,7 @@ drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
+drop cascades to table o_test_parallel_bitmap_bridged
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -1467,8 +1467,118 @@ SELECT count(*), min(id), max(id) FROM (
 (1 row)
 
 COMMIT;
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 3
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap
+                     Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                     Bitmap heap scan
+                     Recheck Cond: (val < 50)
+                     ->  Bitmap Index Scan on o_test_parallel_bitmap_val
+                           Index Cond: (val < 50)
+(10 rows)
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+ count |    sum    
+-------+-----------
+ 10000 | 995445000
+(1 row)
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+ count |    sum     
+-------+------------
+ 11800 | 1180100000
+(1 row)
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+ count 
+-------
+     0
+(1 row)
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+ count |    sum    
+-------+-----------
+  4800 | 285813600
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1488,6 +1598,8 @@ drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
 drop cascades to table o_test_ordered_scan
+drop cascades to table o_test_parallel_bitmap
+drop cascades to table o_test_parallel_bitmap_fixed
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -1643,6 +1643,56 @@ SELECT count(*) FROM o_test_parallel_bitmap_bridged
      0
 (1 row)
 
+-- Rescan of the bridged path.  Putting the Gather on the inner side of a
+-- nested loop (enable_material = off keeps it from being materialized away)
+-- shuts it down and relaunches it once per outer row, so o_bitmap_scan_reinit_
+-- dsm() runs between iterations on a scan that published a shared TIDBitmap
+-- iterator -- the one path where it has a tbm_iter to release, and one no
+-- other test reaches.
+--
+-- What this checks is that reinitializing does not disturb a live scan: a
+-- misplaced free of the shared iterator surfaces here as a crash or a wrong
+-- count.  It cannot check that the shared state was reset at all, because the
+-- bound is the same on every iteration, so a bitmap carried over from the
+-- previous one would still give the right answer.  A correlated bound would
+-- distinguish the two, but the planner does not put a Gather under a
+-- parameterized nested loop, so that plan shape is not reachable from SQL.
+SET LOCAL enable_material = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM
+		(SELECT count(*) AS cnt, sum(id) AS total
+			FROM o_test_parallel_bitmap_bridged
+			WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+		RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Values Scan on "*VALUES*"
+   ->  Finalize Aggregate
+         ->  Gather
+               Workers Planned: 3
+               ->  Partial Aggregate
+                     ->  Parallel Custom Scan (o_scan) on o_test_parallel_bitmap_bridged
+                           Filter: (sqrt((id)::double precision) >= '0'::double precision)
+                           Bitmap heap scan
+                           Recheck Cond: (val < 50)
+                           ->  Bitmap Index Scan on o_test_parallel_bitmap_bridged_val
+                                 Index Cond: (val < 50)
+(12 rows)
+
+SELECT * FROM
+	(SELECT count(*) AS cnt, sum(id) AS total
+		FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+	RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+  cnt  |   total   | x 
+-------+-----------+---
+ 10000 | 995445000 | 1
+ 10000 | 995445000 | 2
+ 10000 | 995445000 | 3
+(3 rows)
+
+RESET enable_material;
 COMMIT;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 22 other objects

--- a/test/specs/parallel_bitmap_scan.spec
+++ b/test/specs/parallel_bitmap_scan.spec
@@ -1,0 +1,95 @@
+# Parallel bitmap heap scan under concurrency.
+#
+# The scanning session parks a parallel bitmap scan in the middle of reading an
+# on-disk leaf (the scan_disk_page stop event, which the leader hits while
+# building the key bitmap or fetching the primary tree cooperatively).  While
+# it is parked, the other session mutates the matching range -- inserting (page
+# splits), deleting (merges), updating, checkpoint, re-eviction -- and only then
+# releases the scan.  The resumed scan must still return its snapshot-consistent
+# result, proving the shared read-only bitmap and the cooperative primary fetch
+# survive the tree changing shape underneath it.
+#
+# An always-true but per-row-expensive sqrt() filter makes the parallel bitmap
+# path win, so the planner picks Gather over a parallel custom bitmap scan.
+
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+	CREATE TABLE IF NOT EXISTS o_bm (
+		id int8 NOT NULL,
+		val int8 NOT NULL,
+		PRIMARY KEY (id)
+	) USING orioledb;
+	TRUNCATE o_bm;
+	INSERT INTO o_bm SELECT i, i % 1000 FROM generate_series(1, 40000) i;
+	CREATE INDEX IF NOT EXISTS o_bm_val ON o_bm (val);
+	ANALYZE o_bm;
+	CHECKPOINT;
+	SELECT orioledb_evict_pages('o_bm'::regclass::oid, 0);
+}
+
+teardown
+{
+	DROP TABLE o_bm;
+}
+
+# --- scanning session -------------------------------------------------------
+session "s1"
+step "s1_setup" {
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_indexscan = off;
+	SET enable_indexonlyscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3; }
+step "s1_begin_rr" { BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; }
+step "s1_begin_rc" { BEGIN ISOLATION LEVEL READ COMMITTED; }
+# Parallel bitmap scan: parks on the first on-disk leaf, resumes after reset.
+step "s1_scan" {
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE val < 50 AND sqrt(id::float8) >= 0; }
+# BitmapOr variant.
+step "s1_scan_or" {
+	SELECT count(*), min(id), max(id), sum(id)
+		FROM o_bm WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0; }
+step "s1_commit" { COMMIT; }
+
+# --- controller / modifier session ------------------------------------------
+session "s2"
+step "s2_arm" {
+	SELECT pg_stopevent_set('scan_disk_page', 'true'); }
+step "s2_insert" {
+	INSERT INTO o_bm SELECT i, i % 1000
+		FROM generate_series(1000000, 1030000) i; }
+step "s2_delete" {
+	DELETE FROM o_bm WHERE id BETWEEN 3000 AND 12000; }
+step "s2_update" {
+	UPDATE o_bm SET val = val + 1 WHERE id BETWEEN 5000 AND 8000; }
+step "s2_checkpoint" { CHECKPOINT; }
+step "s2_evict" {
+	SELECT orioledb_evict_pages('o_bm'::regclass::oid, 0); }
+step "s2_reset" {
+	SELECT pg_stopevent_reset('scan_disk_page'); }
+
+# REPEATABLE READ: paused bitmap scan is unaffected by concurrent inserts
+# (page splits) committed while it is parked.
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan" "s2_insert" "s2_checkpoint" "s2_reset" "s1_commit"
+
+# REPEATABLE READ: paused bitmap scan unaffected by concurrent deletes (merges).
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan" "s2_delete" "s2_checkpoint" "s2_reset" "s1_commit"
+
+# REPEATABLE READ: paused bitmap scan unaffected by concurrent update + re-eviction.
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan" "s2_update" "s2_evict" "s2_reset" "s1_commit"
+
+# REPEATABLE READ: BitmapOr scan, concurrent insert + delete + checkpoint.
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan_or" "s2_insert" "s2_delete" "s2_checkpoint" "s2_reset" "s1_commit"
+
+# READ COMMITTED: the scan's snapshot is fixed at statement start, so a commit
+# landing while it is parked is still not visible; result stays consistent.
+permutation "s2_arm" "s1_setup" "s1_begin_rc" "s1_scan" "s2_delete" "s2_reset" "s1_commit"
+
+# Autocommit (no explicit BEGIN): paused bitmap scan + concurrent update.
+permutation "s2_arm" "s1_setup" "s1_scan" "s2_update" "s2_checkpoint" "s2_reset"

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -756,6 +756,47 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 	WHERE val < 40 AND sqrt(a::float8) >= 0;
 COMMIT;
 
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+ANALYZE o_test_parallel_bitmap_bridged;
+
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+COMMIT;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA parallel_scan CASCADE;
 RESET search_path;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -687,6 +687,75 @@ SELECT count(*), min(id), max(id) FROM (
 		WHERE sqrt(val::float8) >= 0 ORDER BY id DESC) s;
 COMMIT;
 
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+COMMIT;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA parallel_scan CASCADE;
 RESET search_path;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -725,6 +725,75 @@ SELECT count(*), min(id), max(id) FROM (
 		WHERE sqrt(val::float8) >= 0 ORDER BY id DESC) s;
 COMMIT;
 
+-- Parallel bitmap heap scan.  The first worker builds the key bitmap and the
+-- primary tree is fetched cooperatively.  An always-true but per-row-expensive
+-- sqrt() filter makes the parallel bitmap path win, so the planner picks
+-- Gather over a Parallel Custom Scan bitmap scan.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_val ON o_test_parallel_bitmap (val);
+ANALYZE o_test_parallel_bitmap;
+
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+
+-- Plan shape: Gather over a parallel custom bitmap scan.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- Parallel vs serial equivalence (single index).
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- BitmapOr, parallel vs serial.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap
+	WHERE (val < 30 OR val > 970) AND sqrt(id::float8) >= 0;
+
+-- Empty match: parallel scan returns no rows and does not error.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+
+-- Composite (fixed-mode) primary key.
+CREATE TABLE o_test_parallel_bitmap_fixed (
+	a int8,
+	b text,
+	val int8,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_parallel_bitmap_fixed
+	SELECT g, 'k' || (g % 500), g % 1000 FROM generate_series(1, 120000) g;
+CREATE INDEX o_test_parallel_bitmap_fixed_val
+	ON o_test_parallel_bitmap_fixed (val);
+ANALYZE o_test_parallel_bitmap_fixed;
+
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
+	WHERE val < 40 AND sqrt(a::float8) >= 0;
+COMMIT;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA parallel_scan CASCADE;
 RESET search_path;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -833,6 +833,34 @@ SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
 SET LOCAL max_parallel_workers_per_gather = 3;
 SELECT count(*) FROM o_test_parallel_bitmap_bridged
 	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+
+-- Rescan of the bridged path.  Putting the Gather on the inner side of a
+-- nested loop (enable_material = off keeps it from being materialized away)
+-- shuts it down and relaunches it once per outer row, so o_bitmap_scan_reinit_
+-- dsm() runs between iterations on a scan that published a shared TIDBitmap
+-- iterator -- the one path where it has a tbm_iter to release, and one no
+-- other test reaches.
+--
+-- What this checks is that reinitializing does not disturb a live scan: a
+-- misplaced free of the shared iterator surfaces here as a crash or a wrong
+-- count.  It cannot check that the shared state was reset at all, because the
+-- bound is the same on every iteration, so a bitmap carried over from the
+-- previous one would still give the right answer.  A correlated bound would
+-- distinguish the two, but the planner does not put a Gather under a
+-- parameterized nested loop, so that plan shape is not reachable from SQL.
+SET LOCAL enable_material = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM
+		(SELECT count(*) AS cnt, sum(id) AS total
+			FROM o_test_parallel_bitmap_bridged
+			WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+		RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+SELECT * FROM
+	(SELECT count(*) AS cnt, sum(id) AS total
+		FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0) ss
+	RIGHT JOIN (VALUES (1), (2), (3)) v(x) ON true;
+RESET enable_material;
 COMMIT;
 
 DROP EXTENSION orioledb CASCADE;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -794,6 +794,47 @@ SELECT count(*), sum(a) FROM o_test_parallel_bitmap_fixed
 	WHERE val < 40 AND sqrt(a::float8) >= 0;
 COMMIT;
 
+-- Parallel bitmap scan over a single bridged (non-orioledb) index.  The bitmap
+-- qual builds a TIDBitmap in es_query_dsa; workers share its iterator and each
+-- resolves its pages to primary keys.
+BEGIN;
+CREATE TABLE o_test_parallel_bitmap_bridged (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb WITH (index_bridging);
+INSERT INTO o_test_parallel_bitmap_bridged
+	SELECT g, g % 1000 FROM generate_series(1, 200000) g;
+CREATE INDEX o_test_parallel_bitmap_bridged_val
+	ON o_test_parallel_bitmap_bridged USING btree (val) WITH (orioledb_index = off);
+ANALYZE o_test_parallel_bitmap_bridged;
+
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL max_parallel_workers_per_gather = 3;
+
+-- Plan shape: Gather over a parallel custom bitmap scan on the bridged index.
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_bitmap_bridged
+		WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- Parallel vs serial equivalence.
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*), sum(id) FROM o_test_parallel_bitmap_bridged
+	WHERE val < 50 AND sqrt(id::float8) >= 0;
+
+-- Empty match.
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT count(*) FROM o_test_parallel_bitmap_bridged
+	WHERE val = 999999 AND sqrt(id::float8) >= 0;
+COMMIT;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA parallel_scan CASCADE;
 RESET search_path;

--- a/test/t/parallel_bitmap_scan_test.py
+++ b/test/t/parallel_bitmap_scan_test.py
@@ -38,16 +38,22 @@ class ParallelBitmapScanTest(BaseTest):
 		self.node.safe_psql('postgres',
 		                    "CREATE EXTENSION IF NOT EXISTS orioledb;")
 
-	def _load(self):
+	def _load(self, bridged=False):
+		# A bridged secondary index builds a shared DSA TIDBitmap; a native one
+		# builds a shared key bitmap.  Both run the same cooperative fetch.
+		table_opts = " WITH (index_bridging)" if bridged else ""
+		index_sql = ("CREATE INDEX o_bm_val ON o_bm USING btree (val) "
+		             "WITH (orioledb_index = off);"
+		             if bridged else "CREATE INDEX o_bm_val ON o_bm (val);")
 		self.node.safe_psql(
 		    'postgres', f"""
 			DROP TABLE IF EXISTS o_bm;
 			CREATE TABLE o_bm (
 				id int8 PRIMARY KEY,
 				val int8
-			) USING orioledb;
+			) USING orioledb{table_opts};
 			INSERT INTO o_bm SELECT i, i % 1000 FROM generate_series(1, {NROWS}) i;
-			CREATE INDEX o_bm_val ON o_bm (val);
+			{index_sql}
 			ANALYZE o_bm;
 			CHECKPOINT;
 		""")
@@ -99,9 +105,9 @@ class ParallelBitmapScanTest(BaseTest):
 	# Core driver: park a parallel bitmap scan at scan_disk_page, run
 	# mutate(dml_con) while it is parked, release it, and assert the result set
 	# equals the pre-mutation reference.
-	def _run_parked(self, cond, mutate):
+	def _run_parked(self, cond, mutate, bridged=False):
 		node = self.node
-		self._load()
+		self._load(bridged=bridged)
 		reference = self._reference(cond)
 		self.assertGreater(len(reference), 500)
 
@@ -177,6 +183,24 @@ class ParallelBitmapScanTest(BaseTest):
 			con.execute("CHECKPOINT;")
 
 		self._run_parked("val < 30 OR val > 970", mutate)
+
+	# Bridged (non-orioledb) index: the shared DSA TIDBitmap is consumed
+	# cooperatively while the primary tree is mutated (page splits from inserts,
+	# checkpoint, re-eviction) under the parked scan.  Row visibility resolves
+	# from the primary key (the per-page primary scan uses the scan snapshot),
+	# while the bridge index is a separate mapping; to keep the compared result
+	# set deterministic the mutation inserts only non-matching rows (val = 500),
+	# reshaping the tree without changing the val < 50 result.
+	def test_bridged_survives_mutation(self):
+
+		def mutate(con):
+			con.execute("INSERT INTO o_bm SELECT i, 500 FROM "
+			            "generate_series(1000000, 1040000) i;")
+			con.execute("CHECKPOINT;")
+			con.execute(
+			    "SELECT orioledb_evict_pages('o_bm'::regclass::oid, 0);")
+
+		self._run_parked("val < 50", mutate, bridged=True)
 
 	# Two parallel bitmap scans parked at once; cross DML lands while both are
 	# parked, then both are released together.

--- a/test/t/parallel_bitmap_scan_test.py
+++ b/test/t/parallel_bitmap_scan_test.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+# Parallel bitmap heap scan under concurrency, driven with stop events.
+#
+# Each scenario parks a parallel bitmap scan in the middle of reading an
+# on-disk leaf (the scan_disk_page stop event, hit while the first worker
+# builds the key bitmap or while the primary tree is fetched cooperatively) and,
+# while it is parked, mutates the matching range from another connection -- page
+# splits, merges, updates, checkpoints, re-eviction -- before releasing it.  The
+# resumed scan must return exactly its snapshot's matching rows (compared as a
+# sorted set, since the parallel bitmap output is unordered), proving the shared
+# read-only bitmap and the cooperative primary fetch stay correct while the tree
+# changes shape underneath the scan.
+
+import unittest
+
+from .base_test import BaseTest
+from .base_test import ThreadQueryExecutor
+
+# An always-true but per-row-expensive filter makes the parallel bitmap path
+# win, so the planner picks Gather over a parallel custom bitmap scan.
+FILTER = "sqrt(id::float8) >= 0"
+NROWS = 20000
+
+
+class ParallelBitmapScanTest(BaseTest):
+
+	def setUp(self):
+		super().setUp()
+		# Stop events are enabled per-connection in the scanner only, so the
+		# mutating connection never parks on the same event.
+		self.node.append_conf(
+		    'postgresql.conf', "max_worker_processes = 16\n"
+		    "max_parallel_workers = 16\n"
+		    "orioledb.main_buffers = 8MB\n")
+		self.node.start()
+		self.node.safe_psql('postgres',
+		                    "CREATE EXTENSION IF NOT EXISTS orioledb;")
+
+	def _load(self):
+		self.node.safe_psql(
+		    'postgres', f"""
+			DROP TABLE IF EXISTS o_bm;
+			CREATE TABLE o_bm (
+				id int8 PRIMARY KEY,
+				val int8
+			) USING orioledb;
+			INSERT INTO o_bm SELECT i, i % 1000 FROM generate_series(1, {NROWS}) i;
+			CREATE INDEX o_bm_val ON o_bm (val);
+			ANALYZE o_bm;
+			CHECKPOINT;
+		""")
+
+	def _evict(self):
+		self.node.safe_psql(
+		    'postgres',
+		    "SELECT orioledb_evict_pages('o_bm'::regclass::oid, 0);")
+
+	def _scan_setup(self, con):
+		con.execute("SET orioledb.enable_stopevents = true;")
+		con.execute("SET enable_seqscan = off;")
+		con.execute("SET enable_indexscan = off;")
+		con.execute("SET enable_indexonlyscan = off;")
+		con.execute("SET parallel_setup_cost = 0;")
+		con.execute("SET parallel_tuple_cost = 0;")
+		con.execute("SET min_parallel_table_scan_size = 0;")
+		con.execute("SET min_parallel_index_scan_size = 0;")
+		con.execute("SET max_parallel_workers_per_gather = 3;")
+
+	def _scan_sql(self, cond):
+		return f"SELECT id FROM o_bm WHERE ({cond}) AND {FILTER}"
+
+	def _reference(self, cond):
+		rows = self.node.execute(
+		    'postgres', f"SELECT id FROM o_bm WHERE ({cond}) AND {FILTER}")
+		return sorted(r[0] for r in rows)
+
+	def _assert_parallel_plan(self, con, cond):
+		plan = "\n".join(r[0] for r in con.execute("EXPLAIN (COSTS OFF) " +
+		                                           self._scan_sql(cond)))
+		self.assertIn("Gather", plan)
+		self.assertIn("Parallel Custom Scan", plan)
+		self.assertIn("Bitmap", plan)
+
+	def _wait_any_parked(self, ctrl_con, event, timeout=60):
+		import time
+		deadline = time.time() + timeout
+		while True:
+			r = ctrl_con.execute(
+			    "SELECT coalesce(array_length(waiter_pids, 1), 0) "
+			    "FROM pg_stopevents() WHERE stopevent = '%s';" % event)
+			if r and r[0][0] and r[0][0] > 0:
+				return
+			if time.time() > deadline:
+				raise AssertionError("no backend parked on %s" % event)
+			time.sleep(0.05)
+
+	# Core driver: park a parallel bitmap scan at scan_disk_page, run
+	# mutate(dml_con) while it is parked, release it, and assert the result set
+	# equals the pre-mutation reference.
+	def _run_parked(self, cond, mutate):
+		node = self.node
+		self._load()
+		reference = self._reference(cond)
+		self.assertGreater(len(reference), 500)
+
+		scan_con = node.connect()
+		ctrl_con = node.connect()
+		dml_con = node.connect()
+		try:
+			self._scan_setup(scan_con)
+			self._assert_parallel_plan(scan_con, cond)
+
+			self._evict()
+			ctrl_con.execute(
+			    "SELECT pg_stopevent_set('scan_disk_page', 'true');")
+
+			scan = ThreadQueryExecutor(scan_con, self._scan_sql(cond))
+			scan.start()
+			try:
+				self._wait_any_parked(ctrl_con, 'scan_disk_page')
+				self.assertTrue(scan.is_alive())
+				mutate(dml_con)
+			finally:
+				ctrl_con.execute(
+				    "SELECT pg_stopevent_reset('scan_disk_page');")
+
+			result = sorted(r[0] for r in scan.join())
+			self.assertEqual(result, reference)
+			dml_con.commit()
+		finally:
+			scan_con.close()
+			ctrl_con.close()
+			dml_con.close()
+
+		self.assertEqual(
+		    node.execute('postgres',
+		                 "SELECT orioledb_tbl_check('o_bm'::regclass)")[0][0],
+		    True)
+
+	# --- scenarios ----------------------------------------------------------
+
+	# Parked bitmap scan; concurrent inserts split pages, then checkpoint +
+	# re-eviction rewrite them.
+	def test_bitmap_survives_splits(self):
+
+		def mutate(con):
+			con.execute("INSERT INTO o_bm SELECT i, i %% 1000 FROM "
+			            "generate_series(1000000, 1030000) i;")
+			con.execute("CHECKPOINT;")
+			con.execute(
+			    "SELECT orioledb_evict_pages('o_bm'::regclass::oid, 0);")
+
+		self._run_parked("val < 50", mutate)
+
+	# Parked bitmap scan; concurrent deletes across the matching range merge
+	# pages under it.
+	def test_bitmap_survives_merges(self):
+
+		def mutate(con):
+			con.execute("DELETE FROM o_bm WHERE id BETWEEN 3000 AND 12000;")
+			con.execute("CHECKPOINT;")
+
+		self._run_parked("val < 50", mutate)
+
+	# BitmapOr qual; a mix of insert, delete, update and checkpoint land while
+	# the scan is parked.
+	def test_bitmap_or_under_mutation(self):
+
+		def mutate(con):
+			con.execute("INSERT INTO o_bm SELECT i, i %% 1000 FROM "
+			            "generate_series(1000000, 1020000) i;")
+			con.execute("DELETE FROM o_bm WHERE id BETWEEN 5000 AND 8000;")
+			con.execute("UPDATE o_bm SET val = val + 1 "
+			            "WHERE id BETWEEN 9000 AND 11000;")
+			con.execute("CHECKPOINT;")
+
+		self._run_parked("val < 30 OR val > 970", mutate)
+
+	# Two parallel bitmap scans parked at once; cross DML lands while both are
+	# parked, then both are released together.
+	def test_two_concurrent_bitmaps(self):
+		import time
+		node = self.node
+		self._load()
+		ref_a = self._reference("val < 50")
+		ref_b = self._reference("val >= 900")
+
+		a_con = node.connect()
+		b_con = node.connect()
+		ctrl_con = node.connect()
+		dml_con = node.connect()
+		try:
+			self._scan_setup(a_con)
+			self._scan_setup(b_con)
+			self._evict()
+			ctrl_con.execute(
+			    "SELECT pg_stopevent_set('scan_disk_page', 'true');")
+
+			a_scan = ThreadQueryExecutor(a_con, self._scan_sql("val < 50"))
+			b_scan = ThreadQueryExecutor(b_con, self._scan_sql("val >= 900"))
+			a_scan.start()
+			b_scan.start()
+			try:
+				deadline = time.time() + 60
+				while True:
+					n = ctrl_con.execute(
+					    "SELECT coalesce(array_length(waiter_pids, 1), 0) "
+					    "FROM pg_stopevents() "
+					    "WHERE stopevent = 'scan_disk_page';")[0][0]
+					if n and n >= 2:
+						break
+					self.assertLess(time.time(), deadline,
+					                "scans did not both park")
+					time.sleep(0.05)
+				self.assertTrue(a_scan.is_alive() and b_scan.is_alive())
+				dml_con.execute("INSERT INTO o_bm SELECT i, i %% 1000 FROM "
+				                "generate_series(1000000, 1020000) i;")
+				dml_con.execute(
+				    "DELETE FROM o_bm WHERE id BETWEEN 5000 AND 8000;")
+				dml_con.execute("CHECKPOINT;")
+			finally:
+				ctrl_con.execute(
+				    "SELECT pg_stopevent_reset('scan_disk_page');")
+
+			got_a = sorted(r[0] for r in a_scan.join())
+			got_b = sorted(r[0] for r in b_scan.join())
+			self.assertEqual(got_a, ref_a)
+			self.assertEqual(got_b, ref_b)
+		finally:
+			a_con.close()
+			b_con.close()
+			ctrl_con.close()
+			dml_con.close()
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Parallel bitmap heap scan, native key-bitmap path plus a bridged-index path. Stacked on #1011.

**History reworked for review.** The original 12-commit history is preserved unchanged at `parallel-bitmap-scan-orig-20260817`; the tree it produced was verified byte-identical to the reworked one before the rebase (tree `7fab0bc1`), and the diff against the base branch is the same 16 files / +1886 / -36.

Five commits, in review order:

1. **Fix uninitialised csn on the bridged index-fetch planner-probe path** — a pre-existing bug that this branch's valgrind runs surfaced, unrelated to parallel scan. It was the last commit before; it belongs first, and it can be reviewed and merged on its own.
2. **Key bitmap: flat finalized form that can be serialized and attached** — the data-structure work, no behaviour change on its own.
3. **btree scan: parallel callback seq scan constructor** — the scan-side hook the next commit needs.
4. **Parallel bitmap heap scan (native key-bitmap path)** — the feature, with the recovery skip, regression, isolation and testgres tests, and the CI diff filter folded in.
5. **Parallel bitmap scan for a single bridged index (DSA TIDBitmap)** — the bridged variant with its concurrency test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)