### PR TITLE
Replace blanket streaming disable with per-transaction gating

### DIFF
--- a/include/recovery/logical.h
+++ b/include/recovery/logical.h
@@ -17,10 +17,12 @@
 #include "btree/btree.h"
 #include "recovery/internal.h"
 
+#include "access/xact.h"
 #include "replication/decode.h"
 #include "replication/logical.h"
 
 extern void orioledb_decode(LogicalDecodingContext *ctx,
 							XLogRecordBuffer *buf);
+extern DecodingXidStatus orioledb_logical_xid_status(TransactionId xid);
 
 #endif							/* __LOGICAL_H__ */

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -1281,6 +1281,7 @@ _PG_init(void)
 	RegisterXactCallback(undo_xact_callback, NULL);
 	RegisterSubXactCallback(undo_subxact_callback, NULL);
 	get_xidless_commit_lsn_hook = orioledb_get_xidless_commit_lsn;
+	decoding_xid_status_hook = orioledb_logical_xid_status;
 	CacheRegisterUsercacheCallback(orioledb_usercache_hook, PointerGetDatum(NULL));
 	CheckPoint_hook = o_perform_checkpoint;
 	after_checkpoint_cleanup_hook = o_after_checkpoint_cleanup_hook;

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -25,6 +25,9 @@
 #include "tableam/descr.h"
 #include "tuple/slot.h"
 
+#include "transam/oxid.h"
+
+#include "access/transam.h"
 #include "catalog/pg_tablespace.h"
 #include "replication/origin.h"
 #include "replication/reorderbuffer.h"
@@ -141,6 +144,27 @@ get_reorder_buffer_txn(ReorderBuffer *rb, TransactionId xid)
 		return ent->txn;
 	else
 		return NULL;
+}
+
+/*
+ * Mark the top-level transaction of the given xid as not streamable.
+ *
+ * OrioleDB's logical-xid graph (top logical xid, per-subtransaction logical
+ * xids, heap xid for mixed transactions) is fully assembled only when the
+ * finish records are decoded.  Streaming a partially-assembled graph sends
+ * pieces of one transaction as several independent streamed transactions,
+ * which the subscriber applies concurrently: parallel apply workers deadlock
+ * on each other and transaction atomicity is lost.  Until the graph is
+ * linked eagerly at record-emission time, transactions with subtransactions
+ * or heap involvement must take the spill path.
+ */
+static void
+disable_streaming_for_txn(ReorderBuffer *rb, TransactionId xid)
+{
+	ReorderBufferTXN *txn = get_reorder_buffer_txn(rb, xid);
+
+	if (txn != NULL)
+		rbtxn_get_toptxn(txn)->txn_flags |= RBTXN_NO_STREAMING;
 }
 
 /*
@@ -627,6 +651,96 @@ remove_skipped_dml(HTAB **cache, uint64 oxid)
  */
 static HTAB *skippedDMLHash = NULL;
 
+/*
+ * Per-process map from the logical xid Oriole puts into WAL records to the
+ * OXid of the owning transaction.
+ *
+ * Logical xids are allocated from a bitmap (see acquire_logical_xid()) and
+ * have no clog backing, so the concurrent-abort detection in streamed
+ * decoding cannot resolve their status through
+ * TransactionIdIsInProgress()/TransactionIdDidCommit().  During decoding we
+ * observe (oxid, logicalXid) pairs in WAL_REC_XID records; this map lets
+ * orioledb_logical_xid_status() answer status questions from the oxid state
+ * (oxid_get_csn()) instead of clog.
+ *
+ * Entries are created when a WAL_REC_XID record is decoded and removed when
+ * the corresponding finish record (COMMIT/ROLLBACK/JOINT_COMMIT) has been
+ * fully processed.  The map is local to the decoding process.
+ */
+typedef struct LogicalXidOxidEntry
+{
+	TransactionId logicalXid;
+	OXid		oxid;
+} LogicalXidOxidEntry;
+
+static HTAB *logicalXidOxidHash = NULL;
+
+static void
+record_logical_xid_oxid(TransactionId logicalXid, OXid oxid)
+{
+	LogicalXidOxidEntry *entry;
+
+	if (!TransactionIdIsValid(logicalXid) || !OXidIsValid(oxid))
+		return;
+
+	if (logicalXidOxidHash == NULL)
+	{
+		HASHCTL		ctl;
+
+		MemSet(&ctl, 0, sizeof(ctl));
+		ctl.keysize = sizeof(TransactionId);
+		ctl.entrysize = sizeof(LogicalXidOxidEntry);
+		ctl.hcxt = TopMemoryContext;
+		logicalXidOxidHash = hash_create("orioledb logical xid to oxid map",
+										 64, &ctl,
+										 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+	}
+
+	entry = (LogicalXidOxidEntry *) hash_search(logicalXidOxidHash,
+												&logicalXid, HASH_ENTER, NULL);
+	entry->oxid = oxid;
+}
+
+static void
+forget_logical_xid_oxid(TransactionId logicalXid)
+{
+	if (logicalXidOxidHash == NULL || !TransactionIdIsValid(logicalXid))
+		return;
+
+	hash_search(logicalXidOxidHash, &logicalXid, HASH_REMOVE, NULL);
+}
+
+/*
+ * decoding_xid_status_hook implementation: report the status of a logical
+ * xid from the owning transaction's oxid state.  Returns
+ * DECODING_XID_NOT_HANDLED for xids this decoding session has not seen in a
+ * WAL_REC_XID record, which makes the caller fall back to the regular clog
+ * paths (heap transactions).
+ */
+DecodingXidStatus
+orioledb_logical_xid_status(TransactionId xid)
+{
+	LogicalXidOxidEntry *entry;
+	CommitSeqNo csn;
+
+	if (logicalXidOxidHash == NULL)
+		return DECODING_XID_NOT_HANDLED;
+
+	entry = (LogicalXidOxidEntry *) hash_search(logicalXidOxidHash,
+												&xid, HASH_FIND, NULL);
+	if (entry == NULL)
+		return DECODING_XID_NOT_HANDLED;
+
+	csn = oxid_get_csn(entry->oxid, false);
+	if (COMMITSEQNO_IS_ABORTED(csn))
+		return DECODING_XID_ABORTED;
+	if (COMMITSEQNO_IS_INPROGRESS(csn))
+		return DECODING_XID_IN_PROGRESS;
+
+	/* frozen or normal csn: the transaction committed */
+	return DECODING_XID_COMMITTED;
+}
+
 static WalParseResult
 decode_check_version(const WalReaderState *r)
 {
@@ -699,6 +813,8 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 
 					csnSnapshot = SnapBuildGetCSNSnaphot(ctx->decodeCtx->snapshot_builder);
 					csnSnapshot->nextXid = Max(csnSnapshot->nextXid, rec->oxid);
+
+					record_logical_xid_oxid(rec->logicalXid, rec->oxid);
 				}
 				else
 				{
@@ -727,6 +843,7 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 				Assert(TransactionIdIsValid(subXid));
 
 				ReorderBufferAssignChild(ctx->decodeCtx->reorder, topXid, subXid, xlogPtr);
+				disable_streaming_for_txn(ctx->decodeCtx->reorder, topXid);
 
 				break;
 			}
@@ -818,6 +935,7 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 							ReorderBufferForget(ctx->decodeCtx->reorder, txn->xid,
 												ctx->xlogRecPtr);
 
+							forget_logical_xid_oxid(rec->logicalXid);
 							rec->oxid = InvalidOXid;
 							rec->logicalXid = InvalidTransactionId;
 
@@ -882,6 +1000,7 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 
 				UpdateDecodingStats(ctx->decodeCtx);
 
+				forget_logical_xid_oxid(rec->logicalXid);
 				rec->oxid = InvalidOXid;
 				rec->logicalXid = InvalidTransactionId;
 
@@ -961,6 +1080,7 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 					UpdateDecodingStats(ctx->decodeCtx);
 				}
 
+				forget_logical_xid_oxid(rec->logicalXid);
 				rec->oxid = InvalidOXid;
 				rec->logicalXid = InvalidTransactionId;
 
@@ -1105,7 +1225,10 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 				 rec->type, recname, rec->oxid, rec->logicalXid, rec->u.savepoint.parentLogicalXid);
 
 			if (!ctx->decodeCtx->fast_forward)
+			{
 				ReorderBufferAssignChild(ctx->decodeCtx->reorder, rec->u.savepoint.parentLogicalXid, rec->logicalXid, ctx->decodeBuf->origptr);
+				disable_streaming_for_txn(ctx->decodeCtx->reorder, rec->u.savepoint.parentLogicalXid);
+			}
 
 			break;
 
@@ -1257,6 +1380,21 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 				txn = get_reorder_buffer_txn(ctx->decodeCtx->reorder, rec->logicalXid);
 				txn->txn_flags |= RBTXN_DISTR_SKIP_CLEANUP;
 
+				/*
+				 * Gate OrioleDB transactions to the spill path.  Streaming is
+				 * only safe for transactions that commit through the
+				 * pure-OrioleDB commit path (WAL_REC_COMMIT with the same
+				 * logical xid).  A transaction that later creates a savepoint
+				 * or acquires a heap xid is finished through the joint-commit
+				 * machinery, which re-parents the reorder buffer transaction;
+				 * chunks streamed before that point are never
+				 * stream-committed and would be lost by consumers. Whether
+				 * either applies is unknowable when streaming would start, so
+				 * all OrioleDB transactions spill until the logical-xid graph
+				 * is linked eagerly at emission time.
+				 */
+				disable_streaming_for_txn(ctx->decodeCtx->reorder, rec->logicalXid);
+
 				/* Skip actual record processing in fast_forward mode */
 				if (ctx->decodeCtx->fast_forward)
 					break;
@@ -1361,9 +1499,6 @@ orioledb_decode(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 	};
 
 	WalParseResult st;
-
-	/* do our best to disable streaming */
-	ctx->streaming = false;
 
 	elog(DEBUG4, "OrioleDB decode started startXLogPtr %X/%X endXLogPtr %X/%X",
 		 LSN_FORMAT_ARGS(startXLogPtr), LSN_FORMAT_ARGS(endXLogPtr));

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -195,6 +195,44 @@ class LogicalTest(BaseTest):
 		    len([r for r in rows if r.startswith('opening a streamed block')]),
 		    0)
 
+		# Mixed transactions: streaming may already be in progress when the
+		# transaction first touches an OrioleDB table.  The switch record
+		# marks the transaction at that point; the already-streamed part
+		# completes through the regular partial-stream machinery and the
+		# OrioleDB changes travel in the stream-commit tail.  Content and
+		# single-transaction atomicity must be preserved.
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "INSERT INTO h_str SELECT g + 20000, repeat('x', 100) FROM generate_series(1, 5000) g;\n"
+		    "INSERT INTO o_str SELECT g + 30000, repeat('y', 100) FROM generate_series(1, 200) g;\n"
+		    "COMMIT;\n")
+		rows = decode()
+		self.assertEqual(change_lines(rows), 5200)
+		self.assertEqual(
+		    len([r for r in rows if r.startswith('committing streamed')]), 1)
+
+		# Same with the OrioleDB modification first.
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "INSERT INTO o_str SELECT g + 40000, repeat('y', 100) FROM generate_series(1, 200) g;\n"
+		    "INSERT INTO h_str SELECT g + 40000, repeat('x', 100) FROM generate_series(1, 5000) g;\n"
+		    "COMMIT;\n")
+		rows = decode()
+		self.assertEqual(change_lines(rows), 5200)
+
+		# Rolled-back OrioleDB subtransaction inside a streamed heap
+		# transaction: its changes must not reach the output.
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "INSERT INTO h_str SELECT g + 50000, repeat('x', 100) FROM generate_series(1, 5000) g;\n"
+		    "SAVEPOINT s1;\n"
+		    "INSERT INTO o_str SELECT g + 60000, repeat('y', 100) FROM generate_series(1, 200) g;\n"
+		    "ROLLBACK TO SAVEPOINT s1;\n"
+		    "INSERT INTO o_str(id, t) VALUES (70000, 'survivor');\n"
+		    "COMMIT;\n")
+		rows = decode()
+		self.assertEqual(change_lines(rows), 5001)
+
 	def test_simple_replident(self):
 		node = self.node
 		node.start()  # start PostgreSQL

--- a/test/t/logical_test.py
+++ b/test/t/logical_test.py
@@ -114,6 +114,87 @@ class LogicalTest(BaseTest):
 		    "table public.data: INSERT: id[integer]:2 data[text]:'2'\n"
 		    "COMMIT\n")
 
+	@unittest.skipIf(not BaseTest.extension_installed("test_decoding"),
+	                 "'test_decoding' is not installed")
+	def test_streaming_gate(self):
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "logical_decoding_work_mem = 64kB\n")
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_str(id int primary key, t text) USING orioledb;\n"
+		    "CREATE TABLE h_str(id int primary key, t text) USING heap;\n")
+		node.safe_psql(
+		    'postgres',
+		    "SELECT * FROM pg_create_logical_replication_slot('regression_slot', 'test_decoding', false, true);\n"
+		)
+
+		def decode():
+			return [
+			    r[0] for r in node.execute(
+			        "SELECT data FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL, 'stream-changes', '1');"
+			    )
+			]
+
+		# Heap transactions over logical_decoding_work_mem must stream.
+		# Streamed changes are printed by test_decoding as "streaming change
+		# for TXN n" without tuple data; count both forms so the assertion
+		# holds regardless of how much of the transaction was streamed
+		# before the commit was reached.
+		def change_lines(rows):
+			return len([
+			    r for r in rows
+			    if 'INSERT' in r or r.startswith('streaming change')
+			])
+
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "INSERT INTO h_str SELECT g, repeat('x', 100) FROM generate_series(1, 5000) g;\n"
+		    "COMMIT;\n")
+		rows = decode()
+		self.assertGreater(
+		    len([r for r in rows if r.startswith('opening a streamed block')]),
+		    0)
+		self.assertEqual(change_lines(rows), 5000)
+
+		# OrioleDB transactions are gated to the spill path and must decode
+		# completely.
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "INSERT INTO o_str SELECT g, repeat('x', 100) FROM generate_series(1, 5000) g;\n"
+		    "COMMIT;\n")
+		rows = decode()
+		self.assertEqual(len([r for r in rows if 'streamed' in r]), 0)
+		self.assertEqual(len([r for r in rows if 'INSERT' in r]), 5000)
+
+		# The savepoint variant must also decode completely without
+		# streaming (streamed chunks of a transaction that is later
+		# re-parented by the joint-commit machinery would be lost).
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "INSERT INTO o_str SELECT g + 10000, repeat('x', 100) FROM generate_series(1, 2000) g;\n"
+		    "SAVEPOINT s1;\n"
+		    "INSERT INTO o_str SELECT g + 20000, repeat('x', 100) FROM generate_series(1, 3000) g;\n"
+		    "RELEASE SAVEPOINT s1;\n"
+		    "COMMIT;\n")
+		rows = decode()
+		self.assertEqual(len([r for r in rows if 'streamed' in r]), 0)
+		self.assertEqual(len([r for r in rows if 'INSERT' in r]), 5000)
+
+		# A heap transaction following OrioleDB WAL in the same decode pass
+		# must still stream: the gate is per-transaction, not per-session.
+		node.safe_psql('postgres',
+		               "INSERT INTO o_str(id, t) VALUES (99999, 'marker');")
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "INSERT INTO h_str SELECT g + 10000, repeat('x', 100) FROM generate_series(1, 5000) g;\n"
+		    "COMMIT;\n")
+		rows = decode()
+		self.assertGreater(
+		    len([r for r in rows if r.startswith('opening a streamed block')]),
+		    0)
+
 	def test_simple_replident(self):
 		node = self.node
 		node.start()  # start PostgreSQL


### PR DESCRIPTION
Part of #663. Requires the paired orioledb/postgres change
(https://github.com/orioledb/postgres/pull/79) and a `.pgtags` bump after it merges; CI on this PR
will fail the patchset check until then.

## Problem

`orioledb_decode()` sets `ctx->streaming = false` for every OrioleDB WAL
container (`src/recovery/logical.c`, from commit e7feb24448ad
"Temporarily disable streaming replication"). The flag is never
restored, so one decoded OrioleDB record disables streaming for the rest
of the decoding session:

- Heap transactions stop streaming as well. Measured with test_decoding,
  `logical_decoding_work_mem=64kB`, fresh slots: a 5000-row heap
  transaction alone streams (18 blocks); the same transaction preceded
  by a single-row OrioleDB transaction does not stream (0 blocks).
- Consumers requesting `streaming=on/parallel` silently degrade to
  spill-to-disk decoding on the publisher.

## Change

- Every OrioleDB transaction is marked `RBTXN_NO_STREAMING` at its first
  decoded DML record. OrioleDB transactions keep the current spill-path
  behavior; heap transactions stream again.
- A per-decoding-session logicalXid→oxid map (fed from `WAL_REC_XID`
  records, pruned at finish records) backs the fork-side
  `decoding_xid_status_hook`: streamed decoding resolves OrioleDB
  logical-xid status from oxid state (`oxid_get_csn()`) instead of clog,
  removing the `could not access status of transaction` failure mode for
  any streaming that does occur.
- `ctx->streaming = false` is removed.

## Why OrioleDB transactions stay on the spill path

Streaming them is unsafe until the logical-xid graph is linked eagerly.
The graph (top logical xid, per-subtransaction logical xids, heap xid
for mixed transactions) is assembled only when finish records are
decoded (SWITCH_LOGICAL_XID / JOINT_COMMIT / savepoint records +
`ReorderBufferCommitChild`). A transaction that starts streaming and is
later re-parented by that machinery loses its already-streamed chunks:
they are never stream-committed. Observed directly (experimental build
with streaming enabled): a transaction inserting 2000 rows, then
creating a savepoint, then inserting 3000 more streams the first 2000
rows in 8 blocks with no `committing streamed transaction` marker — a
consumer applies only 3000 of 5000 rows. Whether a transaction will
later create a savepoint or acquire a heap xid is unknowable at the
moment streaming would start, so the gate must cover all OrioleDB
transactions. Enabling real streaming requires emitting the parent/child
links at record-emission time — flagged for discussion in #663.

## Validation

Environment: patched PG 17.10 + this extension, `--enable-debug
--enable-cassert`, test_decoding, `logical_decoding_work_mem=64kB`.

- Heap 5000-row transaction: streams (18 blocks + stream commit), all
  rows present.
- OrioleDB 5000-row transaction: 0 stream markers, 5000/5000 rows via
  spill + commit replay.
- OrioleDB 2000+savepoint+3000 transaction: 0 stream markers, 5000/5000
  rows (the data-loss scenario above is gone).
- Heap 5000-row transaction after OrioleDB records in the same decode
  pass: streams (18 blocks) — restores the behavior lost today.
- Suites on this stack: `test.t.logical_test` 50/50 (1 skip: wal2json),
  `regresscheck` 48/48, `isolationcheck` 32/32.
- New regression test `test_streaming_gate` covers the four scenarios.
