### PR TITLE
Ensure default directory for when PK from tablespaced table needs it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  concurrent_truncate \
 				  uniq
 TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
+						test/t/tablespace_test.py \
 						test/t/checkpointer_test.py \
 						test/t/correlation_test.py \
 						test/t/eviction_bgwriter_test.py \

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -264,6 +264,27 @@ btree_smgr_filename(BTreeDescr *desc, off_t offset, uint32 chkpNum)
 	return btree_filename(key, segno, chkpNum);
 }
 
+/*
+ * Ensure the data directory for this tree exists.
+ *
+ * A primary tree can resolve to the database's default tablespace
+ * even when the table lives in a user tablespace, and nothing else
+ * may have created that default directory yet.
+ * See https://github.com/orioledb/orioledb/issues/986
+ */
+static void
+btree_smgr_ensure_dir(BTreeDescr *desc)
+{
+	char	   *prefix,
+			   *db_prefix;
+
+	o_get_prefixes_for_tablespace(desc->oids.datoid, desc->tablespace,
+								  &prefix, &db_prefix);
+	o_verify_dir_exists_or_create(prefix, NULL, NULL);
+	o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
+	pfree(db_prefix);
+}
+
 static File
 btree_open_smgr_file(BTreeDescr *desc, uint32 num, uint32 chkpNum,
 					 uint32 loadId)
@@ -290,6 +311,12 @@ btree_open_smgr_file(BTreeDescr *desc, uint32 num, uint32 chkpNum,
 									   (off_t) num * ORIOLEDB_SEGMENT_SIZE,
 									   chkpNum);
 		hashElem->file = PathNameOpenFile(filename, O_RDWR | O_CREAT | PG_BINARY);
+		if (hashElem->file <= 0 && errno == ENOENT)
+		{
+			/* The data directory may not exist - create and retry. */
+			btree_smgr_ensure_dir(desc);
+			hashElem->file = PathNameOpenFile(filename, O_RDWR | O_CREAT | PG_BINARY);
+		}
 		hashElem->loadId = loadId;
 		if (hashElem->file <= 0)
 			ereport(FATAL,
@@ -328,6 +355,12 @@ btree_open_smgr_file(BTreeDescr *desc, uint32 num, uint32 chkpNum,
 									   (off_t) num * ORIOLEDB_SEGMENT_SIZE,
 									   chkpNum);
 		desc->smgr.array.files[num] = PathNameOpenFile(filename, O_RDWR | O_CREAT | PG_BINARY);
+		if (desc->smgr.array.files[num] <= 0 && errno == ENOENT)
+		{
+			/* The data directory may not exist - create and retry. */
+			btree_smgr_ensure_dir(desc);
+			desc->smgr.array.files[num] = PathNameOpenFile(filename, O_RDWR | O_CREAT | PG_BINARY);
+		}
 
 		if (desc->smgr.array.files[num] <= 0)
 			ereport(FATAL,

--- a/test/t/tablespace_test.py
+++ b/test/t/tablespace_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+An OrioleDB table in a non-default tablespace must keep its primary key tree
+in that tablespace.
+A large insert forces the PK tree to be backed on disk.
+Check that primary key tree is kept in the same non default tablespace
+and is properly resolved.
+Before the fix its tablespace defaulted to the database
+default and the backend died with
+"could not open data file orioledb_data/<db>/<relnode>: No such file or directory".
+"""
+
+import shutil
+import tempfile
+
+from .base_test import BaseTest
+
+
+class TablespaceTest(BaseTest):
+
+	def test_primary_tree_follows_table_tablespace(self):
+		tbsp_dir = tempfile.mkdtemp(prefix='oriole_tbsp_')
+		self.addCleanup(shutil.rmtree, tbsp_dir, ignore_errors=True)
+
+		node = self.node
+		# Small pool so insert overflows it and forces the PK tree onto disk.
+		node.append_conf('postgresql.conf', "orioledb.main_buffers = 8MB\n")
+		node.start()
+
+		node.safe_psql('postgres', "CREATE EXTENSION orioledb;")
+		node.safe_psql('postgres',
+		               f"CREATE TABLESPACE ots LOCATION '{tbsp_dir}';")
+		node.safe_psql(
+		    'postgres', """
+			CREATE TABLE o_ts (k int PRIMARY KEY, v text NOT NULL)
+				USING orioledb TABLESPACE ots;
+		""")
+		node.safe_psql(
+		    'postgres', """
+			INSERT INTO o_ts
+				SELECT i, repeat('x', 2000) FROM generate_series(1, 20000) i;
+		""")
+
+		self.assertEqual(
+		    node.execute('postgres', "SELECT count(*) FROM o_ts;")[0][0],
+		    20000)
+		node.stop()


### PR DESCRIPTION
After learning about this comment in move_database_test:

```
# Primary key relation always create in database default tablespace.
# So it moved with database.
```

I decided to try different approach to #986 - ensure the default directory exists.
Didn't want to create any hot path pressure so it is reactive not proactive.


closes #986 