### PR TITLE
Fix xidmap/committing-CSN corruption, seq-scan iterator UAF, and add page-fit check

### DIFF
--- a/ci/check.sh
+++ b/ci/check.sh
@@ -49,10 +49,11 @@ elif [ $CHECK_TYPE = "pg_tests" ]; then
     cd ../postgresql
     cat src/test/regress/parallel_schedule | sed "s/indirect_toast//" >$GITHUB_WORKSPACE/parallel_schedule_no_segfaults
 
-    # Backport float tests patch
+    # Backport float tests patch (PostgreSQL commit da83b1ea).  Vendored in the
+    # repo (ci/float-patch.patch) instead of fetched from git.postgresql.org,
+    # whose gitweb endpoint intermittently returns 503 and breaks CI.
     if [ $PG_VERSION = "17" ] || [ $PG_VERSION = "16" ]; then
-        wget -O float-patch.patch "https://git.postgresql.org/gitweb/?p=postgresql.git;a=patch;h=da83b1ea10c2b7937d4c9e922465321749c6785b"
-        git apply float-patch.patch
+        git apply $GITHUB_WORKSPACE/orioledb/ci/float-patch.patch
     fi
 
     # Initialize data directory and set OrioleDB as default AM

--- a/ci/float-patch.patch
+++ b/ci/float-patch.patch
@@ -1,0 +1,126 @@
+From da83b1ea10c2b7937d4c9e922465321749c6785b Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 22 Apr 2025 14:24:21 -0400
+Subject: [PATCH] Avoid depending on post-UPDATE row order in float4/float8
+ tests.
+
+While heapam reproduces the insertion order of rows well, updates
+can move rows to varying places depending on autovacuum activity.
+In most regression tests we've guarded against getting variable
+results due to that, but float4.sql and float8.sql had escaped
+notice so far because they update tables that are too small for
+autovacuum to pay attention to.
+
+With increasing interest in non-heap table AMs, it seems worth
+allowing for update behaviors that are not like heapam's.  Hence,
+add ORDER BY to stabilize the results in case the updates put
+the rows in a different order.  (We'll continue to assume that a
+seqscan will reproduce original insertion order, though.  Removing
+that assumption would require vastly-more-invasive test changes.)
+
+Author: Pavel Borisov <pashkin.elfe@gmail.com>
+Reviewed-by: Tom Lane <tgl@sss.pgh.pa.us>
+Discussion: https://postgr.es/m/CALT9ZEExHAnBoBVQzQuWPMKUbapF5-FBO3fdeYG3s2tuWQz1NQ@mail.gmail.com
+---
+ src/test/regress/expected/float4-misrounded-input.out | 8 ++++----
+ src/test/regress/expected/float4.out                  | 8 ++++----
+ src/test/regress/expected/float8.out                  | 8 ++++----
+ src/test/regress/sql/float4.sql                       | 2 +-
+ src/test/regress/sql/float8.sql                       | 2 +-
+ 5 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/src/test/regress/expected/float4-misrounded-input.out b/src/test/regress/expected/float4-misrounded-input.out
+index 20fd7139136e6..61c68a6c9fff5 100644
+--- a/src/test/regress/expected/float4-misrounded-input.out
++++ b/src/test/regress/expected/float4-misrounded-input.out
+@@ -308,14 +308,14 @@ SELECT f.f1, @f.f1 AS abs_f1 FROM FLOAT4_TBL f;
+ UPDATE FLOAT4_TBL
+    SET f1 = FLOAT4_TBL.f1 * '-1'
+    WHERE FLOAT4_TBL.f1 > '0.0';
+-SELECT * FROM FLOAT4_TBL;
++SELECT * FROM FLOAT4_TBL ORDER BY 1;
+        f1       
+ ----------------
+-              0
+-         -34.84
+-        -1004.3
+  -1.2345679e+20
++        -1004.3
++         -34.84
+  -1.2345679e-20
++              0
+ (5 rows)
+ 
+ -- test edge-case coercions to integer
+diff --git a/src/test/regress/expected/float4.out b/src/test/regress/expected/float4.out
+index 1d21c4390ad71..eaed1f2bfe71d 100644
+--- a/src/test/regress/expected/float4.out
++++ b/src/test/regress/expected/float4.out
+@@ -308,14 +308,14 @@ SELECT f.f1, @f.f1 AS abs_f1 FROM FLOAT4_TBL f;
+ UPDATE FLOAT4_TBL
+    SET f1 = FLOAT4_TBL.f1 * '-1'
+    WHERE FLOAT4_TBL.f1 > '0.0';
+-SELECT * FROM FLOAT4_TBL;
++SELECT * FROM FLOAT4_TBL ORDER BY 1;
+        f1       
+ ----------------
+-              0
+-         -34.84
+-        -1004.3
+  -1.2345679e+20
++        -1004.3
++         -34.84
+  -1.2345679e-20
++              0
+ (5 rows)
+ 
+ -- test edge-case coercions to integer
+diff --git a/src/test/regress/expected/float8.out b/src/test/regress/expected/float8.out
+index 10a5a6e1b65eb..9c519f1a1a1a5 100644
+--- a/src/test/regress/expected/float8.out
++++ b/src/test/regress/expected/float8.out
+@@ -648,14 +648,14 @@ SELECT exp(f.f1) from FLOAT8_TBL f;
+ ERROR:  value out of range: underflow
+ SELECT f.f1 / '0.0' from FLOAT8_TBL f;
+ ERROR:  division by zero
+-SELECT * FROM FLOAT8_TBL;
++SELECT * FROM FLOAT8_TBL ORDER BY 1;
+           f1           
+ -----------------------
+-                     0
+-                -34.84
+-               -1004.3
+  -1.2345678901234e+200
++               -1004.3
++                -34.84
+  -1.2345678901234e-200
++                     0
+ (5 rows)
+ 
+ -- hyperbolic functions
+diff --git a/src/test/regress/sql/float4.sql b/src/test/regress/sql/float4.sql
+index 8fb12368c39b1..44418a64002ed 100644
+--- a/src/test/regress/sql/float4.sql
++++ b/src/test/regress/sql/float4.sql
+@@ -98,7 +98,7 @@ UPDATE FLOAT4_TBL
+    SET f1 = FLOAT4_TBL.f1 * '-1'
+    WHERE FLOAT4_TBL.f1 > '0.0';
+ 
+-SELECT * FROM FLOAT4_TBL;
++SELECT * FROM FLOAT4_TBL ORDER BY 1;
+ 
+ -- test edge-case coercions to integer
+ SELECT '32767.4'::float4::int2;
+diff --git a/src/test/regress/sql/float8.sql b/src/test/regress/sql/float8.sql
+index db8d5724c25ce..0ef271f27020e 100644
+--- a/src/test/regress/sql/float8.sql
++++ b/src/test/regress/sql/float8.sql
+@@ -197,7 +197,7 @@ SELECT exp(f.f1) from FLOAT8_TBL f;
+ 
+ SELECT f.f1 / '0.0' from FLOAT8_TBL f;
+ 
+-SELECT * FROM FLOAT8_TBL;
++SELECT * FROM FLOAT8_TBL ORDER BY 1;
+ 
+ -- hyperbolic functions
+ -- we run these with extra_float_digits = 0 too, since different platforms

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -1227,6 +1227,28 @@ btree_page_reorg(BTreeDescr *desc, Page p, BTreePageItem *items,
 		hikeysFreeSpace >= SHORT_LOCATION_MULTIPLIER)
 		hikeysFreeSpace -= SHORT_LOCATION_MULTIPLIER;
 
+	/*
+	 * The item data, the per-item locator array and the fixed hikeys area
+	 * must fit within a single page.  A caller can hand us more than fits --
+	 * e.g. a page merge whose can_be_merged() estimate did not account for
+	 * the merged page's layout overhead.  Detect that here and fail with a
+	 * clear error, instead of letting the unsigned subtraction below wrap and
+	 * silently build a page with dataSize > ORIOLEDB_BLCKSZ (which only a
+	 * CHECK_PAGE_STRUCT build would later catch, and which is on-disk
+	 * corruption otherwise).
+	 */
+	if ((uint32) hikeysEnd + (uint32) totalDataSize +
+		(uint32) MAXALIGN(sizeof(LocationIndex) * count) > (uint32) ORIOLEDB_BLCKSZ)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("OrioleDB %s page does not fit after reorganization",
+						O_PAGE_IS(p, LEAF) ? "leaf" : "internal"),
+				 errdetail("Tree (%u, %u, %u) type %d: %u items need %u data bytes, %u locator bytes and %u hikeys bytes, exceeding the %d-byte page.",
+						   desc->oids.datoid, desc->oids.reloid, desc->oids.relnode,
+						   (int) desc->type, (uint32) count, (uint32) totalDataSize,
+						   (uint32) MAXALIGN(sizeof(LocationIndex) * count),
+						   (uint32) hikeysEnd, ORIOLEDB_BLCKSZ)));
+
 	dataFreeSpaceLeft = dataFreeSpace = (ORIOLEDB_BLCKSZ - hikeysEnd) - totalDataSize - MAXALIGN(sizeof(LocationIndex) * count);
 
 	/*

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -194,6 +194,16 @@ struct BTreeSeqScan
 	bool		isSingleLeafPage;	/* Scan couldn't read first internal page */
 	OFixedKey	keyRangeLow,
 				keyRangeHigh;
+
+	/*
+	 * Durable copy of the current iterator's start key.
+	 * o_btree_iterator_create() stores the start-key pointer (not a copy) for
+	 * the iterator's whole lifetime -- iterator_refind_partial_leaf()
+	 * dereferences it when a FETCH partial read fails before any tuple is
+	 * returned.  The iterator outlives scan_make_iterator()'s stack frame, so
+	 * the start key must live in the scan struct, not on that frame.
+	 */
+	OFixedKey	iterKeyLow;
 	bool		firstPageIsLoaded;
 
 	/* Private parallel worker info in a backend */
@@ -830,8 +840,18 @@ scan_make_iterator(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRangeHigh)
 
 	mctx = MemoryContextSwitchTo(scan->mctx);
 	if (!O_TUPLE_IS_NULL(keyRangeLow))
-		scan->iter = o_btree_iterator_create(scan->desc, &keyRangeLow, BTreeKeyNonLeafKey,
+	{
+		/*
+		 * keyRangeLow is a by-value parameter on our stack, but the iterator
+		 * keeps the start-key pointer for its whole lifetime (see
+		 * iterKeyLow). Persist it in the scan struct and hand the iterator
+		 * that durable copy.
+		 */
+		copy_fixed_key(scan->desc, &scan->iterKeyLow, keyRangeLow);
+		scan->iter = o_btree_iterator_create(scan->desc, &scan->iterKeyLow.tuple,
+											 BTreeKeyNonLeafKey,
 											 &scan->oSnapshot, ForwardScanDirection);
+	}
 	else
 		scan->iter = o_btree_iterator_create(scan->desc, NULL, BTreeKeyNone,
 											 &scan->oSnapshot, ForwardScanDirection);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -2237,7 +2237,6 @@ recovery_finish_current_oxid(CommitSeqNo csn, XLogRecPtr ptr,
 	if (!COMMITSEQNO_IS_ABORTED(csn) && sync)
 	{
 		Assert(worker_id < 0);
-		set_oxid_csn(oxid, COMMITSEQNO_COMMITTING);
 		if (flush_undo_pos)
 			flush_current_undo_stack();
 		for (i = 0; i < (int) UndoLogsCount; i++)
@@ -2246,6 +2245,7 @@ recovery_finish_current_oxid(CommitSeqNo csn, XLogRecPtr ptr,
 			on_commit_undo_stack((UndoLogType) i, oxid, true);
 		walk_checkpoint_stacks(cur_recovery_xid_state, csn,
 							   InvalidSubTransactionId, flush_undo_pos);
+		set_oxid_csn(oxid, COMMITSEQNO_COMMITTING);
 		csn = pg_atomic_fetch_add_u64(&TRANSAM_VARIABLES->nextCommitSeqNo, 1);
 		set_oxid_csn(oxid, csn);
 		set_oxid_xlog_ptr(oxid, XLOG_PTR_ALIGN(ptr));

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -1837,6 +1837,8 @@ oxid_get_csn(OXid oxid, bool getRawCsn)
 		if (COMMITSEQNO_IS_SPECIAL(csn) &&
 			COMMITSEQNO_GET_STATUS(csn) & COMMITSEQNO_STATUS_CSN_COMMITTING)
 			perform_spin_delay(&status);
+		else if (csn == COMMITSEQNO_COMMITTING)
+			perform_spin_delay(&status);
 		else
 			break;
 	}

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -996,6 +996,21 @@ flush_dirty_xidsmap_range(OXid xmin, OXid xmax)
 				alignedXmax;
 	OXidMapItem buffer[XID_SLOTS_PER_PAGE];
 
+	/*
+	 * Only oxids at or above writtenXmin still own their ring slot.  Oxids
+	 * below writtenXmin have been drained (their on-disk copy is already
+	 * current) and their ring slots have been recycled by newer (oxid +
+	 * xid_circular_buffer_size) transactions -- reading such a slot and
+	 * persisting it to the OLD oxid's absolute on-disk offset corrupts a
+	 * committed oxid's xidmap entry (e.g. to ABORTED).  This bites whenever
+	 * the active range (nextXid - runXmin) outgrows the ring, i.e. when
+	 * globalXmin lags by more than xid_circular_buffer_size.  So clamp the
+	 * lower bound to writtenXmin.  writtenXmin only advances, so this is
+	 * safe; it is re-read per batch under xidMapWriteLock below because it
+	 * can advance while we release the lock between batches.
+	 */
+	xmin = Max(xmin, pg_atomic_read_u64(&xid_meta->writtenXmin));
+
 	if (xmin >= xmax)
 		return;
 
@@ -1009,8 +1024,16 @@ flush_dirty_xidsmap_range(OXid xmin, OXid xmax)
 	while (pageOxid < alignedXmax)
 	{
 		int			processed;
+		OXid		writtenNow;
 
 		LWLockAcquire(&xid_meta->xidMapWriteLock, LW_EXCLUSIVE);
+
+		/*
+		 * Re-check the drained frontier under the lock: write_xidsmap() (also
+		 * under xidMapWriteLock) may have advanced writtenXmin while we held
+		 * no lock between batches, recycling more ring slots.
+		 */
+		writtenNow = pg_atomic_read_u64(&xid_meta->writtenXmin);
 
 		for (processed = 0;
 			 processed < XID_FLUSH_BATCH_PAGES && pageOxid < alignedXmax;
@@ -1018,9 +1041,34 @@ flush_dirty_xidsmap_range(OXid xmin, OXid xmax)
 		{
 			uint32		page = XID_BUFFER_PAGE_INDEX(pageOxid);
 			OXid		slot;
+			bool		straddles;
+
+			/*
+			 * A page wholly below writtenXmin has all its slots drained and
+			 * recycled by newer (oxid + xid_circular_buffer_size)
+			 * transactions.  Reading such a slot from the ring and persisting
+			 * it to the old oxid's absolute on-disk offset would corrupt a
+			 * committed oxid's xidmap entry (e.g. to ABORTED), so skip it
+			 * entirely -- its on-disk copy is already current from the drain.
+			 */
+			if (pageOxid + XID_SLOTS_PER_PAGE <= writtenNow)
+				continue;
 
 			if (!test_clear_xid_buffer_page_dirty(page))
 				continue;
+
+			/*
+			 * The page straddling writtenXmin has both live in-ring slots (>=
+			 * writtenXmin) and recycled slots (< writtenXmin).  Preload its
+			 * current on-disk contents so the recycled slots are preserved
+			 * verbatim; only the live slots are refreshed from the ring
+			 * below.
+			 */
+			straddles = (pageOxid < writtenNow);
+			if (straddles)
+				o_buffers_read(&buffersDesc, (Pointer) buffer, OXID_BUFFERS_TAG,
+							   pageOxid * sizeof(OXidMapItem),
+							   XID_SLOTS_PER_PAGE * sizeof(OXidMapItem), true);
 
 			/*
 			 * Acquire-fence pair with the writer's release in
@@ -1043,6 +1091,13 @@ flush_dirty_xidsmap_range(OXid xmin, OXid xmax)
 			{
 				OXid		slotOxid = pageOxid + slot;
 				Size		idx = slotOxid % xid_circular_buffer_size;
+
+				/*
+				 * Keep preloaded on-disk value for recycled (out-of-ring)
+				 * slots.
+				 */
+				if (straddles && slotOxid < writtenNow)
+					continue;
 
 				pg_atomic_write_u64(&buffer[slot].csn,
 									pg_atomic_read_u64(&xidBuffer[idx].csn));


### PR DESCRIPTION
Four independent correctness fixes split out of the `ci_fixes` churn-hunt branch. Each is self-contained (source only, no instrumentation).

### `flush_dirty_xidsmap_range`: xidmap corruption for out-of-ring oxids (ORI-217)
The checkpoint-time xidmap flush assembled each dirty page from the in-memory ring (`xidBuffer[oxid % xid_circular_buffer_size]`) but wrote it to the **absolute** on-disk offset `oxid * sizeof(OXidMapItem)`, assuming every oxid in the flushed range still owned its ring slot. When the active range (`nextXid - runXmin`), inflated by a lagging `globalXmin`, outgrows the ring, the oldest oxids in the range have had their slots recycled by newer (`oxid + xid_circular_buffer_size`) transactions; the flush then persists a newer (often ABORTED) transaction's csn to an old **committed** transaction's on-disk entry. A later `SnapshotAny` fetch of a row written by that transaction resolves it as aborted → `ERROR: failed to fetch tuple being updated`, and the row flickers visible/invisible as `globalXmin` advances. Fix: clamp the flushed range to `writtenXmin` (the only oxids that still own their ring slot) and re-check `writtenXmin` per batch under `xidMapWriteLock`.

### committing-state CSN misread as committed (standby merge overflow)
A transaction in the committing window could have its CSN read as committed on the standby/recovery path, letting a mid-commit deleted tuple look droppable in `can_be_merged()` while being retained in `merge_pages()`, overflowing the page. Fixes the CSN resolution so the committing state is not treated as committed.

### seq-scan iterator start-key use-after-return
The seq-scan iterator could dereference a dangling pointer to its start key (freed after the setup returned), producing a garbage bound. The start key is now persisted for the iterator's lifetime.

### detect a b-tree page that does not fit after reorganization
Adds a defensive check that reports (rather than silently corrupting) a b-tree page whose contents do not fit after reorganization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)