### PR TITLE
Report the retied page's extent under the left page lock

### DIFF
--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -23,6 +23,7 @@
 #include "btree/undo.h"
 #include "checkpoint/checkpoint.h"
 #include "utils/page_pool.h"
+#include "utils/stopevent.h"
 #include "transam/undo.h"
 
 #include "miscadmin.h"
@@ -43,6 +44,23 @@ static bool can_be_merged(BTreeDescr *desc, Page left, Page right,
 static void merge_pages(BTreeDescr *desc, OInMemoryBlkno left_blkno,
 						Page right, CommitSeqNo csn);
 
+static Jsonb *
+prepare_merge_before_free_extent_params(BTreeDescr *desc, int level, uint32 checkpoint_num, bool extent)
+{
+	JsonbParseState *state = NULL;
+	Jsonb	   *res;
+	MemoryContext mctx = MemoryContextSwitchTo(stopevents_cxt);
+
+	pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	btree_desc_stopevent_params_internal(desc, &state);
+	jsonb_push_int8_key(&state, "level", level);
+	jsonb_push_int8_key(&state, "checkpointNum", checkpoint_num);
+	jsonb_push_bool_key(&state, "hadExtent", extent);
+	res = JsonbValueToJsonb(pushJsonbValue(&state, WJB_END_OBJECT, NULL));
+	MemoryContextSwitchTo(mctx);
+
+	return res;
+}
 
 /*
  * Try to merge right page to the left page.  Returns true iff succeed.
@@ -70,6 +88,7 @@ btree_try_merge_pages(BTreeDescr *desc,
 	uint32		checkpoint_number;
 	bool		copy_blkno;
 	bool		needsUndo;
+	bool		extent;
 	int			level = PAGE_GET_LEVEL(right);
 
 	if (RightLinkIsValid(BTREE_PAGE_GET_RIGHTLINK(right)))
@@ -214,11 +233,10 @@ btree_try_merge_pages(BTreeDescr *desc,
 	Assert(checkpoint_state->stack[level].hikeyBlkno != left_blkno);
 	if (checkpoint_state->stack[level].hikeyBlkno == right_blkno)
 		checkpoint_state->stack[level].hikeyBlkno = left_blkno;
-	unlock_page(left_blkno);
-	left_blkno = OInvalidInMemoryBlkno;
 
 	right_desc = O_GET_IN_MEMORY_PAGEDESC(right_blkno);
 	right_extent = right_desc->fileExtent;
+	extent = FileExtentIsValid(right_extent);
 
 	CLEAN_DIRTY(desc->ppool, right_blkno);
 
@@ -243,11 +261,21 @@ btree_try_merge_pages(BTreeDescr *desc,
 
 	END_CRIT_SECTION();
 
+	if (STOPEVENTS_ENABLED())
+	{
+		Jsonb	   *params;
+
+		params = prepare_merge_before_free_extent_params(desc, level, checkpoint_number, extent);
+		STOPEVENT(STOPEVENT_MERGE_BEFORE_FREE_EXTENT, params);
+	}
+
 	if (FileExtentIsValid(right_extent))
 	{
 		free_extent_for_checkpoint(desc, &right_extent,
 								   checkpoint_number);
 	}
+
+	unlock_page(left_blkno);
 
 	return true;
 }

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -35,3 +35,4 @@ before_abort_vxids_clear
 replay_on_record
 undo_flush
 before_o_tables_meta_unlock
+merge_before_free_extent

--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -11,6 +11,7 @@ from testgres.connection import NodeConnection
 from .base_test import BaseTest
 from .base_test import ThreadQueryExecutor
 from .base_test import wait_checkpointer_stopevent
+from .base_test import wait_stopevent
 
 
 class MergeTest(BaseTest):
@@ -333,6 +334,69 @@ class MergeTest(BaseTest):
 		node.start()
 		self.assertEqual(
 		    node.execute("SELECT COUNT(*) FROM o_merge;")[0][0], 5000)
+		self.assertTrue(
+		    node.execute("SELECT orioledb_tbl_check('o_merge'::regclass)")[0]
+		    [0])
+
+	def test_merge_free_extent_concurrent_checkpoint(self):
+		"""
+		btree_try_merge_pages() captures the right page's checkpoint number while
+		parent, left and right are all locked, then reports the retired page's
+		extent via free_extent_for_checkpoint().  If the left page is unlocked
+		before that report, the checkpointer can finish the checkpoint
+		(checkpoint_ix() -> seq_buf_finalize() + free_seq_buf_pages()), so
+		shared->pages[i] becomes OInvalidInMemoryBlkno and the report writes into
+		a freed seq_buf.  The fix reports under the left page lock, which blocks
+		the checkpointer until the report is done.
+		"""
+		node = self.node
+		node.execute(
+		    "INSERT INTO o_merge SELECT g FROM generate_series(1, 20000) g;")
+
+		node.execute("CHECKPOINT;")
+
+		node.execute("DELETE FROM o_merge WHERE mod(id, 8) <> 0;")
+
+		con1 = node.connect()
+		con2 = node.connect()
+		con3 = node.connect()
+		con2_pid = con2.pid
+
+		con1.execute("SELECT pg_stopevent_set('merge_before_free_extent',\n"
+		             "'$.treeName == \"o_merge_pkey\" && "
+		             "$.hadExtent == true && "
+		             "$backendType == \"client backend\"');")
+
+		t2 = ThreadQueryExecutor(
+		    con2, "SELECT orioledb_write_pages('o_merge'::regclass);")
+		t2.start()
+		wait_stopevent(node, con2_pid)
+
+		# Checkpointer should be blocked, because the left page is blocked
+		t3 = ThreadQueryExecutor(con3, "CHECKPOINT;")
+		t3.start()
+		t3.join(10)
+		self.assertTrue(
+		    t3.is_alive(),
+		    "checkpointer must block on the left page lock held by the merge")
+
+		self.assertTrue(
+		    con1.execute(
+		        "SELECT pg_stopevent_reset('merge_before_free_extent')")[0][0])
+		try:
+			t2.join()
+			t3.join()
+		except Exception as e:
+			raise AssertionError("The released merge lost its connection!")
+
+		con1.close()
+		con2.close()
+		con3.close()
+
+		node.stop()
+		node.start()
+		self.assertEqual(
+		    node.execute("SELECT COUNT(*) FROM o_merge;")[0][0], 2500)
 		self.assertTrue(
 		    node.execute("SELECT orioledb_tbl_check('o_merge'::regclass)")[0]
 		    [0])


### PR DESCRIPTION
btree_try_merge_pages() keeps the checkpoint number of the page while parent, left, right pages are locked.  There is a window after all of them are unlocked when checkpointer may call for free_seq_buf_pages() and sets shared->pages[shared->curPageNum] to invalid memory block.