### PR TITLE
FATAL on corrupted page file during checkpoint tree load

### DIFF
--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -5628,13 +5628,13 @@ evictable_tree_init_meta(BTreeDescr *desc, EvictedTreeData **evicted_data,
 		{
 			unlock_page(desc->rootInfo.rootPageBlkno);
 			if (read_result == OReadPageResultChecksumFailed)
-				ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
-								errmsg("invalid rootPageBlkno page in %s",
+				ereport(FATAL, (errcode(ERRCODE_DATA_CORRUPTED),
+								errmsg("invalid rootPageBlkno page in %s: %m",
 									   btree_smgr_filename(desc,
 														   DOWNLINK_GET_DISK_OFF(file_header.rootDownlink),
 														   chkp_num))));
 			else
-				ereport(ERROR, (errcode_for_file_access(),
+				ereport(FATAL, (errcode_for_file_access(),
 								errmsg("could not read rootPageBlkno page from %s: %m",
 									   btree_smgr_filename(desc,
 														   DOWNLINK_GET_DISK_OFF(file_header.rootDownlink),

--- a/test/t/file_operations_test.py
+++ b/test/t/file_operations_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import glob
 import os
 import re
+import time
 
 from .base_test import BaseTest
 
@@ -59,3 +61,59 @@ class FileOperationsTest(BaseTest):
 
 	def getOrioleDBDir(self):
 		return self.node.data_dir + "/orioledb_data"
+
+	def test_checkpoint_fatal_on_corrupted_tree(self):
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', """
+			orioledb.main_buffers = 8MB
+			orioledb.debug_disable_bgwriter = true
+		""")
+		node.start()
+		node.safe_psql(
+		    'postgres', """
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE o_corrupt (
+				k int PRIMARY KEY,
+				v text NOT NULL
+			) USING orioledb;
+			INSERT INTO o_corrupt
+				SELECT i, repeat('x', 200) FROM generate_series(1, 5000) i;
+			CHECKPOINT;
+		""")
+
+		datoid = node.execute(
+		    'postgres',
+		    "SELECT oid FROM pg_database WHERE datname='postgres';")[0][0]
+
+		node.safe_psql(
+		    'postgres',
+		    "SELECT orioledb_evict_pages('o_corrupt'::regclass, 99);")
+
+		datoid_dir = os.path.join(node.data_dir, 'orioledb_data', str(datoid))
+		for f in glob.glob(os.path.join(datoid_dir, '*')):
+			if not f.endswith('.map'):
+				with open(f, 'r+b') as fh:
+					fh.truncate(0)
+
+		# Without the fix the checkpointer gets ERROR and either hits an
+		# Assert (debug builds) or silently skips the corrupted tree on
+		# subsequent checkpoints (release builds). With the fix it FATALs
+		# immediately and shuts down the cluster cleanly.
+		try:
+			node.safe_psql('postgres', "CHECKPOINT;")
+		except Exception:
+			pass
+
+		for _ in range(10):
+			if node.status() != NodeStatus.Running:
+				break
+			time.sleep(1)
+
+		self.assertEqual(node.status(), NodeStatus.Stopped)
+
+		with open(os.path.join(node.logs_dir, 'postgresql.log')) as f:
+			log = f.read()
+			self.assertIn("could not read rootPageBlkno page from", log)
+			# With the fix the shutdown is FATAL, not an Assert crash.
+			self.assertNotIn("TRAP", log)


### PR DESCRIPTION
When read_page_from_disk fails in evictable_tree_init_meta, the ERROR came before the sharedRootInfo was inserted into
SYS_TREES_SHARED_ROOT_INFO. On the next checkpoint cycle o_find_shared_root_info returns NULL, tree_is_under_checkpoint returned true (the checkpointer matches its own state), and o_btree_load_shmem_internal gave up, so the corrupted tree was silently skipped and the checkpoint succeeded.