### PR TITLE
Add CHECK_FOR_INTERRUPTS to workers_synchronize

### DIFF
--- a/include/workers/interrupt.h
+++ b/include/workers/interrupt.h
@@ -14,30 +14,11 @@
 #ifndef __WORKERS_INTERRUPT_H__
 #define __WORKERS_INTERRUPT_H__
 
-#include "miscadmin.h"
-#include "postmaster/startup.h"
-
-extern void o_worker_handle_interrupts(void);
-
-#if PG_VERSION_NUM >= 180000
-#define O_STARTUP_PROC_INTERRUPTS() ProcessStartupProcInterrupts()
-#else
-#define O_STARTUP_PROC_INTERRUPTS() HandleStartupProcInterrupts()
-#endif
-
 /*
  * Like CHECK_FOR_INTERRUPTS(), but backend-aware: the startup process and
  * orioledb's own background workers (recovery/S3/bgwriter workers) redefine
  * signal handling and don't respond to a plain CHECK_FOR_INTERRUPTS().
  */
-#define O_CHECK_FOR_INTERRUPTS() \
-	do { \
-		if (AmStartupProcess()) \
-			O_STARTUP_PROC_INTERRUPTS(); \
-		else if (MyBackendType == B_BG_WORKER) \
-			o_worker_handle_interrupts(); \
-		else \
-			CHECK_FOR_INTERRUPTS(); \
-	} while (0)
+extern void o_worker_handle_interrupts(void);
 
 #endif							/* __WORKERS_INTERRUPT_H__ */

--- a/include/workers/interrupt.h
+++ b/include/workers/interrupt.h
@@ -14,6 +14,30 @@
 #ifndef __WORKERS_INTERRUPT_H__
 #define __WORKERS_INTERRUPT_H__
 
+#include "miscadmin.h"
+#include "postmaster/startup.h"
+
 extern void o_worker_handle_interrupts(void);
+
+#if PG_VERSION_NUM >= 180000
+#define O_STARTUP_PROC_INTERRUPTS() ProcessStartupProcInterrupts()
+#else
+#define O_STARTUP_PROC_INTERRUPTS() HandleStartupProcInterrupts()
+#endif
+
+/*
+ * Like CHECK_FOR_INTERRUPTS(), but backend-aware: the startup process and
+ * orioledb's own background workers (recovery/S3/bgwriter workers) redefine
+ * signal handling and don't respond to a plain CHECK_FOR_INTERRUPTS().
+ */
+#define O_CHECK_FOR_INTERRUPTS() \
+	do { \
+		if (AmStartupProcess()) \
+			O_STARTUP_PROC_INTERRUPTS(); \
+		else if (MyBackendType == B_BG_WORKER) \
+			o_worker_handle_interrupts(); \
+		else \
+			CHECK_FOR_INTERRUPTS(); \
+	} while (0)
 
 #endif							/* __WORKERS_INTERRUPT_H__ */

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -3292,7 +3292,7 @@ worker_wait_shutdown(RecoveryWorkerState *worker)
 
 	while (true)
 	{
-		O_CHECK_FOR_INTERRUPTS();
+		o_worker_handle_interrupts();
 
 		status = GetBackgroundWorkerPid(worker->handle, &not_used);
 
@@ -4652,7 +4652,7 @@ delay_if_queued_for_idxbuild(void)
 		HASH_SEQ_STATUS hash_seq;
 		RecoveryIdxBuildQueueState *cur;
 
-		O_CHECK_FOR_INTERRUPTS();
+		o_worker_handle_interrupts();
 
 		/* Remove hash entries for completed indexes */
 		hash_seq_init(&hash_seq, idxbuild_oids_hash);
@@ -4689,7 +4689,7 @@ delay_rels_queued_for_idxbuild(ORelOids oids)
 	 */
 	while (true)
 	{
-		O_CHECK_FOR_INTERRUPTS();
+		o_worker_handle_interrupts();
 
 		hash_elem = (RecoveryIdxBuildQueueState *) hash_search(idxbuild_oids_hash,
 															   &oids,
@@ -5022,7 +5022,7 @@ workers_synchronize(XLogRecPtr ptr, bool send_synchronize)
 			BgwHandleStatus status;
 			pid_t		pid;
 
-			O_CHECK_FOR_INTERRUPTS();
+			o_worker_handle_interrupts();
 
 			pg_usleep(10);
 

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -3292,7 +3292,7 @@ worker_wait_shutdown(RecoveryWorkerState *worker)
 
 	while (true)
 	{
-		CHECK_FOR_INTERRUPTS();
+		O_CHECK_FOR_INTERRUPTS();
 
 		status = GetBackgroundWorkerPid(worker->handle, &not_used);
 
@@ -4652,18 +4652,7 @@ delay_if_queued_for_idxbuild(void)
 		HASH_SEQ_STATUS hash_seq;
 		RecoveryIdxBuildQueueState *cur;
 
-		/*
-		 * This function might be called by a startup process and by a
-		 * recovery worker, therefore check in which worker we are.
-		 */
-		if (AmStartupProcess())
-#if PG_VERSION_NUM >= 180000
-			ProcessStartupProcInterrupts();
-#else
-			HandleStartupProcInterrupts();
-#endif
-		else
-			o_worker_handle_interrupts();
+		O_CHECK_FOR_INTERRUPTS();
 
 		/* Remove hash entries for completed indexes */
 		hash_seq_init(&hash_seq, idxbuild_oids_hash);
@@ -4700,18 +4689,7 @@ delay_rels_queued_for_idxbuild(ORelOids oids)
 	 */
 	while (true)
 	{
-		/*
-		 * This function might be called by a startup process and by a
-		 * recovery worker, therefore check in which worker we are.
-		 */
-		if (AmStartupProcess())
-#if PG_VERSION_NUM >= 180000
-			ProcessStartupProcInterrupts();
-#else
-			HandleStartupProcInterrupts();
-#endif
-		else
-			o_worker_handle_interrupts();
+		O_CHECK_FOR_INTERRUPTS();
 
 		hash_elem = (RecoveryIdxBuildQueueState *) hash_search(idxbuild_oids_hash,
 															   &oids,
@@ -5044,7 +5022,7 @@ workers_synchronize(XLogRecPtr ptr, bool send_synchronize)
 			BgwHandleStatus status;
 			pid_t		pid;
 
-			CHECK_FOR_INTERRUPTS();
+			O_CHECK_FOR_INTERRUPTS();
 
 			pg_usleep(10);
 

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -5044,6 +5044,8 @@ workers_synchronize(XLogRecPtr ptr, bool send_synchronize)
 			BgwHandleStatus status;
 			pid_t		pid;
 
+			CHECK_FOR_INTERRUPTS();
+
 			pg_usleep(10);
 
 			if (j % 100 == 0)

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -4668,8 +4668,8 @@ delay_if_queued_for_idxbuild(void)
 
 		/*
 		 * We wait on a condition variable that will wake us as soon as the
-		 * pause ends, but we use a timeout so we can check for
-		 * interrupts periodically too.
+		 * pause ends, but we use a timeout so we can check for interrupts
+		 * periodically too.
 		 */
 		ConditionVariableTimedSleep(recovery_index_cv, 1000,
 									WAIT_EVENT_PARALLEL_CREATE_INDEX_SCAN);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -4668,8 +4668,8 @@ delay_if_queued_for_idxbuild(void)
 
 		/*
 		 * We wait on a condition variable that will wake us as soon as the
-		 * pause ends, but we use a timeout so we can check the
-		 * HandleStartupProcInterrupts() periodically too.
+		 * pause ends, but we use a timeout so we can check for
+		 * interrupts periodically too.
 		 */
 		ConditionVariableTimedSleep(recovery_index_cv, 1000,
 									WAIT_EVENT_PARALLEL_CREATE_INDEX_SCAN);

--- a/src/workers/interrupt.c
+++ b/src/workers/interrupt.c
@@ -19,6 +19,13 @@
 #include "workers/interrupt.h"
 
 #include "postmaster/interrupt.h"
+#include "postmaster/startup.h"
+
+#if PG_VERSION_NUM >= 180000
+#define O_STARTUP_PROC_INTERRUPTS() ProcessStartupProcInterrupts()
+#else
+#define O_STARTUP_PROC_INTERRUPTS() HandleStartupProcInterrupts()
+#endif
 
 static void o_worker_shutdown(int elevel);
 
@@ -37,10 +44,21 @@ o_worker_shutdown(int elevel)
 void
 o_worker_handle_interrupts(void)
 {
-	/*
-	 * In case of a pending shutdown request we just raise an ERROR message
-	 * currently.
-	 */
-	if (ShutdownRequestPending)
-		o_worker_shutdown(ERROR);
+	if (AmStartupProcess())
+	{
+		O_STARTUP_PROC_INTERRUPTS();
+	}
+	else if (MyBackendType == B_BG_WORKER)
+	{
+		/*
+		 * In case of a pending shutdown request we just raise an ERROR
+		 * message currently.
+		 */
+		if (ShutdownRequestPending)
+			o_worker_shutdown(ERROR);
+	}
+	else
+	{
+		CHECK_FOR_INTERRUPTS();
+	}
 }


### PR DESCRIPTION
Previously the busy loop in the workers_synchronize function didn't check for interrupts which meant it woudld ignore signals such as SIGTERM and won't exit cleanly.