### PR TITLE
 Fix DELETE/UPDATE of non-requested tuples on table with bridge index

### DIFF
--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -161,6 +161,18 @@ static void undo_it_find_internal(UndoIterator *undoIt, void *key, BTreeKeyType 
 #define IS_LAST_PAGE(page, it) ((IT_IS_FORWARD((it)) && O_PAGE_IS(page, RIGHTMOST)) \
 								|| (IT_IS_BACKWARD((it)) && O_PAGE_IS(page, LEFTMOST)))
 
+static void
+copy_fixed_leaf_key(BTreeDescr *desc, OFixedKey *dst, OTuple leafTup)
+{
+	bool		allocated;
+	OTuple		key;
+
+	key = o_btree_tuple_make_key(desc, leafTup, dst->fixedData, false, &allocated);
+	Assert(!allocated);
+	dst->tuple.formatFlags = key.formatFlags;
+	dst->tuple.data = dst->fixedData;
+}
+
 #define IT_NEXT_OFFSET(it, loc) \
 	do { \
 		if (IT_IS_FORWARD(it)) \
@@ -1018,7 +1030,7 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 			OTuple		tup;
 
 			BTREE_PAGE_READ_LEAF_TUPLE(tup, it->context.img, loc);
-			copy_fixed_key(desc, &it->curKey, tup);
+			copy_fixed_leaf_key(desc, &it->curKey, tup);
 			it->curKeySet = true;
 			it->curKeyReturned = false;
 		}
@@ -1682,7 +1694,7 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn,
 			 * re-find resumes after it.
 			 */
 			BTREE_PAGE_READ_LEAF_TUPLE(posTup, context->img, &leaf_item->locator);
-			copy_fixed_key(desc, &it->curKey, posTup);
+			copy_fixed_leaf_key(desc, &it->curKey, posTup);
 			it->curKeySet = true;
 			it->curKeyReturned = true;
 
@@ -2043,7 +2055,7 @@ btree_iterate_raw_internal(BTreeIterator *it, void *end, BTreeKeyType endKind,
 			 * tuple is being consumed, so mark it returned: a later re-find
 			 * resumes after it.
 			 */
-			copy_fixed_key(context->desc, &it->curKey, result);
+			copy_fixed_leaf_key(context->desc, &it->curKey, result);
 			it->curKeySet = true;
 			it->curKeyReturned = true;
 
@@ -2573,7 +2585,7 @@ orioledb_test_back_refind_skip_tail(PG_FUNCTION_ARGS)
 	fakeValue = Int32GetDatum(fake_curkey);
 	fakeTup = o_form_tuple(primary->leafTupdesc, &primary->leafSpec, 0,
 						   &fakeValue, &fakeNull, NULL);
-	copy_fixed_key(&primary->desc, &it->curKey, fakeTup);
+	copy_fixed_leaf_key(&primary->desc, &it->curKey, fakeTup);
 	pfree(fakeTup.data);
 	it->curKeySet = true;
 	it->curKeyReturned = false;

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -26,6 +26,7 @@
 #include "transam/oxid.h"
 #include "transam/undo.h"
 #include "utils/page_pool.h"
+#include "utils/stopevent.h"
 
 #include "access/transam.h"
 #include "miscadmin.h"
@@ -1657,6 +1658,10 @@ o_btree_iterator_fetch_internal(BTreeIterator *it, CommitSeqNo *tupleCsn,
 		else
 		{
 			OTuple		posTup;
+
+			if (STOPEVENTS_ENABLED() && it->curKeySet)
+				STOPEVENT(STOPEVENT_ITERATOR_NEXT,
+						  btree_page_stopevent_params(desc, context->img));
 
 			/* In FETCH mode the leaf is partial; load this tuple's chunk. */
 			if (BTREE_PAGE_FIND_IS(context, FETCH) &&

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -36,3 +36,4 @@ replay_on_record
 undo_flush
 before_o_tables_meta_unlock
 merge_before_free_extent
+iterator_next

--- a/test/expected/bridge_select_refind.out
+++ b/test/expected/bridge_select_refind.out
@@ -1,0 +1,34 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_setup s2_arm s1_count s2_delete_and_release
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET application_name = 's1';
+
+step s2_arm: 
+	SELECT pg_stopevent_set('iterator_next',
+		'$applicationName == "s1"');
+
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_count: 
+	SELECT count(*) FROM o_bridge_refind;
+ <waiting ...>
+step s2_delete_and_release: 
+	DELETE FROM o_bridge_refind WHERE id BETWEEN 50 AND 80;
+	SELECT pg_stopevent_reset('iterator_next');
+
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_count: <... completed>
+count
+-----
+  469
+(1 row)
+

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -4460,9 +4460,617 @@ CREATE INDEX idx_filled_data ON o_table_filled USING brin(data);
 NOTICE:  index bridging is enabled for orioledb table 'o_table_filled'
 DETAIL:  index access method 'brin' is supported only via index bridging for OrioleDB table
 DROP TABLE o_table_filled;
+---
+--- Bridge DML: basic DELETE and UPDATE
+---
+CREATE TABLE o_bridge_dml_gist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_gist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_gist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_gist;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_gist SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_gist WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_gist;
+ count 
+-------
+   449
+(1 row)
+
+CREATE TABLE o_bridge_dml_spgist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_spgist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_spgist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_spgist;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_spgist SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_spgist WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_spgist;
+ count 
+-------
+   449
+(1 row)
+
+CREATE TABLE o_bridge_dml_gin (
+	id int NOT NULL PRIMARY KEY, tags int[], val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_gin;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_gin WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_gin;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_gin SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_gin WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_gin;
+ count 
+-------
+   449
+(1 row)
+
+CREATE TABLE o_bridge_dml_btree (
+	id int NOT NULL PRIMARY KEY, ival int, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_btree
+	SELECT i, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_btree;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_btree WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_btree;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_btree SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_btree WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_btree;
+ count 
+-------
+   449
+(1 row)
+
+---
+--- Bridge DML: multipage (wide rows force page splits)
+---
+CREATE TABLE o_bridge_big_gist (
+	id int NOT NULL PRIMARY KEY, pad text, pos point
+) USING orioledb;
+INSERT INTO o_bridge_big_gist
+	SELECT i, repeat('x', 200), point(i, i) FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_gist;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_gist WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_gist;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_gist SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_gist WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+CREATE TABLE o_bridge_big_spgist (
+	id int NOT NULL PRIMARY KEY, pad text, pos point
+) USING orioledb;
+INSERT INTO o_bridge_big_spgist
+	SELECT i, repeat('x', 200), point(i, i) FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_spgist;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_spgist WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_spgist;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_spgist SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_spgist WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+CREATE TABLE o_bridge_big_gin (
+	id int NOT NULL PRIMARY KEY, pad text, tags int[]
+) USING orioledb;
+INSERT INTO o_bridge_big_gin
+	SELECT i, repeat('x', 200), ARRAY[i, i+1] FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_gin;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_gin WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_gin;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_gin SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_gin WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+CREATE TABLE o_bridge_big_btree (
+	id int NOT NULL PRIMARY KEY, pad text, ival int
+) USING orioledb;
+INSERT INTO o_bridge_big_btree
+	SELECT i, repeat('x', 200), i FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_btree;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_btree WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_btree;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_btree SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_btree WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+---
+--- Bridge DML: composite primary key
+---
+CREATE TABLE o_bridge_cpk_gist (
+	a int NOT NULL, b int NOT NULL, pos point, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_gist
+	SELECT i / 10, i % 10, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_gist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_gist WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_gist;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_gist SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_gist WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_gist;
+ count 
+-------
+   390
+(1 row)
+
+CREATE TABLE o_bridge_cpk_spgist (
+	a int NOT NULL, b int NOT NULL, pos point, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_spgist
+	SELECT i / 10, i % 10, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_spgist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_spgist WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_spgist;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_spgist SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_spgist WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_spgist;
+ count 
+-------
+   390
+(1 row)
+
+CREATE TABLE o_bridge_cpk_gin (
+	a int NOT NULL, b int NOT NULL, tags int[], val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_gin
+	SELECT i / 10, i % 10, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_gin;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_gin WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_gin;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_gin SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_gin WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_gin;
+ count 
+-------
+   390
+(1 row)
+
+CREATE TABLE o_bridge_cpk_btree (
+	a int NOT NULL, b int NOT NULL, ival int, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_btree
+	SELECT i / 10, i % 10, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_btree;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_btree WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_btree;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_btree SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_btree WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_btree;
+ count 
+-------
+   390
+(1 row)
+
+---
+--- Bridge DML: UPDATE of the indexed column
+---
+CREATE TABLE o_bridge_updidx_gist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+UPDATE o_bridge_updidx_gist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_gist WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+CREATE TABLE o_bridge_updidx_spgist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+UPDATE o_bridge_updidx_spgist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_spgist WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+CREATE TABLE o_bridge_updidx_gin (
+	id int NOT NULL PRIMARY KEY, tags int[], val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+UPDATE o_bridge_updidx_gin SET tags = ARRAY[id + 1000]
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_gin WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+CREATE TABLE o_bridge_updidx_btree (
+	id int NOT NULL PRIMARY KEY, ival int, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_btree
+	SELECT i, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+UPDATE o_bridge_updidx_btree SET ival = ival + 1000
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_btree WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+-- Secondary bridged index query tests: verify that queries through the
+-- bridged secondary index return correct results after DML on the table.
+CREATE TABLE o_bridge_sec_gist (
+	id int NOT NULL PRIMARY KEY,
+	pos point,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   300
+(1 row)
+
+DELETE FROM o_bridge_sec_gist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   249
+(1 row)
+
+UPDATE o_bridge_sec_gist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   198
+(1 row)
+
+RESET enable_seqscan;
+CREATE TABLE o_bridge_sec_spgist (
+	id int NOT NULL PRIMARY KEY,
+	pos point,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   300
+(1 row)
+
+DELETE FROM o_bridge_sec_spgist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   249
+(1 row)
+
+UPDATE o_bridge_sec_spgist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   198
+(1 row)
+
+RESET enable_seqscan;
+CREATE TABLE o_bridge_sec_gin (
+	id int NOT NULL PRIMARY KEY,
+	tags int[],
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+ count 
+-------
+     2
+(1 row)
+
+DELETE FROM o_bridge_sec_gin WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+ count 
+-------
+     2
+(1 row)
+
+UPDATE o_bridge_sec_gin SET tags = ARRAY[id + 1000]
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_seqscan;
+CREATE TABLE o_bridge_sec_btree (
+	id int NOT NULL PRIMARY KEY,
+	ival int,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_btree
+	SELECT i, i, i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+DELETE FROM o_bridge_sec_btree WHERE id BETWEEN 150 AND 180;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+ count 
+-------
+    70
+(1 row)
+
+UPDATE o_bridge_sec_btree SET ival = ival + 1000
+	WHERE id BETWEEN 100 AND 120;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+ count 
+-------
+    49
+(1 row)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 17 other objects
+NOTICE:  drop cascades to 37 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -4480,6 +5088,26 @@ drop cascades to table test_no_bmscan_on_text_pkey
 drop cascades to table brin_test_multi
 drop cascades to table hash_i4_heap
 drop cascades to table gin_test_table
+drop cascades to table o_bridge_dml_gist
+drop cascades to table o_bridge_dml_spgist
+drop cascades to table o_bridge_dml_gin
+drop cascades to table o_bridge_dml_btree
+drop cascades to table o_bridge_big_gist
+drop cascades to table o_bridge_big_spgist
+drop cascades to table o_bridge_big_gin
+drop cascades to table o_bridge_big_btree
+drop cascades to table o_bridge_cpk_gist
+drop cascades to table o_bridge_cpk_spgist
+drop cascades to table o_bridge_cpk_gin
+drop cascades to table o_bridge_cpk_btree
+drop cascades to table o_bridge_updidx_gist
+drop cascades to table o_bridge_updidx_spgist
+drop cascades to table o_bridge_updidx_gin
+drop cascades to table o_bridge_updidx_btree
+drop cascades to table o_bridge_sec_gist
+drop cascades to table o_bridge_sec_spgist
+drop cascades to table o_bridge_sec_gin
+drop cascades to table o_bridge_sec_btree
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -4537,9 +4537,617 @@ CREATE INDEX idx_filled_data ON o_table_filled USING brin(data);
 NOTICE:  index bridging is enabled for orioledb table 'o_table_filled'
 DETAIL:  index access method 'brin' is supported only via index bridging for OrioleDB table
 DROP TABLE o_table_filled;
+---
+--- Bridge DML: basic DELETE and UPDATE
+---
+CREATE TABLE o_bridge_dml_gist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_gist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_gist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_gist;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_gist SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_gist WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_gist;
+ count 
+-------
+   449
+(1 row)
+
+CREATE TABLE o_bridge_dml_spgist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_spgist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_spgist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_spgist;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_spgist SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_spgist WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_spgist;
+ count 
+-------
+   449
+(1 row)
+
+CREATE TABLE o_bridge_dml_gin (
+	id int NOT NULL PRIMARY KEY, tags int[], val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_gin;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_gin WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_gin;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_gin SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_gin WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_gin;
+ count 
+-------
+   449
+(1 row)
+
+CREATE TABLE o_bridge_dml_btree (
+	id int NOT NULL PRIMARY KEY, ival int, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_btree
+	SELECT i, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_dml_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_dml_btree;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_dml_btree WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_btree;
+ count 
+-------
+   449
+(1 row)
+
+UPDATE o_bridge_dml_btree SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_btree WHERE val > 10000;
+ count 
+-------
+    51
+(1 row)
+
+SELECT count(*) FROM o_bridge_dml_btree;
+ count 
+-------
+   449
+(1 row)
+
+---
+--- Bridge DML: multipage (wide rows force page splits)
+---
+CREATE TABLE o_bridge_big_gist (
+	id int NOT NULL PRIMARY KEY, pad text, pos point
+) USING orioledb;
+INSERT INTO o_bridge_big_gist
+	SELECT i, repeat('x', 200), point(i, i) FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_gist;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_gist WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_gist;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_gist SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_gist WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+CREATE TABLE o_bridge_big_spgist (
+	id int NOT NULL PRIMARY KEY, pad text, pos point
+) USING orioledb;
+INSERT INTO o_bridge_big_spgist
+	SELECT i, repeat('x', 200), point(i, i) FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_spgist;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_spgist WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_spgist;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_spgist SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_spgist WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+CREATE TABLE o_bridge_big_gin (
+	id int NOT NULL PRIMARY KEY, pad text, tags int[]
+) USING orioledb;
+INSERT INTO o_bridge_big_gin
+	SELECT i, repeat('x', 200), ARRAY[i, i+1] FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_gin;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_gin WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_gin;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_gin SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_gin WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+CREATE TABLE o_bridge_big_btree (
+	id int NOT NULL PRIMARY KEY, pad text, ival int
+) USING orioledb;
+INSERT INTO o_bridge_big_btree
+	SELECT i, repeat('x', 200), i FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_big_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_big_btree;
+ count 
+-------
+  2000
+(1 row)
+
+DELETE FROM o_bridge_big_btree WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_btree;
+ count 
+-------
+   999
+(1 row)
+
+UPDATE o_bridge_big_btree SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_btree WHERE pad = 'updated';
+ count 
+-------
+   200
+(1 row)
+
+---
+--- Bridge DML: composite primary key
+---
+CREATE TABLE o_bridge_cpk_gist (
+	a int NOT NULL, b int NOT NULL, pos point, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_gist
+	SELECT i / 10, i % 10, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_gist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_gist WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_gist;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_gist SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_gist WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_gist;
+ count 
+-------
+   390
+(1 row)
+
+CREATE TABLE o_bridge_cpk_spgist (
+	a int NOT NULL, b int NOT NULL, pos point, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_spgist
+	SELECT i / 10, i % 10, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_spgist;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_spgist WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_spgist;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_spgist SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_spgist WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_spgist;
+ count 
+-------
+   390
+(1 row)
+
+CREATE TABLE o_bridge_cpk_gin (
+	a int NOT NULL, b int NOT NULL, tags int[], val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_gin
+	SELECT i / 10, i % 10, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_gin;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_gin WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_gin;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_gin SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_gin WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_gin;
+ count 
+-------
+   390
+(1 row)
+
+CREATE TABLE o_bridge_cpk_btree (
+	a int NOT NULL, b int NOT NULL, ival int, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_btree
+	SELECT i / 10, i % 10, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_cpk_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SELECT count(*) FROM o_bridge_cpk_btree;
+ count 
+-------
+   500
+(1 row)
+
+DELETE FROM o_bridge_cpk_btree WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_btree;
+ count 
+-------
+   390
+(1 row)
+
+UPDATE o_bridge_cpk_btree SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_btree WHERE val > 10000;
+ count 
+-------
+    60
+(1 row)
+
+SELECT count(*) FROM o_bridge_cpk_btree;
+ count 
+-------
+   390
+(1 row)
+
+---
+--- Bridge DML: UPDATE of the indexed column
+---
+CREATE TABLE o_bridge_updidx_gist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+UPDATE o_bridge_updidx_gist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_gist WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+CREATE TABLE o_bridge_updidx_spgist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+UPDATE o_bridge_updidx_spgist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_spgist WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+CREATE TABLE o_bridge_updidx_gin (
+	id int NOT NULL PRIMARY KEY, tags int[], val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+UPDATE o_bridge_updidx_gin SET tags = ARRAY[id + 1000]
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_gin WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+CREATE TABLE o_bridge_updidx_btree (
+	id int NOT NULL PRIMARY KEY, ival int, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_btree
+	SELECT i, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_updidx_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+UPDATE o_bridge_updidx_btree SET ival = ival + 1000
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_btree WHERE id BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+-- Secondary bridged index query tests: verify that queries through the
+-- bridged secondary index return correct results after DML on the table.
+CREATE TABLE o_bridge_sec_gist (
+	id int NOT NULL PRIMARY KEY,
+	pos point,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_gist USING gist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_gist'
+DETAIL:  index access method 'gist' is supported only via index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   300
+(1 row)
+
+DELETE FROM o_bridge_sec_gist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   249
+(1 row)
+
+UPDATE o_bridge_sec_gist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   198
+(1 row)
+
+RESET enable_seqscan;
+CREATE TABLE o_bridge_sec_spgist (
+	id int NOT NULL PRIMARY KEY,
+	pos point,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_spgist USING spgist(pos);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_spgist'
+DETAIL:  index access method 'spgist' is supported only via index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   300
+(1 row)
+
+DELETE FROM o_bridge_sec_spgist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   249
+(1 row)
+
+UPDATE o_bridge_sec_spgist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+ count 
+-------
+   198
+(1 row)
+
+RESET enable_seqscan;
+CREATE TABLE o_bridge_sec_gin (
+	id int NOT NULL PRIMARY KEY,
+	tags int[],
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_gin USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_gin'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+ count 
+-------
+     2
+(1 row)
+
+DELETE FROM o_bridge_sec_gin WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+ count 
+-------
+     2
+(1 row)
+
+UPDATE o_bridge_sec_gin SET tags = ARRAY[id + 1000]
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_seqscan;
+CREATE TABLE o_bridge_sec_btree (
+	id int NOT NULL PRIMARY KEY,
+	ival int,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_btree
+	SELECT i, i, i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_btree USING btree(ival) WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_sec_btree'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+ count 
+-------
+   101
+(1 row)
+
+DELETE FROM o_bridge_sec_btree WHERE id BETWEEN 150 AND 180;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+ count 
+-------
+    70
+(1 row)
+
+UPDATE o_bridge_sec_btree SET ival = ival + 1000
+	WHERE id BETWEEN 100 AND 120;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+ count 
+-------
+    49
+(1 row)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 17 other objects
+NOTICE:  drop cascades to 37 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -4557,6 +5165,26 @@ drop cascades to table test_no_bmscan_on_text_pkey
 drop cascades to table brin_test_multi
 drop cascades to table hash_i4_heap
 drop cascades to table gin_test_table
+drop cascades to table o_bridge_dml_gist
+drop cascades to table o_bridge_dml_spgist
+drop cascades to table o_bridge_dml_gin
+drop cascades to table o_bridge_dml_btree
+drop cascades to table o_bridge_big_gist
+drop cascades to table o_bridge_big_spgist
+drop cascades to table o_bridge_big_gin
+drop cascades to table o_bridge_big_btree
+drop cascades to table o_bridge_cpk_gist
+drop cascades to table o_bridge_cpk_spgist
+drop cascades to table o_bridge_cpk_gin
+drop cascades to table o_bridge_cpk_btree
+drop cascades to table o_bridge_updidx_gist
+drop cascades to table o_bridge_updidx_spgist
+drop cascades to table o_bridge_updidx_gin
+drop cascades to table o_bridge_updidx_btree
+drop cascades to table o_bridge_sec_gist
+drop cascades to table o_bridge_sec_spgist
+drop cascades to table o_bridge_sec_gin
+drop cascades to table o_bridge_sec_btree
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/specs/bridge_select_refind.spec
+++ b/test/specs/bridge_select_refind.spec
@@ -1,0 +1,44 @@
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+
+	CREATE TABLE o_bridge_refind (
+		id int NOT NULL PRIMARY KEY,
+		pos point,
+		val int
+	) USING orioledb;
+
+	INSERT INTO o_bridge_refind
+		SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+	CREATE INDEX ON o_bridge_refind USING gist(pos);
+}
+
+teardown
+{
+	DROP TABLE o_bridge_refind;
+}
+
+session "s1"
+
+step "s1_setup" {
+	SET orioledb.enable_stopevents = true;
+	SET application_name = 's1';
+}
+
+step "s1_count" {
+	SELECT count(*) FROM o_bridge_refind;
+}
+
+session "s2"
+
+step "s2_arm" {
+	SELECT pg_stopevent_set('iterator_next',
+		'$applicationName == "s1"');
+}
+
+step "s2_delete_and_release" {
+	DELETE FROM o_bridge_refind WHERE id BETWEEN 50 AND 80;
+	SELECT pg_stopevent_reset('iterator_next');
+}
+
+permutation "s1_setup" "s2_arm" "s1_count" "s2_delete_and_release"

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -933,6 +933,309 @@ INSERT INTO o_table_filled VALUES ('key1', 'some_data');
 CREATE INDEX idx_filled_data ON o_table_filled USING brin(data);
 DROP TABLE o_table_filled;
 
+---
+--- Bridge DML: basic DELETE and UPDATE
+---
+
+CREATE TABLE o_bridge_dml_gist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_gist USING gist(pos);
+
+SELECT count(*) FROM o_bridge_dml_gist;
+DELETE FROM o_bridge_dml_gist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_gist;
+UPDATE o_bridge_dml_gist SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_gist WHERE val > 10000;
+SELECT count(*) FROM o_bridge_dml_gist;
+
+CREATE TABLE o_bridge_dml_spgist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_spgist USING spgist(pos);
+
+SELECT count(*) FROM o_bridge_dml_spgist;
+DELETE FROM o_bridge_dml_spgist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_spgist;
+UPDATE o_bridge_dml_spgist SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_spgist WHERE val > 10000;
+SELECT count(*) FROM o_bridge_dml_spgist;
+
+CREATE TABLE o_bridge_dml_gin (
+	id int NOT NULL PRIMARY KEY, tags int[], val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_gin USING gin(tags);
+
+SELECT count(*) FROM o_bridge_dml_gin;
+DELETE FROM o_bridge_dml_gin WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_gin;
+UPDATE o_bridge_dml_gin SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_gin WHERE val > 10000;
+SELECT count(*) FROM o_bridge_dml_gin;
+
+CREATE TABLE o_bridge_dml_btree (
+	id int NOT NULL PRIMARY KEY, ival int, val int
+) USING orioledb;
+INSERT INTO o_bridge_dml_btree
+	SELECT i, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_dml_btree USING btree(ival) WITH (orioledb_index=off);
+
+SELECT count(*) FROM o_bridge_dml_btree;
+DELETE FROM o_bridge_dml_btree WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_dml_btree;
+UPDATE o_bridge_dml_btree SET val = val + 10000 WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_dml_btree WHERE val > 10000;
+SELECT count(*) FROM o_bridge_dml_btree;
+
+---
+--- Bridge DML: multipage (wide rows force page splits)
+---
+
+CREATE TABLE o_bridge_big_gist (
+	id int NOT NULL PRIMARY KEY, pad text, pos point
+) USING orioledb;
+INSERT INTO o_bridge_big_gist
+	SELECT i, repeat('x', 200), point(i, i) FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_gist USING gist(pos);
+
+SELECT count(*) FROM o_bridge_big_gist;
+DELETE FROM o_bridge_big_gist WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_gist;
+UPDATE o_bridge_big_gist SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_gist WHERE pad = 'updated';
+
+CREATE TABLE o_bridge_big_spgist (
+	id int NOT NULL PRIMARY KEY, pad text, pos point
+) USING orioledb;
+INSERT INTO o_bridge_big_spgist
+	SELECT i, repeat('x', 200), point(i, i) FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_spgist USING spgist(pos);
+
+SELECT count(*) FROM o_bridge_big_spgist;
+DELETE FROM o_bridge_big_spgist WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_spgist;
+UPDATE o_bridge_big_spgist SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_spgist WHERE pad = 'updated';
+
+CREATE TABLE o_bridge_big_gin (
+	id int NOT NULL PRIMARY KEY, pad text, tags int[]
+) USING orioledb;
+INSERT INTO o_bridge_big_gin
+	SELECT i, repeat('x', 200), ARRAY[i, i+1] FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_gin USING gin(tags);
+
+SELECT count(*) FROM o_bridge_big_gin;
+DELETE FROM o_bridge_big_gin WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_gin;
+UPDATE o_bridge_big_gin SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_gin WHERE pad = 'updated';
+
+CREATE TABLE o_bridge_big_btree (
+	id int NOT NULL PRIMARY KEY, pad text, ival int
+) USING orioledb;
+INSERT INTO o_bridge_big_btree
+	SELECT i, repeat('x', 200), i FROM generate_series(1, 2000) i;
+CREATE INDEX ON o_bridge_big_btree USING btree(ival) WITH (orioledb_index=off);
+
+SELECT count(*) FROM o_bridge_big_btree;
+DELETE FROM o_bridge_big_btree WHERE id BETWEEN 500 AND 1500;
+SELECT count(*) FROM o_bridge_big_btree;
+UPDATE o_bridge_big_btree SET pad = 'updated' WHERE id BETWEEN 1 AND 200;
+SELECT count(*) FROM o_bridge_big_btree WHERE pad = 'updated';
+
+---
+--- Bridge DML: composite primary key
+---
+
+CREATE TABLE o_bridge_cpk_gist (
+	a int NOT NULL, b int NOT NULL, pos point, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_gist
+	SELECT i / 10, i % 10, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_gist USING gist(pos);
+
+SELECT count(*) FROM o_bridge_cpk_gist;
+DELETE FROM o_bridge_cpk_gist WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_gist;
+UPDATE o_bridge_cpk_gist SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_gist WHERE val > 10000;
+SELECT count(*) FROM o_bridge_cpk_gist;
+
+CREATE TABLE o_bridge_cpk_spgist (
+	a int NOT NULL, b int NOT NULL, pos point, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_spgist
+	SELECT i / 10, i % 10, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_spgist USING spgist(pos);
+
+SELECT count(*) FROM o_bridge_cpk_spgist;
+DELETE FROM o_bridge_cpk_spgist WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_spgist;
+UPDATE o_bridge_cpk_spgist SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_spgist WHERE val > 10000;
+SELECT count(*) FROM o_bridge_cpk_spgist;
+
+CREATE TABLE o_bridge_cpk_gin (
+	a int NOT NULL, b int NOT NULL, tags int[], val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_gin
+	SELECT i / 10, i % 10, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_gin USING gin(tags);
+
+SELECT count(*) FROM o_bridge_cpk_gin;
+DELETE FROM o_bridge_cpk_gin WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_gin;
+UPDATE o_bridge_cpk_gin SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_gin WHERE val > 10000;
+SELECT count(*) FROM o_bridge_cpk_gin;
+
+CREATE TABLE o_bridge_cpk_btree (
+	a int NOT NULL, b int NOT NULL, ival int, val int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_cpk_btree
+	SELECT i / 10, i % 10, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_cpk_btree USING btree(ival) WITH (orioledb_index=off);
+
+SELECT count(*) FROM o_bridge_cpk_btree;
+DELETE FROM o_bridge_cpk_btree WHERE a BETWEEN 20 AND 30;
+SELECT count(*) FROM o_bridge_cpk_btree;
+UPDATE o_bridge_cpk_btree SET val = val + 10000 WHERE a BETWEEN 10 AND 15;
+SELECT count(*) FROM o_bridge_cpk_btree WHERE val > 10000;
+SELECT count(*) FROM o_bridge_cpk_btree;
+
+---
+--- Bridge DML: UPDATE of the indexed column
+---
+
+CREATE TABLE o_bridge_updidx_gist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_gist USING gist(pos);
+
+UPDATE o_bridge_updidx_gist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_gist WHERE id BETWEEN 100 AND 200;
+
+CREATE TABLE o_bridge_updidx_spgist (
+	id int NOT NULL PRIMARY KEY, pos point, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_spgist USING spgist(pos);
+
+UPDATE o_bridge_updidx_spgist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_spgist WHERE id BETWEEN 100 AND 200;
+
+CREATE TABLE o_bridge_updidx_gin (
+	id int NOT NULL PRIMARY KEY, tags int[], val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_gin USING gin(tags);
+
+UPDATE o_bridge_updidx_gin SET tags = ARRAY[id + 1000]
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_gin WHERE id BETWEEN 100 AND 200;
+
+CREATE TABLE o_bridge_updidx_btree (
+	id int NOT NULL PRIMARY KEY, ival int, val int
+) USING orioledb;
+INSERT INTO o_bridge_updidx_btree
+	SELECT i, i, i FROM generate_series(1, 500) i;
+CREATE INDEX ON o_bridge_updidx_btree USING btree(ival) WITH (orioledb_index=off);
+
+UPDATE o_bridge_updidx_btree SET ival = ival + 1000
+	WHERE id BETWEEN 100 AND 200;
+SELECT count(*) FROM o_bridge_updidx_btree WHERE id BETWEEN 100 AND 200;
+
+-- Secondary bridged index query tests: verify that queries through the
+-- bridged secondary index return correct results after DML on the table.
+
+CREATE TABLE o_bridge_sec_gist (
+	id int NOT NULL PRIMARY KEY,
+	pos point,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_gist
+	SELECT i, point(i, i), i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_gist USING gist(pos);
+
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+DELETE FROM o_bridge_sec_gist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+UPDATE o_bridge_sec_gist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_gist WHERE pos <@ box '(0,0),(300,300)';
+RESET enable_seqscan;
+
+CREATE TABLE o_bridge_sec_spgist (
+	id int NOT NULL PRIMARY KEY,
+	pos point,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_spgist
+	SELECT i, point(i, i), i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_spgist USING spgist(pos);
+
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+DELETE FROM o_bridge_sec_spgist WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+UPDATE o_bridge_sec_spgist SET pos = point(id + 1000, id + 1000)
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_spgist WHERE pos <@ box '(0,0),(300,300)';
+RESET enable_seqscan;
+
+CREATE TABLE o_bridge_sec_gin (
+	id int NOT NULL PRIMARY KEY,
+	tags int[],
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_gin
+	SELECT i, ARRAY[i, i+1], i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_gin USING gin(tags);
+
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+DELETE FROM o_bridge_sec_gin WHERE id BETWEEN 200 AND 250;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+UPDATE o_bridge_sec_gin SET tags = ARRAY[id + 1000]
+	WHERE id BETWEEN 100 AND 150;
+SELECT count(*) FROM o_bridge_sec_gin WHERE tags @> ARRAY[150];
+RESET enable_seqscan;
+
+CREATE TABLE o_bridge_sec_btree (
+	id int NOT NULL PRIMARY KEY,
+	ival int,
+	val int
+) USING orioledb;
+INSERT INTO o_bridge_sec_btree
+	SELECT i, i, i FROM generate_series(1, 300) i;
+CREATE INDEX ON o_bridge_sec_btree USING btree(ival) WITH (orioledb_index=off);
+
+SET enable_seqscan = off;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+DELETE FROM o_bridge_sec_btree WHERE id BETWEEN 150 AND 180;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+UPDATE o_bridge_sec_btree SET ival = ival + 1000
+	WHERE id BETWEEN 100 AND 120;
+SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
+RESET enable_seqscan;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;


### PR DESCRIPTION
 For iterator curKey on bridged primary indexes copy_fixed_key copied
    raw bytes from leaf tuple offset 0, which is bridge_ctid on bridge
    d tables, not the key. The corrupted curKey caused the refind to land
    at a wrong position, and the DELETE scan ended up removing much more
    rows than expected (UPADTE queries were affected in the same way)

Fix iterator curKey on bridged primary indexes using tuple_make_key.
    The affected call sites fire only a few times per page during refind,
    so the overhead of tuple_make_key is negligible.

Also added test for bridged indexes affected

Fixes #999 