### PR TITLE
Fix create bridge index on filled table with text primary key

### DIFF
--- a/src/tuple/format.c
+++ b/src/tuple/format.c
@@ -433,7 +433,7 @@ o_tuple_compute_data_size(TupleDesc tupleDesc, ItemPointer iptr, BridgeData *bri
 
 	if (iptr)
 		ctid_off++;
-	if (has_bridge_ctid)
+	if (has_bridge_ctid && bridge_data->is_pkey)
 		ctid_off++;
 
 	for (i = 0; i < natts; i++)
@@ -512,7 +512,7 @@ o_new_tuple_size(TupleDesc tupleDesc, OTupleFixedFormatSpec *spec,
 
 	if (iptr)
 		ctid_off++;
-	if (has_bridge_ctid)
+	if (has_bridge_ctid && bridge_data->is_pkey)
 		ctid_off++;
 
 	/*

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -4454,6 +4454,12 @@ SELECT 1 AS still_alive;
            1
 (1 row)
 
+CREATE TABLE o_table_filled(pk text PRIMARY KEY, data text) USING orioledb;
+INSERT INTO o_table_filled VALUES ('key1', 'some_data');
+CREATE INDEX idx_filled_data ON o_table_filled USING brin(data);
+NOTICE:  index bridging is enabled for orioledb table 'o_table_filled'
+DETAIL:  index access method 'brin' is supported only via index bridging for OrioleDB table
+DROP TABLE o_table_filled;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 17 other objects

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -4531,6 +4531,12 @@ SELECT 1 AS still_alive;
            1
 (1 row)
 
+CREATE TABLE o_table_filled(pk text PRIMARY KEY, data text) USING orioledb;
+INSERT INTO o_table_filled VALUES ('key1', 'some_data');
+CREATE INDEX idx_filled_data ON o_table_filled USING brin(data);
+NOTICE:  index bridging is enabled for orioledb table 'o_table_filled'
+DETAIL:  index access method 'brin' is supported only via index bridging for OrioleDB table
+DROP TABLE o_table_filled;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 17 other objects

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -928,6 +928,11 @@ DELETE FROM bridge_undo_rollback WHERE id = 1;
 ROLLBACK;
 SELECT 1 AS still_alive;
 
+CREATE TABLE o_table_filled(pk text PRIMARY KEY, data text) USING orioledb;
+INSERT INTO o_table_filled VALUES ('key1', 'some_data');
+CREATE INDEX idx_filled_data ON o_table_filled USING brin(data);
+DROP TABLE o_table_filled;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;


### PR DESCRIPTION
Fix different calculation of expected and filled tuple size, when filling tuple in created bridge index.