### PR TITLE
Fix concurrency bugs found stress-hunting 027_stream_regress under churn

### DIFF
--- a/ci/filter_regression_diff.py
+++ b/ci/filter_regression_diff.py
@@ -148,6 +148,12 @@ skip_hunk_errors = {
 	# both shapes.
 	r"ERROR:  role \"regress_user11\" (already exists|does not exist|cannot be dropped because some objects depend on it)":
 	["generated_stored", "generated_virtual"],
+	# Same regress_user11 race, OID-based variant: when the other test's
+	# concurrent DROP USER removes the role's pg_authid tuple between this
+	# DROP USER's catalog lookup and its delete, the error names the role by
+	# OID ("could not find tuple for role <oid>") instead of by name.
+	r"ERROR:  could not find tuple for role \d+":
+	["generated_stored", "generated_virtual"],
 	r"ERROR:  permission denied for (table gtest\w+|function gf\w+)":
 	["generated_stored", "generated_virtual"],
 	# Upstream anomaly 9a3ddeb519e8 is not reproduced on Oriole as it

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -3711,8 +3711,42 @@ cleanup_btree_files(OIndexKey key, bool fsync)
 static void
 fsync_callback(const char *filename, uint32 segno, char *ext, void *arg)
 {
-	if (ext == NULL || strcmp(ext, "tmp") != 0)
-		fsync_fname(filename, false);
+	File		file;
+
+	if (ext != NULL && strcmp(ext, "tmp") == 0)
+		return;
+
+	/*
+	 * A secondary file (a segment, or a "-<chkp>.map"/".evt" checkpoint
+	 * sidecar) that readdir listed can be unlinked concurrently before we
+	 * fsync it -- the checkpointer's superseded-map cleanup unlinks the old
+	 * map once a newer one is durable.  Open it ourselves and return quietly
+	 * if it has already vanished (ENOENT): a pre-check with access() would
+	 * only narrow the race (the file can still go between the check and the
+	 * open), whereas tolerating ENOENT on the open closes it.  Skipping a
+	 * vanished sidecar is safe -- the current map is durable and the
+	 * transaction's data durability rests on the base and segment files,
+	 * which are not removed concurrently.  A genuine I/O error on a present
+	 * file still ERRORs (a PANIC at the PreCommit undo callback).  Open it
+	 * O_RDWR, not O_RDONLY: pg_fsync() forbids fsyncing a read-only
+	 * descriptor.
+	 */
+	file = PathNameOpenFile(filename, O_RDWR | PG_BINARY);
+	if (file < 0)
+	{
+		if (errno == ENOENT)
+			return;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not open file %s: %m", filename)));
+	}
+
+	if (FileSync(file, WAIT_EVENT_DATA_FILE_SYNC) != 0)
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not fsync file %s: %m", filename)));
+
+	FileClose(file);
 }
 
 bool

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -1104,6 +1104,21 @@ o_btree_iterator_advance(BTreeIterator *it, void *key, BTreeKeyType kind)
 
 	Assert(key != NULL && kind != BTreeKeyNone);
 
+#ifdef USE_ASSERT_CHECKING
+
+	/*
+	 * Advancing to a new "col = ANY" array element begins a fresh ordered
+	 * sub-scan.  Tuples of different array elements are not globally ordered
+	 * (the array need not be sorted and elements' key ranges can be adjacent
+	 * or overlap -- the optimistic resume can even re-verify the previous
+	 * element's parked tuple, giving cmp == 0), so drop the previous
+	 * element's last tuple.  This keeps the monotonicity assert in
+	 * o_btree_iterator_fetch() scoped to a single element, where it still
+	 * holds, without weakening it for plain (non-advancing) scans.
+	 */
+	O_TUPLE_SET_NULL(it->prevTuple.tuple);
+#endif
+
 	/*
 	 * Optimistic next-item check.  The previous element's scan left the leaf
 	 * locator on the first item past its end bound (rewound there by

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1037,7 +1037,28 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 					OFixedKey	jumpKey;
 
 					if (scan->firstPageIsLoaded)
+					{
+						/*
+						 * The rightmost internal page has no hikey and no
+						 * successor, so there is no "next wanted key at or
+						 * after its hikey" to jump to -- the tree is fully
+						 * scanned.  The non-jump path below relies on the
+						 * same invariant (it Asserts !RIGHTMOST before
+						 * copying the hikey), because the loop returns false
+						 * at its O_PAGE_IS(RIGHTMOST) check once the
+						 * rightmost page's downlinks are exhausted.  The jump
+						 * path can reach here with the rightmost page still
+						 * loaded, so it must make the same check itself
+						 * instead of copying a non-existent hikey.
+						 */
+						if (O_PAGE_IS(scan->context.img, RIGHTMOST))
+						{
+							clear_fixed_key(keyRangeLow);
+							clear_fixed_key(keyRangeHigh);
+							return false;
+						}
 						copy_fixed_hikey(scan->desc, &jumpKey, scan->context.img);
+					}
 					else
 						clear_fixed_key(&jumpKey);
 

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -3134,6 +3134,22 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 {
 	Relation	rel;
 
+	/*
+	 * For an object drop `arg` is the caller's ObjectAccessDrop.  ASAN can
+	 * spuriously flag reads of it as stack-use-after-scope: PostgreSQL's
+	 * sigsetjmp/longjmp error unwinding leaves earlier nested-scope stack
+	 * slots poisoned and this live struct on the caller's frame can alias
+	 * one. The RelationRelationId drop branch below already unpoisons its
+	 * copy, but the PG18 ConstraintRelationId branch reads dropflags inside
+	 * its if-condition (before any body runs), so unpoison up front to cover
+	 * it. The read is legitimate; this is a no-op in non-ASAN builds.  arg is
+	 * never NULL for OAT_DROP (the drop branches below already dereference it
+	 * unconditionally); do not add a NULL guard here, or the static analyzer
+	 * infers arg may be NULL and flags those existing dereferences.
+	 */
+	if (access == OAT_DROP)
+		ASAN_UNPOISON_MEMORY_REGION(arg, sizeof(ObjectAccessDrop));
+
 	if (access == OAT_POST_CREATE && classId == ExtensionRelationId)
 	{
 #if PG_VERSION_NUM >= 170000

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -723,7 +723,18 @@ o_table_fill_constr(OTable *o_table, Relation rel, int fieldnum,
 		if (!old_field || (!old_field->hasmissing && !missingIsNull))
 		{
 			attrmiss = &attrmiss_temp;
-			field->hasmissing = true;
+
+			/*
+			 * A missing value exists only when the evaluated default is
+			 * non-null.  For ADD COLUMN (!old_field) the guard above is
+			 * short-circuited, so gate hasmissing on missingIsNull here too;
+			 * otherwise a null default (e.g. adding a domain column with no
+			 * default) would mark the missing value present and datumCopy() a
+			 * NULL varlena below -> crash.  attrmiss stays set so the new
+			 * column's missing slot is still initialized (am_present =
+			 * false).
+			 */
+			field->hasmissing = !missingIsNull;
 		}
 	}
 	o_in_add_column = false;

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -185,7 +185,7 @@ static void sort_checkpoint_tmp_file(BTreeDescr *descr, int cur_chkp_index);
 static inline void checkpoint_ix_init_state(CheckpointState *state, BTreeDescr *descr);
 static void checkpoint_init_new_seq_bufs(BTreeDescr *descr, int chkpNum);
 static bool checkpoint_temporary_tree(int flags, BTreeDescr *descr);
-static bool checkpoint_ix(int flags, BTreeDescr *descr);
+static BTreeDescr *checkpoint_ix(int flags, BTreeDescr *descr);
 static uint64 checkpoint_btree(BTreeDescr **descrPtr, CheckpointState *state,
 							   CheckpointWriteBack *writeback);
 static Jsonb *prepare_checkpoint_step_params(BTreeDescr *descr,
@@ -1127,7 +1127,7 @@ checkpoint_sys_trees(int flags, uint32 cur_chkp_num,
 		if (desc->storageType == BTreeStoragePersistence ||
 			desc->storageType == BTreeStorageUnlogged)
 		{
-			success = checkpoint_ix(flags, desc);
+			success = checkpoint_ix(flags, desc) != NULL;
 			/* System trees can't be concurrently deleted */
 			Assert(success);
 			if (!orioledb_s3_mode)
@@ -1160,7 +1160,7 @@ checkpoint_chkp_nums(int flags, uint32 cur_chkp_num,
 	checkpoint_ix_init_state(checkpoint_state, desc);
 	checkpoint_init_new_seq_bufs(desc, cur_chkp_num);
 
-	success = checkpoint_ix(flags, desc);
+	success = checkpoint_ix(flags, desc) != NULL;
 
 	/* System trees can't be concurrently deleted */
 	Assert(success);
@@ -2711,12 +2711,16 @@ backend_set_autonomous_level(CheckpointState *state, uint32 level)
 /*
  * Make checkpoint of an index (persistent or unlogged).
  *
- * The caller must hold the OrioleDB checkpointer table lock.  On success
- * (true), the lock is still held and the caller must release it.  On
- * failure (false), the lock has already been released by
- * perform_writeback_and_relock() inside checkpoint_btree().
+ * The caller must hold the OrioleDB checkpointer table lock.  On success the
+ * lock is still held and the (possibly re-fetched) descriptor is returned; the
+ * caller MUST switch to it, because checkpoint_btree() /
+ * perform_writeback_and_relock() re-fetch the descriptor after each
+ * unlock/relock cycle and the descriptor passed in may have been freed by a
+ * concurrent invalidation in the meantime.  On failure NULL is returned and
+ * the lock has already been released by perform_writeback_and_relock() inside
+ * checkpoint_btree().
  */
-static bool
+static BTreeDescr *
 checkpoint_ix(int flags, BTreeDescr *descr)
 {
 	FileExtentsArray *free_extents = NULL;
@@ -2746,7 +2750,7 @@ checkpoint_ix(int flags, BTreeDescr *descr)
 	{
 		/* Lock already released by perform_writeback_and_relock() */
 		free_writeback(&writeback);
-		return false;
+		return NULL;
 	}
 	descr = perform_writeback_and_relock(descr, &writeback,
 										 checkpoint_state, NULL, 0);
@@ -2754,7 +2758,7 @@ checkpoint_ix(int flags, BTreeDescr *descr)
 	if (!descr)
 	{
 		/* Lock already released by perform_writeback_and_relock() */
-		return false;
+		return NULL;
 	}
 
 	Assert(checkpoint_state->curKeyType == CurKeyGreatest);
@@ -3045,7 +3049,7 @@ checkpoint_ix(int flags, BTreeDescr *descr)
 		o_update_latest_chkp_num(descr->oids.datoid,
 								 descr->oids.relnode,
 								 chkpNum);
-	return true;
+	return descr;
 }
 
 
@@ -5209,7 +5213,15 @@ checkpoint_tables_callback(OIndexType type, ORelOids treeOids,
 			Assert(td->storageType == BTreeStoragePersistence ||
 				   td->storageType == BTreeStorageUnlogged);
 
-			success = checkpoint_ix(tbl_arg->flags, td);
+			/*
+			 * checkpoint_ix() may have re-fetched the descriptor after an
+			 * unlock/relock cycle (a concurrent invalidation could have freed
+			 * the one we passed in), so adopt the returned descriptor for the
+			 * post-checkpoint steps below (sort_checkpoint_*_file / the
+			 * postProcessList entry) instead of the now-possibly-stale td.
+			 */
+			td = checkpoint_ix(tbl_arg->flags, td);
+			success = (td != NULL);
 
 			if (success)
 			{

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -1397,6 +1397,19 @@ orioledb_amcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 
 	ReleaseVariableStats(vardata);
 
+	/*
+	 * These out-params are cost_index()'s stack locals.  ASAN can report the
+	 * stores below as writes to poisoned stack: PostgreSQL's
+	 * sigsetjmp/longjmp error unwinding leaves stack shadow stale, so a
+	 * reused caller stack slot trips a false stack-use-after-scope.  The
+	 * writes are legitimate; unpoison first.  No-op in non-ASAN builds.
+	 */
+	ASAN_UNPOISON_MEMORY_REGION(indexStartupCost, sizeof(*indexStartupCost));
+	ASAN_UNPOISON_MEMORY_REGION(indexTotalCost, sizeof(*indexTotalCost));
+	ASAN_UNPOISON_MEMORY_REGION(indexSelectivity, sizeof(*indexSelectivity));
+	ASAN_UNPOISON_MEMORY_REGION(indexCorrelation, sizeof(*indexCorrelation));
+	ASAN_UNPOISON_MEMORY_REGION(indexPages, sizeof(*indexPages));
+
 	*indexStartupCost = costs.indexStartupCost;
 	*indexTotalCost = costs.indexTotalCost;
 	*indexSelectivity = costs.indexSelectivity;

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -448,9 +448,16 @@ append_rowid_values(OIndexDescr *id,
 	if (!id->primaryIsCtid)
 	{
 		ORowIdAddendumNonCtid *add;
+		ORowIdAddendumNonCtid addbuf;
 		OTuple		tuple;
 
-		add = (ORowIdAddendumNonCtid *) p;
+		/*
+		 * The rowid varlena may be only 4-byte aligned in storage, so decode
+		 * the addendum through an aligned copy rather than a misaligned typed
+		 * pointer (whose 8-byte csn would be a misalignment UB).
+		 */
+		memcpy(&addbuf, p, sizeof(addbuf));
+		add = &addbuf;
 		p += MAXALIGN(sizeof(ORowIdAddendumNonCtid));
 		*csn = add->csn;
 
@@ -483,9 +490,12 @@ append_rowid_values(OIndexDescr *id,
 	else
 	{
 		ORowIdAddendumCtid *add;
+		ORowIdAddendumCtid addbuf;
 		AttrNumber	attnum = id->nFields - 1;
 
-		add = (ORowIdAddendumCtid *) p;
+		/* Decode through an aligned copy; see the non-ctid branch above. */
+		memcpy(&addbuf, p, sizeof(addbuf));
+		add = &addbuf;
 		*csn = add->csn;
 		*version = add->version;
 		p += MAXALIGN(sizeof(ORowIdAddendumCtid));

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -1385,13 +1385,15 @@ get_index_descr(ORelOids ixOids, OIndexType ixType,
 	OIndex	   *oIndex;
 	MemoryContext mcxt;
 	bool		found = false;
+	bool		existed;
+	int			refcnt = 0;
 
 	result = hash_search(oIndexDescrHash, &ixOids, HASH_ENTER, &found);
 	Assert((found && result) || !found);
 
-	found = found && (ctx.version == O_TABLE_INVALID_VERSION || result->version == ctx.version);
-
-	if (found)
+	existed = found;
+	if (existed && (ctx.version == O_TABLE_INVALID_VERSION ||
+					result->version == ctx.version))
 		return result;
 
 	oIndex = o_indices_get_extended(ixOids, ixType, ctx);
@@ -1402,6 +1404,22 @@ get_index_descr(ORelOids ixOids, OIndexType ixType,
 		Assert(found);
 		return NULL;
 	}
+
+	/*
+	 * Re-filling an existing entry whose metadata version changed.
+	 * o_index_fill_descr() memset()s the descriptor and resets refcnt to 0,
+	 * so free the old tupdescs / index_mctx / btree state and preserve the
+	 * reference count first -- exactly like recreate_index_descr(). Otherwise
+	 * a descriptor still referenced by an OTableDescr would leak its old
+	 * contents and, worse, have its refcnt clobbered to 0, letting a
+	 * concurrent checkpoint invalidation free it while it is still in use
+	 * (use-after-free -> later FreeTupleDesc MAXALIGN crash).
+	 */
+	if (existed)
+	{
+		refcnt = result->refcnt;
+		index_descr_free(result);
+	}
 	mcxt = MemoryContextSwitchTo(descrCxt);
 	o_index_fill_descr(result, oIndex, o_table_source, source);
 	MemoryContextSwitchTo(mcxt);
@@ -1409,6 +1427,8 @@ get_index_descr(ORelOids ixOids, OIndexType ixType,
 						  result->oids, oIndex->indexType,
 						  oIndex->table_persistence, oIndex->tablespace,
 						  oIndex->createOxid, result);
+	if (existed)
+		result->refcnt = refcnt;
 	free_o_index(oIndex);
 
 	return result;

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -2560,10 +2560,18 @@ get_keys_from_rowid(OIndexDescr *primary, Datum pkDatum, OBTreeKeyBound *key,
 	{
 		OTuple		tuple;
 		ORowIdAddendumNonCtid *add;
+		ORowIdAddendumNonCtid addbuf;
 
 		rowid = DatumGetByteaP(pkDatum);
 		p = (Pointer) rowid + MAXALIGN(VARHDRSZ);
-		add = (ORowIdAddendumNonCtid *) p;
+
+		/*
+		 * The rowid varlena may be only 4-byte aligned in storage, so decode
+		 * the addendum through an aligned copy rather than a misaligned typed
+		 * pointer (whose 8-byte csn would be a misalignment UB).
+		 */
+		memcpy(&addbuf, p, sizeof(addbuf));
+		add = &addbuf;
 		p += MAXALIGN(sizeof(ORowIdAddendumNonCtid));
 		if (hint)
 			*hint = add->hint;
@@ -2590,10 +2598,14 @@ get_keys_from_rowid(OIndexDescr *primary, Datum pkDatum, OBTreeKeyBound *key,
 	else
 	{
 		ORowIdAddendumCtid *add;
+		ORowIdAddendumCtid addbuf;
 
 		rowid = DatumGetByteaP(pkDatum);
 		p = (Pointer) rowid + MAXALIGN(VARHDRSZ);
-		add = (ORowIdAddendumCtid *) p;
+
+		/* Decode through an aligned copy; see the non-ctid branch above. */
+		memcpy(&addbuf, p, sizeof(addbuf));
+		add = &addbuf;
 		if (hint)
 			*hint = add->hint;
 		if (csn)
@@ -2629,21 +2641,23 @@ rowid_set_csn(OIndexDescr *id, Datum pkDatum, CommitSeqNo csn)
 
 	if (!id->primaryIsCtid)
 	{
-		ORowIdAddendumNonCtid *add;
-
 		rowid = DatumGetByteaP(pkDatum);
 		p = (Pointer) rowid + MAXALIGN(VARHDRSZ);
-		add = (ORowIdAddendumNonCtid *) p;
-		add->csn = csn;
+
+		/*
+		 * The rowid varlena may be only 4-byte aligned in storage, so store
+		 * the 8-byte csn with memcpy rather than through a misaligned typed
+		 * pointer (which would be a misalignment UB).
+		 */
+		memcpy(p + offsetof(ORowIdAddendumNonCtid, csn), &csn, sizeof(csn));
 	}
 	else
 	{
-		ORowIdAddendumCtid *add;
-
 		rowid = DatumGetByteaP(pkDatum);
 		p = (Pointer) rowid + MAXALIGN(VARHDRSZ);
-		add = (ORowIdAddendumCtid *) p;
-		add->csn = csn;
+
+		/* See the non-ctid branch above. */
+		memcpy(p + offsetof(ORowIdAddendumCtid, csn), &csn, sizeof(csn));
 	}
 }
 

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -1366,9 +1366,16 @@ o_tbl_insert_with_arbiter(Relation rel,
 					if (!primary->primaryIsCtid)
 					{
 						ORowIdAddendumNonCtid *add;
+						ORowIdAddendumNonCtid addbuf;
 						OTuple		tuple;
 
-						add = (ORowIdAddendumNonCtid *) p;
+						/*
+						 * The rowid varlena may be only 4-byte aligned, so
+						 * decode the addendum through an aligned copy rather
+						 * than a misaligned typed pointer (8-byte csn -> UB).
+						 */
+						memcpy(&addbuf, p, sizeof(addbuf));
+						add = &addbuf;
 						p += MAXALIGN(sizeof(ORowIdAddendumNonCtid));
 
 						if (primary->bridging)

--- a/src/tableam/vacuum.c
+++ b/src/tableam/vacuum.c
@@ -944,12 +944,23 @@ lazy_vacuum_bridge_index(LVRelState *vacrel)
 		flush_local_wal(false, false);
 
 	/*
-	 * We set all LP_DEAD items from the first heap pass to LP_UNUSED during
-	 * the second heap pass.  No more, no less.
+	 * We remove all the dead items collected during the first pass, no more
+	 * and no less.
+	 *
+	 * Unlike the heap this invariant is derived from, we do NOT also assert
+	 * vacuumed_pages == lpdead_item_pages.  Both counters count bridge-index
+	 * leaf pages carrying dead items, but they are computed in two separate
+	 * passes over a concurrently-mutable B-tree: lazy_scan_bridge_index()
+	 * counts them while walking page images left-to-right, and this function
+	 * counts them while walking the live tree by dead TID.  Concurrent DML
+	 * (page splits/merges) and eviction between the two passes redistribute
+	 * the same dead items across a different number of pages, so the page
+	 * counts legitimately diverge under load.  The item count is unaffected:
+	 * every dead TID is still located (find_page relocates split items) and
+	 * erased, and TIDs concurrently removed are simply skipped.
 	 */
 	Assert(vacrel->num_index_scans > 1 ||
-		   (NUM_ITEMS(vacrel) == vacrel->lpdead_items &&
-			vacuumed_pages == vacrel->lpdead_item_pages));
+		   NUM_ITEMS(vacrel) == vacrel->lpdead_items);
 
 	ereport(DEBUG2,
 			(errmsg("table \"%s\": removed %lld dead item identifiers in %u pages",

--- a/test/expected/alter_type.out
+++ b/test/expected/alter_type.out
@@ -1226,8 +1226,25 @@ CREATE INDEX o_test_drop_index_list_ix1 ON o_test_drop_index_list (id) WHERE id 
 CREATE INDEX o_test_drop_index_list_ix2 ON o_test_drop_index_list (phone);
 ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE text;
 ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE varchar(15);
+-- ADD COLUMN of a domain type with a NULL missing value to a populated table
+-- must not crash: o_table_fill_constr() used to mark the missing value present
+-- and datumCopy() a NULL varlena (o_in_add_column short-circuited the
+-- missingIsNull guard).
+CREATE DOMAIN alter_type_intarr AS int[];
+CREATE TABLE o_test_add_domain_col (
+	a int PRIMARY KEY
+) USING orioledb;
+INSERT INTO o_test_add_domain_col VALUES (1), (2);
+ALTER TABLE o_test_add_domain_col ADD COLUMN b alter_type_intarr;
+SELECT * FROM o_test_add_domain_col ORDER BY a;
+ a | b 
+---+---
+ 1 | 
+ 2 | 
+(2 rows)
+
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 14 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to table o_ddl_check
 drop cascades to table o_test_alter_change_byval
 drop cascades to table o_test_pkey_alter_type
@@ -1242,5 +1259,7 @@ drop cascades to table o_test_alter_type_not_reuse_index
 drop cascades to table o_test_alter_type_typmod_changed
 drop cascades to table o_test_alter_type_add_column_default
 drop cascades to table o_test_drop_index_list
+drop cascades to table o_test_add_domain_col
 DROP SCHEMA alter_type CASCADE;
+NOTICE:  drop cascades to type alter_type_intarr
 RESET search_path;

--- a/test/sql/alter_type.sql
+++ b/test/sql/alter_type.sql
@@ -371,6 +371,18 @@ CREATE INDEX o_test_drop_index_list_ix2 ON o_test_drop_index_list (phone);
 ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE text;
 ALTER TABLE o_test_drop_index_list ALTER COLUMN phone TYPE varchar(15);
 
+-- ADD COLUMN of a domain type with a NULL missing value to a populated table
+-- must not crash: o_table_fill_constr() used to mark the missing value present
+-- and datumCopy() a NULL varlena (o_in_add_column short-circuited the
+-- missingIsNull guard).
+CREATE DOMAIN alter_type_intarr AS int[];
+CREATE TABLE o_test_add_domain_col (
+	a int PRIMARY KEY
+) USING orioledb;
+INSERT INTO o_test_add_domain_col VALUES (1), (2);
+ALTER TABLE o_test_add_domain_col ADD COLUMN b alter_type_intarr;
+SELECT * FROM o_test_add_domain_col ORDER BY a;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA alter_type CASCADE;
 RESET search_path;


### PR DESCRIPTION
## Summary

A batch of fixes for concurrency bugs surfaced by stress-hunting the
`027_stream_regress` workload under churn (concurrent `createdb`/`dropdb`
plus aggressive checkpoints, `checkpoint_timeout=30s`, on both a primary and a
streaming standby). Each commit fixes one distinct, independently-reproduced
bug (or an invalid debug assert). The stress-hunt harness and the churn-only CI
tuning (the `pg_tests`/`pg_tests_asan` matrix, `-DCHECK_PAGE_STRUCT`, the raised
replica sync timeout) are intentionally **not** part of this PR.

The fixes were validated on the churn matrix (64 `pg_tests` + 8 `pg_tests_asan`
jobs) and build cleanly against the patched PG18.

The sys-tree fuzzy-checkpoint recovery redesign that previously lived here has been split into its own PR (branch `fuzzy-sys-tree-checkpoint`).

## Fixes

### Crashes / invalid asserts under concurrency
- **vacuum: drop invalid page-count assert in the bridge-index second pass.**
  The `vacuumed_pages == lpdead_item_pages` cross-check is invalid for a
  concurrently-mutable B-tree (the two passes count dead-item pages across
  splits/merges), firing as a flaky SIGABRT (~12/64 jobs). The vacuuming is
  correct; only the structural cross-check was wrong. Item-count invariant kept.
- **btree scan: stop the bitmap-jump path at the rightmost internal page.**
  The bitmap "jump" branch copied the current internal page's hikey with no
  rightmost check; the rightmost page has no hikey → assert (`page_get_hikey`)
  / over-read. Made the jump branch terminate like the non-jump branch does.
- **btree iterator: scope the monotonicity assert to a single `col = ANY` element.**
  The cassert monotonicity check compared tuples *across* array elements, which
  need not be ordered relative to each other → rare SELECT crash. Reset
  `prevTuple` in `o_btree_iterator_advance()` so the check stays within one
  element (where ordering does hold).
- **btree io: tolerate a concurrently-removed secondary relnode file at fsync.**
  At PreCommit, `iterate_relnode_files` fsyncs segment/`.map`/`.evt` sidecars;
  the checkpointer's superseded-map cleanup can unlink a listed `.map` before
  the callback runs → `fsync` ERROR → PANIC (seen on CREATE TABLE AS). Rather
  than racily pre-checking with `access()` (which only narrows the window),
  `fsync_callback` now opens the file itself and returns quietly on `ENOENT`,
  closing the race; a genuine I/O error on a present file still ERRORs.
- **checkpoint: return the re-fetched descriptor from `checkpoint_ix`.**
  `checkpoint_ix()` re-fetches the index descriptor after its writeback relock
  (a concurrent DROP/TRUNCATE invalidation can free+rebuild it), but returned
  only `bool`, so `checkpoint_tables_callback()` kept using the stale descriptor
  in `sort_checkpoint_map_file`/`add_index_id_item` → later MAXALIGN trap in
  `FreeTupleDesc`. Return the current descriptor (NULL on failure) and adopt it;
  concurrent-deletion detection is preserved (no refcnt pin, so no `valid_doff`).
- **ddl: don't store a NULL missing value when adding a column.**
  For `ALTER TABLE ... ADD COLUMN`, `o_table_fill_constr()` marked the column's
  fast-default "missing value" present even when the evaluated default was NULL
  (the `!old_field` guard short-circuited the `missingIsNull` check), then
  `datumCopy()`'d a NULL varlena → SIGSEGV (or a garbage-`VARSIZE` hang). Gate
  `hasmissing` on `!missingIsNull`. Surfaced adding a domain-over-array column
  with no default to a populated table.
- **descr: preserve refcnt and free old contents when refilling an index descr.**
  `get_index_descr()` re-filled an existing `oIndexDescrHash` entry in place on a
  metadata-version mismatch via `o_index_fill_descr()`, which `memset`s the descr
  and resets refcnt to 0 — unlike `recreate_index_descr()` it neither freed the
  old tupdescs/`index_mctx` nor preserved refcnt. A descriptor still referenced
  by an `OTableDescr` thus had its refcnt clobbered to 0 and could be freed by a
  concurrent checkpoint invalidation while still in use (use-after-free → later
  `FreeTupleDesc` MAXALIGN trap). Mirror `recreate_index_descr()`: save refcnt,
  free the old contents, refill, restore refcnt.

### Sanitizer (ASAN/UBSAN) fixes
- **btree: decode rowids alignment-safely (no allocation).** Rowid addendum
  structs were decoded by casting a pointer at a MAXALIGN offset from a bytea
  that can be only 4-byte-aligned in place; the structs need 8-byte alignment
  (`CommitSeqNo`) → misalignment UB (UBSAN). Each decode/encode goes through an
  aligned fixed-size stack copy — no heap allocation, nothing to leak.
- **ddl: unpoison the drop arg to silence an ASAN stack-use-after-scope FP.**
  A legitimate `((ObjectAccessDrop *) arg)->dropflags` read tripped a
  false-positive from PG's `sigsetjmp`/`longjmp` stack-shadow staleness.
- **indexam: unpoison `amcostestimate` out-params (same FP class).** Writing
  `cost_index()`'s stack locals tripped the same `sigsetjmp`/`longjmp` false
  stack-use-after-scope. Both ASAN fixes are no-ops off ASAN.

### CI
- **ci: filter the OID-variant of the `regress_user11` role-collision race.**
  Under churn the known cross-test role race also surfaces as
  `could not find tuple for role <oid>`; added that variant to the existing
  scoped `skip_hunk_errors` so it no longer leaks into the filtered residual.


