### PR TITLE
Reindex partition's indexes

### DIFF
--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -507,6 +507,26 @@ get_all_vacuum_rels(int options)
 	return vacrels;
 }
 
+/*
+ * If 'ind' is an orioledb btree index, add its name to reindex_list and return
+ * true; otherwise leave the list unchanged and return false.
+ */
+static bool
+add_index_to_reindex_list(Relation ind)
+{
+	OBTOptions *options = (OBTOptions *) ind->rd_options;
+
+	if (ind->rd_rel->relam == BTREE_AM_OID &&
+		!(options && !options->orioledb_index))
+	{
+		String	   *ix_name = makeString(pstrdup(ind->rd_rel->relname.data));
+
+		reindex_list = list_append_unique(reindex_list, ix_name);
+		return true;
+	}
+	return false;
+}
+
 /* Based on postgres function ReindexMultipleTables */
 static bool
 check_multiple_tables(const char *objectName, ReindexObjectType objectKind, bool concurrently)
@@ -665,16 +685,9 @@ check_multiple_tables(const char *objectName, ReindexObjectType objectKind, bool
 
 			foreach(index, RelationGetIndexList(tbl))
 			{
-				Oid			indexOid = lfirst_oid(index);
-				Relation	ind = relation_open(indexOid, AccessShareLock);
-				OBTOptions *options = (OBTOptions *) ind->rd_options;
+				Relation	ind = relation_open(lfirst_oid(index), AccessShareLock);
 
-				if (ind->rd_rel->relam == BTREE_AM_OID && !(options && !options->orioledb_index))
-				{
-					String	   *ix_name = makeString(pstrdup(ind->rd_rel->relname.data));
-
-					reindex_list = list_append_unique(reindex_list, ix_name);
-				}
+				add_index_to_reindex_list(ind);
 				relation_close(ind, AccessShareLock);
 			}
 
@@ -865,28 +878,37 @@ ReindexPartitions(Oid relid, bool concurrently)
 
 		Assert(part_rel->rd_rel->relkind == RELKIND_INDEX ||
 			   part_rel->rd_rel->relkind == RELKIND_RELATION);
-
-		if (concurrently)
+		if ((part_rel->rd_rel->relkind == RELKIND_RELATION ||
+			 part_rel->rd_rel->relkind == RELKIND_MATVIEW) &&
+			is_orioledb_rel(part_rel))
 		{
-			if ((part_rel->rd_rel->relkind == RELKIND_RELATION ||
-				 part_rel->rd_rel->relkind == RELKIND_MATVIEW) &&
-				is_orioledb_rel(part_rel))
+			ListCell   *index;
+
+			/* Every index of it gets reindexed.  */
+			foreach(index, RelationGetIndexList(part_rel))
 			{
+				Relation	ind = relation_open(lfirst_oid(index), AccessShareLock);
+
+				add_index_to_reindex_list(ind);
+				relation_close(ind, AccessShareLock);
+			}
+
+			if (concurrently)
 				has_orioledb = true;
-			}
-			else if (part_rel->rd_rel->relkind == RELKIND_INDEX)
+		}
+		else if (part_rel->rd_rel->relkind == RELKIND_INDEX)
+		{
+			Relation	tbl = relation_open(part_rel->rd_index->indrelid, AccessShareLock);
+
+			if (tbl->rd_rel->relkind == RELKIND_RELATION &&
+				is_orioledb_rel(tbl))
 			{
-				Relation	tbl;
-
-				tbl = relation_open(part_rel->rd_index->indrelid, AccessShareLock);
-
-				if ((tbl->rd_rel->relkind == RELKIND_RELATION) &&
-					is_orioledb_rel(tbl))
-				{
+				add_index_to_reindex_list(part_rel);
+				if (concurrently)
 					has_orioledb = true;
-				}
-				relation_close(tbl, AccessShareLock);
 			}
+
+			relation_close(tbl, AccessShareLock);
 		}
 		relation_close(part_rel, AccessShareLock);
 	}
@@ -1331,7 +1353,6 @@ orioledb_utility_command(PlannedStmt *pstmt,
 														  false);
 					Relation	iRel,
 								tbl;
-					OBTOptions *options;
 
 					if (get_rel_relkind(indOid) == RELKIND_PARTITIONED_INDEX)
 					{
@@ -1342,18 +1363,9 @@ orioledb_utility_command(PlannedStmt *pstmt,
 					iRel = index_open(indOid, AccessShareLock);
 					tbl = relation_open(iRel->rd_index->indrelid,
 										AccessShareLock);
-					options = (OBTOptions *) iRel->rd_options;
 					if (is_orioledb_rel(tbl) &&
-						iRel->rd_rel->relam == BTREE_AM_OID &&
-						!(options && !options->orioledb_index))
-					{
-						String	   *ix_name;
-
-						ix_name = makeString(pstrdup(iRel->rd_rel->relname.data));
-						reindex_list = list_append_unique(reindex_list, ix_name);
-						if (concurrently)
-							has_orioledb = true;
-					}
+						add_index_to_reindex_list(iRel) && concurrently)
+						has_orioledb = true;
 					relation_close(tbl, AccessShareLock);
 					relation_close(iRel, AccessShareLock);
 				}
@@ -1377,16 +1389,10 @@ orioledb_utility_command(PlannedStmt *pstmt,
 
 						foreach(index, RelationGetIndexList(tbl))
 						{
-							Oid			indexOid = lfirst_oid(index);
-							Relation	ind = relation_open(indexOid, AccessShareLock);
-							OBTOptions *options = (OBTOptions *) ind->rd_options;
+							Relation	ind = relation_open(lfirst_oid(index),
+															AccessShareLock);
 
-							if (ind->rd_rel->relam == BTREE_AM_OID && !(options && !options->orioledb_index))
-							{
-								String	   *ix_name = makeString(pstrdup(ind->rd_rel->relname.data));
-
-								reindex_list = list_append_unique(reindex_list, ix_name);
-							}
+							add_index_to_reindex_list(ind);
 							relation_close(ind, AccessShareLock);
 							if (concurrently)
 								has_orioledb = true;

--- a/test/t/reindex_test.py
+++ b/test/t/reindex_test.py
@@ -283,3 +283,77 @@ class ReindexTest(BaseTest):
 				    replica.execute(
 				        f"{set_scan.format('off', 'on', 'on')}  SELECT * FROM o_test_1 WHERE val_3 = 'test_data250';"
 				    ), [(250, 500, 'test_data250')])
+
+	def _partitioned_setup(self, node):
+		node.safe_psql("""
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			SET default_table_access_method = 'orioledb';
+			CREATE TABLE o_part (id int, val int) PARTITION BY RANGE (id);
+			CREATE TABLE o_part_1 PARTITION OF o_part FOR VALUES FROM (0) TO (100);
+			CREATE TABLE o_part_2 PARTITION OF o_part FOR VALUES FROM (100) TO (200);
+			CREATE INDEX o_part_val_idx ON o_part (val);
+			INSERT INTO o_part SELECT i, i FROM generate_series(0, 199) i;
+		""")
+
+	def _n_indices(self, node, part):
+		# orioledb_tbl_indices() prints one "Index type:" line per orioledb
+		# index of the table; a duplicated index adds one more.
+		descr = node.execute("SELECT orioledb_tbl_indices('%s'::regclass);" %
+		                     part)[0][0]
+		return descr.count('Index type:')
+
+	def test_reindex_table_partitioned_no_duplicate(self):
+		"""
+		REINDEX TABLE <partitioned orioledb table> reindexes every partition's
+		indexes in place; it must NOT create duplicate orioledb indexes.
+
+		Before the ReindexPartitions() fix the partition children were never
+		added to reindex_list, so orioledb_ambuild() ran with reindex=false and
+		o_define_index() added a second copy of each secondary index to every
+		partition's o_table.
+		"""
+		node = self.node
+		node.start()
+		self._partitioned_setup(node)
+
+		before1 = self._n_indices(node, 'o_part_1')
+		before2 = self._n_indices(node, 'o_part_2')
+		# sanity: each leaf partition has ctid primary + the secondary index
+		self.assertEqual(before1, 2)
+		self.assertEqual(before2, 2)
+
+		node.safe_psql("REINDEX TABLE o_part;")
+
+		self.assertEqual(self._n_indices(node, 'o_part_1'), before1,
+		                 "REINDEX TABLE duplicated indices in o_part_1")
+		self.assertEqual(self._n_indices(node, 'o_part_2'), before2,
+		                 "REINDEX TABLE duplicated indices in o_part_2")
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM o_part WHERE val < 50;")[0][0],
+		    50)
+		node.stop()
+
+	def test_reindex_index_partitioned_no_duplicate(self):
+		"""
+		Same as above but for REINDEX INDEX <partitioned index>: each child
+		index must be reindexed in place, not duplicated.
+		"""
+		node = self.node
+		node.start()
+		self._partitioned_setup(node)
+
+		before1 = self._n_indices(node, 'o_part_1')
+		before2 = self._n_indices(node, 'o_part_2')
+		self.assertEqual(before1, 2)
+		self.assertEqual(before2, 2)
+
+		node.safe_psql("REINDEX INDEX o_part_val_idx;")
+
+		self.assertEqual(self._n_indices(node, 'o_part_1'), before1,
+		                 "REINDEX INDEX duplicated indices in o_part_1")
+		self.assertEqual(self._n_indices(node, 'o_part_2'), before2,
+		                 "REINDEX INDEX duplicated indices in o_part_2")
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM o_part WHERE val < 50;")[0][0],
+		    50)
+		node.stop()


### PR DESCRIPTION
Before this patch, ReindexPartitions() never touched reindex_list, but both REINDEX INDEX <partitioned index> and
REINDEX TABLE <partitioned table> will reindex children indexes too; hence, without this, the duplicated indexes would be created.  This patch gather children indices to reindex_list so they are truly reindexed on orioledb' side.