### PR TITLE
Use tablespace value from relation to detect change relation tablespace

### DIFF
--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -4105,20 +4105,29 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 					 (subId == 0))
 			{
 				/*
-				 * We come here during "ALTER TABLE ... SET TABLESPACE" after
-				 * orioledb_relation_copy_data
+				 * We reach here at OAT_POST_ALTER for any RELATION/MATVIEW,
+				 * not only "ALTER TABLE ... SET TABLESPACE" after
+				 * orioledb_relation_copy_data -- an ALTER COLUMN TYPE rewrite
+				 * lands here too.  So act only on a genuine tablespace
+				 * change: compare the pre-command reltablespace against the
+				 * value after CommandCounterIncrement() using the raw stored
+				 * oids (0 is the database default).  Normalizing 0 to
+				 * MyDatabaseTableSpace before the comparison would make a
+				 * default-tablespace relation look changed and clobber the
+				 * saved_oids the rewrite path set above; normalize only once
+				 * a real change is confirmed.
 				 */
 				if (is_orioledb_rel(rel))
 				{
 					ORelOids	old_oids;
 					Oid			old_reltablespace = rel->rd_rel->reltablespace;
 
-					if (!OidIsValid(old_reltablespace))
-						old_reltablespace = MyDatabaseTableSpace;
 					ORelOidsSetFromRel(old_oids, rel);
 					CommandCounterIncrement();
 					if (old_reltablespace != rel->rd_rel->reltablespace)
 					{
+						if (!OidIsValid(old_reltablespace))
+							old_reltablespace = MyDatabaseTableSpace;
 						o_saved_reltablespace = old_reltablespace;
 						saved_oids = old_oids;
 					}

--- a/test/expected/partition.out
+++ b/test/expected/partition.out
@@ -1,6 +1,56 @@
 CREATE SCHEMA partition;
 SET SESSION search_path = 'partition';
 CREATE EXTENSION orioledb;
+set default_table_access_method='orioledb';
+CREATE TABLE test_tbl (id bigserial, start_date timestamp, status_char varchar(1), status_num smallint, note text, data bytea, skills varchar(1)[] ,work_hours INTEGER[7]) PARTITION BY RANGE (id);
+CREATE TABLE test_tbl_p1 PARTITION OF test_tbl FOR VALUES FROM (1) TO (100);
+CREATE TABLE test_tbl_p2 PARTITION OF test_tbl FOR VALUES FROM (100) TO (200);
+CREATE TABLE test_tbl_p3 PARTITION OF test_tbl FOR VALUES FROM (200) TO (300);
+CREATE INDEX test_tbl_id_idx ON test_tbl USING btree (id);
+CREATE INDEX test_tbl_status_num_idx ON test_tbl USING btree (status_num) ;
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','A',1,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+ALTER TABLE test_tbl ALTER COLUMN status_num TYPE NUMERIC(10,4);
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','B',2,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+BEGIN;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Seq Scan on test_tbl_p1 test_tbl_1
+         ->  Seq Scan on test_tbl_p2 test_tbl_2
+         ->  Seq Scan on test_tbl_p3 test_tbl_3
+(5 rows)
+
+SELECT COUNT(*) FROM test_tbl;
+ count 
+-------
+   598
+(1 row)
+
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Index Only Scan using test_tbl_p1_status_num_idx on test_tbl_p1 test_tbl_1
+               Index Cond: (status_num < '2'::numeric)
+         ->  Index Only Scan using test_tbl_p2_status_num_idx on test_tbl_p2 test_tbl_2
+               Index Cond: (status_num < '2'::numeric)
+         ->  Index Only Scan using test_tbl_p3_status_num_idx on test_tbl_p3 test_tbl_3
+               Index Cond: (status_num < '2'::numeric)
+(8 rows)
+
+SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+ count 
+-------
+   299
+(1 row)
+
+COMMIT;
+DROP TABLE test_tbl;
+set default_table_access_method='heap';
 CREATE TABLE o_test_partition_on_conflict_range (
   val_1 int,
   val_2 int

--- a/test/expected/partition_1.out
+++ b/test/expected/partition_1.out
@@ -1,6 +1,56 @@
 CREATE SCHEMA partition;
 SET SESSION search_path = 'partition';
 CREATE EXTENSION orioledb;
+set default_table_access_method='orioledb';
+CREATE TABLE test_tbl (id bigserial, start_date timestamp, status_char varchar(1), status_num smallint, note text, data bytea, skills varchar(1)[] ,work_hours INTEGER[7]) PARTITION BY RANGE (id);
+CREATE TABLE test_tbl_p1 PARTITION OF test_tbl FOR VALUES FROM (1) TO (100);
+CREATE TABLE test_tbl_p2 PARTITION OF test_tbl FOR VALUES FROM (100) TO (200);
+CREATE TABLE test_tbl_p3 PARTITION OF test_tbl FOR VALUES FROM (200) TO (300);
+CREATE INDEX test_tbl_id_idx ON test_tbl USING btree (id);
+CREATE INDEX test_tbl_status_num_idx ON test_tbl USING btree (status_num) ;
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','A',1,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+ALTER TABLE test_tbl ALTER COLUMN status_num TYPE NUMERIC(10,4);
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','B',2,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+BEGIN;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Seq Scan on test_tbl_p1 test_tbl_1
+         ->  Seq Scan on test_tbl_p2 test_tbl_2
+         ->  Seq Scan on test_tbl_p3 test_tbl_3
+(5 rows)
+
+SELECT COUNT(*) FROM test_tbl;
+ count 
+-------
+   598
+(1 row)
+
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Index Only Scan using test_tbl_p1_status_num_idx on test_tbl_p1 test_tbl_1
+               Index Cond: (status_num < '2'::numeric)
+         ->  Index Only Scan using test_tbl_p2_status_num_idx on test_tbl_p2 test_tbl_2
+               Index Cond: (status_num < '2'::numeric)
+         ->  Index Only Scan using test_tbl_p3_status_num_idx on test_tbl_p3 test_tbl_3
+               Index Cond: (status_num < '2'::numeric)
+(8 rows)
+
+SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+ count 
+-------
+   299
+(1 row)
+
+COMMIT;
+DROP TABLE test_tbl;
+set default_table_access_method='heap';
 CREATE TABLE o_test_partition_on_conflict_range (
   val_1 int,
   val_2 int

--- a/test/expected/partition_2.out
+++ b/test/expected/partition_2.out
@@ -1,6 +1,56 @@
 CREATE SCHEMA partition;
 SET SESSION search_path = 'partition';
 CREATE EXTENSION orioledb;
+set default_table_access_method='orioledb';
+CREATE TABLE test_tbl (id bigserial, start_date timestamp, status_char varchar(1), status_num smallint, note text, data bytea, skills varchar(1)[] ,work_hours INTEGER[7]) PARTITION BY RANGE (id);
+CREATE TABLE test_tbl_p1 PARTITION OF test_tbl FOR VALUES FROM (1) TO (100);
+CREATE TABLE test_tbl_p2 PARTITION OF test_tbl FOR VALUES FROM (100) TO (200);
+CREATE TABLE test_tbl_p3 PARTITION OF test_tbl FOR VALUES FROM (200) TO (300);
+CREATE INDEX test_tbl_id_idx ON test_tbl USING btree (id);
+CREATE INDEX test_tbl_status_num_idx ON test_tbl USING btree (status_num) ;
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','A',1,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+ALTER TABLE test_tbl ALTER COLUMN status_num TYPE NUMERIC(10,4);
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','B',2,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+BEGIN;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl;
+                   QUERY PLAN                   
+------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Seq Scan on test_tbl_p1 test_tbl_1
+         ->  Seq Scan on test_tbl_p2 test_tbl_2
+         ->  Seq Scan on test_tbl_p3 test_tbl_3
+(5 rows)
+
+SELECT COUNT(*) FROM test_tbl;
+ count 
+-------
+   598
+(1 row)
+
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Aggregate
+   ->  Append
+         ->  Index Only Scan using test_tbl_p1_status_num_idx on test_tbl_p1 test_tbl_1
+               Index Cond: (status_num < '2'::numeric)
+         ->  Index Only Scan using test_tbl_p2_status_num_idx on test_tbl_p2 test_tbl_2
+               Index Cond: (status_num < '2'::numeric)
+         ->  Index Only Scan using test_tbl_p3_status_num_idx on test_tbl_p3 test_tbl_3
+               Index Cond: (status_num < '2'::numeric)
+(8 rows)
+
+SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+ count 
+-------
+   299
+(1 row)
+
+COMMIT;
+DROP TABLE test_tbl;
+set default_table_access_method='heap';
 CREATE TABLE o_test_partition_on_conflict_range (
   val_1 int,
   val_2 int

--- a/test/sql/partition.sql
+++ b/test/sql/partition.sql
@@ -2,6 +2,26 @@ CREATE SCHEMA partition;
 SET SESSION search_path = 'partition';
 CREATE EXTENSION orioledb;
 
+set default_table_access_method='orioledb';
+CREATE TABLE test_tbl (id bigserial, start_date timestamp, status_char varchar(1), status_num smallint, note text, data bytea, skills varchar(1)[] ,work_hours INTEGER[7]) PARTITION BY RANGE (id);
+CREATE TABLE test_tbl_p1 PARTITION OF test_tbl FOR VALUES FROM (1) TO (100);
+CREATE TABLE test_tbl_p2 PARTITION OF test_tbl FOR VALUES FROM (100) TO (200);
+CREATE TABLE test_tbl_p3 PARTITION OF test_tbl FOR VALUES FROM (200) TO (300);
+CREATE INDEX test_tbl_id_idx ON test_tbl USING btree (id);
+CREATE INDEX test_tbl_status_num_idx ON test_tbl USING btree (status_num) ;
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','A',1,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+ALTER TABLE test_tbl ALTER COLUMN status_num TYPE NUMERIC(10,4);
+INSERT INTO test_tbl SELECT g.id,'2024-07-04 15:34:40.472880','B',2,'book','\x00010203040506070809',ARRAY['X', 'Y', 'Z'],ARRAY[8, 8, 8, 8, 8, 0, 0] FROM generate_series(1,299) g(id);
+BEGIN;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl;
+SELECT COUNT(*) FROM test_tbl;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF) SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+SELECT COUNT(*) FROM test_tbl WHERE status_num < 2;
+COMMIT;
+DROP TABLE test_tbl;
+set default_table_access_method='heap';
+
 CREATE TABLE o_test_partition_on_conflict_range (
   val_1 int,
   val_2 int


### PR DESCRIPTION
Assingment MyDatabaseTableScpace before comparision detected relation tablespace changing causes wrong assinment saved_oid when relation lacated in default tablespace during ALTER COLUMN TYPE. In case of partitioned table with index this cause rewrite previous saved_oid and search in O_SYS_TABLE partition which was not serialized yet.