### PR TITLE
Fix logical decoding of transactions with savepoint before first change

### DIFF
--- a/include/transam/oxid.h
+++ b/include/transam/oxid.h
@@ -209,7 +209,7 @@ extern void oxid_notify(OXid oxid);
 extern void oxid_notify_all(void);
 extern void advance_oxids(OXid new_xid);
 extern OXid get_current_oxid(void);
-extern void assign_subtransaction_logical_xid(void);
+extern void assign_subtransaction_logical_xid(SubTransactionId mySubid);
 extern void set_oxid_csn(OXid oxid, CommitSeqNo csn);
 extern void set_oxid_xlog_ptr(OXid oxid, XLogRecPtr ptr);
 extern void set_current_oxid(OXid oxid);

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -114,16 +114,6 @@ reset_logical_xid_ctx(void)
 	logicalXidContext.useHeap = false;
 }
 
-static inline LogicalXidCtx *
-clone_logical_xid_ctx(void)
-{
-	LogicalXidCtx *clone = (LogicalXidCtx *) palloc(sizeof(LogicalXidCtx));
-
-	Assert(clone);
-	memcpy(clone, &logicalXidContext, sizeof(LogicalXidCtx));
-	return clone;
-}
-
 Datum
 orioledb_get_current_logical_xid(PG_FUNCTION_ARGS)
 {
@@ -136,8 +126,41 @@ orioledb_get_current_heap_xid(PG_FUNCTION_ARGS)
 	PG_RETURN_INT64(GetCurrentTransactionIdIfAny());
 }
 
-static List *prevLogicalXids = NIL; /* remember all xids on subxact's chain
-									 * for correct release */
+/*
+ * Saved logical xid context together with the subtransaction whose start
+ * pushed it.  The subid tag makes push and pop symmetric: a subtransaction
+ * end must only pop the entry it pushed itself.  A subtransaction that
+ * started before the transaction's first OrioleDB modification pushes
+ * nothing (see undo_subxact_callback), so its end must leave the current
+ * context untouched.
+ */
+typedef struct
+{
+	LogicalXidCtx ctx;
+	SubTransactionId subid;
+} PrevLogicalXidEntry;
+
+static List *prevLogicalXids = NIL; /* stack of PrevLogicalXidEntry for all
+									 * xids on subxact's chain, for correct
+									 * restore and release */
+
+/*
+ * Check whether the top of prevLogicalXids was pushed by the subtransaction
+ * identified by subid.
+ */
+static bool
+prev_logical_xid_pushed_by(SubTransactionId subid)
+{
+	PrevLogicalXidEntry *entry;
+
+	if (prevLogicalXids == NIL)
+		return false;
+
+	entry = (PrevLogicalXidEntry *) llast(prevLogicalXids);
+
+	return entry != NULL && entry->subid == subid;
+}
+
 static OXidMapItem *xidBuffer;
 
 /*
@@ -558,52 +581,55 @@ acquire_logical_xid_wrapper(bool *isValidHeapXid)
 }
 
 void
-assign_subtransaction_logical_xid(void)
+assign_subtransaction_logical_xid(SubTransactionId mySubid)
 {
 	TransactionId nextLogicalXid;
 	bool		isValidHeapXid = false;
+	PrevLogicalXidEntry *entry;
+	MemoryContext mcxt;
 
 	nextLogicalXid = acquire_logical_xid_wrapper(&isValidHeapXid);
 
 	/*
-	 * Check previous logical xid if present and store it in a list of xids
+	 * Store the previous logical xid context (even an invalid one) tagged
+	 * with the subtransaction id, so that the end of this subtransaction can
+	 * recognize its own entry and other subtransaction ends leave the stack
+	 * alone.
 	 */
-	if (TransactionIdIsValid(logicalXidContext.xid))
-	{
-		MemoryContext mcxt = MemoryContextSwitchTo(TopMemoryContext);
-
-		elog(DEBUG4, "STORE logical xid %u useHeap %d", logicalXidContext.xid, logicalXidContext.useHeap);
-		prevLogicalXids = lappend(prevLogicalXids, clone_logical_xid_ctx());
-		MemoryContextSwitchTo(mcxt);
-	}
+	mcxt = MemoryContextSwitchTo(TopMemoryContext);
+	elog(DEBUG4, "STORE logical xid %u useHeap %d subid %u",
+		 logicalXidContext.xid, logicalXidContext.useHeap, mySubid);
+	entry = (PrevLogicalXidEntry *) palloc(sizeof(PrevLogicalXidEntry));
+	entry->ctx = logicalXidContext;
+	entry->subid = mySubid;
+	prevLogicalXids = lappend(prevLogicalXids, entry);
+	MemoryContextSwitchTo(mcxt);
 
 	logicalXidContext.xid = nextLogicalXid;
 	logicalXidContext.useHeap = isValidHeapXid;
 }
 
 static void
-setup_prev_logical_xid_ctx(void)
+setup_prev_logical_xid_ctx(SubTransactionId mySubid)
 {
-	int			llen = 0;
-	LogicalXidCtx *ptr = NULL;
+	PrevLogicalXidEntry *entry;
 
-	llen = list_length(prevLogicalXids);
-	if (llen > 0)
-	{
-		ptr = (LogicalXidCtx *) llast(prevLogicalXids);
-		if (ptr)
-		{
-			logicalXidContext.xid = ptr->xid;
-			logicalXidContext.useHeap = ptr->useHeap;
-			elog(DEBUG4, "RESTORE logical xid %u useHeap %d", logicalXidContext.xid, logicalXidContext.useHeap);
-			pfree(ptr);
-		}
-		prevLogicalXids = list_delete_last(prevLogicalXids);
-	}
-	else
-	{
-		reset_logical_xid_ctx();
-	}
+	/*
+	 * Pop only the entry this subtransaction pushed itself.  If the
+	 * subtransaction started before the transaction's first OrioleDB
+	 * modification, nothing was pushed for it, and the current context
+	 * (possibly assigned lazily inside this subtransaction) must stay valid
+	 * up to the top-level commit record.
+	 */
+	if (!prev_logical_xid_pushed_by(mySubid))
+		return;
+
+	entry = (PrevLogicalXidEntry *) llast(prevLogicalXids);
+	logicalXidContext = entry->ctx;
+	elog(DEBUG4, "RESTORE logical xid %u useHeap %d subid %u",
+		 logicalXidContext.xid, logicalXidContext.useHeap, mySubid);
+	pfree(entry);
+	prevLogicalXids = list_delete_last(prevLogicalXids);
 }
 
 void
@@ -619,7 +645,16 @@ oxid_subxact_callback(
 			{
 				if (have_retained_undo_location())
 				{
-					if (TransactionIdIsValid(logicalXidContext.xid))
+					/*
+					 * Release and restore only the logical xid this
+					 * subtransaction assigned at its start.  If nothing was
+					 * pushed for it (the subtransaction started before the
+					 * first OrioleDB modification), the current logical xid
+					 * belongs to the whole transaction and must survive up to
+					 * the top-level commit record.
+					 */
+					if (TransactionIdIsValid(logicalXidContext.xid) &&
+						prev_logical_xid_pushed_by(mySubid))
 					{
 						release_logical_xid(&logicalXidContext);
 
@@ -649,7 +684,7 @@ oxid_subxact_callback(
 
 						if (!RecoveryInProgress())
 						{
-							setup_prev_logical_xid_ctx();
+							setup_prev_logical_xid_ctx(mySubid);
 						}
 					}
 				}
@@ -670,7 +705,7 @@ oxid_subxact_callback(
 								 logicalXidContext.xid,
 								 GetTopTransactionIdIfAny());
 
-							setup_prev_logical_xid_ctx();
+							setup_prev_logical_xid_ctx(mySubid);
 						}
 					}
 				}
@@ -1681,15 +1716,17 @@ release_assigned_logical_xids(void)
 	if (GET_CUR_PROCDATA()->autonomousNestingLevel == 0)
 	{
 		ListCell   *lc = NULL;
-		LogicalXidCtx *ptr = NULL;
+		PrevLogicalXidEntry *entry = NULL;
 
 		foreach(lc, prevLogicalXids)
 		{
-			ptr = lfirst(lc);
-			if (ptr)
+			entry = lfirst(lc);
+			if (entry)
 			{
-				release_logical_xid(ptr);
-				pfree(ptr);
+				/* Entries saved before the first assignment hold no xid */
+				if (TransactionIdIsValid(entry->ctx.xid))
+					release_logical_xid(&entry->ctx);
+				pfree(entry);
 			}
 		}
 		list_free(prevLogicalXids);

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -2855,7 +2855,7 @@ undo_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
 				(void) get_current_oxid();
 				add_subxact_undo_item(parentSubid);
 				prentLogicalXid = GetTopTransactionId();
-				assign_subtransaction_logical_xid();
+				assign_subtransaction_logical_xid(mySubid);
 				add_savepoint_wal_record(parentSubid, prentLogicalXid);
 				if (minParentSubId == InvalidSubTransactionId)
 					minParentSubId = parentSubid;

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -114,6 +114,61 @@ class LogicalTest(BaseTest):
 		    "table public.data: INSERT: id[integer]:2 data[text]:'2'\n"
 		    "COMMIT\n")
 
+	@unittest.skipIf(not BaseTest.extension_installed("test_decoding"),
+	                 "'test_decoding' is not installed")
+	def test_savepoint_before_first_change(self):
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE data(id serial primary key, data text) USING orioledb;\n"
+		)
+
+		node.safe_psql(
+		    'postgres',
+		    "SELECT * FROM pg_create_logical_replication_slot('regression_slot', 'test_decoding', false, true);\n"
+		)
+
+		# The savepoint is created before the transaction's first OrioleDB
+		# modification: the whole transaction must still be decoded.
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "SAVEPOINT s1;\n"
+		    "INSERT INTO data(data) VALUES('1');\n"
+		    "RELEASE SAVEPOINT s1;\n"
+		    "INSERT INTO data(data) VALUES('2');\n"
+		    "COMMIT;\n")
+		self.assertEqual(
+		    self.retrieve_logical_changes(), "BEGIN\n"
+		    "table public.data: INSERT: id[integer]:1 data[text]:'1'\n"
+		    "table public.data: INSERT: id[integer]:2 data[text]:'2'\n"
+		    "COMMIT\n")
+
+		# Same, without an explicit RELEASE before COMMIT.
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "SAVEPOINT s1;\n"
+		    "INSERT INTO data(data) VALUES('3');\n"
+		    "COMMIT;\n")
+		self.assertEqual(
+		    self.retrieve_logical_changes(), "BEGIN\n"
+		    "table public.data: INSERT: id[integer]:3 data[text]:'3'\n"
+		    "COMMIT\n")
+
+		# Rollback to a savepoint created before the first change: only the
+		# changes made after the rollback must be decoded.
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "SAVEPOINT s1;\n"
+		    "INSERT INTO data(data) VALUES('4');\n"
+		    "ROLLBACK TO SAVEPOINT s1;\n"
+		    "INSERT INTO data(data) VALUES('5');\n"
+		    "COMMIT;\n")
+		self.assertEqual(
+		    self.retrieve_logical_changes(), "BEGIN\n"
+		    "table public.data: INSERT: id[integer]:5 data[text]:'5'\n"
+		    "COMMIT\n")
+
 	def test_simple_replident(self):
 		node = self.node
 		node.start()  # start PostgreSQL


### PR DESCRIPTION
Fixes #936.

## Problem

If a transaction's first OrioleDB modification occurs inside a
subtransaction, and the subtransaction was created before any OrioleDB
modification, the transaction is not emitted by logical decoding:

```sql
BEGIN;
SAVEPOINT s1;
INSERT INTO data(data) VALUES ('savepoint');
RELEASE SAVEPOINT s1;
COMMIT;
```

The row is written to the table. No records for the transaction are emitted
to logical slots (test_decoding, pgoutput). No error is raised.

## Root cause

Push and pop of the logical-xid context are both guarded by
`have_retained_undo_location()`, evaluated at different points in time:

1. At `SAVEPOINT`, `undo_subxact_callback(SUBXACT_EVENT_START_SUB)` does not
   call `assign_subtransaction_logical_xid()` because
   `have_retained_undo_location()` is false. Nothing is pushed onto
   `prevLogicalXids`.
2. The first modification inside the subtransaction assigns the logical xid
   lazily in `get_current_oxid()`. `have_retained_undo_location()` becomes
   true.
3. At subtransaction end, `oxid_subxact_callback(SUBXACT_EVENT_COMMIT_SUB)`
   evaluates the guard again (now true), calls `release_logical_xid()`, and
   calls `setup_prev_logical_xid_ctx()`, which pops the empty stack and
   resets `logicalXidContext` to `InvalidTransactionId`.
4. Top-level commit calls
   `wal_commit(oxid, get_current_logical_xid(), ...)` and writes
   `WAL_REC_COMMIT` with `logicalXid = InvalidTransactionId`.
5. In `decode_on_record()`, an invalid logicalXid on `WAL_REC_COMMIT` is
   treated as an autonomous transaction and skipped. The DML records queued
   in the reorder buffer under the xid from step 2 are never committed.

DEBUG4 output from an unpatched build (`main@9ba4d1b`, PG17 patchset
`d48d155c`):

```
DEBUG:  RECEIVE record type 5 (INSERT) oids [ 5 16473 16483 ] oxid 55 logicalXId 96 heapXid 0
DEBUG:  RECEIVE record type 2 (COMMIT) oxid 55 logicalXId 0 heapXid 0
DEBUG:  IGNORED record type 2 (COMMIT) invalid logicalXid for oxid 55
```

The INSERT record carries logicalXId 96; the COMMIT record for the same oxid
carries 0. No `STORE logical xid` / `RESTORE logical xid` lines are present,
consistent with a pop without a preceding push.

The same reset suppresses `wal_joint_commit()` in `XACT_EVENT_PRE_COMMIT`
(`src/transam/undo.c:2460`), which requires a valid
`logicalXidContext.xid`. Mixed heap+OrioleDB transactions with the same
savepoint ordering therefore lose their OrioleDB changes in decoding as
well, when no heap xid exists at subtransaction end (i.e. the heap
modification happens after the subtransaction closes). Verified on
main@9ba4d1b: `BEGIN; SAVEPOINT s1; INSERT INTO oriole_tbl ...; RELEASE
SAVEPOINT s1; INSERT INTO heap_tbl ...; COMMIT;` decodes only the heap
row. If the heap modification happens inside the subtransaction, the
subtransaction-level `wal_joint_commit()` path compensates and decoding
is complete even without this fix.

## Change

- `prevLogicalXids` entries are now `PrevLogicalXidEntry`
  (`LogicalXidCtx` + `SubTransactionId` of the pushing subtransaction).
- `assign_subtransaction_logical_xid()` takes the `SubTransactionId` and
  pushes unconditionally, including an invalid context.
- `setup_prev_logical_xid_ctx()` pops only if the stack top was pushed by
  the ending subtransaction; otherwise it returns without modifying
  `logicalXidContext`.
- The release/restore block in `SUBXACT_EVENT_COMMIT_SUB` runs only when the
  stack top matches the ending subtransaction.
- `release_assigned_logical_xids()` skips entries with invalid xids.

## Validation

Environment: PG17.10, patchset `d48d155c`, extension `main@9ba4d1b`,
`--enable-debug --enable-cassert`.

Unpatched build: repro above inserts the row, `pg_logical_slot_get_changes`
returns no records for the transaction.

Patched build, `pg_logical_slot_get_changes` output verified for:

- savepoint → insert → release → commit: emitted;
- savepoint → insert → commit (no explicit release): emitted;
- savepoint → insert → rollback to savepoint → insert → commit: only the
  second insert emitted;
- insert → savepoint → insert → release → commit (previously working path):
  both inserts emitted, no regression.

Added testgres test `test_savepoint_before_first_change`
(`test/t/logical_test.py`) covering the first three cases. Full
`test.t.logical_test` suite run on the patched build.

## Notes

- Pre-existing, unchanged by this patch: `SUBXACT_EVENT_ABORT_SUB` restores
  the parent context without releasing the aborted subtransaction's logical
  xid slot; the slot is freed at backend transaction end only if still on
  the stack.
- During validation, transaction id `4286578688` (0xFF800000) appeared in
  test_decoding output as the decoded xid. Produced by the wraparound branch
  of `acquire_logical_xid()` (`src/transam/oxid.c:503`). Pre-existing
  behavior; possibly related to #663
  (`could not access status of transaction 4286578688`).

