### PR TITLE
Standalone backend fix for end-of-recovery checkpoint

### DIFF
--- a/include/catalog/o_sys_cache.h
+++ b/include/catalog/o_sys_cache.h
@@ -662,6 +662,9 @@ o_set_sys_cache_search_datoid(Oid datoid)
 	}
 }
 
+#if PG_VERSION_NUM >= 180000
+extern void o_database_cache_restore_default_locale(void);
+#endif
 extern void o_get_prefixes_for_tablespace(Oid datoid, Oid tablespace,
 										  char **prefix, char **db_prefix);
 

--- a/src/catalog/o_database_cache.c
+++ b/src/catalog/o_database_cache.c
@@ -172,6 +172,40 @@ o_database_cache_set_database_encoding()
 	SetDatabaseEncoding(encoding);
 }
 
+#if PG_VERSION_NUM >= 180000
+static struct pg_locale_struct o_default_locale;
+static pg_locale_t prev_default_locale = NULL;
+static bool o_default_locale_installed = false;
+static bool o_default_locale_initialized = false;
+
+/* Remember the previous value of default_locale.  */
+static pg_locale_t
+o_database_cache_install_default_locale(void)
+{
+	if (!o_default_locale_installed)
+	{
+		prev_default_locale = default_locale;
+		o_default_locale_installed = true;
+	}
+
+	default_locale = &o_default_locale;
+	return default_locale;
+}
+
+/* Restore the previous default_locale.  */
+void
+o_database_cache_restore_default_locale(void)
+{
+	/* We didn't change default locale.  */
+	if (!o_default_locale_installed)
+		return;
+
+	default_locale = prev_default_locale;
+	prev_default_locale = NULL;
+	o_default_locale_installed = false;
+}
+#endif
+
 #if PG_VERSION_NUM >= 170000
 void
 o_database_cache_set_default_locale_provider()
@@ -185,25 +219,34 @@ o_database_cache_set_default_locale_provider()
 	if (o_database)
 	{
 #if PG_VERSION_NUM >= 180000
-		if (default_locale == NULL)
-			default_locale = MemoryContextAllocZero(TopMemoryContext,
-													sizeof(struct pg_locale_struct));
+		pg_locale_t loc = o_database_cache_install_default_locale();
 
-		if (o_database->datlocprovider == COLLPROVIDER_BUILTIN)
+		/*
+		 * template1's locale is constant for the life of the process, so
+		 * initialize the shared struct only once.  Re-running
+		 * init_pg_locale_*() on every checkpoint would leak the previously
+		 * allocated locale resources (e.g. the ICU collator), since
+		 * pg_locale_t has no public deinitializer.
+		 */
+		if (!o_default_locale_initialized)
 		{
-			init_pg_locale_builtin(default_locale, o_database->datlocale,
+			if (o_database->datlocprovider == COLLPROVIDER_BUILTIN)
+			{
+				init_pg_locale_builtin(loc, o_database->datlocale,
+									   TopMemoryContext);
+			}
+			else if (o_database->datlocprovider == COLLPROVIDER_ICU)
+			{
+				init_pg_locale_icu(loc, o_database->datlocale,
+								   o_database->daticurules, true,
 								   TopMemoryContext);
-		}
-		else if (o_database->datlocprovider == COLLPROVIDER_ICU)
-		{
-			init_pg_locale_icu(default_locale, o_database->datlocale,
-							   o_database->daticurules, true,
-							   TopMemoryContext);
-		}
-		else if (o_database->datlocprovider == COLLPROVIDER_LIBC)
-		{
-			init_pg_locale_libc(default_locale, o_database->datcollate,
-								o_database->datctype);
+			}
+			else if (o_database->datlocprovider == COLLPROVIDER_LIBC)
+			{
+				init_pg_locale_libc(loc, o_database->datcollate,
+									o_database->datctype);
+			}
+			o_default_locale_initialized = true;
 		}
 #else
 		if (o_database->datlocprovider == COLLPROVIDER_BUILTIN)
@@ -223,7 +266,7 @@ o_database_cache_set_default_locale_provider()
 	else
 	{
 #if PG_VERSION_NUM >= 180000
-		pg_locale_t loc = default_locale;
+		pg_locale_t loc = o_default_locale_installed ? &o_default_locale : NULL;
 #else
 		pg_locale_t loc = &default_locale;
 #endif

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -536,7 +536,7 @@ perform_writeback(BTreeDescr *desc, CheckpointWriteBack *writeback)
 static void
 acquire_chkp_lock_drain(LWLock *lock)
 {
-	Assert(AmCheckpointerProcess());
+	Assert(AmCheckpointerProcess() || !IsPostmasterEnvironment);
 
 	while (!LWLockConditionalAcquire(lock, LW_EXCLUSIVE))
 	{
@@ -1377,11 +1377,14 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 		 checkpoint_state->lastCheckpointNumber + 1);
 
 	o_set_syscache_hooks();
-	o_database_cache_set_database_encoding();
+	if (!OidIsValid(MyDatabaseId))
+	{
+		o_database_cache_set_database_encoding();
 #if PG_VERSION_NUM >= 170000
-	o_database_cache_set_default_locale_provider();
+		o_database_cache_set_default_locale_provider();
 #endif
-	o_database_cache_set_lc_collate();
+		o_database_cache_set_lc_collate();
+	}
 
 	memset(&control, 0, sizeof(control));
 
@@ -1687,6 +1690,11 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 
 	if (orioledb_s3_mode)
 		s3_perform_backup(flags, maxLocation);
+
+#if PG_VERSION_NUM >= 180000
+	if (!IsPostmasterEnvironment)
+		o_database_cache_restore_default_locale();
+#endif
 
 	MemoryContextResetOnly(chkp_main_context);
 	MemoryContextSwitchTo(prev_context);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1305,6 +1305,11 @@ o_recovery_finish_hook(bool cleanup)
 	if (cleanup && remove_old_checkpoint_files)
 		recovery_cleanup_old_files(startup_chkp_num, false);
 
+#if PG_VERSION_NUM >= 180000
+	if (!IsPostmasterEnvironment)
+		o_database_cache_restore_default_locale();
+#endif
+
 	elog(LOG, "orioledb recovery finished.");
 	recovery_undo_loc_flush->completedCheckpointNumber = UINT32_MAX;
 }

--- a/test/t/recovery_test.py
+++ b/test/t/recovery_test.py
@@ -3,6 +3,7 @@
 
 import os
 import random
+import subprocess
 import time
 
 from .base_test import BaseTest
@@ -2728,6 +2729,42 @@ class RecoveryTest(BaseTest):
 		    node.execute(
 		        'postgres',
 		        "SELECT orioledb_tbl_check('o_sk_self'::regclass)")[0][0])
+		node.stop()
+
+	def test_single_user_recovery(self):
+		"""
+		Crash recovery in a standalone backend
+
+		This one should call for checkpoint.
+		"""
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', """
+				CREATE EXTENSION IF NOT EXISTS orioledb;
+				CREATE TABLE o_single_user(
+					id int PRIMARY KEY,
+					val text COLLATE "C"
+				) USING orioledb;
+				INSERT INTO o_single_user SELECT g, g || 'val' FROM generate_series(1, 1000) g;
+		""")
+		node.stop(['-m', 'immediate'])
+		# Standalone backend: crash recovery (with its end-of-recovery
+		# checkpoint) and the queries all run in this single process.
+		res = subprocess.run(
+		    ['postgres', '--single', '-D', node.data_dir, 'postgres'],
+		    input="SELECT count(*) FROM o_single_user;\n"
+		    "CHECKPOINT;\n"
+		    "SELECT count(*) FROM o_single_user;\n",
+		    capture_output=True,
+		    text=True)
+		self.assertEqual(res.returncode, 0,
+		                 f"standalone backend failed: {res.stderr!r}")
+		self.assertEqual(res.stdout.count('count = "1000"'), 2, res.stdout)
+
+		node.start()
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM o_single_user")[0][0], 1000)
 		node.stop()
 
 


### PR DESCRIPTION
On standalone backend the checkpoint happens on recovery: the same process which then connects to a database.  After pg18 the default_locale must be set once and only once AFTER the checkpoint, so double allocation provokes assert.  This patch returns default_locale back to old value before orioledb checkpoint set it.

Let the standalone backend call for acquire_chkp_lock_drain().