### PR TITLE
Fix primary index tree ignoring the table's tablespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  concurrent_truncate \
 				  uniq
 TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
+						test/t/tablespace_test.py \
 						test/t/checkpointer_test.py \
 						test/t/correlation_test.py \
 						test/t/eviction_bgwriter_test.py \

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -374,7 +374,11 @@ make_primary_o_index(OTable *table, OIndexVersionMode ixVerMode)
 	else
 		result->compress = table->primary_compress;
 	result->fillfactor = table->fillfactor;
-	result->tablespace = tableIndex->tablespace;
+
+	/*
+	 * Explicitly set tablespace or it will be defaulted
+	 */
+	result->tablespace = table->tablespace;
 	Assert(result->tablespace);
 	saved_nLeafFields = table->nfields;
 	result->nLeafFields = table->nfields;

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -1058,7 +1058,15 @@ o_table_make_index_keys(OTable *table, int *num)
 	for (i = 0; i < trees_num; i++)
 	{
 		trees[i].oids = table->indices[i].oids;
-		trees[i].tablespace = table->indices[i].tablespace;
+
+		/*
+		 * The primary follows the table's tablespace. See also
+		 * make_o_index();
+		 */
+		if (table->indices[i].type == oIndexPrimary)
+			trees[i].tablespace = table->tablespace;
+		else
+			trees[i].tablespace = table->indices[i].tablespace;
 	}
 
 	if (ORelOidsIsValid(table->bridge_oids))

--- a/test/t/move_database_test.py
+++ b/test/t/move_database_test.py
@@ -282,13 +282,12 @@ class TablespaceTest(BaseTest):
                         CREATE TABLE test_tbl_ctid(i int, j int, t text) USING orioledb TABLESPACE user_ts1;
                         CREATE INDEX secondary_idx_ctid1 ON test_tbl_ctid (t);
                         CREATE INDEX secondary_idx_ctid2 ON test_tbl_ctid (j);"""
-		# Primary key relation always create in database default tablespace.
-		# So it moved with database.
+		# test_tbl_pkey is in user_ts1, so its pk stays in the tablespace.
 		moved_relations = [
-		    'secondary_idx_ctid1', 'secondary_idx_ctid2', 'test_tbl_pkey_pkey',
+		    'secondary_idx_ctid1', 'secondary_idx_ctid2',
 		    'secondary_idx_pkey1', 'secondary_idx_pkey2'
 		]
-		stay_relations = ['test_tbl_ctid']
+		stay_relations = ['test_tbl_ctid', 'test_tbl_pkey_pkey']
 		created_ts = (None,
 		              os.path.join(self.node.base_dir, 'data',
 		                           'orioledb_data'))

--- a/test/t/tablespace_test.py
+++ b/test/t/tablespace_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+An OrioleDB table in a non-default tablespace must keep its primary key tree
+in that tablespace.
+A large insert forces the PK tree to be backed on disk.
+Check that primary key tree is kept in the same non default tablespace
+and is properly resolved.
+Before the fix its tablespace defaulted to the database
+default and the backend died with
+"could not open data file orioledb_data/<db>/<relnode>: No such file or directory".
+"""
+
+import shutil
+import tempfile
+
+from .base_test import BaseTest
+
+
+class TablespaceTest(BaseTest):
+
+	def test_primary_tree_follows_table_tablespace(self):
+		tbsp_dir = tempfile.mkdtemp(prefix='oriole_tbsp_')
+		self.addCleanup(shutil.rmtree, tbsp_dir, ignore_errors=True)
+
+		node = self.node
+		# Small pool so insert overflows it and forces the PK tree onto disk.
+		node.append_conf('postgresql.conf', "orioledb.main_buffers = 8MB\n")
+		node.start()
+
+		node.safe_psql('postgres', "CREATE EXTENSION orioledb;")
+		node.safe_psql('postgres',
+		               f"CREATE TABLESPACE ots LOCATION '{tbsp_dir}';")
+		node.safe_psql(
+		    'postgres', """
+			CREATE TABLE o_ts (k int PRIMARY KEY, v text NOT NULL)
+				USING orioledb TABLESPACE ots;
+		""")
+		node.safe_psql(
+		    'postgres', """
+			INSERT INTO o_ts
+				SELECT i, repeat('x', 2000) FROM generate_series(1, 20000) i;
+		""")
+
+		self.assertEqual(
+		    node.execute('postgres', "SELECT count(*) FROM o_ts;")[0][0],
+		    20000)
+		node.stop()


### PR DESCRIPTION
When writing a repro for pg_checksums crash I hit this strange "no such file or directory" error

```
    FATAL: could not open data file orioledb_data/5/16481: No such file or directory
```

The key tree was resolving not to the table's tablespace, but default, which wasn't
there, IIUC because repro script didn't have anything in the default tablespace yet.

Somewhat large set is needed to spill the key on disk.

Fixed by forcing the primary tree to follow table's tablespace.

I did so many multi-terabyte tests and didn't catch it with tpcc, oh well.

closes #986

