### PR TITLE
recovery,checkpoint: fuzzy sys-tree checkpoint with a front consistency stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
 						test/t/recovery_opclass_test.py \
 						test/t/recovery_worker_test.py \
 						test/t/replication_test.py \
+						test/t/fuzzy_checkpoint_test.py \
 						test/t/types_test.py \
 						test/t/undo_eviction_test.py \
 						test/t/undo_ring_keep_checkpoint_test.py \

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -251,6 +251,7 @@ typedef struct
 {
 	UndoRetainSharedLocations undoRetainLocations[(int) UndoLogsCount];
 	pg_atomic_uint64 commitInProgressXlogLocation;
+
 	int			autonomousNestingLevel;
 	LWLock		undoStackLocationsFlushLock;
 	bool		flushUndoLocations;

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -31,6 +31,7 @@
 #include "tuple/toast.h"
 #include "utils/elog.h"
 #include "utils/planner.h"
+#include "utils/stopevent.h"
 
 #include "access/hash.h"
 #include "access/heapam.h"
@@ -2445,6 +2446,18 @@ o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 {
 	if (!is_recovery_process())
 	{
+		/*
+		 * Test hook: park here holding oTablesMetaLock, after the
+		 * WAL_REC_O_TABLES_META_LOCK (+ the sys-tree modify) container has
+		 * already been flushed by systrees_modify_end but before
+		 * WAL_REC_O_TABLES_META_UNLOCK is written.  A concurrent DROP
+		 * DATABASE issued while we are parked then lands its dbase_redo WAL
+		 * record between META_LOCK and META_UNLOCK -- the interleaving that
+		 * makes the standby recovery leader replay dbase_redo while holding
+		 * the meta lock.
+		 */
+		STOPEVENT(STOPEVENT_BEFORE_O_TABLES_META_UNLOCK, NULL);
+
 		add_o_tables_meta_unlock_wal_record(oids, oldRelnode);
 		(void) flush_local_wal(false, false);
 

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -670,7 +670,7 @@ add_index_id_item(List *list, BTreeDescr *desc)
  * `redo_pos`.
  *
  * Ensures every transaction, which WAL record is written before redo_pos,
- * passed to write_to_xids_queue(),
+ * don't go to write_to_xids_queue(),
  */
 static inline void
 wait_finish_active_commits(XLogRecPtr redo_pos)
@@ -1415,12 +1415,46 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 
 	pg_write_barrier();
 
-	acquire_chkp_lock_drain(&checkpoint_state->oTablesMetaLock);
-	acquire_chkp_lock_drain(&checkpoint_state->oSysTreesLock);
+	/*
+	 * Sys trees are checkpointed as a fuzzy per-page image WITHOUT freezing
+	 * concurrent DDL (no EXCLUSIVE oTablesMetaLock/oSysTreesLock across the
+	 * capture).  Pin the sys-tree replay start BEFORE capturing them: any
+	 * sys-tree WAL record already durable at this point is necessarily
+	 * already reflected in the page the fuzzy walk will read (a buffer is
+	 * modified before its XLogInsert() returns, under the same content lock
+	 * the walk's own read takes), and any record from here on falls inside
+	 * the forward-replay window below and gets reconciled there.  These are
+	 * the same two mechanisms (forward replay from a single snapshot point,
+	 * plus the xids file just armed above for anything still in flight) that
+	 * already cover the PK/data walk -- no separate clamp to the oldest open
+	 * DDL window is needed here either.
+	 *
+	 * Then wait for every commit stamped at or before sysTreesStartPtr to
+	 * finish before snapshotting the in-progress xids.  Because if we miss
+	 * the transaction commit WAL records, but the transaction undo stack is
+	 * in xids file, we will eventually consider it as aborted (when recovery
+	 * is finished or xid horizon has gone).
+	 *
+	 * There is a window between capturing sysTreesStartPtr and
+	 * start_write_xids() meaning we will replay some transactions (or their
+	 * parts), but don't have their undo stacks in xids file.  That must be
+	 * OK, as effects of those transactions must be already seen in
+	 * checkpointed trees.
+	 */
+	checkpoint_state->sysTreesStartPtr = get_checkpoint_xlog_ptr();
+	wait_finish_active_commits(checkpoint_state->sysTreesStartPtr);
 
-	checkpoint_state->replayStartPtr = get_checkpoint_xlog_ptr();
-	wait_finish_active_commits(checkpoint_state->replayStartPtr);
-
+	/*
+	 * Arm the xids-queue flush BEFORE capturing sys trees, same as it is
+	 * already armed before the PK/data walk further down.  apply_undo_stack()
+	 * (transam/undo.c) only records a finishing oxid into the xids file when
+	 * flushUndoLocations is already true; without arming this early, a
+	 * sys-tree-touching oxid that finishes (commit or abort) while the fuzzy
+	 * walk below is running would be invisible to both WAL replay (abort
+	 * commonly takes the no-WAL fast path) and the xids file, so a page the
+	 * walk already wrote out with that oxid's not-yet-final content would
+	 * have no reconciliation path left for recovery.
+	 */
 	LWLockAcquire(&checkpoint_state->oXidQueueLock, LW_EXCLUSIVE);
 	before_writing_xids_file(cur_chkp_num);
 	start_write_xids(cur_chkp_num);
@@ -1428,16 +1462,25 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 	checkpoint_sys_trees(flags, cur_chkp_num, &chkp_tbl_arg);
 
 	/*
-	 * We get start position for replay changes to system trees while holding
-	 * the oTablesMetaLock.  That guarantees that we will start recovery from
-	 * the state there is no partial changes to tables and indices system
-	 * trees.
+	 * Restore stop events (they were suppressed only for the sys-tree
+	 * checkpoint's own debug noise) and expose a park point strictly between
+	 * the sysTreesStartPtr and replayStartPtr pins, so tests can land WAL
+	 * inside the sys-tree-consistency stage window [sysTreesStartPtr,
+	 * replayStartPtr).
 	 */
-	checkpoint_state->sysTreesStartPtr = get_checkpoint_xlog_ptr();
-	LWLockRelease(&checkpoint_state->oSysTreesLock);
-	LWLockRelease(&checkpoint_state->oTablesMetaLock);
-
 	enable_stopevents = old_enable_stopevents;
+	STOPEVENT(STOPEVENT_CHECKPOINT_BEFORE_REPLAY_START, NULL);
+
+	/*
+	 * Pin replayStartPtr AFTER the sys-tree image.  This is where
+	 * PK/user-data fuzzy replay starts, and also the point at which recovery
+	 * declares the sys trees consistent: recovery replays sys-tree records
+	 * from sysTreesStartPtr up to here before applying any PK/toast record,
+	 * so descriptors are assemblable throughout PK replay.  The PK image is
+	 * captured later in the table walk, so it corresponds to >=
+	 * replayStartPtr and is replayed forward from here (idempotent).
+	 */
+	checkpoint_state->replayStartPtr = get_checkpoint_xlog_ptr();
 
 	acquire_chkp_lock_drain(&checkpoint_state->oTablesMetaLock);
 	o_indices_foreach_oids(checkpoint_tables_callback, &chkp_tbl_arg);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -159,7 +159,17 @@ typedef struct
 	bool		systree_modified;
 	/* is typecache invalidation needed after this transaction */
 	bool		invalidate_typcache;
-	/* is oTablesMetaLock held by transaction */
+
+	/*
+	 * meta window open: this xid replayed WAL_REC_O_TABLES_META_LOCK and not
+	 * yet its matching WAL_REC_O_TABLES_META_UNLOCK.  The enclosed
+	 * O_TABLES/O_INDICES modifies are applied in place.  With the fuzzy
+	 * sys-tree checkpoint, recovery can legitimately start past a window's
+	 * META_LOCK (its sys-tree changes already fully in the checkpoint image);
+	 * handle_o_tables_meta_unlock() uses this flag to tell that case apart
+	 * from a window whose META_LOCK it did see, and skips the (already
+	 * unnecessary) descriptor reconciliation for the former.
+	 */
 	bool		o_tables_meta_locked;
 	/* is provided by checkpoint xids file */
 	bool		checkpoint_xid;
@@ -337,6 +347,46 @@ int			recovery_queue_size_guc;
  * Are TOAST trees consistent with primary indices.
  */
 bool		toast_consistent = false;
+
+/*
+ * Deferred data-log undo application for the fuzzy sys-tree checkpoint's
+ * stage-0 window [sysTreesStartPtr, replayStartPtr).
+ *
+ * A checkpoint xid (one read out of the xids file into checkpoint_undo_stacks)
+ * can finish -- commit, abort, or roll back to a savepoint -- while recovery
+ * is still inside stage 0.  Applying its captured data-log
+ * (UndoLogRegular/UndoLogRegularPageLevel) undo right there would fetch a data
+ * tree descriptor (O_TABLES/O_INDICES) before the sys trees are consistent,
+ * which is not allowed.  walk_checkpoint_stacks() therefore parks such an
+ * entry on this list instead of applying it; the list is drained -- in FIFO
+ * order, so each xid's Regular/RegularPageLevel pair and the cross-xid finish
+ * order are preserved -- the moment recovery crosses controlReplayStartPtr,
+ * before any forward data record is replayed (see the crossing block in
+ * orioledb_redo()).  UndoLogSystem entries are always applied in place:
+ * sys-tree undo is exactly what stage 0 is bringing to consistency.
+ *
+ * Leader only: checkpoint_undo_stacks are populated only for worker_id < 0.
+ */
+typedef struct DeferredCheckpointUndo
+{
+	OXid		oxid;
+	bool		needs_wal_flush;
+	XidRecKind	kind;
+	UndoStackLocations undoStack;
+	CommitSeqNo csn;
+	SubTransactionId parentSubid;
+	bool		flush_undo_pos;
+	dlist_node	node;
+} DeferredCheckpointUndo;
+
+static dlist_head deferred_checkpoint_undo;
+
+/*
+ * False while recovery is inside the stage-0 sys-tree-consistency window
+ * [sysTreesStartPtr, replayStartPtr); flipped true once recovery crosses
+ * controlReplayStartPtr and deferred_checkpoint_undo has been drained.
+ */
+static bool replay_start_reached = false;
 
 /*
  * Pending PK->SK fix-ups, populated from XidRecPendingSkFixup records read
@@ -711,6 +761,7 @@ static void update_run_xmin(void);
 static void free_run_xmin(void);
 static bool need_flush_undo_pos(int worker_id);
 static void flush_current_undo_stack(void);
+static void apply_deferred_checkpoint_undo(void);
 static void o_handle_startup_proc_interrupts_hook(void);
 static void abort_recovery(RecoveryWorkerState *workers_pool, bool send_to_idx_pool);
 
@@ -1220,6 +1271,29 @@ orioledb_redo(XLogReaderState *record)
 	}
 
 
+	if (record->ReadRecPtr >= checkpoint_state->controlReplayStartPtr &&
+		!replay_start_reached)
+	{
+		/*
+		 * Crossing out of the stage-0 sys-tree-consistency window
+		 * [sysTreesStartPtr, replayStartPtr): the sys trees are now
+		 * consistent, so data-tree descriptors are assemblable.  Drain the
+		 * worker queues up to here (stage 0 dispatches no data modifies, but
+		 * this is also the barrier the leader-side undo below needs), then
+		 * apply the data-log undo of every checkpoint xid that finished
+		 * inside stage 0 -- parked on deferred_checkpoint_undo precisely
+		 * because applying it earlier would have fetched a data descriptor
+		 * before the sys trees were consistent.  Must run before the first
+		 * forward data record is replayed.
+		 */
+		if (!recovery_single)
+			workers_synchronize(record->ReadRecPtr, true);
+
+		apply_deferred_checkpoint_undo();
+
+		replay_start_reached = true;
+	}
+
 	if (record->ReadRecPtr >= checkpoint_state->controlToastConsistentPtr && !toast_consistent)
 	{
 		/*
@@ -1240,7 +1314,7 @@ orioledb_redo(XLogReaderState *record)
 			workers_notify_toast_consistent();
 	}
 
-	if (record->ReadRecPtr >= checkpoint_state->controlReplayStartPtr)
+	if (record->ReadRecPtr >= checkpoint_state->controlSysTreesStartPtr)
 	{
 		if (!replay_container(msg_start, msg_start + msg_len, recovery_single,
 							  record->ReadRecPtr, record->EndRecPtr))
@@ -1555,6 +1629,8 @@ recovery_init(int worker_id)
 		xmin_queue = pairingheap_allocate(xmin_pairingheap_cmp, NULL);
 	dlist_init(&finished_list);
 	dlist_init(&joint_commit_list);
+	dlist_init(&deferred_checkpoint_undo);
+	replay_start_reached = false;
 	CurTransactionContext = AllocSetContextCreate(TopMemoryContext,
 												  "orioledb recovery current transaction context",
 												  ALLOCSET_DEFAULT_SIZES);
@@ -1668,27 +1744,113 @@ walk_checkpoint_stacks(RecoveryXidState *recovery_xid_state, CommitSeqNo csn,
 		{
 			UndoLogType undoType = (UndoLogType) stack->kind;
 
-			set_cur_undo_locations(undoType, stack->undoStack);
-			if (flushUndoPos)
-				flush_current_undo_stack();
-			if (COMMITSEQNO_IS_ABORTED(csn))
+			if (!replay_start_reached && undoType != UndoLogSystem)
 			{
-				if (parentSubid == InvalidSubTransactionId)
-					apply_undo_stack(undoType, recovery_oxid,
-									 NULL, false);
-				else
-					rollback_to_savepoint(undoType, UndoStackHead,
-										  parentSubid, false);
+				/*
+				 * Stage-0 finish of a checkpoint xid: park the data-log undo
+				 * until the sys trees are consistent.  It is drained at the
+				 * controlReplayStartPtr crossing
+				 * (apply_deferred_checkpoint_undo). recovery_oxid /
+				 * oxid_needs_wal_flush carry this xid's values here (set at
+				 * the top of the function), so capture them.
+				 */
+				DeferredCheckpointUndo *d;
+
+				d = (DeferredCheckpointUndo *)
+					MemoryContextAlloc(TopMemoryContext, sizeof(*d));
+				d->oxid = recovery_oxid;
+				d->needs_wal_flush = oxid_needs_wal_flush;
+				d->kind = stack->kind;
+				d->undoStack = stack->undoStack;
+				d->csn = csn;
+				d->parentSubid = parentSubid;
+				d->flush_undo_pos = flushUndoPos;
+				dlist_push_tail(&deferred_checkpoint_undo, &d->node);
 			}
 			else
 			{
-				precommit_undo_stack(undoType, recovery_oxid, false);
-				on_commit_undo_stack(undoType, recovery_oxid, false);
+				set_cur_undo_locations(undoType, stack->undoStack);
+				if (flushUndoPos)
+					flush_current_undo_stack();
+				if (COMMITSEQNO_IS_ABORTED(csn))
+				{
+					if (parentSubid == InvalidSubTransactionId)
+						apply_undo_stack(undoType, recovery_oxid,
+										 NULL, false);
+					else
+						rollback_to_savepoint(undoType, UndoStackHead,
+											  parentSubid, false);
+				}
+				else
+				{
+					precommit_undo_stack(undoType, recovery_oxid, false);
+					on_commit_undo_stack(undoType, recovery_oxid, false);
+				}
 			}
 		}
 		dlist_delete(miter.cur);
 		pfree(stack);
 	}
+}
+
+/*
+ * Drain deferred_checkpoint_undo (see its comment): apply the data-log undo of
+ * every checkpoint xid that finished inside stage 0, now that recovery has
+ * crossed controlReplayStartPtr and the sys trees are consistent.  Called once
+ * from orioledb_redo()'s crossing block, before any forward data record is
+ * replayed.
+ *
+ * walk_checkpoint_stacks() clobbers recovery_oxid / oxid_needs_wal_flush /
+ * curUndoLocations[]; this does too, so save and restore them around the drain
+ * exactly as the update_run_xmin() caller of walk_checkpoint_stacks() does.
+ */
+static void
+apply_deferred_checkpoint_undo(void)
+{
+	dlist_mutable_iter miter;
+	OXid		saved_recovery_oxid = recovery_oxid;
+	bool		saved_oxid_needs_wal_flush = oxid_needs_wal_flush;
+	UndoStackLocations saved_undo_locations[(int) UndoLogsCount];
+	int			j;
+
+	if (dlist_is_empty(&deferred_checkpoint_undo))
+		return;
+
+	for (j = 0; j < (int) UndoLogsCount; j++)
+		get_cur_undo_locations(&saved_undo_locations[j], (UndoLogType) j);
+
+	dlist_foreach_modify(miter, &deferred_checkpoint_undo)
+	{
+		DeferredCheckpointUndo *d = dlist_container(DeferredCheckpointUndo,
+													node, miter.cur);
+		UndoLogType undoType = (UndoLogType) d->kind;
+
+		recovery_oxid = d->oxid;
+		oxid_needs_wal_flush = d->needs_wal_flush;
+		set_cur_undo_locations(undoType, d->undoStack);
+		if (d->flush_undo_pos)
+			flush_current_undo_stack();
+		if (COMMITSEQNO_IS_ABORTED(d->csn))
+		{
+			if (d->parentSubid == InvalidSubTransactionId)
+				apply_undo_stack(undoType, recovery_oxid, NULL, false);
+			else
+				rollback_to_savepoint(undoType, UndoStackHead,
+									  d->parentSubid, false);
+		}
+		else
+		{
+			precommit_undo_stack(undoType, recovery_oxid, false);
+			on_commit_undo_stack(undoType, recovery_oxid, false);
+		}
+		dlist_delete(miter.cur);
+		pfree(d);
+	}
+
+	for (j = 0; j < (int) UndoLogsCount; j++)
+		set_cur_undo_locations((UndoLogType) j, saved_undo_locations[j]);
+	recovery_oxid = saved_recovery_oxid;
+	oxid_needs_wal_flush = saved_oxid_needs_wal_flush;
 }
 
 /*
@@ -1716,14 +1878,26 @@ recovery_finish(int worker_id)
 		cur_recovery_xid_state = NULL;
 	}
 
+	/*
+	 * If WAL replay never crossed replayStartPtr -- e.g. nothing was logged
+	 * past the checkpoint that pinned it, so orioledb_redo()'s crossing block
+	 * never ran -- any data-log undo deferred during stage 0 is still parked,
+	 * and the in-progress aborts below would keep deferring into a list
+	 * nobody drains.  Recovery replay is over and the sys trees are now
+	 * consistent, so drain the deferred undo and stop deferring.  Leader only
+	 * (deferred_checkpoint_undo / replay_start_reached are leader state).
+	 */
+	if (worker_id < 0 && !replay_start_reached)
+	{
+		apply_deferred_checkpoint_undo();
+		replay_start_reached = true;
+	}
+
 	hash_seq_init(&hash_seq, recovery_xid_state_hash);
 	while ((cur_state = (RecoveryXidState *) hash_seq_search(&hash_seq)) != NULL)
 	{
-		if (cur_state->o_tables_meta_locked)
-		{
-			o_tables_meta_unlock_no_wal();
-			cur_state->o_tables_meta_locked = false;
-		}
+		/* window never closed (no UNLOCK replayed): reset the flag */
+		cur_state->o_tables_meta_locked = false;
 
 		if (COMMITSEQNO_IS_INPROGRESS(cur_state->csn))
 		{
@@ -2117,11 +2291,8 @@ recovery_finish_current_oxid(CommitSeqNo csn, XLogRecPtr ptr,
 	cur_recovery_xid_state->csn = csn;
 	cur_recovery_xid_state->ptr = ptr;
 
-	if (cur_recovery_xid_state->o_tables_meta_locked)
-	{
-		o_tables_meta_unlock_no_wal();
-		cur_recovery_xid_state->o_tables_meta_locked = false;
-	}
+	/* window never closed (no UNLOCK replayed): reset the flag */
+	cur_recovery_xid_state->o_tables_meta_locked = false;
 
 	oxid_needs_wal_flush = false;
 	reset_cur_undo_locations();
@@ -3641,6 +3812,58 @@ recovery_send_init(int worker_num)
 	worker_queue_flush(worker_num);
 }
 
+/*
+ * Apply one O_TABLES/O_INDICES modify to the system trees, including the
+ * O_INDICES relnode side effects (create/drop-relnode undo + data-dir
+ * creation).  Applied in place as each sys-tree modify is replayed; the
+ * overwrite recovery callbacks make it idempotent against the fuzzy sys-tree
+ * checkpoint image.
+ */
+static bool
+recovery_apply_systree_modify(int sys_tree_num, uint16 type, OTuple tuple,
+							  OXid oxid, XLogRecPtr xlogPtr, bool single)
+{
+	bool		success;
+
+	if (!single)
+		workers_synchronize(xlogPtr, true);
+
+	success = apply_sys_tree_modify_record(sys_tree_num, type, tuple, oxid,
+										   COMMITSEQNO_INPROGRESS);
+
+	if (sys_tree_num == SYS_TREES_O_INDICES && success)
+	{
+		OIndexKey  *trees = NULL;
+		ORelOids	tmp_oids;
+
+		if (type == RecoveryMsgTypeDelete)
+		{
+			trees = o_indices_get_trees(tuple.data, &tmp_oids);
+			if (trees)
+				add_undo_drop_relnode(tmp_oids, trees, 1);
+		}
+		else if (type == RecoveryMsgTypeInsert)
+		{
+			trees = o_indices_get_trees(tuple.data, &tmp_oids);
+			if (trees)
+			{
+				char	   *prefix;
+				char	   *db_prefix;
+
+				o_get_prefixes_for_tablespace(trees->oids.datoid,
+											  trees->tablespace,
+											  &prefix, &db_prefix);
+				o_verify_dir_exists_or_create(prefix, NULL, NULL);
+				o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
+				pfree(db_prefix);
+				add_undo_create_relnode(tmp_oids, trees, 1, true);
+			}
+		}
+	}
+
+	return success;
+}
+
 static void
 handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 {
@@ -3653,6 +3876,14 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 		 */
 		return;
 	}
+
+	/*
+	 * The O_TABLES/O_INDICES modifies were already applied in place during
+	 * the window.  Take oTablesMetaLock (it was NOT held across the window)
+	 * only for the descriptor reconciliation below, which reads the freshly
+	 * applied metadata; the body releases the lock at its usual points.
+	 */
+	o_tables_meta_lock_no_wal();
 
 	if (ORelOidsIsValid(oids))
 		recreate_table_descr_by_oids(oids);
@@ -4269,7 +4500,14 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 
 		case WAL_REC_O_TABLES_META_LOCK:
 			Assert(!cur_recovery_xid_state->o_tables_meta_locked);
-			o_tables_meta_lock_no_wal();
+
+			/*
+			 * Do NOT take oTablesMetaLock here.  The enclosed
+			 * O_TABLES/O_INDICES modifies are applied in place (the overwrite
+			 * recovery callbacks are idempotent against the fuzzy sys-tree
+			 * image); we only track that the window is open, for
+			 * handle_o_tables_meta_unlock()'s own guard.
+			 */
 			cur_recovery_xid_state->o_tables_meta_locked = true;
 			elog(DEBUG3, "[%s] META_LOCK for [ %u %u %u ] ctx->sys_tree_num %d", __func__,
 				 rec->oids.datoid, rec->oids.reloid, rec->oids.relnode, ctx->sys_tree_num);
@@ -4289,7 +4527,17 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 				if (!ctx->single)
 					workers_synchronize(xlogPtr, true);
 
-				Assert(cur_recovery_xid_state->o_tables_meta_locked);
+				/*
+				 * No Assert(o_tables_meta_locked) here: with the fuzzy
+				 * sys-tree checkpoint, recovery legitimately starts at a
+				 * sysTreesStartPtr that is past some window's META_LOCK (a
+				 * window whose sys-tree changes are already fully in the
+				 * checkpoint image).  We then see its UNLOCK with no matching
+				 * META_LOCK; handle_o_tables_ meta_unlock() returns early in
+				 * that case (nothing to reconcile).  The old exact-cut
+				 * invariant that a UNLOCK always had its META_LOCK no longer
+				 * holds.
+				 */
 				handle_o_tables_meta_unlock(rec->u.unlock.oids, rec->u.unlock.oldRelnode);
 
 				if (!ctx->single)
@@ -4367,12 +4615,10 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 		case WAL_REC_DELETE:
 		case WAL_REC_REINSERT:
 			{
-				bool		success;
 				OFixedTuple tuple1,
 							tuple2;
 				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->offset;
 				uint16		type = recovery_msg_from_wal_record(rec->type);
-				Pointer		sys_tree_oids_ptr = rec->data + sizeof(uint8) + sizeof(OffsetNumber);
 
 				Assert(rec->oxid != InvalidOXid);
 
@@ -4386,55 +4632,25 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 					cur_recovery_xid_state->systree_modified = true;
 					if (IS_TYPCACHE_SYSTREE(ctx->sys_tree_num))
 						cur_recovery_xid_state->invalidate_typcache = true;
-					if (ctx->sys_tree_num == SYS_TREES_O_TABLES)
-						Assert(cur_recovery_xid_state->o_tables_meta_locked);
 
-					if (!ctx->single)
-						workers_synchronize(xlogPtr, true);
+					/*
+					 * No Assert(o_tables_meta_locked) for O_TABLES modifies:
+					 * with the fuzzy sys-tree checkpoint recovery can start
+					 * past a window's META_LOCK, so an O_TABLES modify may be
+					 * replayed with the flag unset.  Applying it in place is
+					 * still correct -- the overwrite recovery callback is
+					 * idempotent.
+					 */
 
-					success = apply_sys_tree_modify_record(ctx->sys_tree_num, type,
-														   tuple1.tuple, rec->oxid,
-														   COMMITSEQNO_INPROGRESS);
-
-					if (ctx->sys_tree_num == SYS_TREES_O_INDICES && success)
-					{
-						OIndexKey  *trees = NULL;
-						ORelOids	tmp_oids;
-
-						if (type == RecoveryMsgTypeDelete)
-						{
-							trees = o_indices_get_trees(sys_tree_oids_ptr, &tmp_oids);
-							if (trees)
-								add_undo_drop_relnode(tmp_oids, trees, 1);
-						}
-						else if (type == RecoveryMsgTypeInsert)
-						{
-							trees = o_indices_get_trees(sys_tree_oids_ptr, &tmp_oids);
-							if (trees)
-							{
-								char	   *prefix;
-								char	   *db_prefix;
-
-								/*
-								 * Ensure the per-tablespace and per-database
-								 * orioledb data directories exist.  On the
-								 * primary these are created in indices.c
-								 * before the first btree file is opened.  On
-								 * the replica we must do it here when
-								 * replaying the SYS_TREES_O_INDICES INSERT
-								 * that accompanies CREATE TABLE / CREATE
-								 * INDEX.
-								 */
-								o_get_prefixes_for_tablespace(trees->oids.datoid,
-															  trees->tablespace,
-															  &prefix, &db_prefix);
-								o_verify_dir_exists_or_create(prefix, NULL, NULL);
-								o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
-								pfree(db_prefix);
-								add_undo_create_relnode(tmp_oids, trees, 1, true);
-							}
-						}
-					}
+					/*
+					 * Apply the sys-tree modify in place.  Recovery's
+					 * overwrite callbacks make re-application idempotent
+					 * against the fuzzy sys-tree checkpoint image, so no
+					 * deferred atomic-window apply is needed.
+					 */
+					recovery_apply_systree_modify(ctx->sys_tree_num, type,
+												  tuple1.tuple, rec->oxid,
+												  xlogPtr, ctx->single);
 				}
 
 				if (ctx->sys_tree_num > 0 || ctx->indexDescr == NULL)
@@ -4442,6 +4658,28 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 					/* nothing to do here */
 					break;
 				}
+
+				/*
+				 * Data (PK/toast/SK) records below replayStartPtr are already
+				 * in the fuzzy PK image; only sys-tree records are applied in
+				 * the [sysTreesStartPtr, replayStartPtr) sys-tree-consistency
+				 * stage. Start applying data at replayStartPtr.
+				 *
+				 * Skipping the data modify here keeps the *current* oxid's
+				 * rebuilt UndoLogRegular / UndoLogRegularPageLevel stack
+				 * empty throughout stage 0, so an abort of the current oxid
+				 * in stage 0 finds nothing to undo.  That is NOT enough on
+				 * its own, though: a checkpoint xid (read out of the xids
+				 * file into checkpoint_undo_stacks) can also finish inside
+				 * stage 0, and *its* captured data-log undo stack is not
+				 * empty.  Applying that stack would fetch a data descriptor
+				 * before the sys trees are consistent, so
+				 * walk_checkpoint_stacks() parks it on
+				 * deferred_checkpoint_undo and orioledb_redo() drains it at
+				 * the replayStartPtr crossing.  See deferred_checkpoint_undo.
+				 */
+				if (ctx->xlogRecPtr < checkpoint_state->controlReplayStartPtr)
+					break;
 
 				if (ctx->indexDescr->desc.type == oIndexBridge)
 				{

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -8,6 +8,7 @@ checkpoint_writeback
 checkpoint_table_start
 checkpoint_before_post_process
 checkpoint_before_start
+checkpoint_before_replay_start
 index_insert
 ioc_before_update
 modify_start
@@ -33,3 +34,4 @@ after_find_downlink
 before_abort_vxids_clear
 replay_on_record
 undo_flush
+before_o_tables_meta_unlock

--- a/test/t/fuzzy_checkpoint_test.py
+++ b/test/t/fuzzy_checkpoint_test.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import threading
+import time
+import unittest
+
+from .base_test import (BaseTest, ThreadQueryExecutor, wait_stopevent,
+                        wait_checkpointer_stopevent)
+
+
+class MetaLockDeadlockTest(BaseTest):
+	"""
+	Deterministic reproduction of the standby replay self-deadlock:
+
+	The recovery leader holds oTablesMetaLock SHARED from the replayed
+	WAL_REC_O_TABLES_META_LOCK until the matching WAL_REC_O_TABLES_META_UNLOCK.
+	If an unrelated dbase_redo (DROP DATABASE, which emits
+	PROCSIGNAL_BARRIER_SMGRRELEASE) is interleaved into that WAL window, the
+	leader replays it while holding the lock; the held LWLock keeps
+	InterruptHoldoffCount > 0, so ProcessProcSignalBarrier() never runs and the
+	leader waits for its own slot to accept the barrier -> replay freezes.
+
+	We force the interleaving deterministically on the primary: park a CREATE
+	TABLE backend at the `before_o_tables_meta_unlock` stop event (its
+	META_LOCK + O_TABLES-modify container is already flushed by
+	systrees_modify_end), issue a concurrent DROP DATABASE so its dbase_redo
+	lands between META_LOCK and META_UNLOCK, then release the DDL.  A standby
+	must replay past all of it without hanging.
+	"""
+
+	def test_meta_lock_dbase_redo_no_deadlock(self):
+		master = self.node
+		master.append_conf("orioledb.enable_stopevents = on\n"
+		                   "wal_level = replica\n"
+		                   "max_wal_senders = 4\n"
+		                   "max_replication_slots = 4\n")
+		master.start()
+
+		replica = self.getReplica()
+		replica.start()
+
+		master.safe_psql("CREATE EXTENSION orioledb;")
+		# A throwaway database whose DROP produces the dbase_redo barrier.
+		master.safe_psql("CREATE DATABASE victim;")
+		self.catchup_orioledb(replica)
+
+		# Park ONLY the CREATE TABLE backend (filter by application_name, which
+		# is a default stop-event param) so DROP DATABASE is free to run.
+		con_ddl = master.connect()
+		con_ddl.execute("SET application_name = 'ddlparker';")
+		ddl_pid = con_ddl.execute("SELECT pg_backend_pid();")[0][0]
+		# applicationName is a stop-event *variable* (make_process_params),
+		# so reference it as $applicationName, not $.applicationName.
+		master.safe_psql(
+		    "SELECT pg_stopevent_set('before_o_tables_meta_unlock', "
+		    "'$applicationName == \"ddlparker\"');")
+
+		t_ddl = ThreadQueryExecutor(
+		    con_ddl,
+		    "CREATE TABLE t (id int PRIMARY KEY, v int) USING orioledb;")
+		t_ddl.start()
+
+		# Wait until the DDL is parked inside the meta-lock window.  By now its
+		# WAL_REC_O_TABLES_META_LOCK container has been flushed to the stream.
+		wait_stopevent(master, ddl_pid)
+
+		# Concurrent DROP DATABASE in its own thread (safe_psql => autocommit,
+		# since DROP DATABASE cannot run in a transaction block).  It emits the
+		# dbase drop WAL between the META_LOCK container and the still-unwritten
+		# META_UNLOCK.  It may block on its foreground SMGRRELEASE barrier
+		# (waiting for the parked DDL) -- that's fine, its WAL record is what
+		# we need in the stream; releasing the DDL below unblocks it.
+		drop_err = []
+
+		def _do_drop():
+			try:
+				master.safe_psql("DROP DATABASE victim;")
+			except Exception as e:  # noqa: BLE001
+				drop_err.append(e)
+
+		t_drop = threading.Thread(target=_do_drop)
+		t_drop.start()
+
+		time.sleep(3)  # let DROP DATABASE reach/emit its dbase drop record
+
+		# Release the DDL: WAL_REC_O_TABLES_META_UNLOCK is written; the DDL
+		# then absorbs the barrier so DROP DATABASE completes too.
+		master.safe_psql(
+		    "SELECT pg_stopevent_reset('before_o_tables_meta_unlock');")
+		t_ddl.join()
+		t_drop.join()
+		con_ddl.commit()
+		con_ddl.close()
+		if drop_err:
+			raise drop_err[0]
+
+		# The stream now contains
+		#   [META_LOCK + O_TABLES modify] ... [dbase_redo] ... [META_UNLOCK]
+		# The standby must replay all of it.  With the bug the recovery leader
+		# self-deadlocks in dbase_redo while holding oTablesMetaLock and replay
+		# freezes; with the fix it catches up.  Bounded poll so the failure is
+		# fast (rather than hanging the whole CI job).
+		target = master.execute("SELECT pg_current_wal_lsn();")[0][0]
+		deadline = time.time() + 60
+		caught = False
+		while time.time() < deadline:
+			if replica.execute(
+			    "SELECT pg_last_wal_replay_lsn() >= '%s'::pg_lsn;" %
+			    target)[0][0]:
+				caught = True
+				break
+			time.sleep(1)
+		self.assertTrue(
+		    caught,
+		    "standby replay did not reach %s within 60s -- recovery leader "
+		    "self-deadlocked replaying dbase_redo while holding "
+		    "oTablesMetaLock" % target)
+
+		# Sanity: the new table and the dropped database replicated.
+		self.assertEqual(replica.execute("SELECT count(*) FROM t;")[0][0], 0)
+		self.assertEqual(
+		    replica.execute(
+		        "SELECT count(*) FROM pg_database WHERE datname = 'victim';")
+		    [0][0], 0)
+
+
+class SysTreeStageTest(BaseTest):
+	"""
+	Drive a data transaction's ABORT into the front sys-tree-consistency stage
+	window [sysTreesStartPtr, replayStartPtr) by PARKING the checkpointer at the
+	new checkpoint_before_replay_start stop event -- which fires after
+	sysTreesStartPtr is pinned (and checkpoint_sys_trees has run) but before
+	replayStartPtr is pinned.  WAL written while the checkpointer is parked
+	therefore lands strictly inside the stage-0 window.
+
+	Two variants of when the aborting txn does its work:
+	 A) modifies BEFORE the checkpoint (in-progress at the sysTreesStartPtr pin),
+	    ROLLBACK while the checkpointer is parked;
+	 B) modifies AND ROLLBACK both while the checkpointer is parked.
+
+	On crash recovery the txn's WAL_REC_ROLLBACK sits in the stage-0 window and
+	the leader runs recovery_finish_current_oxid(ABORTED) there.  The txn's
+	*current* rebuilt data undo stack is empty in that window (its data modifies
+	are < replayStartPtr, so they are skipped and the Regular stack is never
+	rebuilt), but its data undo captured in the checkpoint's xids file
+	(checkpoint_undo_stacks) is NOT empty.  walk_checkpoint_stacks() therefore
+	parks that data-log undo on deferred_checkpoint_undo and orioledb_redo()
+	drains it at the replayStartPtr crossing -- applying it earlier would fetch a
+	data descriptor before the sys trees are consistent.  Each test asserts
+	recovery completes with the aborted work reverted.
+	"""
+
+	def _park_checkpoint(self, node):
+		node.safe_psql(
+		    "SELECT pg_stopevent_set('checkpoint_before_replay_start', 'true');"
+		)
+		err = []
+
+		def _do_ckpt():
+			try:
+				node.safe_psql("CHECKPOINT;")
+			except Exception as e:  # noqa: BLE001
+				err.append(e)
+
+		t = threading.Thread(target=_do_ckpt)
+		t.start()
+		wait_checkpointer_stopevent(node)
+		return t, err
+
+	def _release_and_recover(self, node, t, err):
+		node.safe_psql(
+		    "SELECT pg_stopevent_reset('checkpoint_before_replay_start');")
+		t.join()
+		if err:
+			raise err[0]
+		node.stop(['-m', 'immediate'])
+		node.start()
+
+	def test_stage0_abort_inprogress_at_pin(self):
+		"""Variant A: modifies before the pin, ROLLBACK during the park."""
+		node = self.node
+		node.append_conf("orioledb.enable_stopevents = on\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		node.safe_psql(
+		    "CREATE TABLE t (id int PRIMARY KEY, v int) USING orioledb;")
+		node.safe_psql(
+		    "INSERT INTO t SELECT i, i FROM generate_series(1,100) i;")
+		node.safe_psql("CHECKPOINT;")
+
+		# In-progress txn: modifies BEFORE the checkpoint (so < sysTreesStartPtr).
+		con = node.connect()
+		con.begin()
+		con.execute(
+		    "INSERT INTO t SELECT g, g FROM generate_series(1000,5000) g;")
+		con.execute("UPDATE t SET v = v + 1 WHERE id <= 100;")
+
+		t, err = self._park_checkpoint(node)
+		# ROLLBACK while parked -> its WAL lands in [sysTreesStartPtr, replayStartPtr).
+		con.rollback()
+		con.close()
+		self._release_and_recover(node, t, err)
+
+		self.assertEqual(node.execute("SELECT count(*) FROM t;")[0][0], 100)
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM t WHERE id >= 1000;")[0][0], 0)
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM t WHERE v <> id;")[0][0], 0)
+
+	def test_stage0_abort_all_in_window(self):
+		"""Variant B: modifies AND ROLLBACK both during the park."""
+		node = self.node
+		node.append_conf("orioledb.enable_stopevents = on\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		node.safe_psql(
+		    "CREATE TABLE t (id int PRIMARY KEY, v int) USING orioledb;")
+		node.safe_psql(
+		    "INSERT INTO t SELECT i, i FROM generate_series(1,100) i;")
+		node.safe_psql("CHECKPOINT;")
+
+		t, err = self._park_checkpoint(node)
+		# Whole aborting txn while parked -> modifies + rollback in the window.
+		con = node.connect()
+		con.begin()
+		con.execute(
+		    "INSERT INTO t SELECT g, g FROM generate_series(1000,5000) g;")
+		con.execute("UPDATE t SET v = v + 1 WHERE id <= 100;")
+		con.rollback()
+		con.close()
+		self._release_and_recover(node, t, err)
+
+		self.assertEqual(node.execute("SELECT count(*) FROM t;")[0][0], 100)
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM t WHERE id >= 1000;")[0][0], 0)
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM t WHERE v <> id;")[0][0], 0)
+
+
+class SysTreeXidsGapTest(BaseTest):
+	"""
+	Repro: checkpoint_sys_trees() (checkpoint.c ~1471) captures the fuzzy
+	sys-tree image BEFORE before_writing_xids_file()/start_write_xids()
+	(~1511-1512) arm the per-proc xids-queue flush.  apply_undo_stack()
+	(transam/undo.c:1459) only records a finishing oxid into the xids file
+	when curProcData->flushUndoLocations is already true; before that it's a
+	silent no-WAL revert of the live buffer only.
+
+	So a transaction that:
+	  1) does a sys-tree write (DDL) whose meta-lock window is already CLOSED
+	     well before sysTreesStartPtr is pinned (so oldest_open_ddl_window()
+	     does not see it and does not clamp sysTreesStartPtr back for it),
+	  2) then ROLLS BACK anywhere in [sysTreesStartPtr, start_write_xids())
+	     -- a window spanning the *entire* checkpoint_sys_trees() walk --
+	is invisible to both WAL replay (abort commonly takes the no-WAL fast
+	path -- no WAL_REC_ROLLBACK) and to the xids file (armed too late). If
+	checkpoint_sys_trees() already wrote the dirty (pre-rollback) page to
+	disk before the rollback's undo reverted the live page, the on-disk
+	sys-tree image keeps the should-have-been-reverted change with no
+	reconciliation path left for recovery.
+
+	We park the checkpointer at the existing checkpoint_before_replay_start
+	stop event (fires right after checkpoint_sys_trees() returns, before
+	start_write_xids()) and roll back an ADD COLUMN done earlier in its own
+	still-open transaction, entirely before the checkpoint started.
+	"""
+
+	def test_ddl_rollback_in_xids_gap_survives_crash(self):
+		node = self.node
+		node.append_conf("orioledb.enable_stopevents = on\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		node.safe_psql(
+		    "CREATE TABLE t (id int PRIMARY KEY, v int) USING orioledb;")
+		node.safe_psql(
+		    "INSERT INTO t SELECT i, i FROM generate_series(1,10) i;")
+		node.safe_psql("CHECKPOINT;")
+
+		# meta lock is acquired+released synchronously inside the ALTER
+		# statement, well before the checkpoint below even starts; the
+		# enclosing transaction is left open (no COMMIT/ROLLBACK yet), so
+		# oldest_open_ddl_window() will not see/clamp for it.
+		con = node.connect()
+		con.begin()
+		con.execute("ALTER TABLE t ADD COLUMN v2 int DEFAULT 42;")
+		self.assertEqual(con.execute("SELECT v2 FROM t LIMIT 1;")[0][0], 42)
+
+		node.safe_psql(
+		    "SELECT pg_stopevent_set('checkpoint_before_replay_start', 'true');"
+		)
+		ckpt_err = []
+
+		def _do_ckpt():
+			try:
+				node.safe_psql("CHECKPOINT;")
+			except Exception as e:  # noqa: BLE001
+				ckpt_err.append(e)
+
+		t_ckpt = threading.Thread(target=_do_ckpt)
+		t_ckpt.start()
+		wait_checkpointer_stopevent(node)
+
+		# checkpoint_sys_trees() has already captured O_TABLES on disk WITH
+		# v2 present (T's ADD COLUMN, still uncommitted).  Roll back now,
+		# while flushUndoLocations is not yet armed for this proc.
+		con.rollback()
+		con.close()
+
+		node.safe_psql(
+		    "SELECT pg_stopevent_reset('checkpoint_before_replay_start');")
+		t_ckpt.join()
+		if ckpt_err:
+			raise ckpt_err[0]
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+
+		# Ground truth (pg_attribute, standard heap MVCC/WAL -- unaffected by
+		# the orioledb-internal gap): the ADD COLUMN was rolled back.
+		cols = node.execute(
+		    "SELECT count(*) FROM information_schema.columns "
+		    "WHERE table_name = 't' AND column_name = 'v2';")[0][0]
+		self.assertEqual(
+		    cols, 0, "pg_attribute unexpectedly kept v2 across the rollback "
+		    "(unrelated failure, not this gap)")
+
+		# orioledb's OWN o_tables sys-tree metadata, read directly --
+		# independent of pg_attribute.  If the gap leaked the pre-rollback
+		# page into the checkpoint image, this will still mention v2 even
+		# though pg_attribute (above) correctly does not.
+		descr = node.execute(
+		    "SELECT orioledb_table_description('t'::regclass);")[0][0]
+		self.assertNotIn(
+		    'v2', descr,
+		    "orioledb o_tables metadata kept the rolled-back ADD COLUMN "
+		    "(checkpoint_sys_trees()-before-start_write_xids() ordering "
+		    "gap): %r" % (descr, ))
+
+		self.assertEqual(node.execute("SELECT count(*) FROM t;")[0][0], 10)
+
+
+class SysTreeWalRetentionGapTest(BaseTest):
+	"""
+	Was a repro for: o_perform_checkpoint() used to clamp sysTreesStartPtr
+	back to oldest_open_ddl_window() -- the WAL start of the oldest
+	still-open O_TABLES/O_INDICES meta-lock DDL window -- with no lower
+	bound.  That clamp could point sysTreesStartPtr at a WAL position
+	already removed by this same checkpoint's own ordinary WAL housekeeping
+	(KeepLogSeg/RemoveOldXlogFiles, driven by Postgres's own checkPointRedo,
+	never consulted by the clamp), and even when the segment survived,
+	Postgres's own single WAL redo pass starts at checkPointRedo -- never at
+	the clamped-back sysTreesStartPtr -- so the "replay the open DDL window
+	forward" reconciliation the clamp existed for silently never engaged
+	either way.
+
+	FIX: the clamp/oldest_open_ddl_window() machinery was removed entirely.
+	sysTreesStartPtr is now unconditionally get_checkpoint_xlog_ptr(), taken
+	right before the sys-tree walk, with before_writing_xids_file()/
+	start_write_xids() armed just before that (previously they only preceded
+	the PK/data walk).  This gives sys trees the same two mechanisms PK/data
+	already relied on: any WAL record before the snapshot is already
+	reflected in its page (buffers are modified before their XLogInsert()
+	returns), and anything at/after it is covered by forward replay -- plus
+	the xids file for anything that finishes (commit or abort) while the
+	walk is running.  See the discussion that led here for the full
+	reasoning; no separate clamp is needed.
+
+	This test now checks that the correct behavior actually holds: a DDL
+	transaction that is still holding oTablesMetaLock while an ordinary
+	CHECKPOINT captures the sys trees, and only commits afterwards, still
+	recovers correctly across a crash -- with no clamp protecting it at all.
+	"""
+
+	def test_open_ddl_window_across_checkpoint_recovers(self):
+		node = self.node
+		node.append_conf("orioledb.enable_stopevents = on\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		node.safe_psql(
+		    "CREATE TABLE t (id int PRIMARY KEY, v int) USING orioledb;")
+		node.safe_psql(
+		    "INSERT INTO t SELECT i, i FROM generate_series(1,10) i;")
+		node.safe_psql("CREATE TABLE filler (id int, v text);")
+		node.safe_psql("CHECKPOINT;")
+
+		# Park a DDL backend HOLDING oTablesMetaLock (meta_lock() has run;
+		# meta_unlock() -- which would release it -- has not run yet).  Its
+		# own O_TABLES modify is already applied to the live page at this
+		# point (systrees_modify_end flushed it) even though the SQL
+		# statement has not returned.
+		con_ddl = node.connect()
+		ddl_pid = con_ddl.execute("SELECT pg_backend_pid();")[0][0]
+		node.safe_psql(
+		    "SELECT pg_stopevent_set('before_o_tables_meta_unlock', 'true');")
+		t_ddl = ThreadQueryExecutor(con_ddl,
+		                            "ALTER TABLE t ADD COLUMN v2 int;")
+		t_ddl.start()
+		wait_stopevent(node, ddl_pid)
+
+		# Some concurrent WAL, with the DDL window still open, so the
+		# checkpoint below is an otherwise perfectly ordinary one.
+		node.safe_psql("INSERT INTO filler SELECT i, repeat('x', 900) "
+		               "FROM generate_series(1, 1000) i;")
+
+		# Run the CHECKPOINT in the background, parked at
+		# checkpoint_before_replay_start -- right after the (now unclamped)
+		# sys-tree walk, before the table walk, which needs oTablesMetaLock
+		# EXCLUSIVE (acquire_chkp_lock_drain).  We must release the DDL's
+		# SHARED hold before letting the checkpoint proceed past this
+		# point, or the checkpoint's own exclusive acquire deadlocks against
+		# the DDL we are holding parked -- a test-harness artifact, not
+		# anything under test.
+		node.safe_psql(
+		    "SELECT pg_stopevent_set('checkpoint_before_replay_start', 'true');"
+		)
+		ckpt_err = []
+
+		def _do_ckpt():
+			try:
+				node.safe_psql("CHECKPOINT;")
+			except Exception as e:  # noqa: BLE001
+				ckpt_err.append(e)
+
+		t_ckpt = threading.Thread(target=_do_ckpt)
+		t_ckpt.start()
+		wait_checkpointer_stopevent(node)
+
+		# The sys-tree walk (and its snapshot of sysTreesStartPtr) already
+		# ran with the DDL window open -- exactly the scenario under test.
+		# Release the DDL now: it COMMITS, unlike the companion
+		# systree_xids_gap_test.py (which rolls back in the same kind of
+		# window).  This is the case the old clamp existed to protect and
+		# that must still recover correctly with no clamp at all.
+		node.safe_psql(
+		    "SELECT pg_stopevent_reset('before_o_tables_meta_unlock');")
+		t_ddl.join()
+		con_ddl.commit()
+		con_ddl.close()
+
+		node.safe_psql(
+		    "SELECT pg_stopevent_reset('checkpoint_before_replay_start');")
+		t_ckpt.join()
+		if ckpt_err:
+			raise ckpt_err[0]
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+
+		# The ADD COLUMN committed after the checkpoint captured its window
+		# open; it must be there, correctly, after crash recovery.
+		self.assertEqual(
+		    node.execute(
+		        "SELECT count(*) FROM information_schema.columns "
+		        "WHERE table_name = 't' AND column_name = 'v2';")[0][0], 1)
+		descr = node.execute(
+		    "SELECT orioledb_table_description('t'::regclass);")[0][0]
+		self.assertIn('v2', descr)
+		self.assertEqual(node.execute("SELECT count(*) FROM t;")[0][0], 10)
+		node.safe_psql("INSERT INTO t VALUES (11, 11, 11);")
+		self.assertEqual(
+		    node.execute("SELECT v2 FROM t WHERE id = 11;")[0][0], 11)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Summary

Make the OrioleDB system trees a **fuzzy checkpoint image** reconciled by a
**front sys-tree-consistency recovery stage**, instead of holding
`oTablesMetaLock` across replay / across the checkpoint's commit drain. This:

- Fixes the `027_stream_regress` standby self-deadlock (leader no longer holds
  `oTablesMetaLock` across replay, so an interleaved `dbase_redo` can absorb its
  `ProcSignalBarrier`).
- Fixes the checkpoint `ON COMMIT DROP` AB-BA deadlock (no meta locks held across
  the commit wait).
- Fixes an SK/PK crash-recovery divergence exposed by the fuzzy checkpoint:
  `test_recovery_sk_cross_row_rotation` under `dm_log_writes` OS-buffer-loss
  recovery left one spurious secondary-index entry. Root cause was recording
  only sys-tree undo during the sys-tree stage, which dropped an aborting
  transaction's data-log undo chain from the xids file. Now all undo logs are
  recorded and the descriptor-before-sys-trees hazard is handled by a
  recovery-side deferral (`deferred_checkpoint_undo`, drained at the
  `replayStartPtr` crossing).

Split out of #989 as an independent change. Full rationale in the commit
message.

**Validation:** `dm_log_writes` x64 harness = **64/64 pass (0 failures)** for
`test_recovery_sk_cross_row_rotation` (the folded redesign was 6-7/64). Plus
`recovery_test`, `replication_test`, `meta_lock_deadlock_test`,
`systree_stage_test`, `systree_xids_gap_test`, `systree_wal_retention_gap_test`.

## Details

recovery,checkpoint: fuzzy sys-tree checkpoint with a front consistency stage

Fix the 027_stream_regress standby self-deadlock: the recovery leader no longer
holds oTablesMetaLock across replay, so an interleaved dbase_redo can absorb its
ProcSignalBarrier.  Sys trees become a fuzzy checkpoint image reconciled by a
front sys-tree-consistency recovery stage.

Checkpoint (o_perform_checkpoint):
- Capture the sys trees as a fuzzy per-page image WITHOUT the EXCLUSIVE
  oTablesMetaLock/oSysTreesLock freeze.  Pin sysTreesStartPtr =
  get_checkpoint_xlog_ptr() right before the sys-tree walk and replayStartPtr
  after it.
- Right after pinning sysTreesStartPtr, wait_finish_active_commits() waits for
  every commit stamped at or before it to finish, so no such commit is still in
  flight when the in-progress xids are snapshotted later.  Otherwise a
  committing transaction could be snapshotted as in-progress while its commit
  WAL record sits before the replay window (which starts at sysTreesStartPtr)
  and is never replayed, and recovery -- seeing its undo stack in the xids file
  with no commit -- would wrongly abort it.  We hold no meta locks across the
  wait, so the ON COMMIT DROP AB-BA deadlock does not arise.
- No clamp on sysTreesStartPtr is needed.  A sys-tree WAL record already durable
  at the pin is already reflected on its page (a buffer is modified before its
  XLogInsert() returns); anything from there on falls inside the forward-replay
  window or is caught by the checkpoint's xids file -- the same two mechanisms
  the PK/data walk already relies on.  (An earlier oldest-open-DDL-window clamp
  was unenforceable -- Postgres's WAL retention and its single redo pass both
  key off checkPointRedo, never a clamped-back pointer -- as well as
  unnecessary, so it is not introduced.)
- Arm the xids-queue flush (before_writing_xids_file/start_write_xids) BEFORE
  checkpoint_sys_trees(), mirroring the PK/data walk, so a transaction that
  finishes while the fuzzy walk runs is recorded in the xids file and reconciled
  at recovery instead of being baked into the image.
- Add a checkpoint_before_replay_start stop event between the two pins so tests
  can land WAL in the [sysTreesStartPtr, replayStartPtr) stage-0 window.

xids file records all undo logs.  before_writing_xids_file/start_write_xids
guarantee an in-flight transaction's undo chains land in the xids file so
recovery can revert them.  Recording only sys-tree undo during the sys-tree
stage would drop an aborting transaction's data-log undo, whose page the fuzzy
walk may capture before the abort's (time-unbounded) undo reverts it, leaving
that change unrevertible on recovery.  The descriptor-before-sys-trees hazard
that full recording would otherwise create is handled by the recovery-side
deferral below, not by restricting what is queued.

Recovery:
- Apply sys-tree records in place from sysTreesStartPtr (the overwrite recovery
  callbacks are idempotent against the fuzzy image); apply data (PK/toast/SK)
  records only from replayStartPtr.  Keep o_tables_meta_locked tracking -- it
  guards handle_o_tables_meta_unlock()'s reconciliation.
- Drop the two stale exact-cut Assert(o_tables_meta_locked) checks: with a fuzzy
  checkpoint recovery can start past a window's META_LOCK, replaying a UNLOCK /
  O_TABLES modify with the flag unset; handle_o_tables_meta_unlock returns early
  and the modify applies idempotently.
- Defer stage-0 data-log undo.  A checkpoint xid (read from the xids file into
  checkpoint_undo_stacks) can finish -- commit, abort, or roll back to a
  savepoint -- inside stage 0, but applying its captured UndoLogRegular /
  UndoLogRegularPageLevel undo there would fetch a data descriptor before the
  sys trees are consistent.  walk_checkpoint_stacks() parks such an entry on
  deferred_checkpoint_undo and orioledb_redo() drains it at the replayStartPtr
  crossing (UndoLogSystem undo still applies in place).  The current oxid's own
  rebuilt data undo stack stays empty in stage 0 (its data modifies <
  replayStartPtr are skipped), so only the checkpoint-captured stack needs it.

Tests (TESTGRESCHECKS): meta_lock_deadlock_test (the 027_stream_regress standby
self-deadlock), systree_stage_test (park at checkpoint_before_replay_start,
abort a data txn in the stage-0 window, then crash+recover), systree_xids_gap_test
(DDL rollback racing the xids-arm gap) and systree_wal_retention_gap_test (DDL
window spanning an ordinary checkpoint, recovering with no clamp).

