### PR TITLE
Add tablespace to tree identity (ORelOids.spcoid) + reserve bridge relnode

### DIFF
--- a/include/btree/btree.h
+++ b/include/btree/btree.h
@@ -269,7 +269,6 @@ struct BTreeDescr
 	void	   *arg;
 	OSmgr		smgr;
 	ORelOids	oids;
-	Oid			tablespace;
 	OIndexType	type;
 	PagePool   *ppool;
 	OCompress	compress;

--- a/include/btree/io.h
+++ b/include/btree/io.h
@@ -75,6 +75,7 @@ extern uint64 perform_page_io_autonomous(BTreeDescr *desc, uint32 chkpNum,
 extern uint64 perform_page_io_build(BTreeDescr *desc, Page img,
 									FileExtent *extent, BTreeMetaPage *metaPageBlkno);
 extern BTreeDescr *index_oids_get_btree_descr(ORelOids oids, OIndexType type);
+extern BTreeDescr *index_oids_get_btree_descr_cached(ORelOids oids);
 extern void try_to_punch_holes(BTreeDescr *desc);
 
 #endif							/* __BTREE_IO_H__ */

--- a/include/catalog/o_indices.h
+++ b/include/catalog/o_indices.h
@@ -28,7 +28,6 @@ typedef struct
 	char		table_persistence;
 	uint8		fillfactor;
 	uint16		data_version;
-	Oid			tablespace;
 	OXid		createOxid;
 	NameData	name;
 	bool		primaryIsCtid;
@@ -94,7 +93,7 @@ typedef struct
 
 /* callback for o_indices_foreach_oids() */
 typedef void (*OIndexOidsCallback) (OIndexType type, ORelOids treeOids,
-									ORelOids tableOids, Oid tablespace, void *arg);
+									ORelOids tableOids, void *arg);
 
 typedef enum
 {
@@ -118,10 +117,13 @@ extern bool o_indices_add(OTable *table, OIndexNumber ixNum, OXid oxid,
 extern bool o_indices_del(OTable *table, OIndexNumber ixNum, OXid oxid,
 						  CommitSeqNo csn);
 extern OIndex *o_indices_get(ORelOids oids, OIndexType type);
-extern OIndex *o_indices_get_extended(ORelOids oids, OIndexType type, OTableFetchContext ctx);
+extern OIndex *o_indices_get_extended(ORelOids oids, OIndexType type,
+									  OTableFetchContext ctx);
 
 extern bool o_indices_update(OTable *table, OIndexNumber ixNum,
 							 OXid oxid, CommitSeqNo csn);
+extern bool o_indices_move(OTable *table, OIndexNumber ixNum,
+						   Oid old_tablespace, OXid oxid, CommitSeqNo csn);
 extern bool o_indices_find_table_oids(ORelOids indexOids, OIndexType type,
 									  OSnapshot *oSnapshot,
 									  ORelOids *tableOids);

--- a/include/catalog/o_tables.h
+++ b/include/catalog/o_tables.h
@@ -172,6 +172,13 @@ extern OTable *o_table_tableam_create(ORelOids oids, TupleDesc tupdesc,
 									  char relpersistence, uint8 fillfactor,
 									  Oid tablespace, bool bridging);
 
+/* Assigns a bridge-index relnode and reserves it against relnode reuse. */
+extern Oid	o_bridge_new_relnode(Oid tablespace, char relpersistence);
+
+/* Drops the marker file reserving a bridge relnode. */
+extern void o_bridge_drop_relnode_marker(Oid datoid, Oid tablespace,
+										 Oid relnode);
+
 OTableField *o_tables_get_builtin_field(Oid type);
 extern void o_tables_tupdesc_init_builtin(TupleDesc desc, AttrNumber att_num,
 										  char *name, Oid type);

--- a/include/catalog/o_tables.h
+++ b/include/catalog/o_tables.h
@@ -80,7 +80,6 @@ typedef struct
 	List	   *expressions;	/* list of Expr */
 	char	   *predicate_str;
 	List	   *predicate;		/* list of Expr */
-	Oid			tablespace;
 	Oid		   *exclops;
 	bool		immediate;
 	MemoryContext index_mctx;
@@ -134,7 +133,6 @@ typedef struct
 	OTableIndex *indices;
 	OTableField *fields;
 	AttrMissing *missing;		/* missing attributes values, NULL if none */
-	Oid			tablespace;
 	uint32		version;		/* not serialized in serialize_o_table */
 	MemoryContext tbl_mctx;		/* not serialized in serialize_o_table */
 

--- a/include/catalog/sys_trees.h
+++ b/include/catalog/sys_trees.h
@@ -66,6 +66,7 @@ typedef struct
 {
 	Oid			datoid;
 	Oid			relnode;
+	Oid			tablespace;
 } SharedRootInfoKey;
 
 typedef struct

--- a/include/checkpoint/checkpoint.h
+++ b/include/checkpoint/checkpoint.h
@@ -260,10 +260,13 @@ extern CheckpointState *checkpoint_state;
 
 extern Size checkpoint_shmem_size(void);
 extern void checkpoint_shmem_init(Pointer ptr, bool found);
-extern uint32 o_get_latest_chkp_num(Oid datoid, Oid relnode,
+extern uint32 o_get_latest_chkp_num(Oid datoid, Oid relnode, Oid tablespace,
 									uint32 max_chkp_num, bool *found);
-extern void o_update_latest_chkp_num(Oid datoid, Oid relnode, uint32 chkp_num);
-extern void o_delete_chkp_num(Oid datoid, Oid relnode);
+extern void o_update_latest_chkp_num(Oid datoid, Oid relnode, Oid tablespace,
+									 uint32 chkp_num);
+extern void o_delete_chkp_num(Oid datoid, Oid relnode, Oid tablespace);
+extern void o_move_latest_chkp_num(Oid datoid, Oid relnode, Oid old_tablespace,
+								   Oid new_tablespace);
 
 extern void o_perform_checkpoint(XLogRecPtr redo_pos, int flags);
 extern void o_after_checkpoint_cleanup_hook(XLogRecPtr checkPointRedo,
@@ -277,7 +280,7 @@ extern uint32 get_cur_checkpoint_number(ORelOids *oids, OIndexType type, bool *c
 extern bool can_use_checkpoint_extents(BTreeDescr *desc, uint32 chkp_num);
 extern void free_extent_for_checkpoint(BTreeDescr *desc, FileExtent *extent, uint32 chkp_num);
 extern void backend_set_autonomous_level(CheckpointState *state, uint32 level);
-extern bool tbl_data_exists(ORelOids *oids, Oid tablespace);
+extern bool tbl_data_exists(ORelOids *oids);
 extern void evictable_tree_init(BTreeDescr *desc, bool init_shmem,
 								bool *was_evicted);
 extern void checkpointable_tree_init(BTreeDescr *desc, bool init_shmem,

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -98,8 +98,8 @@
  * these values makes sense only within one ORIOLEDB_BINARY_VERSION value.
  */
 #define ORIOLEDB_VERSION "OrioleDB beta 16"
-#define ORIOLEDB_BINARY_VERSION 10
-#define ORIOLEDB_SYS_TREE_VERSION	1	/* Version of system catalog */
+#define ORIOLEDB_BINARY_VERSION 11
+#define ORIOLEDB_SYS_TREE_VERSION	2	/* Version of system catalog */
 #define ORIOLEDB_PAGE_VERSION		1	/* Version of binary page format */
 #define ORIOLEDB_COMPRESS_VERSION	1	/* Version of page compression (only
 										 * for compressed pages) */
@@ -275,6 +275,9 @@ typedef struct
 	Oid			datoid;
 	Oid			reloid;
 	Oid			relnode;
+	Oid			spcoid;			/* tablespace: part of the tree identity,
+								 * since relfilenumber uniqueness is only
+								 * per-tablespace */
 } ORelOids;
 
 typedef uint64 S3TaskLocation;
@@ -286,6 +289,8 @@ typedef RelFileLocator RelFileNode;
 		(oids).datoid = MyDatabaseId; \
 		(oids).reloid = (rel)->rd_id; \
 		(oids).relnode = (rel)->rd_locator.relNumber; \
+		(oids).spcoid = OidIsValid((rel)->rd_rel->reltablespace) ? \
+			(rel)->rd_rel->reltablespace : MyDatabaseTableSpace; \
 	} while (0)
 #define RelIsInMyDatabase(rel) ((rel)->rd_locator.dbOid == MyDatabaseId)
 #define RelGetNode(rel) ((rel)->rd_locator)
@@ -295,9 +300,16 @@ typedef RelFileLocator RelFileNode;
 		RelationSetNewRelfilenumber(relation, persistence)
 
 #define ORelOidsIsValid(oids) (OidIsValid((oids).datoid) && OidIsValid((oids).reloid) && OidIsValid((oids).relnode))
+/*
+ * Tree identity: (datoid, reloid, relnode).  spcoid (tablespace) is
+ * deliberately NOT compared here -- reloid is already unique per relation, so
+ * this triple never suffers the cross-tablespace relnode collision.  spcoid
+ * matters only for the reloid-omitting keys (sys trees, seq_buf), which
+ * compare it explicitly.
+ */
 #define ORelOidsIsEqual(l, r) ((l).datoid == (r).datoid && (l).reloid == (r).reloid && (l).relnode == (r).relnode)
 #define ORelOidsSetInvalid(oids) \
-	((oids).datoid = (oids).reloid = (oids).relnode = InvalidOid)
+	((oids).datoid = (oids).reloid = (oids).relnode = (oids).spcoid = InvalidOid)
 
 #if PG_VERSION_NUM >= 170000
 

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -327,6 +327,7 @@ typedef RelFileLocator RelFileNode;
 #define MYPROCNUMBER MyProcNumber
 #define MyBackendId MyProcNumber
 #define	PROCNUMBER(proc) GetNumberFromPGProc(proc)
+#define O_INVALID_PROCNUMBER INVALID_PROC_NUMBER
 /* Deprecated */
 #define palloc0fast palloc0
 
@@ -341,6 +342,7 @@ typedef RelFileLocator RelFileNode;
 #define PROCBACKENDID backendId
 #define MYPROCNUMBER MyProc->pgprocno
 #define PROCNUMBER(proc) ((proc)->pgprocno)
+#define O_INVALID_PROCNUMBER InvalidBackendId
 
 #endif
 

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -275,6 +275,9 @@ typedef struct
 	Oid			datoid;
 	Oid			reloid;
 	Oid			relnode;
+	Oid			spcoid;			/* tablespace: part of the tree identity,
+								 * since relfilenumber uniqueness is only
+								 * per-tablespace */
 } ORelOids;
 
 typedef uint64 S3TaskLocation;
@@ -286,6 +289,8 @@ typedef RelFileLocator RelFileNode;
 		(oids).datoid = MyDatabaseId; \
 		(oids).reloid = (rel)->rd_id; \
 		(oids).relnode = (rel)->rd_locator.relNumber; \
+		(oids).spcoid = OidIsValid((rel)->rd_rel->reltablespace) ? \
+			(rel)->rd_rel->reltablespace : MyDatabaseTableSpace; \
 	} while (0)
 #define RelIsInMyDatabase(rel) ((rel)->rd_locator.dbOid == MyDatabaseId)
 #define RelGetNode(rel) ((rel)->rd_locator)
@@ -295,9 +300,16 @@ typedef RelFileLocator RelFileNode;
 		RelationSetNewRelfilenumber(relation, persistence)
 
 #define ORelOidsIsValid(oids) (OidIsValid((oids).datoid) && OidIsValid((oids).reloid) && OidIsValid((oids).relnode))
+/*
+ * Tree identity: (datoid, reloid, relnode).  spcoid (tablespace) is
+ * deliberately NOT compared here -- reloid is already unique per relation, so
+ * this triple never suffers the cross-tablespace relnode collision.  spcoid
+ * matters only for the reloid-omitting keys (sys trees, seq_buf), which
+ * compare it explicitly.
+ */
 #define ORelOidsIsEqual(l, r) ((l).datoid == (r).datoid && (l).reloid == (r).reloid && (l).relnode == (r).relnode)
 #define ORelOidsSetInvalid(oids) \
-	((oids).datoid = (oids).reloid = (oids).relnode = InvalidOid)
+	((oids).datoid = (oids).reloid = (oids).relnode = (oids).spcoid = InvalidOid)
 
 #if PG_VERSION_NUM >= 170000
 

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -28,7 +28,7 @@
  * ORIOLEDB_COMPRESS_VERSION (see big comment on versioning
  * in include/orioledb.h)
  */
-#define ORIOLEDB_WAL_VERSION (17)
+#define ORIOLEDB_WAL_VERSION (18)
 
 /*
  * Value has been fixed at the moment of introducing WAL versioning.
@@ -93,6 +93,8 @@ typedef struct
 	uint8		cid[sizeof(CommandId)];
 	uint8		version[sizeof(uint32)];
 	uint8		baseVersion[sizeof(uint32)];
+	/* Since ORIOLEDB_WAL_VERSION = 18 */
+	uint8		tablespace[sizeof(Oid)];
 } WALRecRelation;
 
 typedef struct

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -28,7 +28,7 @@
  * ORIOLEDB_COMPRESS_VERSION (see big comment on versioning
  * in include/orioledb.h)
  */
-#define ORIOLEDB_WAL_VERSION (17)
+#define ORIOLEDB_WAL_VERSION (18)
 
 /*
  * Value has been fixed at the moment of introducing WAL versioning.
@@ -50,6 +50,14 @@
  * We should never change this value.
  */
 #define ORIOLEDB_CONTAINER_FLAGS_WAL_VERSION (17)
+
+/*
+ * Particular WAL version when the relation's tablespace was added to the
+ * WAL_REC_RELATION record (tablespace became part of the tree identity).
+ *
+ * We should never change this value.
+ */
+#define ORIOLEDB_REL_TABLESPACE_WAL_VERSION (18)
 
 /* Constants for commitInProgressXlogLocation */
 #define OWalTmpCommitPos			(0)
@@ -93,6 +101,8 @@ typedef struct
 	uint8		cid[sizeof(CommandId)];
 	uint8		version[sizeof(uint32)];
 	uint8		baseVersion[sizeof(uint32)];
+	/* Since ORIOLEDB_REL_TABLESPACE_WAL_VERSION */
+	uint8		tablespace[sizeof(Oid)];
 } WALRecRelation;
 
 typedef struct

--- a/include/s3/headers.h
+++ b/include/s3/headers.h
@@ -38,7 +38,7 @@ typedef enum
 #define S3HeaderTagsIsEqual(t1, t2) \
 	((t1).key.oids.datoid == (t2).key.oids.datoid && \
 	 (t1).key.oids.relnode == (t2).key.oids.relnode && \
-	 (t1).key.tablespace == (t2).key.tablespace && \
+	 (t1).key.oids.spcoid == (t2).key.oids.spcoid && \
 	 (t1).checkpointNum == (t2).checkpointNum && \
 	 (t1).segNum == (t2).segNum)
 

--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -318,6 +318,7 @@ extern OIndexDescr *o_fetch_index_descr_extended(ORelOids oids, OIndexType type,
 extern OTableDescr *o_fetch_table_descr(ORelOids oids);
 extern OIndexDescr *o_fetch_index_descr(ORelOids oids, OIndexType type,
 										bool lock, bool *nested);
+extern OIndexDescr *get_cached_index_descr(ORelOids oids);
 
 extern void recreate_table_descr_by_oids(ORelOids oids);
 extern void o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table);

--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -275,9 +275,6 @@ struct OTableDescr
 	int			nIndices;
 	/* number of unique trees */
 	int			nUniqueIndices;
-	/* OID of the tablespace for table */
-	Oid			tablespace;
-
 	bool		noInvalidation;
 };
 
@@ -321,6 +318,7 @@ extern OIndexDescr *o_fetch_index_descr_extended(ORelOids oids, OIndexType type,
 extern OTableDescr *o_fetch_table_descr(ORelOids oids);
 extern OIndexDescr *o_fetch_index_descr(ORelOids oids, OIndexType type,
 										bool lock, bool *nested);
+extern OIndexDescr *get_cached_index_descr(ORelOids oids);
 
 extern void recreate_table_descr_by_oids(ORelOids oids);
 extern void o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table);
@@ -337,7 +335,9 @@ extern bool o_btree_load_shmem_checkpoint(BTreeDescr *desc);
 extern bool o_btree_try_use_shmem(BTreeDescr *desc);
 
 extern SharedRootInfo *o_find_shared_root_info(SharedRootInfoKey *key);
-extern void o_insert_shared_root_placeholder(Oid datoid, Oid relnode);
+extern void o_insert_shared_root_placeholder(Oid datoid, Oid relnode, Oid tablespace);
+extern void o_move_tree_meta(Oid datoid, Oid relnode, Oid old_tablespace,
+							 Oid new_tablespace);
 
 extern OComparator *o_find_comparator(Oid opfamily,
 									  Oid lefttype,
@@ -348,7 +348,7 @@ extern int	o_call_comparator(OComparator *comparator, Datum left,
 extern int	o_call_exclusion_fn(OExclusionFn *exclusion_fn, Datum left, Datum right, Oid collation);
 extern uint32 o_call_hash_fn(OHashFn *hash_fn, Oid collation, Datum val);
 
-extern EvictedTreeData *read_evicted_data(Oid datoid, Oid relnode, bool delete);
+extern EvictedTreeData *read_evicted_data(Oid datoid, Oid relnode, Oid tablespace, bool delete);
 extern void insert_evicted_data(EvictedTreeData *data);
 
 extern void oFillFieldOpClassAndComparator(OIndexField *field, Oid datoid,

--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -275,9 +275,6 @@ struct OTableDescr
 	int			nIndices;
 	/* number of unique trees */
 	int			nUniqueIndices;
-	/* OID of the tablespace for table */
-	Oid			tablespace;
-
 	bool		noInvalidation;
 };
 
@@ -337,7 +334,9 @@ extern bool o_btree_load_shmem_checkpoint(BTreeDescr *desc);
 extern bool o_btree_try_use_shmem(BTreeDescr *desc);
 
 extern SharedRootInfo *o_find_shared_root_info(SharedRootInfoKey *key);
-extern void o_insert_shared_root_placeholder(Oid datoid, Oid relnode);
+extern void o_insert_shared_root_placeholder(Oid datoid, Oid relnode, Oid tablespace);
+extern void o_move_tree_meta(Oid datoid, Oid relnode, Oid old_tablespace,
+							 Oid new_tablespace);
 
 extern OComparator *o_find_comparator(Oid opfamily,
 									  Oid lefttype,
@@ -348,7 +347,7 @@ extern int	o_call_comparator(OComparator *comparator, Datum left,
 extern int	o_call_exclusion_fn(OExclusionFn *exclusion_fn, Datum left, Datum right, Oid collation);
 extern uint32 o_call_hash_fn(OHashFn *hash_fn, Oid collation, Datum val);
 
-extern EvictedTreeData *read_evicted_data(Oid datoid, Oid relnode, bool delete);
+extern EvictedTreeData *read_evicted_data(Oid datoid, Oid relnode, Oid tablespace, bool delete);
 extern void insert_evicted_data(EvictedTreeData *data);
 
 extern void oFillFieldOpClassAndComparator(OIndexField *field, Oid datoid,

--- a/include/tableam/handler.h
+++ b/include/tableam/handler.h
@@ -127,7 +127,7 @@ get_ea_counters(OrioleDBPageDesc *desc)
 	}
 
 extern void cleanup_btree(OIndexKey ix_key, bool files, bool fsync);
-extern bool o_drop_shared_root_info(Oid datoid, Oid relnode);
+extern bool o_drop_shared_root_info(Oid datoid, Oid relnode, Oid tablespace);
 extern void o_tableam_descr_init(void);
 extern void o_invalidate_descrs(Oid datoid, Oid reloid, Oid relfilenode);
 extern bool o_start_saving_inval_messages(void);

--- a/include/utils/seq_buf.h
+++ b/include/utils/seq_buf.h
@@ -24,7 +24,6 @@ typedef enum
 typedef struct
 {
 	ORelOids	oids;
-	Oid			tablespace;
 } OIndexKey;
 
 typedef struct
@@ -36,6 +35,7 @@ typedef struct
 
 #define SeqBufTagEqual(l, r) ((l)->key.oids.datoid == (r)->key.oids.datoid && \
 							  (l)->key.oids.relnode == (r)->key.oids.relnode && \
+							  (l)->key.oids.spcoid == (r)->key.oids.spcoid && \
 							  (l)->num == (r)->num && \
 							  (l)->type == (r)->type)
 

--- a/src/btree/build.c
+++ b/src/btree/build.c
@@ -429,7 +429,7 @@ btree_write_file_header(BTreeDescr *desc, CheckpointFileHeader *file_header)
 
 		memset(&prev_chkp_tag, 0, sizeof(prev_chkp_tag));
 		prev_chkp_tag.key.oids = desc->oids;
-		prev_chkp_tag.key.tablespace = desc->tablespace;
+		prev_chkp_tag.key.oids.spcoid = desc->oids.spcoid;
 		prev_chkp_tag.num = checkpoint_number;
 		prev_chkp_tag.type = 'm';
 
@@ -463,11 +463,12 @@ btree_write_file_header(BTreeDescr *desc, CheckpointFileHeader *file_header)
 
 		o_update_latest_chkp_num(desc->oids.datoid,
 								 desc->oids.relnode,
+								 desc->oids.spcoid,
 								 checkpoint_number);
 
 		if (orioledb_s3_mode)
 		{
-			OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+			OIndexKey	key = {.oids = desc->oids};
 
 			result = s3_schedule_file_part_write(checkpoint_number, key, -1, -1);
 		}
@@ -478,6 +479,7 @@ btree_write_file_header(BTreeDescr *desc, CheckpointFileHeader *file_header)
 
 		evicted_tree_data.key.datoid = desc->oids.datoid;
 		evicted_tree_data.key.relnode = desc->oids.relnode;
+		evicted_tree_data.key.tablespace = desc->oids.spcoid;
 		evicted_tree_data.file_header = *file_header;
 		insert_evicted_data(&evicted_tree_data);
 	}

--- a/src/btree/check.c
+++ b/src/btree/check.c
@@ -200,9 +200,10 @@ check_btree(BTreeDescr *desc, bool force_file_check, bool wait_for_checkpoint)
 		memset(&tmp_extents, 0, sizeof(ExtentsArray));
 
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.num = o_get_latest_chkp_num(desc->oids.datoid,
 										desc->oids.relnode,
+										desc->oids.spcoid,
 										checkpoint_number - 1,
 										&found);
 		tag.type = 'm';
@@ -279,7 +280,7 @@ get_free_extents(BTreeDescr *desc, ExtentsArray *free_extents,
 	bool		is_compressed = OCompressIsValid(desc->compress);
 
 	chkp_tag.key.oids = desc->oids;
-	chkp_tag.key.tablespace = desc->tablespace;
+	chkp_tag.key.oids.spcoid = desc->oids.spcoid;
 
 	if (force_file_check)
 	{
@@ -291,6 +292,7 @@ get_free_extents(BTreeDescr *desc, ExtentsArray *free_extents,
 		chkp_tag.type = 'm';
 		chkp_tag.num = o_get_latest_chkp_num(desc->oids.datoid,
 											 desc->oids.relnode,
+											 desc->oids.spcoid,
 											 chkp_num,
 											 &found);
 

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -2837,6 +2837,35 @@ index_oids_get_btree_descr(ORelOids oids, OIndexType type)
 	return desc;
 }
 
+/*
+ * Like index_oids_get_btree_descr(), but never builds or rebuilds the
+ * descriptor: it only returns one that is already cached for the tablespace in
+ * oids.spcoid.  This avoids the O_INDICES TOAST read (a multi-kilobyte palloc)
+ * that get_index_descr() performs on a cache miss / tablespace mismatch, so it
+ * is safe to call from a critical section.  Used by the CHECK_PAGE_STATS
+ * diagnostic in unlock_check_page(); the checked page is locked in memory, so
+ * the tree's shared root is already loaded and o_btree_try_use_shmem() below
+ * hits its fast path without reserving pages.  Returns NULL when no suitable
+ * cached descriptor exists (the diagnostic then simply skips the page).
+ */
+BTreeDescr *
+index_oids_get_btree_descr_cached(ORelOids oids)
+{
+	OIndexDescr *indexDescr;
+	BTreeDescr *desc;
+
+	indexDescr = get_cached_index_descr(oids);
+	if (indexDescr == NULL)
+		return NULL;
+
+	desc = &indexDescr->desc;
+
+	if (!o_btree_try_use_shmem(desc))
+		return NULL;
+
+	return desc;
+}
+
 typedef struct
 {
 	bool		indexRegularLock;

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -238,7 +238,7 @@ btree_filename(OIndexKey key, int segno, uint32 chkpNum)
 	char	   *result;
 	char	   *db_prefix;
 
-	o_get_prefixes_for_tablespace(key.oids.datoid, key.tablespace,
+	o_get_prefixes_for_tablespace(key.oids.datoid, key.oids.spcoid,
 								  NULL, &db_prefix);
 
 	if (orioledb_s3_mode)
@@ -276,7 +276,7 @@ char *
 btree_smgr_filename(BTreeDescr *desc, off_t offset, uint32 chkpNum)
 {
 	int			segno = offset / ORIOLEDB_SEGMENT_SIZE;
-	OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+	OIndexKey	key = {.oids = desc->oids};
 
 	return btree_filename(key, segno, chkpNum);
 }
@@ -295,7 +295,7 @@ btree_smgr_ensure_dir(BTreeDescr *desc)
 	char	   *prefix,
 			   *db_prefix;
 
-	o_get_prefixes_for_tablespace(desc->oids.datoid, desc->tablespace,
+	o_get_prefixes_for_tablespace(desc->oids.datoid, desc->oids.spcoid,
 								  &prefix, &db_prefix);
 	o_verify_dir_exists_or_create(prefix, NULL, NULL);
 	o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
@@ -461,8 +461,7 @@ btree_close_smgr(BTreeDescr *descr)
 				partNum = descr->buildPartsInfo[j].dirtyParts[i].partNum;
 				if (segNum >= 0 && partNum >= 0)
 				{
-					OIndexKey	key = {.oids = descr->oids,
-					.tablespace = descr->tablespace};
+					OIndexKey	key = {.oids = descr->oids};
 
 					location = s3_schedule_file_part_write(chkpNum, key, segNum,
 														   partNum);
@@ -516,7 +515,7 @@ btree_s3_flush(BTreeDescr *desc, uint32 chkpNum)
 		partNum = meta->partsInfo[chkpNum % 2].dirtyParts[i].partNum;
 		if (segNum >= 0 && partNum >= 0)
 		{
-			OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+			OIndexKey	key = {.oids = desc->oids};
 
 			Assert(chkpNum == meta->partsInfo[chkpNum % 2].dirtyParts[i].chkpNum);
 			location = s3_schedule_file_part_write(chkpNum, key, segNum, partNum);
@@ -576,7 +575,7 @@ btree_smgr_schedule_s3_write(BTreeDescr *desc, uint32 chkpNum,
 		if (i == MAX_NUM_DIRTY_PARTS - 1)
 		{
 			S3TaskLocation location;
-			OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+			OIndexKey	key = {.oids = desc->oids};
 
 			location = s3_schedule_file_part_write(curChkpNum, key, curSegNum,
 												   curPartNum);
@@ -614,7 +613,7 @@ btree_smgr_write(BTreeDescr *desc, char *buffer, uint32 chkpNum,
 	{
 		granularity = ORIOLEDB_S3_PART_SIZE;
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.checkpointNum = chkpNum;
 	}
 	else
@@ -706,7 +705,7 @@ btree_smgr_read(BTreeDescr *desc, char *buffer, uint32 chkpNum,
 	{
 		granularity = ORIOLEDB_S3_PART_SIZE;
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.checkpointNum = chkpNum;
 	}
 	else
@@ -782,7 +781,7 @@ btree_smgr_writeback(BTreeDescr *desc, uint32 chkpNum,
 		if (orioledb_s3_mode)
 		{
 			S3HeaderTag tag = {
-				.key = {.oids = desc->oids,.tablespace = desc->tablespace},
+				.key = {.oids = desc->oids},
 				.checkpointNum = chkpNum,
 			.segNum = segno};
 
@@ -830,7 +829,7 @@ btree_smgr_sync(BTreeDescr *desc, uint32 chkpNum, off_t length)
 		if (orioledb_s3_mode)
 		{
 			S3HeaderTag tag = {
-				.key = {.oids = desc->oids,.tablespace = desc->tablespace},
+				.key = {.oids = desc->oids},
 				.checkpointNum = chkpNum,
 			.segNum = num};
 
@@ -1014,7 +1013,7 @@ get_free_disk_offset(BTreeDescr *desc)
 		}
 
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.num = free_buf_num + 1;
 		tag.type = 't';
 
@@ -1029,6 +1028,7 @@ get_free_disk_offset(BTreeDescr *desc)
 			{
 				uint32		chkpNum = o_get_latest_chkp_num(tag.key.oids.datoid,
 															tag.key.oids.relnode,
+															tag.key.oids.spcoid,
 															checkpoint_state->lastCheckpointNumber,
 															NULL);
 
@@ -1774,6 +1774,7 @@ load_page(OBTreeFindPageContext *context)
 	 */
 	page_desc->type = desc->type;
 	page_desc->oids = desc->oids;
+	page_desc->oids.spcoid = desc->oids.spcoid;
 
 	Assert(O_PAGE_IS(page, LEAF) ||
 		   (PAGE_GET_N_ONDISK(page) == BTREE_PAGE_ITEMS_COUNT(page)));
@@ -2279,7 +2280,7 @@ perform_page_io_build(BTreeDescr *desc, Page img,
 				   (extent->off + threshold - 1 + extent->len) / threshold);
 
 			tag.key.oids = desc->oids;
-			tag.key.tablespace = desc->tablespace;
+			tag.key.oids.spcoid = desc->oids.spcoid;
 			tag.checkpointNum = chkpNum;
 			tag.segNum = offset / ORIOLEDB_SEGMENT_SIZE;
 			index = (offset % ORIOLEDB_SEGMENT_SIZE) / ORIOLEDB_S3_PART_SIZE;
@@ -2668,6 +2669,7 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 	 */
 	evict_key.datoid = desc->oids.datoid;
 	evict_key.relnode = desc->oids.relnode;
+	evict_key.tablespace = desc->oids.spcoid;
 	evict_lockNo = tag_hash(&evict_key, sizeof(evict_key)) % SHARED_ROOT_INFO_INSERT_NUM_LOCKS;
 	if (!LWLockConditionalAcquire(&checkpoint_state->oSharedRootInfoInsertLocks[evict_lockNo],
 								  LW_EXCLUSIVE))
@@ -2757,6 +2759,7 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 
 	evicted_tree_data.key.datoid = desc->oids.datoid;
 	evicted_tree_data.key.relnode = desc->oids.relnode;
+	evicted_tree_data.key.tablespace = desc->oids.spcoid;
 	evicted_tree_data.file_header = file_header;
 	evicted_tree_data.maxLocation[0] = metaPage->partsInfo[0].writeMaxLocation;
 	evicted_tree_data.maxLocation[1] = metaPage->partsInfo[1].writeMaxLocation;
@@ -2801,7 +2804,8 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 	 * Shared descr drops to signalize other backends that tree is evicted.
 	 * Backends and workers can create a new SharedRootInfo* after this.
 	 */
-	o_drop_shared_root_info(desc->oids.datoid, desc->oids.relnode);
+	o_drop_shared_root_info(desc->oids.datoid, desc->oids.relnode,
+							desc->oids.spcoid);
 
 	LWLockRelease(&checkpoint_state->oSharedRootInfoInsertLocks[evict_lockNo]);
 
@@ -2819,8 +2823,38 @@ index_oids_get_btree_descr(ORelOids oids, OIndexType type)
 	bool		nested;
 
 	/* Check is this table is visible for us */
-	indexDescr = o_fetch_index_descr(oids, type, false, &nested);
+	indexDescr = o_fetch_index_descr(oids, type,
+									 false, &nested);
 
+	if (indexDescr == NULL)
+		return NULL;
+
+	desc = &indexDescr->desc;
+
+	if (!o_btree_try_use_shmem(desc))
+		return NULL;
+
+	return desc;
+}
+
+/*
+ * Like index_oids_get_btree_descr(), but never builds or rebuilds the
+ * descriptor: it only returns one that is already cached for the tablespace in
+ * oids.spcoid.  This avoids the O_INDICES TOAST read (a multi-kilobyte palloc)
+ * that get_index_descr() performs on a cache miss / tablespace mismatch, so it
+ * is safe to call from a critical section.  Used by the CHECK_PAGE_STATS
+ * diagnostic in unlock_check_page(); the checked page is locked in memory, so
+ * the tree's shared root is already loaded and o_btree_try_use_shmem() below
+ * hits its fast path without reserving pages.  Returns NULL when no suitable
+ * cached descriptor exists (the diagnostic then simply skips the page).
+ */
+BTreeDescr *
+index_oids_get_btree_descr_cached(ORelOids oids)
+{
+	OIndexDescr *indexDescr;
+	BTreeDescr *desc;
+
+	indexDescr = get_cached_index_descr(oids);
 	if (indexDescr == NULL)
 		return NULL;
 
@@ -2847,8 +2881,8 @@ typedef struct
  * the table as well, because a concurrent seq scan can lock only the table.
  */
 static BTreeDescr *
-get_evict_btree_locks(OInMemoryBlkno blkno, ORelOids oids, OIndexType type,
-					  EvictBtreeLocksState *state)
+get_evict_btree_locks(OInMemoryBlkno blkno, ORelOids oids,
+					  OIndexType type, EvictBtreeLocksState *state)
 {
 	BTreeDescr *desc;
 	OIndexDescr *id;
@@ -2969,7 +3003,8 @@ walk_page_prelock_check(OInMemoryBlkno blkno, bool evict,
 	else
 	{
 		/* Check is this index is visible for us */
-		desc = index_oids_get_btree_descr(*oids, page_desc->type);
+		desc = index_oids_get_btree_descr(*oids,
+										  page_desc->type);
 
 		if (desc == NULL)
 			return NULL;
@@ -3082,7 +3117,8 @@ walk_page_evict_root(BTreeDescr *desc, OInMemoryBlkno blkno,
 
 	memset(&locksState, 0, sizeof(locksState));
 
-	desc = get_evict_btree_locks(blkno, oids, page_desc->type, &locksState);
+	desc = get_evict_btree_locks(blkno, oids,
+								 page_desc->type, &locksState);
 
 	if (!desc)
 	{
@@ -3491,7 +3527,7 @@ writeback_put_extent(IOWriteBack *writeback, BTreeDescr *desc,
 	Assert(extent.len <= (ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ));
 
 	offset.key.oids = desc->oids;
-	offset.key.tablespace = desc->tablespace;
+	offset.key.oids.spcoid = desc->oids.spcoid;
 	offset.compressed = OCompressIsValid(desc->compress);
 	blcksz = offset.compressed ? ORIOLEDB_COMP_BLCKSZ : ORIOLEDB_BLCKSZ;
 	offset.segno = blcksz * extent.off / ORIOLEDB_SEGMENT_SIZE;
@@ -3658,7 +3694,7 @@ iterate_relnode_files(OIndexKey key, RelnodeFileCallback callback, void *arg)
 	bool		first_file_deleted = false;
 	char	   *db_prefix;
 
-	o_get_prefixes_for_tablespace(key.oids.datoid, key.tablespace,
+	o_get_prefixes_for_tablespace(key.oids.datoid, key.oids.spcoid,
 								  NULL, &db_prefix);
 
 	dir = opendir(db_prefix);
@@ -3833,7 +3869,7 @@ try_to_punch_holes(BTreeDescr *desc)
 		}
 
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.type = 't';
 		tag.num = chkp_num;
 		if (!seq_buf_file_exist(&tag))

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -238,7 +238,7 @@ btree_filename(OIndexKey key, int segno, uint32 chkpNum)
 	char	   *result;
 	char	   *db_prefix;
 
-	o_get_prefixes_for_tablespace(key.oids.datoid, key.tablespace,
+	o_get_prefixes_for_tablespace(key.oids.datoid, key.oids.spcoid,
 								  NULL, &db_prefix);
 
 	if (orioledb_s3_mode)
@@ -276,7 +276,7 @@ char *
 btree_smgr_filename(BTreeDescr *desc, off_t offset, uint32 chkpNum)
 {
 	int			segno = offset / ORIOLEDB_SEGMENT_SIZE;
-	OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+	OIndexKey	key = {.oids = desc->oids};
 
 	return btree_filename(key, segno, chkpNum);
 }
@@ -295,7 +295,7 @@ btree_smgr_ensure_dir(BTreeDescr *desc)
 	char	   *prefix,
 			   *db_prefix;
 
-	o_get_prefixes_for_tablespace(desc->oids.datoid, desc->tablespace,
+	o_get_prefixes_for_tablespace(desc->oids.datoid, desc->oids.spcoid,
 								  &prefix, &db_prefix);
 	o_verify_dir_exists_or_create(prefix, NULL, NULL);
 	o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
@@ -461,8 +461,7 @@ btree_close_smgr(BTreeDescr *descr)
 				partNum = descr->buildPartsInfo[j].dirtyParts[i].partNum;
 				if (segNum >= 0 && partNum >= 0)
 				{
-					OIndexKey	key = {.oids = descr->oids,
-					.tablespace = descr->tablespace};
+					OIndexKey	key = {.oids = descr->oids};
 
 					location = s3_schedule_file_part_write(chkpNum, key, segNum,
 														   partNum);
@@ -516,7 +515,7 @@ btree_s3_flush(BTreeDescr *desc, uint32 chkpNum)
 		partNum = meta->partsInfo[chkpNum % 2].dirtyParts[i].partNum;
 		if (segNum >= 0 && partNum >= 0)
 		{
-			OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+			OIndexKey	key = {.oids = desc->oids};
 
 			Assert(chkpNum == meta->partsInfo[chkpNum % 2].dirtyParts[i].chkpNum);
 			location = s3_schedule_file_part_write(chkpNum, key, segNum, partNum);
@@ -576,7 +575,7 @@ btree_smgr_schedule_s3_write(BTreeDescr *desc, uint32 chkpNum,
 		if (i == MAX_NUM_DIRTY_PARTS - 1)
 		{
 			S3TaskLocation location;
-			OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+			OIndexKey	key = {.oids = desc->oids};
 
 			location = s3_schedule_file_part_write(curChkpNum, key, curSegNum,
 												   curPartNum);
@@ -614,7 +613,7 @@ btree_smgr_write(BTreeDescr *desc, char *buffer, uint32 chkpNum,
 	{
 		granularity = ORIOLEDB_S3_PART_SIZE;
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.checkpointNum = chkpNum;
 	}
 	else
@@ -706,7 +705,7 @@ btree_smgr_read(BTreeDescr *desc, char *buffer, uint32 chkpNum,
 	{
 		granularity = ORIOLEDB_S3_PART_SIZE;
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.checkpointNum = chkpNum;
 	}
 	else
@@ -782,7 +781,7 @@ btree_smgr_writeback(BTreeDescr *desc, uint32 chkpNum,
 		if (orioledb_s3_mode)
 		{
 			S3HeaderTag tag = {
-				.key = {.oids = desc->oids,.tablespace = desc->tablespace},
+				.key = {.oids = desc->oids},
 				.checkpointNum = chkpNum,
 			.segNum = segno};
 
@@ -830,7 +829,7 @@ btree_smgr_sync(BTreeDescr *desc, uint32 chkpNum, off_t length)
 		if (orioledb_s3_mode)
 		{
 			S3HeaderTag tag = {
-				.key = {.oids = desc->oids,.tablespace = desc->tablespace},
+				.key = {.oids = desc->oids},
 				.checkpointNum = chkpNum,
 			.segNum = num};
 
@@ -1014,7 +1013,7 @@ get_free_disk_offset(BTreeDescr *desc)
 		}
 
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.num = free_buf_num + 1;
 		tag.type = 't';
 
@@ -1029,6 +1028,7 @@ get_free_disk_offset(BTreeDescr *desc)
 			{
 				uint32		chkpNum = o_get_latest_chkp_num(tag.key.oids.datoid,
 															tag.key.oids.relnode,
+															tag.key.oids.spcoid,
 															checkpoint_state->lastCheckpointNumber,
 															NULL);
 
@@ -1774,6 +1774,7 @@ load_page(OBTreeFindPageContext *context)
 	 */
 	page_desc->type = desc->type;
 	page_desc->oids = desc->oids;
+	page_desc->oids.spcoid = desc->oids.spcoid;
 
 	Assert(O_PAGE_IS(page, LEAF) ||
 		   (PAGE_GET_N_ONDISK(page) == BTREE_PAGE_ITEMS_COUNT(page)));
@@ -2279,7 +2280,7 @@ perform_page_io_build(BTreeDescr *desc, Page img,
 				   (extent->off + threshold - 1 + extent->len) / threshold);
 
 			tag.key.oids = desc->oids;
-			tag.key.tablespace = desc->tablespace;
+			tag.key.oids.spcoid = desc->oids.spcoid;
 			tag.checkpointNum = chkpNum;
 			tag.segNum = offset / ORIOLEDB_SEGMENT_SIZE;
 			index = (offset % ORIOLEDB_SEGMENT_SIZE) / ORIOLEDB_S3_PART_SIZE;
@@ -2668,6 +2669,7 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 	 */
 	evict_key.datoid = desc->oids.datoid;
 	evict_key.relnode = desc->oids.relnode;
+	evict_key.tablespace = desc->oids.spcoid;
 	evict_lockNo = tag_hash(&evict_key, sizeof(evict_key)) % SHARED_ROOT_INFO_INSERT_NUM_LOCKS;
 	if (!LWLockConditionalAcquire(&checkpoint_state->oSharedRootInfoInsertLocks[evict_lockNo],
 								  LW_EXCLUSIVE))
@@ -2757,6 +2759,7 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 
 	evicted_tree_data.key.datoid = desc->oids.datoid;
 	evicted_tree_data.key.relnode = desc->oids.relnode;
+	evicted_tree_data.key.tablespace = desc->oids.spcoid;
 	evicted_tree_data.file_header = file_header;
 	evicted_tree_data.maxLocation[0] = metaPage->partsInfo[0].writeMaxLocation;
 	evicted_tree_data.maxLocation[1] = metaPage->partsInfo[1].writeMaxLocation;
@@ -2801,7 +2804,8 @@ evict_btree(BTreeDescr *desc, uint32 checkpoint_number)
 	 * Shared descr drops to signalize other backends that tree is evicted.
 	 * Backends and workers can create a new SharedRootInfo* after this.
 	 */
-	o_drop_shared_root_info(desc->oids.datoid, desc->oids.relnode);
+	o_drop_shared_root_info(desc->oids.datoid, desc->oids.relnode,
+							desc->oids.spcoid);
 
 	LWLockRelease(&checkpoint_state->oSharedRootInfoInsertLocks[evict_lockNo]);
 
@@ -2819,7 +2823,8 @@ index_oids_get_btree_descr(ORelOids oids, OIndexType type)
 	bool		nested;
 
 	/* Check is this table is visible for us */
-	indexDescr = o_fetch_index_descr(oids, type, false, &nested);
+	indexDescr = o_fetch_index_descr(oids, type,
+									 false, &nested);
 
 	if (indexDescr == NULL)
 		return NULL;
@@ -2847,8 +2852,8 @@ typedef struct
  * the table as well, because a concurrent seq scan can lock only the table.
  */
 static BTreeDescr *
-get_evict_btree_locks(OInMemoryBlkno blkno, ORelOids oids, OIndexType type,
-					  EvictBtreeLocksState *state)
+get_evict_btree_locks(OInMemoryBlkno blkno, ORelOids oids,
+					  OIndexType type, EvictBtreeLocksState *state)
 {
 	BTreeDescr *desc;
 	OIndexDescr *id;
@@ -2969,7 +2974,8 @@ walk_page_prelock_check(OInMemoryBlkno blkno, bool evict,
 	else
 	{
 		/* Check is this index is visible for us */
-		desc = index_oids_get_btree_descr(*oids, page_desc->type);
+		desc = index_oids_get_btree_descr(*oids,
+										  page_desc->type);
 
 		if (desc == NULL)
 			return NULL;
@@ -3082,7 +3088,8 @@ walk_page_evict_root(BTreeDescr *desc, OInMemoryBlkno blkno,
 
 	memset(&locksState, 0, sizeof(locksState));
 
-	desc = get_evict_btree_locks(blkno, oids, page_desc->type, &locksState);
+	desc = get_evict_btree_locks(blkno, oids,
+								 page_desc->type, &locksState);
 
 	if (!desc)
 	{
@@ -3491,7 +3498,7 @@ writeback_put_extent(IOWriteBack *writeback, BTreeDescr *desc,
 	Assert(extent.len <= (ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ));
 
 	offset.key.oids = desc->oids;
-	offset.key.tablespace = desc->tablespace;
+	offset.key.oids.spcoid = desc->oids.spcoid;
 	offset.compressed = OCompressIsValid(desc->compress);
 	blcksz = offset.compressed ? ORIOLEDB_COMP_BLCKSZ : ORIOLEDB_BLCKSZ;
 	offset.segno = blcksz * extent.off / ORIOLEDB_SEGMENT_SIZE;
@@ -3658,7 +3665,7 @@ iterate_relnode_files(OIndexKey key, RelnodeFileCallback callback, void *arg)
 	bool		first_file_deleted = false;
 	char	   *db_prefix;
 
-	o_get_prefixes_for_tablespace(key.oids.datoid, key.tablespace,
+	o_get_prefixes_for_tablespace(key.oids.datoid, key.oids.spcoid,
 								  NULL, &db_prefix);
 
 	dir = opendir(db_prefix);
@@ -3833,7 +3840,7 @@ try_to_punch_holes(BTreeDescr *desc)
 		}
 
 		tag.key.oids = desc->oids;
-		tag.key.tablespace = desc->tablespace;
+		tag.key.oids.spcoid = desc->oids.spcoid;
 		tag.type = 't';
 		tag.num = chkp_num;
 		if (!seq_buf_file_exist(&tag))

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -379,6 +379,7 @@ init_new_btree_page(BTreeDescr *desc, OInMemoryBlkno blkno, uint16 flags,
 	}
 
 	page_desc->oids = desc->oids;
+	page_desc->oids.spcoid = desc->oids.spcoid;
 	page_desc->type = desc->type;
 	page_desc->fileExtent.len = InvalidFileExtentLen;
 	page_desc->fileExtent.off = InvalidFileExtentOff;
@@ -435,6 +436,7 @@ init_meta_page(OInMemoryBlkno blkno, uint32 leafPagesNum)
 
 	page_desc->type = oIndexInvalid;
 	ORelOidsSetInvalid(page_desc->oids);
+	page_desc->oids.spcoid = InvalidOid;
 	page_desc->fileExtent.len = InvalidFileExtentLen;
 	page_desc->fileExtent.off = InvalidFileExtentOff;
 

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -857,8 +857,11 @@ unlock_check_page(OInMemoryBlkno blkno)
 #ifdef CHECK_PAGE_STATS
 	{
 		/*
-		 * XXX: index_oids_get_btree_descr() might expand a hash table under
-		 * critical section.
+		 * This runs inside a critical section, so use the cache-only
+		 * descriptor lookup: it never reads the O_INDICES sys-tree (a
+		 * multi-kilobyte TOAST palloc) and never rebuilds the descriptor.  A
+		 * cache miss just skips the statistics check for this page, which is
+		 * acceptable for a diagnostic.
 		 */
 		OrioleDBPageDesc *page_desc = O_GET_IN_MEMORY_PAGEDESC(blkno);
 
@@ -868,8 +871,7 @@ unlock_check_page(OInMemoryBlkno blkno)
 			BTreeDescr *desc;
 
 			if (!IS_SYS_TREE_OIDS(oids))
-				desc = index_oids_get_btree_descr(oids,
-												  page_desc->type);
+				desc = index_oids_get_btree_descr_cached(oids);
 			else
 				desc = get_sys_tree_no_init(oids.reloid);
 			if (desc)

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -857,8 +857,11 @@ unlock_check_page(OInMemoryBlkno blkno)
 #ifdef CHECK_PAGE_STATS
 	{
 		/*
-		 * XXX: index_oids_get_btree_descr() might expand a hash table under
-		 * critical section.
+		 * This runs inside a critical section, so use the cache-only
+		 * descriptor lookup: it never reads the O_INDICES sys-tree (a
+		 * multi-kilobyte TOAST palloc) and never rebuilds the descriptor.  A
+		 * cache miss just skips the statistics check for this page, which is
+		 * acceptable for a diagnostic.
 		 */
 		OrioleDBPageDesc *page_desc = O_GET_IN_MEMORY_PAGEDESC(blkno);
 
@@ -868,7 +871,7 @@ unlock_check_page(OInMemoryBlkno blkno)
 			BTreeDescr *desc;
 
 			if (!IS_SYS_TREE_OIDS(oids))
-				desc = index_oids_get_btree_descr(oids, page_desc->type);
+				desc = index_oids_get_btree_descr_cached(oids);
 			else
 				desc = get_sys_tree_no_init(oids.reloid);
 			if (desc)

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -868,7 +868,8 @@ unlock_check_page(OInMemoryBlkno blkno)
 			BTreeDescr *desc;
 
 			if (!IS_SYS_TREE_OIDS(oids))
-				desc = index_oids_get_btree_descr(oids, page_desc->type);
+				desc = index_oids_get_btree_descr(oids,
+												  page_desc->type);
 			else
 				desc = get_sys_tree_no_init(oids.reloid);
 			if (desc)

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1677,14 +1677,12 @@ init_checkpoit_number(BTreeSeqScan *scan)
 	 * concurrent switching tree to the next checkpoint.  So, we have to
 	 * workaround this with recheck-retry loop,
 	 */
-	checkpointNumberBefore = get_cur_checkpoint_number(&desc->oids,
-													   desc->type,
+	checkpointNumberBefore = get_cur_checkpoint_number(&desc->oids, desc->type,
 													   &checkpointConcurrent);
 	while (true)
 	{
 		(void) pg_atomic_fetch_add_u32(&metaPage->numSeqScans[checkpointNumberBefore % NUM_SEQ_SCANS_ARRAY_SIZE], 1);
-		checkpointNumberAfter = get_cur_checkpoint_number(&desc->oids,
-														  desc->type,
+		checkpointNumberAfter = get_cur_checkpoint_number(&desc->oids, desc->type,
 														  &checkpointConcurrent);
 		if (checkpointNumberAfter == checkpointNumberBefore)
 		{

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -22,6 +22,7 @@
 #include "btree/scan.h"
 #include "btree/undo.h"
 #include "catalog/o_sys_cache.h"
+#include "catalog/o_tables.h"
 #include "recovery/recovery.h"
 #include "rewind/rewind.h"
 #include "tableam/descr.h"
@@ -1000,6 +1001,22 @@ btree_relnode_undo_callback(UndoLogType undoType, UndoLocation location,
 				o_delete_chkp_num(dropTrees[i].oids.datoid,
 								  dropTrees[i].oids.relnode,
 								  dropTrees[i].oids.spcoid);
+
+				/*
+				 * A bridge index (reloid == relnode) reserved its relnode
+				 * with a standard-path marker file (o_bridge_new_relnode).
+				 * Now that the bridge is durably dropped, remove the marker
+				 * so PG can reuse the relnode.  The locator is rebuilt from
+				 * the undo item's (datoid, spcoid, relnode) -- all carried in
+				 * ORelOids -- so this is correct in recovery too.  Only on
+				 * commit: an aborted create's marker is removed by the
+				 * register_delete pending-delete instead.
+				 */
+				if (stage == OUndoCallbackStageCommit &&
+					dropTrees[i].oids.reloid == dropTrees[i].oids.relnode)
+					o_bridge_drop_relnode_marker(dropTrees[i].oids.datoid,
+												 dropTrees[i].oids.spcoid,
+												 dropTrees[i].oids.relnode);
 			}
 			o_invalidate_oids(dropTrees[i].oids);
 			if (!recovery)

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -501,7 +501,8 @@ get_tree_descr(ORelOids oids, OIndexType type)
 	}
 	else
 	{
-		OIndexDescr *descr = o_fetch_index_descr(oids, type, false, NULL);
+		OIndexDescr *descr = o_fetch_index_descr(oids, type,
+												 false, NULL);
 
 		if (!descr)
 			return NULL;
@@ -518,7 +519,8 @@ modify_undo_callback(UndoLogType undoType, UndoLocation location,
 					 OUndoCallbackStage stage, bool changeCountsValid)
 {
 	BTreeModifyUndoStackItem *item = (BTreeModifyUndoStackItem *) baseItem;
-	BTreeDescr *desc = get_tree_descr(item->oids, item->header.indexType);
+	BTreeDescr *desc = get_tree_descr(item->oids,
+									  item->header.indexType);
 	OTuple		tuple;
 	Page		p;
 	int			cmp;
@@ -638,7 +640,8 @@ lock_undo_callback(UndoLogType undoType, UndoLocation location,
 				   OUndoCallbackStage stage, bool changeCountsValid)
 {
 	BTreeModifyUndoStackItem *item = (BTreeModifyUndoStackItem *) baseItem;
-	BTreeDescr *desc = get_tree_descr(item->oids, item->header.indexType);
+	BTreeDescr *desc = get_tree_descr(item->oids,
+									  item->header.indexType);
 	OTuple		key;
 	Page		p;
 	int			cmp;
@@ -995,7 +998,8 @@ btree_relnode_undo_callback(UndoLogType undoType, UndoLocation location,
 			{
 				cleanup_btree(dropTrees[i], cleanupFiles, true);
 				o_delete_chkp_num(dropTrees[i].oids.datoid,
-								  dropTrees[i].oids.relnode);
+								  dropTrees[i].oids.relnode,
+								  dropTrees[i].oids.spcoid);
 			}
 			o_invalidate_oids(dropTrees[i].oids);
 			if (!recovery)

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -2167,6 +2167,9 @@ set_toast_oids_and_options(Relation rel, Relation toast_rel, bool only_fillfacto
 				GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
 									rel->rd_rel->relpersistence);
 			o_table->bridge_oids.reloid = o_table->bridge_oids.relnode;
+			/* A bridge index lives in its table's tablespace. */
+			o_table->bridge_oids.spcoid = OidIsValid(rel->rd_rel->reltablespace) ?
+				rel->rd_rel->reltablespace : MyDatabaseTableSpace;
 		}
 	}
 
@@ -4075,7 +4078,7 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 						Assert(ix_num < o_table->nindices);
 						if (!OidIsValid(reltablespace))
 							reltablespace = MyDatabaseTableSpace;
-						if (o_table->indices[ix_num].tablespace == reltablespace)
+						if (o_table->indices[ix_num].oids.spcoid == reltablespace)
 						{
 							int			ctid_idx_off = o_table->has_primary ? 0 : 1;
 

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -2157,6 +2157,9 @@ set_toast_oids_and_options(Relation rel, Relation toast_rel, bool only_fillfacto
 		if (index_bridging)
 		{
 			o_table->bridge_oids.datoid = MyDatabaseId;
+			/* A bridge index lives in its table's tablespace. */
+			o_table->bridge_oids.spcoid = OidIsValid(rel->rd_rel->reltablespace) ?
+				rel->rd_rel->reltablespace : MyDatabaseTableSpace;
 
 			/*
 			 * Under pg_upgrade fresh relfilenumber allocation is forbidden
@@ -2164,12 +2167,9 @@ set_toast_oids_and_options(Relation rel, Relation toast_rel, bool only_fillfacto
 			 * is discarded after the schema restore, so leave it invalid.
 			 */
 			o_table->bridge_oids.relnode = IsBinaryUpgrade ? InvalidOid :
-				GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
-									rel->rd_rel->relpersistence);
+				o_bridge_new_relnode(o_table->bridge_oids.spcoid,
+									 rel->rd_rel->relpersistence);
 			o_table->bridge_oids.reloid = o_table->bridge_oids.relnode;
-			/* A bridge index lives in its table's tablespace. */
-			o_table->bridge_oids.spcoid = OidIsValid(rel->rd_rel->reltablespace) ?
-				rel->rd_rel->reltablespace : MyDatabaseTableSpace;
 		}
 	}
 

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -210,6 +210,9 @@ assign_new_oids(OTable *oTable, Relation rel, bool drop_pkey)
 		oTable->bridge_oids.relnode = GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
 														  rel->rd_rel->relpersistence);
 		oTable->bridge_oids.reloid = oTable->bridge_oids.relnode;
+		/* A bridge index lives in its table's tablespace. */
+		oTable->bridge_oids.spcoid = OidIsValid(rel->rd_rel->reltablespace) ?
+			rel->rd_rel->reltablespace : MyDatabaseTableSpace;
 	}
 
 	PG_TRY();
@@ -378,12 +381,14 @@ rebuild_indices_insert_placeholders(OTableDescr *descr)
 		if (descr->indices[i]->desc.storageType == BTreeStorageTemporary)
 			continue;
 		o_insert_shared_root_placeholder(descr->indices[i]->desc.oids.datoid,
-										 descr->indices[i]->desc.oids.relnode);
+										 descr->indices[i]->desc.oids.relnode,
+										 descr->indices[i]->desc.oids.spcoid);
 	}
 	if (descr->toast &&
 		descr->toast->desc.storageType != BTreeStorageTemporary)
 		o_insert_shared_root_placeholder(descr->toast->desc.oids.datoid,
-										 descr->toast->desc.oids.relnode);
+										 descr->toast->desc.oids.relnode,
+										 descr->toast->desc.oids.spcoid);
 }
 
 static Jsonb *
@@ -519,17 +524,12 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 		else
 		{
 			ORelOids	primary_oids;
-			Oid			primary_tablespace;
 
 			primary_oids = ix_type == oIndexPrimary ||
 				!old_o_table->has_primary ?
 				old_o_table->oids :
 				old_o_table->indices[PrimaryIndexNumber].oids;
-			primary_tablespace = ix_type == oIndexPrimary ||
-				!old_o_table->has_primary ?
-				old_o_table->tablespace :
-				old_o_table->indices[PrimaryIndexNumber].tablespace;
-			is_build = tbl_data_exists(&primary_oids, primary_tablespace);
+			is_build = tbl_data_exists(&primary_oids);
 
 			/* Rebuild, assign new oids */
 			if (ix_type == oIndexPrimary)
@@ -603,8 +603,8 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 	table_index->oids.reloid = index->rd_rel->oid;
 	if (tablespace == 0)
 		tablespace = MyDatabaseTableSpace;
-	table_index->tablespace = tablespace;
-	Assert(table_index->tablespace);
+	table_index->oids.spcoid = tablespace;
+	Assert(table_index->oids.spcoid);
 	table_index->immediate = index->rd_index->indimmediate;
 
 	if (!reuse_relnode && is_build)
@@ -631,8 +631,7 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 		o_tables_update(o_table, oxid, oSnapshot.csn);
 		if (!reuse_relnode)
 		{
-			OIndexKey	key = {.oids = table_index->oids,
-			.tablespace = table_index->tablespace};
+			OIndexKey	key = {.oids = table_index->oids};
 
 			add_undo_create_relnode(o_table->oids, &key, 1, !is_temp);
 		}
@@ -676,7 +675,8 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 			 */
 			if (o_table->persistence != RELPERSISTENCE_TEMP)
 				o_insert_shared_root_placeholder(table_index->oids.datoid,
-												 table_index->oids.relnode);
+												 table_index->oids.relnode,
+												 table_index->oids.spcoid);
 		}
 	}
 
@@ -685,7 +685,7 @@ o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,
 	 * have to be located in differen tablespace then the table, but table is
 	 * an empty yet.
 	 */
-	if (!is_build && table_index->type != oIndexPrimary && o_table->tablespace != tablespace)
+	if (!is_build && table_index->type != oIndexPrimary && o_table->oids.spcoid != tablespace)
 	{
 		char	   *prefix;
 		char	   *db_prefix;
@@ -1488,7 +1488,7 @@ o_calculate_index_workers(BTreeDescr *primary, bool shmem_loaded, int nindices)
 	{
 		Assert(primary);
 
-		if (tbl_data_exists(&primary->oids, primary->tablespace))
+		if (tbl_data_exists(&primary->oids))
 		{
 			if (!shmem_loaded)
 				o_btree_load_shmem(primary);
@@ -1729,7 +1729,8 @@ build_secondary_index(Oid oldTblRelnode, OTable *o_table,
 	btree_write_file_header(&idx->desc, &fileHeader);
 	if (!setting_tbl_tablespace)
 		o_drop_shared_root_info(idx->desc.oids.datoid,
-								idx->desc.oids.relnode);
+								idx->desc.oids.relnode,
+								idx->desc.oids.spcoid);
 
 	o_tables_table_meta_unlock(o_table, oldTblRelnode);
 
@@ -2192,19 +2193,22 @@ rebuild_indices(OTable *old_o_table, OTableDescr *old_descr,
 		{
 			location = btree_write_file_header(&descr->indices[i]->desc, &fileHeaders[i]);
 			o_drop_shared_root_info(descr->indices[i]->desc.oids.datoid,
-									descr->indices[i]->desc.oids.relnode);
+									descr->indices[i]->desc.oids.relnode,
+									descr->indices[i]->desc.oids.spcoid);
 		}
 		else if (descr->toast && i == descr->nIndices)	/* TOAST sort state */
 		{
 			location = btree_write_file_header(&descr->toast->desc, &fileHeaders[i]);
 			o_drop_shared_root_info(descr->toast->desc.oids.datoid,
-									descr->toast->desc.oids.relnode);
+									descr->toast->desc.oids.relnode,
+									descr->toast->desc.oids.spcoid);
 		}
 		else if (descr->bridge) /* bridge_index sort state */
 		{
 			location = btree_write_file_header(&descr->bridge->desc, &fileHeaders[i]);
 			o_drop_shared_root_info(descr->bridge->desc.oids.datoid,
-									descr->bridge->desc.oids.relnode);
+									descr->bridge->desc.oids.relnode,
+									descr->bridge->desc.oids.spcoid);
 		}
 		maxLocation = Max(maxLocation, location);
 	}
@@ -2291,7 +2295,7 @@ drop_secondary_index(OTable *o_table, OIndexNumber ix_num)
 	Assert(o_table->indices[ix_num].type != oIndexInvalid);
 
 	deletedTrees.oids = o_table->indices[ix_num].oids;
-	deletedTrees.tablespace = o_table->indices[ix_num].tablespace;
+	deletedTrees.oids.spcoid = o_table->indices[ix_num].oids.spcoid;
 	o_table->nindices--;
 	if (o_table->nindices > 0)
 	{

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -166,6 +166,7 @@ oIndicesFetchCallback(OTuple tuple, OXid tupOxid, OSnapshot *oSnapshot,
 	/* Ignore reloid because it may changes */
 	if (tupleKey->oids.datoid == boundKey->key.oids.datoid &&
 		tupleKey->oids.relnode == boundKey->key.oids.relnode &&
+		tupleKey->oids.spcoid == boundKey->key.oids.spcoid &&
 		tupleKey->type == boundKey->key.type)
 	{
 		if (COMMITSEQNO_IS_INPROGRESS(oSnapshot->csn) &&
@@ -287,8 +288,8 @@ make_ctid_o_index(OTable *table, OIndexVersionMode ixVerMode)
 	result->primaryIsCtid = true;
 	result->compress = table->primary_compress;
 	result->fillfactor = table->fillfactor;
-	result->tablespace = table->tablespace;
-	Assert(result->tablespace);
+	result->indexOids.spcoid = table->oids.spcoid;
+	Assert(result->indexOids.spcoid);
 	result->nLeafFields = table->nfields + 1;
 	if (table->index_bridging)
 		result->nLeafFields++;
@@ -376,8 +377,8 @@ make_primary_o_index(OTable *table, OIndexVersionMode ixVerMode)
 	else
 		result->compress = table->primary_compress;
 	result->fillfactor = table->fillfactor;
-	result->tablespace = tableIndex->tablespace;
-	Assert(result->tablespace);
+	result->indexOids.spcoid = tableIndex->oids.spcoid;
+	Assert(result->indexOids.spcoid);
 	saved_nLeafFields = table->nfields;
 	result->nLeafFields = table->nfields;
 	if (table->index_bridging)
@@ -547,8 +548,8 @@ make_secondary_o_index(OTable *table, OTableIndex *tableIndex, OIndexVersionMode
 	result->bridging = table->index_bridging;
 	result->compress = tableIndex->compress;
 	result->fillfactor = tableIndex->fillfactor;
-	result->tablespace = tableIndex->tablespace;
-	Assert(result->tablespace);
+	result->indexOids.spcoid = tableIndex->oids.spcoid;
+	Assert(result->indexOids.spcoid);
 	result->nulls_not_distinct = tableIndex->nulls_not_distinct;
 	result->nIncludedFields = tableIndex->nfields - tableIndex->nkeyfields;
 	result->nLeafFields = tableIndex->nfields;
@@ -625,8 +626,8 @@ make_toast_o_index(OTable *table, OIndexVersionMode ixVerMode)
 	result->primaryIsCtid = !table->has_primary;
 	result->compress = table->toast_compress;
 	result->fillfactor = HEAP_DEFAULT_FILLFACTOR;
-	result->tablespace = table->tablespace;
-	Assert(result->tablespace);
+	result->indexOids.spcoid = table->oids.spcoid;
+	Assert(result->indexOids.spcoid);
 	if (table->has_primary)
 	{
 		primary = &table->indices[0];
@@ -705,7 +706,7 @@ make_bridge_o_index(OTable *table, OIndexVersionMode ixVerMode)
 	result->primaryIsCtid = !table->has_primary;
 	result->compress = table->primary_compress;
 	result->nLeafFields = 1;
-	result->tablespace = table->tablespace;
+	result->indexOids.spcoid = table->oids.spcoid;
 	if (table->has_primary)
 	{
 		primary = &table->indices[0];
@@ -1603,6 +1604,7 @@ o_indices_add(OTable *table, OIndexNumber ixNum, OXid oxid, CommitSeqNo csn)
 
 	oIndex->createOxid = oxid;
 	key.oids = oIndex->indexOids;
+	key.oids.spcoid = oIndex->indexOids.spcoid;
 	key.type = oIndex->indexType;
 	key.chunknum = 0;
 	key.version = 0;
@@ -1635,6 +1637,7 @@ o_indices_del(OTable *table, OIndexNumber ixNum, OXid oxid, CommitSeqNo csn)
 
 	oIndex = make_o_index(table, ixNum, OIndexVersionPass);
 	key.oids = oIndex->indexOids;
+	key.oids.spcoid = oIndex->indexOids.spcoid;
 	key.type = oIndex->indexType;
 	key.chunknum = 0;
 	key.version = oIndex->indexVersion;
@@ -1657,7 +1660,8 @@ o_indices_del(OTable *table, OIndexNumber ixNum, OXid oxid, CommitSeqNo csn)
 OIndex *
 o_indices_get(ORelOids oids, OIndexType type)
 {
-	return o_indices_get_extended(oids, type, default_table_fetch_context);
+	return o_indices_get_extended(oids, type,
+								  default_table_fetch_context);
 }
 
 /*
@@ -1666,7 +1670,8 @@ o_indices_get(ORelOids oids, OIndexType type)
  * O_DESERIALIZE_MAX_RETRIES times before reporting an error.
  */
 OIndex *
-o_indices_get_extended(ORelOids oids, OIndexType type, OTableFetchContext ctx)
+o_indices_get_extended(ORelOids oids, OIndexType type,
+					   OTableFetchContext ctx)
 {
 	OIndexChunkKey key;
 	int			retry;
@@ -1739,7 +1744,9 @@ o_indices_update(OTable *table, OIndexNumber ixNum, OXid oxid, CommitSeqNo csn)
 	BTreeDescr *sys_tree;
 
 	oIndex = make_o_index(table, ixNum, OIndexVersionPass);
-	oIndexOld = o_indices_get_extended(oIndex->indexOids, oIndex->indexType, default_table_fetch_context);
+	oIndexOld = o_indices_get_extended(oIndex->indexOids,
+									   oIndex->indexType,
+									   default_table_fetch_context);
 	if (oIndexOld)
 	{
 		oIndex->createOxid = oIndexOld->createOxid;
@@ -1747,6 +1754,7 @@ o_indices_update(OTable *table, OIndexNumber ixNum, OXid oxid, CommitSeqNo csn)
 	}
 	data = serialize_o_index(oIndex, &len);
 	key.oids = oIndex->indexOids;
+	key.oids.spcoid = oIndex->indexOids.spcoid;
 	key.type = oIndex->indexType;
 	key.chunknum = 0;
 	key.version = oIndex->indexVersion;
@@ -1764,6 +1772,72 @@ o_indices_update(OTable *table, OIndexNumber ixNum, OXid oxid, CommitSeqNo csn)
 											   (Pointer) &key, data, len, oxid,
 											   csn, sys_tree, table->persistence != RELPERSISTENCE_TEMP);
 	systrees_modify_end(table->persistence != RELPERSISTENCE_TEMP);
+
+	pfree(data);
+
+	return result;
+}
+
+/*
+ * Re-key an OIndex chunk from old_tablespace to the tablespace currently set
+ * on `table` (used by ALTER DATABASE ... SET TABLESPACE).
+ *
+ * The tablespace is now part of OIndexChunkKey, so a plain o_indices_update()
+ * keyed by the new tablespace would insert a fresh entry and leave the old
+ * entry orphaned at the source tablespace, making the tree resolvable at both
+ * (or neither) tablespace.  We therefore delete the old-tablespace-keyed chunk
+ * and insert a new-tablespace-keyed one, preserving the index incarnation
+ * version and createOxid so concurrent catalog MVCC and logical decoding keep
+ * seeing a consistent OIndex.
+ */
+bool
+o_indices_move(OTable *table, OIndexNumber ixNum, Oid old_tablespace,
+			   OXid oxid, CommitSeqNo csn)
+{
+	OIndex	   *oIndex;
+	OIndex	   *oIndexOld;
+	OIndexChunkKey oldKey;
+	OIndexChunkKey newKey;
+	bool		result;
+	bool		wal = table->persistence != RELPERSISTENCE_TEMP;
+	Pointer		data;
+	int			len;
+	BTreeDescr *sys_tree;
+
+	/* `table` already carries the destination tablespace */
+	oIndex = make_o_index(table, ixNum, OIndexVersionPass);
+	Assert(oIndex->indexOids.spcoid != old_tablespace);
+
+	oIndexOld = o_indices_get_extended(oIndex->indexOids,
+									   oIndex->indexType,
+									   default_table_fetch_context);
+	if (oIndexOld)
+	{
+		oIndex->createOxid = oIndexOld->createOxid;
+		free_o_index(oIndexOld);
+	}
+	data = serialize_o_index(oIndex, &len);
+
+	oldKey.oids = oIndex->indexOids;
+	oldKey.oids.spcoid = old_tablespace;
+	oldKey.type = oIndex->indexType;
+	oldKey.chunknum = 0;
+	oldKey.version = oIndex->indexVersion;
+
+	newKey = oldKey;
+	newKey.oids.spcoid = oIndex->indexOids.spcoid;
+
+	free_o_index(oIndex);
+
+	systrees_modify_start();
+	sys_tree = get_sys_tree(SYS_TREES_O_INDICES);
+	(void) generic_toast_delete_optional_wal(&oIndicesToastAPI,
+											 (Pointer) &oldKey, oxid, csn,
+											 sys_tree, wal);
+	result = generic_toast_insert_optional_wal(&oIndicesToastAPI,
+											   (Pointer) &newKey, data, len,
+											   oxid, csn, sys_tree, wal);
+	systrees_modify_end(wal);
 
 	pfree(data);
 
@@ -1803,6 +1877,7 @@ o_indices_foreach_oids(OIndexOidsCallback callback, void *arg)
 	OIndexChunkKey chunkKey;
 	ORelOids	oids = {0, 0, 0},
 				old_oids PG_USED_FOR_ASSERTS_ONLY;
+	Oid			old_tablespace PG_USED_FOR_ASSERTS_ONLY = InvalidOid;
 	OIndexType	type = oIndexInvalid;
 	BTreeIterator *it;
 	OTuple		tuple;
@@ -1810,6 +1885,7 @@ o_indices_foreach_oids(OIndexOidsCallback callback, void *arg)
 
 	chunkKey.type = type;
 	chunkKey.oids = oids;
+	chunkKey.oids.spcoid = 0;
 	chunkKey.chunknum = 0;
 	chunkKey.version = O_TABLE_INVALID_VERSION;
 
@@ -1829,25 +1905,37 @@ o_indices_foreach_oids(OIndexOidsCallback callback, void *arg)
 		OIndexChunk *chunk = (OIndexChunk *) tuple.data;
 		ORelOids	tableOids;
 		bool		temp_table;
-		Oid			tablespace;
 
 		type = chunk->key.type;
 		oids = chunk->key.oids;
 		Assert(chunk->dataLength >= sizeof(tableOids));
 		memcpy(&tableOids, chunk->data, sizeof(tableOids));
 		memcpy(&temp_table, chunk->data + sizeof(tableOids), sizeof(bool));
-		memcpy(&tablespace, chunk->data + (offsetof(OIndex, tablespace) - offsetof(OIndex, tableOids)), sizeof(Oid));
 		Assert(chunk->key.chunknum == 0);
 		Assert(ORelOidsIsValid(oids));
-		Assert(!ORelOidsIsEqual(old_oids, oids));
-		old_oids = oids;
 
-		callback(type, oids, tableOids, tablespace, arg);
+		/*
+		 * The same (datoid, relnode) can appear under different tablespaces,
+		 * so only a full (oids, tablespace) repeat means we failed to
+		 * advance.
+		 */
+		Assert(!(ORelOidsIsEqual(old_oids, oids) &&
+				 old_tablespace == chunk->key.oids.spcoid));
+		old_oids = oids;
+		old_tablespace = chunk->key.oids.spcoid;
+
+		callback(type, oids, tableOids, arg);
 
 		pfree(tuple.data);
 		btree_iterator_free(it);
 
-		oids.relnode += 1;		/* go to the next oid */
+		/*
+		 * Advance to the next tree.  tablespace sorts above relnode, so
+		 * bumping relnode within the current tablespace lands on the next
+		 * tree (a higher relnode in this tablespace, or the first tree of the
+		 * next tablespace).
+		 */
+		oids.relnode += 1;
 		chunkKey.oids = oids;
 		chunkKey.type = type;
 		chunkKey.chunknum = 0;
@@ -1903,7 +1991,7 @@ index_type_from_str(const char *s, int len)
 
 static void
 o_index_oids_array_callback(OIndexType type, ORelOids treeOids,
-							ORelOids tableOids, Oid tablespace, void *arg)
+							ORelOids tableOids, void *arg)
 {
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) arg;
 	Datum		values[6];
@@ -2069,7 +2157,12 @@ orioledb_index_description(PG_FUNCTION_ARGS)
 	oids.reloid = PG_GETARG_OID(1);
 	oids.relnode = PG_GETARG_OID(2);
 
-	PG_RETURN_DATUM(HeapTupleGetDatum(describe_index(tupdesc, oids, indexType)));
+	oids.spcoid = get_rel_tablespace(oids.reloid);
+	if (!OidIsValid(oids.spcoid))
+		oids.spcoid = MyDatabaseTableSpace;
+
+	PG_RETURN_DATUM(HeapTupleGetDatum(describe_index(tupdesc, oids,
+													 indexType)));
 }
 
 /*

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -881,8 +881,8 @@ o_table_tableam_create(ORelOids oids, TupleDesc tupdesc, char relpersistence,
 	o_table->primary_init_nfields = o_table->nfields + 1;	/* + ctid field */
 	o_table->fields = palloc0(o_table->nfields * sizeof(OTableField));
 	o_table->oids = oids;
-	o_table->tablespace = tablespace;
-	Assert(o_table->tablespace);
+	o_table->oids.spcoid = tablespace;
+	Assert(o_table->oids.spcoid);
 	o_table->tid_btree_ops_oid = GetDefaultOpClass(TIDOID, BTREE_AM_OID);
 
 	hash_opclass = GetDefaultOpClass(TIDOID, HASH_AM_OID);
@@ -1150,20 +1150,20 @@ o_table_make_index_keys(OTable *table, int *num)
 	for (i = 0; i < trees_num; i++)
 	{
 		trees[i].oids = table->indices[i].oids;
-		trees[i].tablespace = table->indices[i].tablespace;
+		trees[i].oids.spcoid = table->indices[i].oids.spcoid;
 	}
 
 	if (ORelOidsIsValid(table->bridge_oids))
 	{
 		trees[trees_num].oids = table->bridge_oids;
-		trees[trees_num].tablespace = table->tablespace;
+		trees[trees_num].oids.spcoid = table->oids.spcoid;
 		trees_num++;
 	}
 
 	if (ORelOidsIsValid(table->toast_oids))
 	{
 		trees[trees_num].oids = table->toast_oids;
-		trees[trees_num].tablespace = table->tablespace;
+		trees[trees_num].oids.spcoid = table->oids.spcoid;
 		trees_num++;
 	}
 
@@ -1172,7 +1172,7 @@ o_table_make_index_keys(OTable *table, int *num)
 		table->indices[PrimaryIndexNumber].type != oIndexPrimary)
 	{
 		trees[trees_num].oids = table->oids;
-		trees[trees_num].tablespace = table->tablespace;
+		trees[trees_num].oids.spcoid = table->oids.spcoid;
 		trees_num++;
 	}
 
@@ -1348,22 +1348,38 @@ o_tables_move_all_callback(OTable *o_table, void *arg)
 	if (move_arg->datoid != o_table->oids.datoid)
 		return;
 
-	if (o_table->tablespace == move_arg->old_tablespace)
+	/*
+	 * The tablespace is part of the tree-identity keys (OIndexChunkKey,
+	 * SharedRootInfo, seq_buf, ...), so moving a tree between tablespaces
+	 * must delete the old-tablespace-keyed OIndex entry and insert a
+	 * new-tablespace-keyed one (o_indices_move), rather than an in-place
+	 * update keyed by the new tablespace which would orphan the old entry.
+	 */
+	if (o_table->oids.spcoid == move_arg->old_tablespace)
 	{
-		o_table->tablespace = move_arg->new_tablespace;
+		o_table->oids.spcoid = move_arg->new_tablespace;
 		if (!o_table->has_primary)
 		{
-			o_indices_update(o_table, PrimaryIndexNumber, move_arg->oxid, move_arg->csn);
+			o_indices_move(o_table, PrimaryIndexNumber, move_arg->old_tablespace,
+						   move_arg->oxid, move_arg->csn);
+			o_move_tree_meta(o_table->oids.datoid, o_table->oids.relnode,
+							 move_arg->old_tablespace, move_arg->new_tablespace);
 			table_moved = true;
 		}
 		if (ORelOidsIsValid(o_table->toast_oids))
 		{
-			o_indices_update(o_table, TOASTIndexNumber, move_arg->oxid, move_arg->csn);
+			o_indices_move(o_table, TOASTIndexNumber, move_arg->old_tablespace,
+						   move_arg->oxid, move_arg->csn);
+			o_move_tree_meta(o_table->toast_oids.datoid, o_table->toast_oids.relnode,
+							 move_arg->old_tablespace, move_arg->new_tablespace);
 			table_moved = true;
 		}
 		if (ORelOidsIsValid(o_table->bridge_oids))
 		{
-			o_indices_update(o_table, BridgeIndexNumber, move_arg->oxid, move_arg->csn);
+			o_indices_move(o_table, BridgeIndexNumber, move_arg->old_tablespace,
+						   move_arg->oxid, move_arg->csn);
+			o_move_tree_meta(o_table->bridge_oids.datoid, o_table->bridge_oids.relnode,
+							 move_arg->old_tablespace, move_arg->new_tablespace);
 			table_moved = true;
 		}
 	}
@@ -1373,16 +1389,44 @@ o_tables_move_all_callback(OTable *o_table, void *arg)
 		OTableIndex *ix_table;
 
 		ix_table = &o_table->indices[ixnum];
-		if (ix_table->tablespace != move_arg->old_tablespace)
+		if (ix_table->oids.spcoid != move_arg->old_tablespace)
 			continue;
-		ix_table->tablespace = move_arg->new_tablespace;
-		o_indices_update(o_table, ixnum + ctid_idx_off, move_arg->oxid, move_arg->csn);
-		o_invalidate_oids(ix_table->oids);
-		o_invalidate_descrs(ix_table->oids.datoid, ix_table->oids.reloid, ix_table->oids.relnode);
+		ix_table->oids.spcoid = move_arg->new_tablespace;
+		o_indices_move(o_table, ixnum + ctid_idx_off, move_arg->old_tablespace,
+					   move_arg->oxid, move_arg->csn);
+		o_move_tree_meta(ix_table->oids.datoid, ix_table->oids.relnode,
+						 move_arg->old_tablespace, move_arg->new_tablespace);
+		/* A secondary index can move while its table stays behind. */
+		table_moved = true;
 	}
+
 	if (table_moved)
 	{
+		/*
+		 * Persist the OTable carrying the new per-tree tablespaces before
+		 * invalidating descriptors: a rebuild fetches each OIndex using the
+		 * table's tablespace as part of the key, so it must already resolve
+		 * to the destination tablespace.
+		 */
 		o_tables_update(o_table, move_arg->oxid, move_arg->csn);
+
+		/*
+		 * Drop cached descriptors of the moved trees so the next fetch
+		 * rebuilds them (and their seq_buf tags / file paths) at the
+		 * destination tablespace.  Invalidating the table descr recreates the
+		 * whole table descriptor, including primary/toast/bridge and
+		 * secondary indices.
+		 */
+		for (int ixnum = 0; ixnum < o_table->nindices; ixnum++)
+		{
+			o_invalidate_oids(o_table->indices[ixnum].oids);
+			o_invalidate_descrs(o_table->indices[ixnum].oids.datoid,
+								o_table->indices[ixnum].oids.reloid,
+								o_table->indices[ixnum].oids.relnode);
+		}
+		o_invalidate_oids(o_table->oids);
+		o_invalidate_descrs(o_table->oids.datoid, o_table->oids.reloid,
+							o_table->oids.relnode);
 	}
 	o_tables_after_update(o_table, move_arg->oxid, move_arg->csn);
 }
@@ -1571,7 +1615,8 @@ o_tables_get_by_tree(ORelOids oids, OIndexType type)
 	bool		result;
 
 	/* See if it's index oid first */
-	result = o_indices_find_table_oids(oids, type, &o_in_progress_snapshot,
+	result = o_indices_find_table_oids(oids, type,
+									   &o_in_progress_snapshot,
 									   &tableOids);
 	if (!result)
 		return NULL;
@@ -2084,7 +2129,7 @@ serialize_o_table_index(OTableIndex *o_table_index, StringInfo str)
 	 */
 	o_serialize_string(o_table_index->predicate_str, str);
 	o_serialize_node((Node *) o_table_index->expressions, str);
-	appendBinaryStringInfo(str, (Pointer) &o_table_index->tablespace, sizeof(Oid));
+	appendBinaryStringInfo(str, (Pointer) &o_table_index->oids.spcoid, sizeof(Oid));
 	if (o_table_index->type == oIndexExclusion)
 		appendBinaryStringInfo(str, (Pointer) o_table_index->exclops, sizeof(Oid) * o_table_index->nkeyfields);
 	appendBinaryStringInfo(str, &o_table_index->immediate, sizeof(bool));
@@ -2134,7 +2179,7 @@ serialize_o_table(OTable *o_table, int *size)
 		appendBinaryStringInfo(&str, buf_start, field_size);
 	}
 
-	appendBinaryStringInfo(&str, (Pointer) &o_table->tablespace, sizeof(Oid));
+	appendBinaryStringInfo(&str, (Pointer) &o_table->oids.spcoid, sizeof(Oid));
 
 	*size = str.len;
 	return str.data;
@@ -2196,7 +2241,7 @@ deserialize_o_table_index(OTableIndex *o_table_index, Pointer *ptr,
 		MemoryContextSwitchTo(old_mcxt);
 		return false;
 	}
-	memcpy(&o_table_index->tablespace, *ptr, len);
+	memcpy(&o_table_index->oids.spcoid, *ptr, len);
 	*ptr += len;
 
 	if (o_table_index->type == oIndexExclusion)
@@ -2381,7 +2426,7 @@ deserialize_o_table(Pointer data, Size length)
 		o_table_free(o_table);
 		return NULL;
 	}
-	memcpy(&o_table->tablespace, ptr, len);
+	memcpy(&o_table->oids.spcoid, ptr, len);
 	ptr += len;
 
 	if (ptr - data != length)
@@ -2459,6 +2504,8 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 	oTable->oids.datoid = MyDatabaseId;
 	oTable->oids.reloid = rel->rd_id;
 	oTable->oids.relnode = RelFileNodeGetNode(newrnode);
+	oTable->oids.spcoid = OidIsValid(rel->rd_rel->reltablespace) ?
+		rel->rd_rel->reltablespace : MyDatabaseTableSpace;
 
 	if (rel->rd_rel->reltoastrelid)
 	{
@@ -2484,6 +2531,8 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 			GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
 								rel->rd_rel->relpersistence);
 		oTable->bridge_oids.reloid = oTable->bridge_oids.relnode;
+		/* A bridge index lives in its table's tablespace. */
+		oTable->bridge_oids.spcoid = oTable->oids.spcoid;
 	}
 
 	for (i = 0; i < oTable->nindices; i++)

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -1370,6 +1370,7 @@ o_tables_move_all_callback(OTable *o_table, void *arg)
 		}
 		if (ORelOidsIsValid(o_table->toast_oids))
 		{
+			o_table->toast_oids.spcoid = move_arg->new_tablespace;
 			o_indices_move(o_table, TOASTIndexNumber, move_arg->old_tablespace,
 						   move_arg->oxid, move_arg->csn);
 			o_move_tree_meta(o_table->toast_oids.datoid, o_table->toast_oids.relnode,
@@ -1378,6 +1379,7 @@ o_tables_move_all_callback(OTable *o_table, void *arg)
 		}
 		if (ORelOidsIsValid(o_table->bridge_oids))
 		{
+			o_table->bridge_oids.spcoid = move_arg->new_tablespace;
 			o_indices_move(o_table, BridgeIndexNumber, move_arg->old_tablespace,
 						   move_arg->oxid, move_arg->csn);
 			o_move_tree_meta(o_table->bridge_oids.datoid, o_table->bridge_oids.relnode,

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -881,8 +881,8 @@ o_table_tableam_create(ORelOids oids, TupleDesc tupdesc, char relpersistence,
 	o_table->primary_init_nfields = o_table->nfields + 1;	/* + ctid field */
 	o_table->fields = palloc0(o_table->nfields * sizeof(OTableField));
 	o_table->oids = oids;
-	o_table->tablespace = tablespace;
-	Assert(o_table->tablespace);
+	o_table->oids.spcoid = tablespace;
+	Assert(o_table->oids.spcoid);
 	o_table->tid_btree_ops_oid = GetDefaultOpClass(TIDOID, BTREE_AM_OID);
 
 	hash_opclass = GetDefaultOpClass(TIDOID, HASH_AM_OID);
@@ -1150,20 +1150,20 @@ o_table_make_index_keys(OTable *table, int *num)
 	for (i = 0; i < trees_num; i++)
 	{
 		trees[i].oids = table->indices[i].oids;
-		trees[i].tablespace = table->indices[i].tablespace;
+		trees[i].oids.spcoid = table->indices[i].oids.spcoid;
 	}
 
 	if (ORelOidsIsValid(table->bridge_oids))
 	{
 		trees[trees_num].oids = table->bridge_oids;
-		trees[trees_num].tablespace = table->tablespace;
+		trees[trees_num].oids.spcoid = table->oids.spcoid;
 		trees_num++;
 	}
 
 	if (ORelOidsIsValid(table->toast_oids))
 	{
 		trees[trees_num].oids = table->toast_oids;
-		trees[trees_num].tablespace = table->tablespace;
+		trees[trees_num].oids.spcoid = table->oids.spcoid;
 		trees_num++;
 	}
 
@@ -1172,7 +1172,7 @@ o_table_make_index_keys(OTable *table, int *num)
 		table->indices[PrimaryIndexNumber].type != oIndexPrimary)
 	{
 		trees[trees_num].oids = table->oids;
-		trees[trees_num].tablespace = table->tablespace;
+		trees[trees_num].oids.spcoid = table->oids.spcoid;
 		trees_num++;
 	}
 
@@ -1348,22 +1348,40 @@ o_tables_move_all_callback(OTable *o_table, void *arg)
 	if (move_arg->datoid != o_table->oids.datoid)
 		return;
 
-	if (o_table->tablespace == move_arg->old_tablespace)
+	/*
+	 * The tablespace is part of the tree-identity keys (OIndexChunkKey,
+	 * SharedRootInfo, seq_buf, ...), so moving a tree between tablespaces
+	 * must delete the old-tablespace-keyed OIndex entry and insert a
+	 * new-tablespace-keyed one (o_indices_move), rather than an in-place
+	 * update keyed by the new tablespace which would orphan the old entry.
+	 */
+	if (o_table->oids.spcoid == move_arg->old_tablespace)
 	{
-		o_table->tablespace = move_arg->new_tablespace;
+		o_table->oids.spcoid = move_arg->new_tablespace;
 		if (!o_table->has_primary)
 		{
-			o_indices_update(o_table, PrimaryIndexNumber, move_arg->oxid, move_arg->csn);
+			o_indices_move(o_table, PrimaryIndexNumber, move_arg->old_tablespace,
+						   move_arg->oxid, move_arg->csn);
+			o_move_tree_meta(o_table->oids.datoid, o_table->oids.relnode,
+							 move_arg->old_tablespace, move_arg->new_tablespace);
 			table_moved = true;
 		}
 		if (ORelOidsIsValid(o_table->toast_oids))
 		{
-			o_indices_update(o_table, TOASTIndexNumber, move_arg->oxid, move_arg->csn);
+			o_table->toast_oids.spcoid = move_arg->new_tablespace;
+			o_indices_move(o_table, TOASTIndexNumber, move_arg->old_tablespace,
+						   move_arg->oxid, move_arg->csn);
+			o_move_tree_meta(o_table->toast_oids.datoid, o_table->toast_oids.relnode,
+							 move_arg->old_tablespace, move_arg->new_tablespace);
 			table_moved = true;
 		}
 		if (ORelOidsIsValid(o_table->bridge_oids))
 		{
-			o_indices_update(o_table, BridgeIndexNumber, move_arg->oxid, move_arg->csn);
+			o_table->bridge_oids.spcoid = move_arg->new_tablespace;
+			o_indices_move(o_table, BridgeIndexNumber, move_arg->old_tablespace,
+						   move_arg->oxid, move_arg->csn);
+			o_move_tree_meta(o_table->bridge_oids.datoid, o_table->bridge_oids.relnode,
+							 move_arg->old_tablespace, move_arg->new_tablespace);
 			table_moved = true;
 		}
 	}
@@ -1373,16 +1391,44 @@ o_tables_move_all_callback(OTable *o_table, void *arg)
 		OTableIndex *ix_table;
 
 		ix_table = &o_table->indices[ixnum];
-		if (ix_table->tablespace != move_arg->old_tablespace)
+		if (ix_table->oids.spcoid != move_arg->old_tablespace)
 			continue;
-		ix_table->tablespace = move_arg->new_tablespace;
-		o_indices_update(o_table, ixnum + ctid_idx_off, move_arg->oxid, move_arg->csn);
-		o_invalidate_oids(ix_table->oids);
-		o_invalidate_descrs(ix_table->oids.datoid, ix_table->oids.reloid, ix_table->oids.relnode);
+		ix_table->oids.spcoid = move_arg->new_tablespace;
+		o_indices_move(o_table, ixnum + ctid_idx_off, move_arg->old_tablespace,
+					   move_arg->oxid, move_arg->csn);
+		o_move_tree_meta(ix_table->oids.datoid, ix_table->oids.relnode,
+						 move_arg->old_tablespace, move_arg->new_tablespace);
+		/* A secondary index can move while its table stays behind. */
+		table_moved = true;
 	}
+
 	if (table_moved)
 	{
+		/*
+		 * Persist the OTable carrying the new per-tree tablespaces before
+		 * invalidating descriptors: a rebuild fetches each OIndex using the
+		 * table's tablespace as part of the key, so it must already resolve
+		 * to the destination tablespace.
+		 */
 		o_tables_update(o_table, move_arg->oxid, move_arg->csn);
+
+		/*
+		 * Drop cached descriptors of the moved trees so the next fetch
+		 * rebuilds them (and their seq_buf tags / file paths) at the
+		 * destination tablespace.  Invalidating the table descr recreates the
+		 * whole table descriptor, including primary/toast/bridge and
+		 * secondary indices.
+		 */
+		for (int ixnum = 0; ixnum < o_table->nindices; ixnum++)
+		{
+			o_invalidate_oids(o_table->indices[ixnum].oids);
+			o_invalidate_descrs(o_table->indices[ixnum].oids.datoid,
+								o_table->indices[ixnum].oids.reloid,
+								o_table->indices[ixnum].oids.relnode);
+		}
+		o_invalidate_oids(o_table->oids);
+		o_invalidate_descrs(o_table->oids.datoid, o_table->oids.reloid,
+							o_table->oids.relnode);
 	}
 	o_tables_after_update(o_table, move_arg->oxid, move_arg->csn);
 }
@@ -1571,7 +1617,8 @@ o_tables_get_by_tree(ORelOids oids, OIndexType type)
 	bool		result;
 
 	/* See if it's index oid first */
-	result = o_indices_find_table_oids(oids, type, &o_in_progress_snapshot,
+	result = o_indices_find_table_oids(oids, type,
+									   &o_in_progress_snapshot,
 									   &tableOids);
 	if (!result)
 		return NULL;
@@ -1859,6 +1906,8 @@ orioledb_table_description(PG_FUNCTION_ARGS)
 		oids.datoid = PG_GETARG_OID(0);
 		oids.reloid = PG_GETARG_OID(1);
 		oids.relnode = PG_GETARG_OID(2);
+		/* describe_table() looks up by reloid, so spcoid is not consulted. */
+		oids.spcoid = InvalidOid;
 	}
 	else
 	{
@@ -2084,7 +2133,7 @@ serialize_o_table_index(OTableIndex *o_table_index, StringInfo str)
 	 */
 	o_serialize_string(o_table_index->predicate_str, str);
 	o_serialize_node((Node *) o_table_index->expressions, str);
-	appendBinaryStringInfo(str, (Pointer) &o_table_index->tablespace, sizeof(Oid));
+	appendBinaryStringInfo(str, (Pointer) &o_table_index->oids.spcoid, sizeof(Oid));
 	if (o_table_index->type == oIndexExclusion)
 		appendBinaryStringInfo(str, (Pointer) o_table_index->exclops, sizeof(Oid) * o_table_index->nkeyfields);
 	appendBinaryStringInfo(str, &o_table_index->immediate, sizeof(bool));
@@ -2134,7 +2183,7 @@ serialize_o_table(OTable *o_table, int *size)
 		appendBinaryStringInfo(&str, buf_start, field_size);
 	}
 
-	appendBinaryStringInfo(&str, (Pointer) &o_table->tablespace, sizeof(Oid));
+	appendBinaryStringInfo(&str, (Pointer) &o_table->oids.spcoid, sizeof(Oid));
 
 	*size = str.len;
 	return str.data;
@@ -2196,7 +2245,7 @@ deserialize_o_table_index(OTableIndex *o_table_index, Pointer *ptr,
 		MemoryContextSwitchTo(old_mcxt);
 		return false;
 	}
-	memcpy(&o_table_index->tablespace, *ptr, len);
+	memcpy(&o_table_index->oids.spcoid, *ptr, len);
 	*ptr += len;
 
 	if (o_table_index->type == oIndexExclusion)
@@ -2381,7 +2430,7 @@ deserialize_o_table(Pointer data, Size length)
 		o_table_free(o_table);
 		return NULL;
 	}
-	memcpy(&o_table->tablespace, ptr, len);
+	memcpy(&o_table->oids.spcoid, ptr, len);
 	ptr += len;
 
 	if (ptr - data != length)
@@ -2459,6 +2508,8 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 	oTable->oids.datoid = MyDatabaseId;
 	oTable->oids.reloid = rel->rd_id;
 	oTable->oids.relnode = RelFileNodeGetNode(newrnode);
+	oTable->oids.spcoid = OidIsValid(rel->rd_rel->reltablespace) ?
+		rel->rd_rel->reltablespace : MyDatabaseTableSpace;
 
 	if (rel->rd_rel->reltoastrelid)
 	{
@@ -2484,6 +2535,8 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 			GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
 								rel->rd_rel->relpersistence);
 		oTable->bridge_oids.reloid = oTable->bridge_oids.relnode;
+		/* A bridge index lives in its table's tablespace. */
+		oTable->bridge_oids.spcoid = oTable->oids.spcoid;
 	}
 
 	for (i = 0; i < oTable->nindices; i++)

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -1906,6 +1906,8 @@ orioledb_table_description(PG_FUNCTION_ARGS)
 		oids.datoid = PG_GETARG_OID(0);
 		oids.reloid = PG_GETARG_OID(1);
 		oids.relnode = PG_GETARG_OID(2);
+		/* describe_table() looks up by reloid, so spcoid is not consulted. */
+		oids.spcoid = InvalidOid;
 	}
 	else
 	{

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -45,6 +45,8 @@
 #include "catalog/pg_range.h"
 #include "catalog/pg_tablespace_d.h"
 #include "catalog/pg_type.h"
+#include "catalog/storage.h"
+#include "storage/smgr.h"
 #include "commands/defrem.h"
 #include "executor/execExpr.h"
 #include "executor/functions.h"
@@ -2498,6 +2500,88 @@ o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid type_oid)
 					 &o_in_progress_snapshot, &arg);
 }
 
+/*
+ * Build the RelFileLocator of a bridge relnode's standard-path marker file.
+ *
+ * The marker lives in the bridge's own tablespace, resolving an unset (0)
+ * tablespace to DEFAULTTABLESPACE_OID -- the same rule
+ * o_get_prefixes_for_tablespace() uses -- so that the create side and the drop
+ * side (which runs the marker unlink from btree_relnode_undo_callback, possibly
+ * during recovery) agree on the path using only values carried in the undo item
+ * (datoid, tablespace, relnode).  No dependence on MyDatabaseId /
+ * MyDatabaseTableSpace, which are unset while applying undo in recovery.
+ */
+static RelFileLocator
+o_bridge_marker_locator(Oid datoid, Oid tablespace, Oid relnode)
+{
+	RelFileLocator locator;
+
+	locator.spcOid = OidIsValid(tablespace) ? tablespace : DEFAULTTABLESPACE_OID;
+	locator.dbOid = (locator.spcOid == GLOBALTABLESPACE_OID) ? InvalidOid : datoid;
+	locator.relNumber = relnode;
+
+	return locator;
+}
+
+/*
+ * Assign a fresh relnode for a bridge index and reserve it against PG's
+ * GetNewRelFileNumber() uniqueness probe.
+ *
+ * The bridge index is the only OrioleDB tree that self-assigns its
+ * relfilenumber via GetNewRelFileNumber() and, unlike every other tree, has no
+ * pg_class row.  GetNewRelFileNumber() guarantees uniqueness solely by probing
+ * for an existing main-fork file at the standard path (access(relpath(...),
+ * F_OK)); OrioleDB keeps the bridge in orioledb_data/, so that probe is blind to
+ * it.  Since the relnode comes from the wrapping OID counter and the counter can
+ * regress on crash recovery, PG can then hand the same relnode out again to
+ * another relation in the same tablespace -- two relations end up sharing a
+ * (tablespace, relnode) and the tree-identity layer (descr / SharedRootInfo /
+ * seq_bufs / files) corrupts (observed as the SEQBUF_BADPAGE nextChkp
+ * double-finalize).
+ *
+ * Regular OrioleDB tables avoid this because orioledb_relation_set_new_filenode
+ * creates the standard-path storage (RelationCreateStorage), which the probe
+ * detects.  Mirror that for the bridge: create the main-fork file so the probe
+ * sees the relnode and never reuses it.  register_delete = true unlinks it if
+ * the creating transaction aborts.  o_bridge_drop_relnode_marker() removes it
+ * when the bridge is durably dropped.
+ */
+Oid
+o_bridge_new_relnode(Oid tablespace, char relpersistence)
+{
+	RelFileLocator locator;
+	SMgrRelation srel;
+	Oid			spcOid;
+	Oid			relnode;
+
+	spcOid = OidIsValid(tablespace) ? tablespace : DEFAULTTABLESPACE_OID;
+	relnode = GetNewRelFileNumber(spcOid, NULL, relpersistence);
+
+	locator = o_bridge_marker_locator(MyDatabaseId, tablespace, relnode);
+	srel = RelationCreateStorage(locator, relpersistence, true);
+	smgrclose(srel);
+
+	return relnode;
+}
+
+/*
+ * Drop the standard-path marker file that o_bridge_new_relnode() created, once
+ * the bridge is durably dropped, so PG can reuse the relnode.  Called from
+ * btree_relnode_undo_callback(); the locator is rebuilt purely from the undo
+ * item's (datoid, tablespace, relnode), so it is correct while applying undo in
+ * recovery too.
+ */
+void
+o_bridge_drop_relnode_marker(Oid datoid, Oid tablespace, Oid relnode)
+{
+	RelFileLocator locator = o_bridge_marker_locator(datoid, tablespace, relnode);
+	SMgrRelation srel;
+
+	srel = smgropen(locator, O_INVALID_PROCNUMBER);
+	smgrdounlinkall(&srel, 1, false);
+	smgrclose(srel);
+}
+
 void
 o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, bool drop_pkey)
 {
@@ -2525,6 +2609,8 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 	if (oTable->index_bridging)
 	{
 		oTable->bridge_oids.datoid = MyDatabaseId;
+		/* A bridge index lives in its table's tablespace. */
+		oTable->bridge_oids.spcoid = oTable->oids.spcoid;
 
 		/*
 		 * Under pg_upgrade fresh relfilenumber allocation is forbidden and
@@ -2532,11 +2618,9 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 		 * discarded after the schema restore, so leave it invalid.
 		 */
 		oTable->bridge_oids.relnode = IsBinaryUpgrade ? InvalidOid :
-			GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
-								rel->rd_rel->relpersistence);
+			o_bridge_new_relnode(oTable->bridge_oids.spcoid,
+								 rel->rd_rel->relpersistence);
 		oTable->bridge_oids.reloid = oTable->bridge_oids.relnode;
-		/* A bridge index lives in its table's tablespace. */
-		oTable->bridge_oids.spcoid = oTable->oids.spcoid;
 	}
 
 	for (i = 0; i < oTable->nindices; i++)

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -45,6 +45,8 @@
 #include "catalog/pg_range.h"
 #include "catalog/pg_tablespace_d.h"
 #include "catalog/pg_type.h"
+#include "catalog/storage.h"
+#include "storage/smgr.h"
 #include "commands/defrem.h"
 #include "executor/execExpr.h"
 #include "executor/functions.h"
@@ -2494,6 +2496,88 @@ o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid type_oid)
 					 &o_in_progress_snapshot, &arg);
 }
 
+/*
+ * Build the RelFileLocator of a bridge relnode's standard-path marker file.
+ *
+ * The marker lives in the bridge's own tablespace, resolving an unset (0)
+ * tablespace to DEFAULTTABLESPACE_OID -- the same rule
+ * o_get_prefixes_for_tablespace() uses -- so that the create side and the drop
+ * side (which runs the marker unlink from btree_relnode_undo_callback, possibly
+ * during recovery) agree on the path using only values carried in the undo item
+ * (datoid, tablespace, relnode).  No dependence on MyDatabaseId /
+ * MyDatabaseTableSpace, which are unset while applying undo in recovery.
+ */
+static RelFileLocator
+o_bridge_marker_locator(Oid datoid, Oid tablespace, Oid relnode)
+{
+	RelFileLocator locator;
+
+	locator.spcOid = OidIsValid(tablespace) ? tablespace : DEFAULTTABLESPACE_OID;
+	locator.dbOid = (locator.spcOid == GLOBALTABLESPACE_OID) ? InvalidOid : datoid;
+	locator.relNumber = relnode;
+
+	return locator;
+}
+
+/*
+ * Assign a fresh relnode for a bridge index and reserve it against PG's
+ * GetNewRelFileNumber() uniqueness probe.
+ *
+ * The bridge index is the only OrioleDB tree that self-assigns its
+ * relfilenumber via GetNewRelFileNumber() and, unlike every other tree, has no
+ * pg_class row.  GetNewRelFileNumber() guarantees uniqueness solely by probing
+ * for an existing main-fork file at the standard path (access(relpath(...),
+ * F_OK)); OrioleDB keeps the bridge in orioledb_data/, so that probe is blind to
+ * it.  Since the relnode comes from the wrapping OID counter and the counter can
+ * regress on crash recovery, PG can then hand the same relnode out again to
+ * another relation in the same tablespace -- two relations end up sharing a
+ * (tablespace, relnode) and the tree-identity layer (descr / SharedRootInfo /
+ * seq_bufs / files) corrupts (observed as the SEQBUF_BADPAGE nextChkp
+ * double-finalize).
+ *
+ * Regular OrioleDB tables avoid this because orioledb_relation_set_new_filenode
+ * creates the standard-path storage (RelationCreateStorage), which the probe
+ * detects.  Mirror that for the bridge: create the main-fork file so the probe
+ * sees the relnode and never reuses it.  register_delete = true unlinks it if
+ * the creating transaction aborts.  o_bridge_drop_relnode_marker() removes it
+ * when the bridge is durably dropped.
+ */
+Oid
+o_bridge_new_relnode(Oid tablespace, char relpersistence)
+{
+	RelFileLocator locator;
+	SMgrRelation srel;
+	Oid			spcOid;
+	Oid			relnode;
+
+	spcOid = OidIsValid(tablespace) ? tablespace : DEFAULTTABLESPACE_OID;
+	relnode = GetNewRelFileNumber(spcOid, NULL, relpersistence);
+
+	locator = o_bridge_marker_locator(MyDatabaseId, tablespace, relnode);
+	srel = RelationCreateStorage(locator, relpersistence, true);
+	smgrclose(srel);
+
+	return relnode;
+}
+
+/*
+ * Drop the standard-path marker file that o_bridge_new_relnode() created, once
+ * the bridge is durably dropped, so PG can reuse the relnode.  Called from
+ * btree_relnode_undo_callback(); the locator is rebuilt purely from the undo
+ * item's (datoid, tablespace, relnode), so it is correct while applying undo in
+ * recovery too.
+ */
+void
+o_bridge_drop_relnode_marker(Oid datoid, Oid tablespace, Oid relnode)
+{
+	RelFileLocator locator = o_bridge_marker_locator(datoid, tablespace, relnode);
+	SMgrRelation srel;
+
+	srel = smgropen(locator, O_INVALID_PROCNUMBER);
+	smgrdounlinkall(&srel, 1, false);
+	smgrclose(srel);
+}
+
 void
 o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, bool drop_pkey)
 {
@@ -2521,6 +2605,8 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 	if (oTable->index_bridging)
 	{
 		oTable->bridge_oids.datoid = MyDatabaseId;
+		/* A bridge index lives in its table's tablespace. */
+		oTable->bridge_oids.spcoid = oTable->oids.spcoid;
 
 		/*
 		 * Under pg_upgrade fresh relfilenumber allocation is forbidden and
@@ -2528,11 +2614,9 @@ o_table_fill_oids(OTable *oTable, Relation rel, const RelFileNode *newrnode, boo
 		 * discarded after the schema restore, so leave it invalid.
 		 */
 		oTable->bridge_oids.relnode = IsBinaryUpgrade ? InvalidOid :
-			GetNewRelFileNumber(MyDatabaseTableSpace, NULL,
-								rel->rd_rel->relpersistence);
+			o_bridge_new_relnode(oTable->bridge_oids.spcoid,
+								 rel->rd_rel->relpersistence);
 		oTable->bridge_oids.reloid = oTable->bridge_oids.relnode;
-		/* A bridge index lives in its table's tablespace. */
-		oTable->bridge_oids.spcoid = oTable->oids.spcoid;
 	}
 
 	for (i = 0; i < oTable->nindices; i++)

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -830,7 +830,7 @@ sys_tree_init(int i, bool init_shmem)
 	descr->oids.datoid = SYS_TREES_DATOID;
 	descr->oids.reloid = i + 1;
 	descr->oids.relnode = i + 1;
-	descr->tablespace = DEFAULTTABLESPACE_OID;
+	descr->oids.spcoid = DEFAULTTABLESPACE_OID;
 
 	descr->arg = meta;
 	ops->key_to_jsonb = meta->keyToJsonb;
@@ -864,7 +864,7 @@ sys_tree_init(int i, bool init_shmem)
 			OIndexKey	key;
 
 			key.oids = descr->oids;
-			key.tablespace = descr->tablespace;
+			key.oids.spcoid = descr->oids.spcoid;
 			cleanup_btree_files(key, false);
 		}
 		checkpointable_tree_init(descr, init_shmem, NULL);
@@ -949,6 +949,11 @@ shared_root_info_key_cmp(BTreeDescr *desc,
 	else if (key1->relnode > key2->relnode)
 		return 1;
 
+	if (key1->tablespace < key2->tablespace)
+		return -1;
+	else if (key1->tablespace > key2->tablespace)
+		return 1;
+
 	return 0;
 }
 
@@ -957,7 +962,8 @@ idx_descr_key_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg)
 {
 	SharedRootInfoKey *key = (SharedRootInfoKey *) tup.data;
 
-	appendStringInfo(buf, "(%u, %u)", key->datoid, key->relnode);
+	appendStringInfo(buf, "(%u, %u, %u)", key->datoid, key->relnode,
+					 key->tablespace);
 }
 
 static void
@@ -965,9 +971,10 @@ idx_descr_tup_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer arg)
 {
 	SharedRootInfo *sh_descr = (SharedRootInfo *) tup.data;
 
-	appendStringInfo(buf, "((%u, %u), %u, %u)",
+	appendStringInfo(buf, "((%u, %u, %u), %u, %u)",
 					 sh_descr->key.datoid,
 					 sh_descr->key.relnode,
+					 sh_descr->key.tablespace,
 					 sh_descr->rootInfo.rootPageBlkno,
 					 sh_descr->rootInfo.metaPageBlkno);
 }
@@ -980,6 +987,7 @@ idx_descr_key_to_jsonb(BTreeDescr *desc, OTuple tup, JsonbParseState **state)
 	(void) pushJsonbValue(state, WJB_BEGIN_OBJECT, NULL);
 	jsonb_push_int8_key(state, "datoid", key->datoid);
 	jsonb_push_int8_key(state, "relnode", key->relnode);
+	jsonb_push_int8_key(state, "tablespace", key->tablespace);
 	return pushJsonbValue(state, WJB_END_OBJECT, NULL);
 }
 
@@ -1112,6 +1120,16 @@ o_index_chunk_cmp(BTreeDescr *desc,
 	if (key1->oids.datoid != key2->oids.datoid)
 		return (key1->oids.datoid < key2->oids.datoid) ? -1 : 1;
 
+	/*
+	 * Tablespace before relnode: relfilenumber uniqueness is per-tablespace,
+	 * so the same (datoid, relnode) can name two different indexes in
+	 * different tablespaces.  Keeping tablespace above relnode also preserves
+	 * the relnode+1 "next key" boundary used by oIndicesGetNextKey() and
+	 * o_indices_foreach_oids().
+	 */
+	if (key1->oids.spcoid != key2->oids.spcoid)
+		return (key1->oids.spcoid < key2->oids.spcoid) ? -1 : 1;
+
 	if (key1->oids.relnode != key2->oids.relnode)
 		return (key1->oids.relnode < key2->oids.relnode) ? -1 : 1;
 
@@ -1134,7 +1152,7 @@ o_index_chunk_key_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer ar
 {
 	OIndexChunkKey *key = (OIndexChunkKey *) tup.data;
 
-	appendStringInfo(buf, "(%d, (%u, %u, %u), %u)", (int) key->type, key->oids.datoid, key->oids.relnode, key->oids.reloid, key->chunknum);
+	appendStringInfo(buf, "(%d, (%u, %u, %u), %u, %u)", (int) key->type, key->oids.datoid, key->oids.relnode, key->oids.reloid, key->oids.spcoid, key->chunknum);
 }
 
 static void
@@ -1142,11 +1160,12 @@ o_index_chunk_tup_print(BTreeDescr *desc, StringInfo buf, OTuple tup, Pointer ar
 {
 	OIndexChunk *chunk = (OIndexChunk *) tup.data;
 
-	appendStringInfo(buf, "((%d, (%u, %u, %u), %u), %u)",
+	appendStringInfo(buf, "((%d, (%u, %u, %u), %u, %u), %u)",
 					 (int) chunk->key.type,
 					 chunk->key.oids.datoid,
 					 chunk->key.oids.relnode,
 					 chunk->key.oids.reloid,
+					 chunk->key.oids.spcoid,
 					 chunk->key.chunknum,
 					 chunk->dataLength);
 }
@@ -1161,6 +1180,7 @@ o_index_chunk_key_to_jsonb(BTreeDescr *desc, OTuple tup, JsonbParseState **state
 	jsonb_push_int8_key(state, "datoid", key->oids.datoid);
 	jsonb_push_int8_key(state, "reloid", key->oids.reloid);
 	jsonb_push_int8_key(state, "relnode", key->oids.relnode);
+	jsonb_push_int8_key(state, "tablespace", key->oids.spcoid);
 	jsonb_push_int8_key(state, "chunknum", key->chunknum);
 	return pushJsonbValue(state, WJB_END_OBJECT, NULL);
 }

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -119,7 +119,6 @@ typedef struct CheckpointWriteBack
 typedef struct
 {
 	ORelOids	oids;
-	Oid			tablespace;
 	OIndexType	type;
 	bool		freeExtents;
 	bool		cleanupMap;
@@ -203,7 +202,7 @@ static void checkpoint_lock_page(BTreeDescr *descr, CheckpointState *state,
 								 OInMemoryBlkno *blkno, uint32 page_chage_count,
 								 int level);
 static void checkpoint_tables_callback(OIndexType type, ORelOids treeOids,
-									   ORelOids tableOids, Oid tablespace, void *arg);
+									   ORelOids tableOids, void *arg);
 static inline void init_seq_buf_pages(BTreeDescr *desc, SeqBufDescShared *shared);
 static inline void free_seq_buf_pages(BTreeDescr *desc, SeqBufDescShared *shared);
 static FileExtentsArray *file_extents_array_init(void);
@@ -641,7 +640,6 @@ add_index_id_item(List *list, BTreeDescr *desc)
 	old_context = MemoryContextSwitchTo(chkp_main_context);
 	item = palloc(sizeof(IndexIdItem));
 	item->oids = desc->oids;
-	item->tablespace = desc->tablespace;
 	item->type = desc->type;
 	item->chkpNum = checkpoint_state->lastCheckpointNumber;
 	item->freeExtents = OCompressIsValid(desc->compress);
@@ -650,6 +648,7 @@ add_index_id_item(List *list, BTreeDescr *desc)
 	if (remove_old_checkpoint_files)
 	{
 		item->lastMapChkpNum = o_get_latest_chkp_num(desc->oids.datoid, desc->oids.relnode,
+													 desc->oids.spcoid,
 													 checkpoint_state->lastCheckpointNumber,
 													 NULL);
 		if (!OCompressIsValid(desc->compress) &&
@@ -1183,8 +1182,8 @@ checkpoint_chkp_nums(int flags, uint32 cur_chkp_num,
 }
 
 uint32
-o_get_latest_chkp_num(Oid datoid, Oid relnode, uint32 max_chkp_num,
-					  bool *found)
+o_get_latest_chkp_num(Oid datoid, Oid relnode, Oid tablespace,
+					  uint32 max_chkp_num, bool *found)
 {
 	OTuple		key_tuple,
 				result_tuple;
@@ -1201,6 +1200,7 @@ o_get_latest_chkp_num(Oid datoid, Oid relnode, uint32 max_chkp_num,
 
 	key.datoid = datoid;
 	key.relnode = relnode;
+	key.tablespace = tablespace;
 	key_tuple.data = (Pointer) &key;
 
 	result_tuple = o_btree_find_tuple_by_key(get_sys_tree(SYS_TREES_CHKP_NUM),
@@ -1231,7 +1231,8 @@ o_get_latest_chkp_num(Oid datoid, Oid relnode, uint32 max_chkp_num,
 }
 
 void
-o_update_latest_chkp_num(Oid datoid, Oid relnode, uint32 chkp_num)
+o_update_latest_chkp_num(Oid datoid, Oid relnode, Oid tablespace,
+						 uint32 chkp_num)
 {
 	OTuple		key_tuple,
 				tuple,
@@ -1254,6 +1255,7 @@ o_update_latest_chkp_num(Oid datoid, Oid relnode, uint32 chkp_num)
 
 	key.datoid = datoid;
 	key.relnode = relnode;
+	key.tablespace = tablespace;
 	key_tuple.data = (Pointer) &key;
 
 	tuple = o_btree_find_tuple_by_key(desc,
@@ -1296,7 +1298,7 @@ o_update_latest_chkp_num(Oid datoid, Oid relnode, uint32 chkp_num)
 }
 
 void
-o_delete_chkp_num(Oid datoid, Oid relnode)
+o_delete_chkp_num(Oid datoid, Oid relnode, Oid tablespace)
 {
 	OTuple		key_tuple;
 	SharedRootInfoKey key;
@@ -1311,6 +1313,7 @@ o_delete_chkp_num(Oid datoid, Oid relnode)
 
 	key.datoid = datoid;
 	key.relnode = relnode;
+	key.tablespace = tablespace;
 	key_tuple.data = (Pointer) &key;
 	key_tuple.formatFlags = 0;
 
@@ -1323,6 +1326,72 @@ o_delete_chkp_num(Oid datoid, Oid relnode)
 						  RowLockUpdate,
 						  NULL,
 						  &nullCallbackInfo);
+}
+
+/*
+ * Re-key a tree's latest-checkpoint-number record from old_tablespace to
+ * new_tablespace (ALTER DATABASE ... SET TABLESPACE).
+ *
+ * The CHKP_NUM record is keyed by (datoid, relnode, tablespace) and tells
+ * recovery which map/tmp checkpoint files to load for the tree.  If it were
+ * left under the source tablespace, recovery would fail to find the moved
+ * tree's checkpoint at the destination and lose its data.
+ */
+void
+o_move_latest_chkp_num(Oid datoid, Oid relnode, Oid old_tablespace,
+					   Oid new_tablespace)
+{
+	OTuple		key_tuple,
+				new_key_tuple,
+				tuple,
+				newTuple;
+	SharedRootInfoKey key,
+				new_key;
+	ChkpNumTuple data;
+	static BTreeModifyCallbackInfo callbackInfo =
+	{
+		.waitCallback = NULL,
+		.modifyCallback = recovery_insert_overwrite_callback,
+		.modifyDeletedCallback = NULL,
+		.needsUndoForSelfCreated = false,
+		.arg = NULL
+	};
+	BTreeDescr *desc = get_sys_tree(SYS_TREES_CHKP_NUM);
+	OBTreeModifyResult result PG_USED_FOR_ASSERTS_ONLY;
+
+	key.datoid = datoid;
+	key.relnode = relnode;
+	key.tablespace = old_tablespace;
+	key_tuple.data = (Pointer) &key;
+	key_tuple.formatFlags = 0;
+
+	tuple = o_btree_find_tuple_by_key(desc, &key_tuple, BTreeKeyNonLeafKey,
+									  &o_in_progress_snapshot, NULL,
+									  CurrentMemoryContext, NULL);
+	if (O_TUPLE_IS_NULL(tuple))
+		return;
+
+	data = *((ChkpNumTuple *) tuple.data);
+	pfree(tuple.data);
+
+	/* Remove the source-tablespace record and re-insert it verbatim. */
+	o_delete_chkp_num(datoid, relnode, old_tablespace);
+
+	new_key = key;
+	new_key.tablespace = new_tablespace;
+	data.key = new_key;
+	new_key_tuple.data = (Pointer) &new_key;
+	new_key_tuple.formatFlags = 0;
+	newTuple.formatFlags = 0;
+	newTuple.data = (Pointer) &data;
+
+	result = o_btree_modify(desc, BTreeOperationInsert,
+							newTuple, BTreeKeyLeafTuple,
+							(Pointer) &new_key_tuple, BTreeKeyNonLeafKey,
+							InvalidOXid, COMMITSEQNO_INPROGRESS,
+							RowLockUpdate, NULL, &callbackInfo);
+	Assert(result == OBTreeModifyResultInserted ||
+		   result == OBTreeModifyResultUpdated);
 }
 
 /*
@@ -1675,8 +1744,7 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 
 			if (item->freeExtents)
 			{
-				descr = o_fetch_index_descr(item->oids, item->type,
-											true, NULL);
+				descr = o_fetch_index_descr(item->oids, item->type, true, NULL);
 				if (descr == NULL)
 				{
 					/* table might be deleted */
@@ -1695,7 +1763,7 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 				cleanup_tag.type = 'm';
 				cleanup_tag.num = item->lastMapChkpNum;
 				cleanup_tag.key.oids = item->oids;
-				cleanup_tag.key.tablespace = item->tablespace;
+				cleanup_tag.key.oids.spcoid = item->oids.spcoid;
 				seq_buf_remove_file(&cleanup_tag);
 			}
 
@@ -1711,8 +1779,7 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 				{
 					OIndexDescr *id;
 
-					id = o_fetch_index_descr(item->oids, item->type,
-											 true, NULL);
+					id = o_fetch_index_descr(item->oids, item->type, true, NULL);
 					if (id == NULL)
 					{
 						/* table might be deleted */
@@ -1776,7 +1843,7 @@ checkpoint_init_new_seq_bufs(BTreeDescr *descr, int chkpNum)
 
 	memset(&next_tmp_tag, 0, sizeof(next_tmp_tag));
 	next_tmp_tag.key.oids = descr->oids;
-	next_tmp_tag.key.tablespace = descr->tablespace;
+	next_tmp_tag.key.oids.spcoid = descr->oids.spcoid;
 	next_tmp_tag.num = chkpNum + 1;
 	next_tmp_tag.type = 't';
 
@@ -1796,7 +1863,7 @@ checkpoint_init_new_seq_bufs(BTreeDescr *descr, int chkpNum)
 
 	memset(&next_chkp_tag, 0, sizeof(next_chkp_tag));
 	next_chkp_tag.key.oids = descr->oids;
-	next_chkp_tag.key.tablespace = descr->tablespace;
+	next_chkp_tag.key.oids.spcoid = descr->oids.spcoid;
 	next_chkp_tag.num = chkpNum + 1;
 	next_chkp_tag.type = 'm';
 
@@ -2062,7 +2129,7 @@ finalize_chkp_map(File chkp_file, uint64 len, char *input_filename,
 
 		tmp_tag.key.oids.datoid = checkpoint_state->datoid;
 		tmp_tag.key.oids.relnode = checkpoint_state->relnode;
-		tmp_tag.key.tablespace = checkpoint_state->tablespace;
+		tmp_tag.key.oids.spcoid = checkpoint_state->tablespace;
 		tmp_tag.num = input_num;
 		tmp_tag.type = 't';
 		if (seq_buf_file_exist(&tmp_tag))
@@ -2297,7 +2364,7 @@ checkpoint_ix_init_state(CheckpointState *state, BTreeDescr *descr)
 	checkpoint_state->datoid = descr->oids.datoid;
 	checkpoint_state->reloid = descr->oids.reloid;
 	checkpoint_state->relnode = descr->oids.relnode;
-	checkpoint_state->tablespace = descr->tablespace;
+	checkpoint_state->tablespace = descr->oids.spcoid;
 	checkpoint_state->completed = false;
 	checkpoint_state->curKeyType = CurKeyLeast;
 	chkp_inc_changecount_after(checkpoint_state);
@@ -2573,8 +2640,8 @@ side_of_checkpoint_bound(BTreeDescr *descr, Page page,
  * Compare tree identifiers in the same order we process them on checkpoint.
  */
 static int
-chkp_ordering_cmp(OIndexType type1, Oid datoid1, Oid relnode1,
-				  OIndexType type2, Oid datoid2, Oid relnode2)
+chkp_ordering_cmp(OIndexType type1, Oid datoid1, Oid tablespace1, Oid relnode1,
+				  OIndexType type2, Oid datoid2, Oid tablespace2, Oid relnode2)
 {
 	if (datoid1 == SYS_TREES_DATOID && relnode1 == SYS_TREES_CHKP_NUM &&
 		!(datoid2 == SYS_TREES_DATOID && relnode2 == SYS_TREES_CHKP_NUM))
@@ -2594,6 +2661,16 @@ chkp_ordering_cmp(OIndexType type1, Oid datoid1, Oid relnode1,
 		return type1 < type2 ? -1 : 1;
 	if (datoid1 != datoid2)
 		return datoid1 < datoid2 ? -1 : 1;
+
+	/*
+	 * Tablespace before relnode, matching o_index_chunk_cmp() (the order in
+	 * which o_indices_foreach_oids drives the checkpoint): relfilenumber
+	 * uniqueness is per-tablespace, so two trees can share (datoid, relnode)
+	 * in different tablespaces and must be ordered distinctly, else
+	 * get_cur_checkpoint_number() confuses them.
+	 */
+	if (tablespace1 != tablespace2)
+		return tablespace1 < tablespace2 ? -1 : 1;
 	if (relnode1 != relnode2)
 		return relnode1 < relnode2 ? -1 : 1;
 
@@ -2613,7 +2690,8 @@ get_checkpoint_number(BTreeDescr *desc, OInMemoryBlkno blkno,
 				cur_key;
 	Page		page = O_GET_IN_MEMORY_PAGE(blkno);
 	Oid			datoid,
-				relnode;
+				relnode,
+				tablespace;
 	int			level = PAGE_GET_LEVEL(page),
 				before_changecount,
 				after_changecount,
@@ -2634,6 +2712,7 @@ get_checkpoint_number(BTreeDescr *desc, OInMemoryBlkno blkno,
 		type = checkpoint_state->treeType;
 		datoid = checkpoint_state->datoid;
 		relnode = checkpoint_state->relnode;
+		tablespace = checkpoint_state->tablespace;
 		chkp_lvl_blkno = checkpoint_state->stack[level].blkno;
 		chkp_lvl_hikey_blkno = checkpoint_state->stack[level].hikeyBlkno;
 		bound = checkpoint_state->stack[level].bound;
@@ -2644,8 +2723,8 @@ get_checkpoint_number(BTreeDescr *desc, OInMemoryBlkno blkno,
 			continue;
 
 		cmp = chkp_ordering_cmp(desc->type, desc->oids.datoid,
-								desc->oids.relnode,
-								type, datoid, relnode);
+								desc->oids.spcoid, desc->oids.relnode,
+								type, datoid, tablespace, relnode);
 
 		if (cmp != 0)
 		{
@@ -2897,7 +2976,7 @@ checkpoint_ix(int flags, BTreeDescr *descr)
 
 		memset(&next_chkp_tag, 0, sizeof(next_chkp_tag));
 		next_chkp_tag.key.oids = descr->oids;
-		next_chkp_tag.key.tablespace = descr->tablespace;
+		next_chkp_tag.key.oids.spcoid = descr->oids.spcoid;
 		next_chkp_tag.num = chkpNum;
 		next_chkp_tag.type = 'm';
 
@@ -3093,7 +3172,7 @@ checkpoint_ix(int flags, BTreeDescr *descr)
 
 	if (orioledb_s3_mode)
 	{
-		OIndexKey	key = {.oids = descr->oids,.tablespace = descr->tablespace};
+		OIndexKey	key = {.oids = descr->oids};
 		S3TaskLocation location;
 
 		location = s3_schedule_file_part_write(chkpNum, key, -1, -1);
@@ -3108,6 +3187,7 @@ checkpoint_ix(int flags, BTreeDescr *descr)
 	if (!IS_SYS_TREE_OIDS(descr->oids))
 		o_update_latest_chkp_num(descr->oids.datoid,
 								 descr->oids.relnode,
+								 descr->oids.spcoid,
 								 chkpNum);
 	return descr;
 }
@@ -5085,7 +5165,7 @@ prepare_leaf_page(BTreeDescr *descr, CheckpointState *state)
  * checkpoint_state.
  */
 static bool
-check_tree_needs_checkpointing(OIndexType type, ORelOids treeOids, Oid tablespace)
+check_tree_needs_checkpointing(OIndexType type, ORelOids treeOids)
 {
 	SharedRootInfoKey key;
 	OTuple		keyTuple;
@@ -5101,6 +5181,7 @@ check_tree_needs_checkpointing(OIndexType type, ORelOids treeOids, Oid tablespac
 	 */
 	key.datoid = treeOids.datoid;
 	key.relnode = treeOids.relnode;
+	key.tablespace = treeOids.spcoid;
 
 	lockNo = tag_hash(&key, sizeof(key)) % SHARED_ROOT_INFO_INSERT_NUM_LOCKS;
 	LWLockAcquire(&checkpoint_state->oSharedRootInfoInsertLocks[lockNo],
@@ -5130,7 +5211,7 @@ check_tree_needs_checkpointing(OIndexType type, ORelOids treeOids, Oid tablespac
 			checkpoint_state->datoid = treeOids.datoid;
 			checkpoint_state->reloid = treeOids.reloid;
 			checkpoint_state->relnode = treeOids.relnode;
-			checkpoint_state->tablespace = tablespace;
+			checkpoint_state->tablespace = treeOids.spcoid;
 			checkpoint_state->completed = true;
 			checkpoint_state->curKeyType = CurKeyFinished;
 			chkp_inc_changecount_after(checkpoint_state);
@@ -5150,7 +5231,7 @@ check_tree_needs_checkpointing(OIndexType type, ORelOids treeOids, Oid tablespac
 
 static void
 checkpoint_tables_callback(OIndexType type, ORelOids treeOids,
-						   ORelOids tableOids, Oid tablespace, void *arg)
+						   ORelOids tableOids, void *arg)
 {
 	CheckpointTablesArg *tbl_arg = (CheckpointTablesArg *) arg;
 	OIndexDescr *descr;
@@ -5161,7 +5242,7 @@ checkpoint_tables_callback(OIndexType type, ORelOids treeOids,
 
 	prev_context = MemoryContextSwitchTo(chkp_tree_context);
 
-	if (!check_tree_needs_checkpointing(type, treeOids, tablespace))
+	if (!check_tree_needs_checkpointing(type, treeOids))
 	{
 		MemoryContextSwitchTo(prev_context);
 		MemoryContextResetOnly(chkp_tree_context);
@@ -5239,7 +5320,7 @@ checkpoint_tables_callback(OIndexType type, ORelOids treeOids,
 				checkpoint_state->datoid = td->oids.datoid;
 				checkpoint_state->reloid = td->oids.reloid;
 				checkpoint_state->relnode = td->oids.relnode;
-				checkpoint_state->tablespace = td->tablespace;
+				checkpoint_state->tablespace = td->oids.spcoid;
 				checkpoint_state->completed = true;
 				checkpoint_state->curKeyType = CurKeyFinished;
 				skip = true;
@@ -5316,7 +5397,8 @@ get_cur_checkpoint_number(ORelOids *oids, OIndexType type,
 {
 	OIndexType	chkp_tree_type = oIndexInvalid;
 	Oid			datoid = InvalidOid,
-				relnode = InvalidOid;
+				relnode = InvalidOid,
+				chkp_tablespace = InvalidOid;
 	int			before_changecount,
 				after_changecount;
 	uint32		result,
@@ -5331,6 +5413,7 @@ get_cur_checkpoint_number(ORelOids *oids, OIndexType type,
 		chkp_tree_type = checkpoint_state->treeType;
 		datoid = checkpoint_state->datoid;
 		relnode = checkpoint_state->relnode;
+		chkp_tablespace = checkpoint_state->tablespace;
 		result = checkpoint_state->lastCheckpointNumber;
 		completed = checkpoint_state->completed;
 
@@ -5345,8 +5428,8 @@ get_cur_checkpoint_number(ORelOids *oids, OIndexType type,
 			/* datoid, relnode and ix_num setups inside changecount section */
 			Assert(OidIsValid(relnode));
 
-			cmp = chkp_ordering_cmp(type, oids->datoid, oids->relnode,
-									chkp_tree_type, datoid, relnode);
+			cmp = chkp_ordering_cmp(type, oids->datoid, oids->spcoid, oids->relnode,
+									chkp_tree_type, datoid, chkp_tablespace, relnode);
 
 			if (cmp < 0 || (cmp == 0 && completed))
 			{
@@ -5442,7 +5525,7 @@ checkpointable_tree_fill_seq_buffers(BTreeDescr *td, bool init,
 	else if (init)
 	{
 		prev_chkp_tag.key.oids = td->oids;
-		prev_chkp_tag.key.tablespace = td->tablespace;
+		prev_chkp_tag.key.oids.spcoid = td->oids.spcoid;
 		prev_chkp_tag.num = map_chkp_num;
 		prev_chkp_tag.type = map_file_exists ? 'm' : 't';
 	}
@@ -5452,7 +5535,7 @@ checkpointable_tree_fill_seq_buffers(BTreeDescr *td, bool init,
 	}
 
 	cur_chkp_tag.key.oids = td->oids;
-	cur_chkp_tag.key.tablespace = td->tablespace;
+	cur_chkp_tag.key.oids.spcoid = td->oids.spcoid;
 	cur_chkp_tag.num = chkp_num + 1;
 	cur_chkp_tag.type = 'm';
 	Assert(evicted_next == NULL || SeqBufTagEqual(&cur_chkp_tag, &evicted_next->tag));
@@ -5536,6 +5619,7 @@ evictable_tree_init_meta(BTreeDescr *desc, EvictedTreeData **evicted_data,
 
 	*evicted_data = read_evicted_data(desc->oids.datoid,
 									  desc->oids.relnode,
+									  desc->oids.spcoid,
 									  true);
 
 	if (*evicted_data != NULL)
@@ -5562,9 +5646,10 @@ evictable_tree_init_meta(BTreeDescr *desc, EvictedTreeData **evicted_data,
 
 		memset(&prev_chkp_tag, 0, sizeof(prev_chkp_tag));
 		prev_chkp_tag.key.oids = desc->oids;
-		prev_chkp_tag.key.tablespace = desc->tablespace;
+		prev_chkp_tag.key.oids.spcoid = desc->oids.spcoid;
 		prev_chkp_tag.num = o_get_latest_chkp_num(desc->oids.datoid,
 												  desc->oids.relnode,
+												  desc->oids.spcoid,
 												  chkp_num,
 												  &found);
 		prev_chkp_tag.type = 'm';
@@ -5585,6 +5670,7 @@ evictable_tree_init_meta(BTreeDescr *desc, EvictedTreeData **evicted_data,
 		if (!IS_SYS_TREE_OIDS(desc->oids) && !found && prev_chkp_file_exist)
 			o_update_latest_chkp_num(desc->oids.datoid,
 									 desc->oids.relnode,
+									 desc->oids.spcoid,
 									 chkp_num);
 
 		if (!prev_chkp_file_exist)
@@ -5730,7 +5816,7 @@ evictable_tree_init_meta(BTreeDescr *desc, EvictedTreeData **evicted_data,
 
 /* TODO: move this method ? */
 bool
-tbl_data_exists(ORelOids *oids, Oid tablespace)
+tbl_data_exists(ORelOids *oids)
 {
 	char	   *filename;
 	File		file;
@@ -5738,10 +5824,11 @@ tbl_data_exists(ORelOids *oids, Oid tablespace)
 	OTuple		keyTuple;
 	OTuple		resultTuple;
 	char	   *db_prefix;
-	OIndexKey	ix_key = {.oids = *oids,.tablespace = tablespace};
+	OIndexKey	ix_key = {.oids = *oids};
 
 	key.datoid = oids->datoid;
 	key.relnode = oids->relnode;
+	key.tablespace = oids->spcoid;
 	keyTuple.formatFlags = 0;
 	keyTuple.data = (Pointer) &key;
 
@@ -5755,7 +5842,7 @@ tbl_data_exists(ORelOids *oids, Oid tablespace)
 		return true;
 	}
 
-	o_get_prefixes_for_tablespace(ix_key.oids.datoid, ix_key.tablespace,
+	o_get_prefixes_for_tablespace(ix_key.oids.datoid, ix_key.oids.spcoid,
 								  NULL, &db_prefix);
 
 	/* TODO: more smart check */
@@ -5799,7 +5886,7 @@ evictable_tree_init(BTreeDescr *desc, bool init_shmem, bool *was_evicted)
 
 	chkp_index = (chkp_num + 1) % 2;
 	tmp_tag.key.oids = desc->oids;
-	tmp_tag.key.tablespace = desc->tablespace;
+	tmp_tag.key.oids.spcoid = desc->oids.spcoid;
 	tmp_tag.num = chkp_num + 1;
 	tmp_tag.type = 't';
 	meta_page = BTREE_GET_META(desc);

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -614,7 +614,8 @@ orioledb_aminsert(Relation rel, Datum *values, bool *isnull,
 
 	ORelOidsSetFromRel(oids, rel);
 	ix_type = o_index_rel_get_ix_type(rel);
-	index_descr = o_fetch_index_descr(oids, ix_type, false, NULL);
+	index_descr = o_fetch_index_descr(oids, ix_type,
+									  false, NULL);
 	Assert(index_descr != NULL);
 	descr = o_fetch_table_descr(index_descr->tableOids);
 	Assert(descr != NULL);
@@ -750,7 +751,8 @@ orioledb_amupdate(Relation rel, bool new_valid, bool old_valid,
 
 	ORelOidsSetFromRel(oids, rel);
 	ix_type = o_index_rel_get_ix_type(rel);
-	index_descr = o_fetch_index_descr(oids, ix_type, false, NULL);
+	index_descr = o_fetch_index_descr(oids, ix_type,
+									  false, NULL);
 	Assert(index_descr != NULL);
 	descr = o_fetch_table_descr(index_descr->tableOids);
 	Assert(descr != NULL);
@@ -900,7 +902,8 @@ orioledb_amdelete(Relation rel, Datum *values, bool *isnull,
 
 	ORelOidsSetFromRel(oids, rel);
 	ix_type = o_index_rel_get_ix_type(rel);
-	index_descr = o_fetch_index_descr(oids, ix_type, false, NULL);
+	index_descr = o_fetch_index_descr(oids, ix_type,
+									  false, NULL);
 	Assert(index_descr != NULL);
 	descr = o_fetch_table_descr(index_descr->tableOids);
 	Assert(descr != NULL);
@@ -1569,7 +1572,8 @@ orioledb_ambeginscan(Relation rel, int nkeys, int norderbys)
 
 	ORelOidsSetFromRel(oids, rel);
 	ix_type = o_index_rel_get_ix_type(rel);
-	index_descr = o_fetch_index_descr(oids, ix_type, false, NULL);
+	index_descr = o_fetch_index_descr(oids, ix_type,
+									  false, NULL);
 
 	/*
 	 * Under pg_upgrade's binary-upgrade restore the carried-over OrioleDB

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -1291,7 +1291,7 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 #else
 						change = ReorderBufferGetChange(ctx->decodeCtx->reorder);
 #endif
-						change->data.tp.rlocator.spcOid = ctx->descr->tablespace;
+						change->data.tp.rlocator.spcOid = ctx->descr->oids.spcoid;
 						change->data.tp.rlocator.dbOid = rec->oids.datoid;
 						change->data.tp.rlocator.relNumber = rec->oids.relnode;
 						elog(DEBUG4, "reloid: %u", rec->oids.reloid);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -65,6 +65,7 @@
 #include "utils/memutils.h"
 #include "utils/typcache.h"
 #include "catalog/pg_database.h"
+#include "catalog/pg_tablespace_d.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -3482,7 +3483,8 @@ worker_wait_shutdown(RecoveryWorkerState *worker)
 }
 
 static void
-cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
+cleanup_tablespace_old_files(char *path, Oid tablespace, uint32 chkp_num,
+							 bool before_recovery)
 {
 	DIR		   *dir,
 			   *dbDir;
@@ -3559,13 +3561,14 @@ cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
 						bool		found;
 
 						my_chkp_num = o_get_latest_chkp_num(dbOid, file_reloid,
+															tablespace,
 															chkp_num, &found);
 
 						cleanup = (file_chkp > my_chkp_num);
 
 						if (!found && file_chkp == chkp_num)
 							o_update_latest_chkp_num(dbOid, file_reloid,
-													 file_chkp);
+													 tablespace, file_chkp);
 					}
 
 					if (!cleanup)
@@ -3590,6 +3593,7 @@ cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
 						uint32		my_chkp_num;
 
 						my_chkp_num = o_get_latest_chkp_num(dbOid, file_reloid,
+															tablespace,
 															chkp_num, NULL);
 
 						cleanup = (file_chkp < my_chkp_num);
@@ -3650,17 +3654,22 @@ recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 
 	path[0] = '\0';
 	strlcat(path, ORIOLEDB_DATA_DIR, MAXPGPATH);
-	cleanup_tablespace_old_files(path, chkp_num, before_recovery);
+	cleanup_tablespace_old_files(path, DEFAULTTABLESPACE_OID, chkp_num,
+								 before_recovery);
 
 	dir = opendir(PG_TBLSPC);
 	while (errno = 0, (file = readdir(dir)) != NULL)
 	{
 		struct stat st;
 		int			rllen;
+		Oid			tablespace;
 
 		/* Skip special stuff */
 		if (strcmp(file->d_name, ".") == 0 || strcmp(file->d_name, "..") == 0)
 			continue;
+
+		tablespace = pg_strtoint64(file->d_name);
+		Assert(OidIsValid(tablespace));
 
 		path[0] = '\0';
 		pg_snprintf(path, MAXPGPATH,
@@ -3677,7 +3686,8 @@ recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 		if (!S_ISLNK(st.st_mode))
 		{
 			strlcat(path, "/" ORIOLEDB_DATA_DIR, MAXPGPATH);
-			cleanup_tablespace_old_files(path, chkp_num, before_recovery);
+			cleanup_tablespace_old_files(path, tablespace, chkp_num,
+										 before_recovery);
 		}
 		else
 		{
@@ -3698,7 +3708,8 @@ recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 			pg_snprintf(path, MAXPGPATH,
 						"%s/" ORIOLEDB_DATA_DIR,
 						targetpath);
-			cleanup_tablespace_old_files(path, chkp_num, before_recovery);
+			cleanup_tablespace_old_files(path, tablespace, chkp_num,
+										 before_recovery);
 		}
 	}
 	closedir(dir);
@@ -3716,19 +3727,16 @@ o_indices_get_trees(Pointer tuple, ORelOids *tableOids)
 	if (chunk.key.chunknum != 0)
 		return NULL;
 
-	/*
-	 * The serialized OIndex blob starts at OIndex.tableOids (the key fields
-	 * indexOids/indexType/indexVersion are stored in OIndexChunkKey).
-	 * tablespace must lie after tableOids in the struct so the subtraction
-	 * below is positive and the field lands in the first chunk.
-	 */
-	StaticAssertStmt(offsetof(OIndex, tablespace) > offsetof(OIndex, tableOids),
-					 "OIndex.tablespace must follow OIndex.tableOids");
 	Assert(chunk.dataLength >= sizeof(*tableOids));
 	memcpy(tableOids, tuple + offsetof(OIndexChunk, data), sizeof(*tableOids));
 	trees = (OIndexKey *) MemoryContextAlloc(CurTransactionContext, sizeof(OIndexKey));
+
+	/*
+	 * The tablespace is part of the tree identity (ORelOids.spcoid) and is
+	 * stored in OIndexChunkKey.oids, so copying the key oids carries it too
+	 * -- no need to read it back out of the serialized OIndex blob.
+	 */
 	trees->oids = chunk.key.oids;
-	memcpy(&trees->tablespace, tuple + offsetof(OIndexChunk, data) + (offsetof(OIndex, tablespace) - offsetof(OIndex, tableOids)), sizeof(Oid));
 
 	return trees;
 }
@@ -3856,7 +3864,7 @@ recovery_apply_systree_modify(int sys_tree_num, uint16 type, OTuple tuple,
 				char	   *db_prefix;
 
 				o_get_prefixes_for_tablespace(trees->oids.datoid,
-											  trees->tablespace,
+											  trees->oids.spcoid,
 											  &prefix, &db_prefix);
 				o_verify_dir_exists_or_create(prefix, NULL, NULL);
 				o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
@@ -3938,7 +3946,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 				break;
 		}
 
-		if (new_o_table->tablespace != old_o_table->tablespace)
+		if (new_o_table->oids.spcoid != old_o_table->oids.spcoid)
 			changed_tablespace = true;
 		if (new_o_table->nindices > old_o_table->nindices)
 		{
@@ -3947,7 +3955,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			o_fill_tmp_table_descr(&tmp_descr, new_o_table);
 			if (new_o_table->indices[ix_num].type == oIndexPrimary)
 			{
-				if (tbl_data_exists(&old_o_table->oids, old_o_table->tablespace))
+				if (tbl_data_exists(&old_o_table->oids))
 				{
 					old_descr = o_fetch_table_descr(old_o_table->oids);
 					if (!changed_tablespace)
@@ -3984,7 +3992,8 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			{
 				if (!changed_tablespace)
 					o_insert_shared_root_placeholder(new_o_table->indices[ix_num].oids.datoid,
-													 new_o_table->indices[ix_num].oids.relnode);
+													 new_o_table->indices[ix_num].oids.relnode,
+													 new_o_table->indices[ix_num].oids.spcoid);
 				o_tables_meta_unlock_no_wal();
 
 				Assert(is_recovery_in_progress());
@@ -4021,7 +4030,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 				OTableDescr tmp_descr;
 
 				o_fill_tmp_table_descr(&tmp_descr, new_o_table);
-				if (tbl_data_exists(&old_o_table->indices[ix_num].oids, old_o_table->indices[ix_num].tablespace))
+				if (tbl_data_exists(&old_o_table->indices[ix_num].oids))
 				{
 					old_descr = o_fetch_table_descr(old_o_table->oids);
 					if (!changed_tablespace)
@@ -4071,14 +4080,10 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			 */
 			OTableDescr tmp_descr;
 			ORelOids	srcOids;
-			Oid			srcTablespace;
 
 			srcOids = old_o_table->has_primary ?
 				old_o_table->indices[PrimaryIndexNumber].oids :
 				old_o_table->oids;
-			srcTablespace = old_o_table->has_primary ?
-				old_o_table->indices[PrimaryIndexNumber].tablespace :
-				old_o_table->tablespace;
 
 			/*
 			 * o_fill_tmp_table_descr() already initializes shared root info
@@ -4086,7 +4091,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			 * call rebuild_indices_insert_placeholders() afterwards.
 			 */
 			o_fill_tmp_table_descr(&tmp_descr, new_o_table);
-			if (tbl_data_exists(&srcOids, srcTablespace))
+			if (tbl_data_exists(&srcOids))
 			{
 				old_descr = o_fetch_table_descr(old_o_table->oids);
 				o_tables_meta_unlock_no_wal();
@@ -4235,13 +4240,19 @@ handle_movedb(Oid dbOid, Oid src_tblspcoid, Oid dst_tblspcoid)
 		EvictedTreeData *evicted_data = NULL;
 		Oid			relnode = lfirst_oid(lc);
 
-		evicted_data = read_evicted_data(dbOid, relnode, true);
+		evicted_data = read_evicted_data(dbOid, relnode, src_tblspcoid, true);
 
 		if (evicted_data != NULL)
 		{
-			evicted_data->freeBuf.tag.key.tablespace = dst_tblspcoid;
-			evicted_data->nextChkp.tag.key.tablespace = dst_tblspcoid;
-			evicted_data->tmpBuf.tag.key.tablespace = dst_tblspcoid;
+			/*
+			 * Re-key the EVICTED_DATA entry (and its seq_buf tags) to the
+			 * destination tablespace: tablespace is part of the tree
+			 * identity, so the entry must move with the tree.
+			 */
+			evicted_data->key.tablespace = dst_tblspcoid;
+			evicted_data->freeBuf.tag.key.oids.spcoid = dst_tblspcoid;
+			evicted_data->nextChkp.tag.key.oids.spcoid = dst_tblspcoid;
+			evicted_data->tmpBuf.tag.key.oids.spcoid = dst_tblspcoid;
 			insert_evicted_data(evicted_data);
 		}
 	}
@@ -4468,7 +4479,8 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 				{
 					Assert(ix_type == oIndexToast || ix_type == oIndexBridge);
 					ctx->descr = NULL;
-					ctx->indexDescr = o_fetch_index_descr(rec->oids, ix_type, false, NULL);
+					ctx->indexDescr = o_fetch_index_descr(rec->oids, ix_type,
+														  false, NULL);
 				}
 
 				if (ctx->sys_tree_num == -1 && (ctx->descr || ctx->indexDescr))
@@ -4481,13 +4493,13 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 					if (ctx->descr)
 					{
 						oids = GET_PRIMARY(ctx->descr)->desc.oids;
-						tablespace = GET_PRIMARY(ctx->descr)->desc.tablespace;
+						tablespace = GET_PRIMARY(ctx->descr)->desc.oids.spcoid;
 					}
 					else
 					{
 						Assert(ctx->indexDescr);
 						oids = ctx->indexDescr->oids;
-						tablespace = ctx->indexDescr->desc.tablespace;
+						tablespace = ctx->indexDescr->desc.oids.spcoid;
 					}
 					o_get_prefixes_for_tablespace(oids.datoid, tablespace,
 												  &prefix, &db_prefix);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1678,11 +1678,12 @@ recovery_init(int worker_id)
 		HASHCTL		reloid_ctl;
 
 		MemSet(&reloid_ctl, 0, sizeof(reloid_ctl));
+
 		/*
 		 * Key by tree identity (datoid, reloid, relnode) only -- spcoid is
 		 * excluded so a modify and the queued index build match regardless of
-		 * which resolves the tablespace, keeping data applies delayed behind an
-		 * in-progress build (else they race into the unbuilt placeholder).
+		 * which resolves the tablespace, keeping data applies delayed behind
+		 * an in-progress build (else they race into the unbuilt placeholder).
 		 */
 		reloid_ctl.keysize = offsetof(ORelOids, spcoid);
 		reloid_ctl.entrysize = sizeof(RecoveryIdxBuildQueueState);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -65,6 +65,7 @@
 #include "utils/memutils.h"
 #include "utils/typcache.h"
 #include "catalog/pg_database.h"
+#include "catalog/pg_tablespace_d.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -1677,7 +1678,14 @@ recovery_init(int worker_id)
 		HASHCTL		reloid_ctl;
 
 		MemSet(&reloid_ctl, 0, sizeof(reloid_ctl));
-		reloid_ctl.keysize = sizeof(ORelOids);
+
+		/*
+		 * Key by tree identity (datoid, reloid, relnode) only -- spcoid is
+		 * excluded so a modify and the queued index build match regardless of
+		 * which resolves the tablespace, keeping data applies delayed behind
+		 * an in-progress build (else they race into the unbuilt placeholder).
+		 */
+		reloid_ctl.keysize = offsetof(ORelOids, spcoid);
 		reloid_ctl.entrysize = sizeof(RecoveryIdxBuildQueueState);
 		reloid_ctl.hcxt = TopMemoryContext;
 		idxbuild_oids_hash = hash_create("orioledb recovery index build queue relations hash",
@@ -3482,7 +3490,8 @@ worker_wait_shutdown(RecoveryWorkerState *worker)
 }
 
 static void
-cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
+cleanup_tablespace_old_files(char *path, Oid tablespace, uint32 chkp_num,
+							 bool before_recovery)
 {
 	DIR		   *dir,
 			   *dbDir;
@@ -3559,13 +3568,14 @@ cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
 						bool		found;
 
 						my_chkp_num = o_get_latest_chkp_num(dbOid, file_reloid,
+															tablespace,
 															chkp_num, &found);
 
 						cleanup = (file_chkp > my_chkp_num);
 
 						if (!found && file_chkp == chkp_num)
 							o_update_latest_chkp_num(dbOid, file_reloid,
-													 file_chkp);
+													 tablespace, file_chkp);
 					}
 
 					if (!cleanup)
@@ -3590,6 +3600,7 @@ cleanup_tablespace_old_files(char *path, uint32 chkp_num, bool before_recovery)
 						uint32		my_chkp_num;
 
 						my_chkp_num = o_get_latest_chkp_num(dbOid, file_reloid,
+															tablespace,
 															chkp_num, NULL);
 
 						cleanup = (file_chkp < my_chkp_num);
@@ -3650,17 +3661,22 @@ recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 
 	path[0] = '\0';
 	strlcat(path, ORIOLEDB_DATA_DIR, MAXPGPATH);
-	cleanup_tablespace_old_files(path, chkp_num, before_recovery);
+	cleanup_tablespace_old_files(path, DEFAULTTABLESPACE_OID, chkp_num,
+								 before_recovery);
 
 	dir = opendir(PG_TBLSPC);
 	while (errno = 0, (file = readdir(dir)) != NULL)
 	{
 		struct stat st;
 		int			rllen;
+		Oid			tablespace;
 
 		/* Skip special stuff */
 		if (strcmp(file->d_name, ".") == 0 || strcmp(file->d_name, "..") == 0)
 			continue;
+
+		tablespace = pg_strtoint64(file->d_name);
+		Assert(OidIsValid(tablespace));
 
 		path[0] = '\0';
 		pg_snprintf(path, MAXPGPATH,
@@ -3677,7 +3693,8 @@ recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 		if (!S_ISLNK(st.st_mode))
 		{
 			strlcat(path, "/" ORIOLEDB_DATA_DIR, MAXPGPATH);
-			cleanup_tablespace_old_files(path, chkp_num, before_recovery);
+			cleanup_tablespace_old_files(path, tablespace, chkp_num,
+										 before_recovery);
 		}
 		else
 		{
@@ -3698,7 +3715,8 @@ recovery_cleanup_old_files(uint32 chkp_num, bool before_recovery)
 			pg_snprintf(path, MAXPGPATH,
 						"%s/" ORIOLEDB_DATA_DIR,
 						targetpath);
-			cleanup_tablespace_old_files(path, chkp_num, before_recovery);
+			cleanup_tablespace_old_files(path, tablespace, chkp_num,
+										 before_recovery);
 		}
 	}
 	closedir(dir);
@@ -3716,19 +3734,16 @@ o_indices_get_trees(Pointer tuple, ORelOids *tableOids)
 	if (chunk.key.chunknum != 0)
 		return NULL;
 
-	/*
-	 * The serialized OIndex blob starts at OIndex.tableOids (the key fields
-	 * indexOids/indexType/indexVersion are stored in OIndexChunkKey).
-	 * tablespace must lie after tableOids in the struct so the subtraction
-	 * below is positive and the field lands in the first chunk.
-	 */
-	StaticAssertStmt(offsetof(OIndex, tablespace) > offsetof(OIndex, tableOids),
-					 "OIndex.tablespace must follow OIndex.tableOids");
 	Assert(chunk.dataLength >= sizeof(*tableOids));
 	memcpy(tableOids, tuple + offsetof(OIndexChunk, data), sizeof(*tableOids));
 	trees = (OIndexKey *) MemoryContextAlloc(CurTransactionContext, sizeof(OIndexKey));
+
+	/*
+	 * The tablespace is part of the tree identity (ORelOids.spcoid) and is
+	 * stored in OIndexChunkKey.oids, so copying the key oids carries it too
+	 * -- no need to read it back out of the serialized OIndex blob.
+	 */
 	trees->oids = chunk.key.oids;
-	memcpy(&trees->tablespace, tuple + offsetof(OIndexChunk, data) + (offsetof(OIndex, tablespace) - offsetof(OIndex, tableOids)), sizeof(Oid));
 
 	return trees;
 }
@@ -3856,7 +3871,7 @@ recovery_apply_systree_modify(int sys_tree_num, uint16 type, OTuple tuple,
 				char	   *db_prefix;
 
 				o_get_prefixes_for_tablespace(trees->oids.datoid,
-											  trees->tablespace,
+											  trees->oids.spcoid,
 											  &prefix, &db_prefix);
 				o_verify_dir_exists_or_create(prefix, NULL, NULL);
 				o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
@@ -3938,7 +3953,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 				break;
 		}
 
-		if (new_o_table->tablespace != old_o_table->tablespace)
+		if (new_o_table->oids.spcoid != old_o_table->oids.spcoid)
 			changed_tablespace = true;
 		if (new_o_table->nindices > old_o_table->nindices)
 		{
@@ -3947,7 +3962,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			o_fill_tmp_table_descr(&tmp_descr, new_o_table);
 			if (new_o_table->indices[ix_num].type == oIndexPrimary)
 			{
-				if (tbl_data_exists(&old_o_table->oids, old_o_table->tablespace))
+				if (tbl_data_exists(&old_o_table->oids))
 				{
 					old_descr = o_fetch_table_descr(old_o_table->oids);
 					if (!changed_tablespace)
@@ -3984,7 +3999,8 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			{
 				if (!changed_tablespace)
 					o_insert_shared_root_placeholder(new_o_table->indices[ix_num].oids.datoid,
-													 new_o_table->indices[ix_num].oids.relnode);
+													 new_o_table->indices[ix_num].oids.relnode,
+													 new_o_table->indices[ix_num].oids.spcoid);
 				o_tables_meta_unlock_no_wal();
 
 				Assert(is_recovery_in_progress());
@@ -4021,7 +4037,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 				OTableDescr tmp_descr;
 
 				o_fill_tmp_table_descr(&tmp_descr, new_o_table);
-				if (tbl_data_exists(&old_o_table->indices[ix_num].oids, old_o_table->indices[ix_num].tablespace))
+				if (tbl_data_exists(&old_o_table->indices[ix_num].oids))
 				{
 					old_descr = o_fetch_table_descr(old_o_table->oids);
 					if (!changed_tablespace)
@@ -4071,14 +4087,10 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			 */
 			OTableDescr tmp_descr;
 			ORelOids	srcOids;
-			Oid			srcTablespace;
 
 			srcOids = old_o_table->has_primary ?
 				old_o_table->indices[PrimaryIndexNumber].oids :
 				old_o_table->oids;
-			srcTablespace = old_o_table->has_primary ?
-				old_o_table->indices[PrimaryIndexNumber].tablespace :
-				old_o_table->tablespace;
 
 			/*
 			 * o_fill_tmp_table_descr() already initializes shared root info
@@ -4086,7 +4098,7 @@ handle_o_tables_meta_unlock(ORelOids oids, Oid oldRelnode)
 			 * call rebuild_indices_insert_placeholders() afterwards.
 			 */
 			o_fill_tmp_table_descr(&tmp_descr, new_o_table);
-			if (tbl_data_exists(&srcOids, srcTablespace))
+			if (tbl_data_exists(&srcOids))
 			{
 				old_descr = o_fetch_table_descr(old_o_table->oids);
 				o_tables_meta_unlock_no_wal();
@@ -4235,13 +4247,19 @@ handle_movedb(Oid dbOid, Oid src_tblspcoid, Oid dst_tblspcoid)
 		EvictedTreeData *evicted_data = NULL;
 		Oid			relnode = lfirst_oid(lc);
 
-		evicted_data = read_evicted_data(dbOid, relnode, true);
+		evicted_data = read_evicted_data(dbOid, relnode, src_tblspcoid, true);
 
 		if (evicted_data != NULL)
 		{
-			evicted_data->freeBuf.tag.key.tablespace = dst_tblspcoid;
-			evicted_data->nextChkp.tag.key.tablespace = dst_tblspcoid;
-			evicted_data->tmpBuf.tag.key.tablespace = dst_tblspcoid;
+			/*
+			 * Re-key the EVICTED_DATA entry (and its seq_buf tags) to the
+			 * destination tablespace: tablespace is part of the tree
+			 * identity, so the entry must move with the tree.
+			 */
+			evicted_data->key.tablespace = dst_tblspcoid;
+			evicted_data->freeBuf.tag.key.oids.spcoid = dst_tblspcoid;
+			evicted_data->nextChkp.tag.key.oids.spcoid = dst_tblspcoid;
+			evicted_data->tmpBuf.tag.key.oids.spcoid = dst_tblspcoid;
 			insert_evicted_data(evicted_data);
 		}
 	}
@@ -4468,7 +4486,8 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 				{
 					Assert(ix_type == oIndexToast || ix_type == oIndexBridge);
 					ctx->descr = NULL;
-					ctx->indexDescr = o_fetch_index_descr(rec->oids, ix_type, false, NULL);
+					ctx->indexDescr = o_fetch_index_descr(rec->oids, ix_type,
+														  false, NULL);
 				}
 
 				if (ctx->sys_tree_num == -1 && (ctx->descr || ctx->indexDescr))
@@ -4481,13 +4500,13 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 					if (ctx->descr)
 					{
 						oids = GET_PRIMARY(ctx->descr)->desc.oids;
-						tablespace = GET_PRIMARY(ctx->descr)->desc.tablespace;
+						tablespace = GET_PRIMARY(ctx->descr)->desc.oids.spcoid;
 					}
 					else
 					{
 						Assert(ctx->indexDescr);
 						oids = ctx->indexDescr->oids;
-						tablespace = ctx->indexDescr->desc.tablespace;
+						tablespace = ctx->indexDescr->desc.oids.spcoid;
 					}
 					o_get_prefixes_for_tablespace(oids.datoid, tablespace,
 												  &prefix, &db_prefix);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1678,7 +1678,13 @@ recovery_init(int worker_id)
 		HASHCTL		reloid_ctl;
 
 		MemSet(&reloid_ctl, 0, sizeof(reloid_ctl));
-		reloid_ctl.keysize = sizeof(ORelOids);
+		/*
+		 * Key by tree identity (datoid, reloid, relnode) only -- spcoid is
+		 * excluded so a modify and the queued index build match regardless of
+		 * which resolves the tablespace, keeping data applies delayed behind an
+		 * in-progress build (else they race into the unbuilt placeholder).
+		 */
+		reloid_ctl.keysize = offsetof(ORelOids, spcoid);
 		reloid_ctl.entrysize = sizeof(RecoveryIdxBuildQueueState);
 		reloid_ctl.hcxt = TopMemoryContext;
 		idxbuild_oids_hash = hash_create("orioledb recovery index build queue relations hash",

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -510,6 +510,9 @@ add_rel_wal_record(ORelOids oids, OIndexType type, uint32 version, uint32 base_v
 	memcpy(rec->version, &version, sizeof(version));
 	memcpy(rec->baseVersion, &base_version, sizeof(base_version));
 
+	/* Since ORIOLEDB_REL_TABLESPACE_WAL_VERSION */
+	memcpy(rec->tablespace, &oids.spcoid, sizeof(Oid));
+
 	elog(DEBUG4, "[%s] WAL_REC_RELATION ADD oids [ %u %u %u ] type %d xmin/csn/cid " UINT64_FORMAT "/" UINT64_FORMAT "/%u version %u base_version %u", __func__,
 		 oids.datoid, oids.reloid, oids.relnode,
 		 type, runXmin, csn, cid, version, base_version);

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -510,6 +510,9 @@ add_rel_wal_record(ORelOids oids, OIndexType type, uint32 version, uint32 base_v
 	memcpy(rec->version, &version, sizeof(version));
 	memcpy(rec->baseVersion, &base_version, sizeof(base_version));
 
+	/* Since ORIOLEDB_WAL_VERSION = 18 */
+	memcpy(rec->tablespace, &oids.spcoid, sizeof(Oid));
+
 	elog(DEBUG4, "[%s] WAL_REC_RELATION ADD oids [ %u %u %u ] type %d xmin/csn/cid " UINT64_FORMAT "/" UINT64_FORMAT "/%u version %u base_version %u", __func__,
 		 oids.datoid, oids.reloid, oids.relnode,
 		 type, runXmin, csn, cid, version, base_version);

--- a/src/recovery/wal_reader.c
+++ b/src/recovery/wal_reader.c
@@ -22,6 +22,8 @@
 
 #include "orioledb.h"
 
+#include "catalog/pg_tablespace_d.h"
+
 #include "btree/page_contents.h"
 #include "catalog/sys_trees.h"
 #include "recovery/wal_reader.h"
@@ -141,6 +143,19 @@ wal_parse_rec_relation(WalReaderState *r, WalRecord *rec)
 		rec->u.relation.version = O_TABLE_INVALID_VERSION;
 		rec->u.relation.base_version = O_TABLE_INVALID_VERSION;
 	}
+
+	/*
+	 * The tablespace is part of the tree identity (ORelOids.spcoid).  WAL
+	 * written before version 18 predates the per-tablespace relnode identity,
+	 * so default it to the default tablespace (matching
+	 * o_get_prefixes_for_tablespace()).
+	 */
+	if (r->container.version >= 18)
+	{
+		WR_PARSE(r, &rec->oids.spcoid);
+	}
+	else
+		rec->oids.spcoid = DEFAULTTABLESPACE_OID;
 
 	return WALPARSE_OK;
 }

--- a/src/recovery/wal_reader.c
+++ b/src/recovery/wal_reader.c
@@ -22,6 +22,8 @@
 
 #include "orioledb.h"
 
+#include "catalog/pg_tablespace_d.h"
+
 #include "btree/page_contents.h"
 #include "catalog/sys_trees.h"
 #include "recovery/wal_reader.h"
@@ -141,6 +143,19 @@ wal_parse_rec_relation(WalReaderState *r, WalRecord *rec)
 		rec->u.relation.version = O_TABLE_INVALID_VERSION;
 		rec->u.relation.base_version = O_TABLE_INVALID_VERSION;
 	}
+
+	/*
+	 * The tablespace is part of the tree identity (ORelOids.spcoid).  WAL
+	 * written before ORIOLEDB_REL_TABLESPACE_WAL_VERSION predates the
+	 * per-tablespace relnode identity, so default it to the default
+	 * tablespace (matching o_get_prefixes_for_tablespace()).
+	 */
+	if (r->container.version >= ORIOLEDB_REL_TABLESPACE_WAL_VERSION)
+	{
+		WR_PARSE(r, &rec->oids.spcoid);
+	}
+	else
+		rec->oids.spcoid = DEFAULTTABLESPACE_OID;
 
 	return WALPARSE_OK;
 }

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -438,7 +438,7 @@ recovery_queue_process(shm_mq_handle *queue, int id)
 														 NULL);
 					}
 					o_get_prefixes_for_tablespace(oids.datoid,
-												  indexDescr->desc.tablespace,
+												  indexDescr->desc.oids.spcoid,
 												  &prefix, &db_prefix);
 					o_verify_dir_exists_or_create(prefix, NULL, NULL);
 					o_verify_dir_exists_or_create(db_prefix, NULL, NULL);

--- a/src/s3/headers.c
+++ b/src/s3/headers.c
@@ -55,7 +55,7 @@ s3_header_tag_hash(S3HeaderTag tag)
 
 	hashKey.datoid = tag.key.oids.datoid;
 	hashKey.relnode = tag.key.oids.relnode;
-	hashKey.tablespace = tag.key.tablespace;
+	hashKey.tablespace = tag.key.oids.spcoid;
 	hashKey.checkpointNum = tag.checkpointNum;
 	hashKey.segNum = tag.segNum;
 	return hash_any((unsigned char *) &hashKey, sizeof(hashKey));
@@ -659,8 +659,8 @@ s3_header_compare_and_swap(S3HeaderTag tag, int index,
 /*
  * We allow only one part to be locked simultaneosly.
  */
-static S3HeaderTag curLockedTag = {{{InvalidOid, InvalidOid, InvalidOid},
-InvalidOid}, 0, 0};
+static S3HeaderTag curLockedTag = {{{InvalidOid, InvalidOid, InvalidOid,
+InvalidOid}}, 0, 0};
 static int	curLockedIndex = 0;
 
 /*
@@ -1033,7 +1033,7 @@ iterate_tablespace_files(Oid tablespace, char *path, IterateFilesCallback callba
 			{
 				tag.key.oids.datoid = dbOid;
 				tag.key.oids.relnode = file_relnode;
-				tag.key.tablespace = tablespace;
+				tag.key.oids.spcoid = tablespace;
 				tag.checkpointNum = file_chkp;
 				tag.segNum = 0;
 				callback(tag);
@@ -1044,7 +1044,7 @@ iterate_tablespace_files(Oid tablespace, char *path, IterateFilesCallback callba
 			{
 				tag.key.oids.datoid = dbOid;
 				tag.key.oids.relnode = file_relnode;
-				tag.key.tablespace = tablespace;
+				tag.key.oids.spcoid = tablespace;
 				tag.checkpointNum = file_chkp;
 				tag.segNum = file_segno;
 				callback(tag);

--- a/src/s3/worker.c
+++ b/src/s3/worker.c
@@ -677,7 +677,7 @@ s3_schedule_file_part_read(uint32 chkpNum, OIndexKey key, int32 segNum,
 	char	   *prefix;
 	char	   *db_prefix;
 
-	o_get_prefixes_for_tablespace(key.oids.datoid, key.tablespace,
+	o_get_prefixes_for_tablespace(key.oids.datoid, key.oids.spcoid,
 								  &prefix, &db_prefix);
 	o_verify_dir_exists_or_create(prefix, NULL, NULL);
 	o_verify_dir_exists_or_create(db_prefix, NULL, NULL);
@@ -799,7 +799,7 @@ s3_schedule_downlink_load(BTreeDescr *desc, uint64 downlink)
 
 	while (true)
 	{
-		OIndexKey	key = {.oids = desc->oids,.tablespace = desc->tablespace};
+		OIndexKey	key = {.oids = desc->oids};
 		S3TaskLocation location;
 
 		segNum = byte_offset / ORIOLEDB_SEGMENT_SIZE;

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -1511,6 +1511,36 @@ get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchCon
 	return result;
 }
 
+/*
+ * Return an already-built index descriptor straight from the descriptor cache,
+ * or NULL when it is absent or was built for a different tablespace.  Unlike
+ * get_index_descr(), this NEVER reads the O_INDICES sys-tree (which would
+ * palloc a multi-kilobyte TOAST buffer) and never rebuilds the descriptor, so
+ * it is safe to call from a critical section -- e.g. the CHECK_PAGE_STATS
+ * diagnostic in unlock_check_page(), which runs while a page is locked.
+ */
+OIndexDescr *
+get_cached_index_descr(ORelOids oids)
+{
+	OIndexDescr *result;
+	bool		found;
+
+	result = hash_search(oIndexDescrHash, &oids, HASH_FIND, &found);
+	if (!found || result == NULL)
+		return NULL;
+
+	/*
+	 * The cache is keyed by (datoid, reloid, relnode); the tablespace
+	 * (spcoid) is part of the tree identity.  A descriptor cached for a
+	 * different tablespace is stale here (rebuilding it is exactly what we
+	 * must avoid), so treat it as a miss.
+	 */
+	if (result->desc.oids.spcoid != oids.spcoid)
+		return NULL;
+
+	return result;
+}
+
 static void
 recreate_index_descr(OIndexDescr *descr)
 {

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -61,8 +61,7 @@ typedef struct
 	Oid			righttype;
 } InvalidateComparatorUndoStackItem;
 
-static OIndexDescr *get_index_descr(ORelOids ixOids, OIndexType ixType,
-									bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source);
+static OIndexDescr *get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source);
 static bool o_table_descr_fill_indices(OTableDescr *descr, OTable *table, OSnapshot *snapshot);
 static void init_shared_root_info(PagePool *pool,
 								  SharedRootInfo *sharedRootInfo);
@@ -239,7 +238,7 @@ drop_local_shared_root_info(SharedRootInfoKey *key)
 }
 
 EvictedTreeData *
-read_evicted_data(Oid datoid, Oid relnode, bool delete)
+read_evicted_data(Oid datoid, Oid relnode, Oid tablespace, bool delete)
 {
 	SharedRootInfoKey key;
 	OTuple		keyTuple;
@@ -255,6 +254,7 @@ read_evicted_data(Oid datoid, Oid relnode, bool delete)
 
 	key.datoid = datoid;
 	key.relnode = relnode;
+	key.tablespace = tablespace;
 	keyTuple.formatFlags = 0;
 	keyTuple.data = (Pointer) &key;
 
@@ -385,6 +385,7 @@ o_btree_load_shmem_internal(BTreeDescr *desc, bool checkpoint)
 	memset(&key, 0, sizeof(SharedRootInfoKey));
 	key.datoid = desc->oids.datoid;
 	key.relnode = desc->oids.relnode;
+	key.tablespace = desc->oids.spcoid;
 
 	/*
 	 * evictable_tree_init() needs that.  Initialized it before we get one of
@@ -568,6 +569,7 @@ o_btree_try_use_shmem(BTreeDescr *desc)
 
 		key.datoid = desc->oids.datoid;
 		key.relnode = desc->oids.relnode;
+		key.tablespace = desc->oids.spcoid;
 
 		shared = o_find_shared_root_info(&key);
 		if (shared == NULL)
@@ -804,7 +806,7 @@ fill_table_descr_common_fields(OTableDescr *descr, OTable *o_table)
 	descr->refcnt = refcnt;
 	descr->oids = o_table->oids;
 	descr->version = o_table->version;
-	descr->tablespace = o_table->tablespace;
+	descr->oids.spcoid = o_table->oids.spcoid;
 	descr->tupdesc = o_table_tupdesc(o_table);
 	descr->oldTuple = MakeSingleTupleTableSlot(descr->tupdesc,
 											   &TTSOpsOrioleDB);
@@ -867,7 +869,7 @@ o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table)
 		index_btree_desc_init(&indexDescr->desc, indexDescr->compress,
 							  indexDescr->fillfactor, indexDescr->oids,
 							  index->indexType, index->table_persistence,
-							  index->tablespace, index->createOxid,
+							  index->indexOids.spcoid, index->createOxid,
 							  indexDescr);
 		free_o_index(index);
 		descr->indices[cur_ix] = indexDescr;
@@ -879,7 +881,7 @@ o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table)
 	index_btree_desc_init(&indexDescr->desc, indexDescr->compress,
 						  indexDescr->fillfactor, indexDescr->oids,
 						  index->indexType, index->table_persistence,
-						  index->tablespace, index->createOxid, indexDescr);
+						  index->indexOids.spcoid, index->createOxid, indexDescr);
 	free_o_index(index);
 	descr->toast = indexDescr;
 
@@ -891,7 +893,7 @@ o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table)
 		index_btree_desc_init(&indexDescr->desc, indexDescr->compress,
 							  indexDescr->fillfactor,
 							  indexDescr->oids, index->indexType,
-							  index->table_persistence, index->tablespace,
+							  index->table_persistence, index->indexOids.spcoid,
 							  index->createOxid, indexDescr);
 		free_o_index(index);
 		descr->bridge = indexDescr;
@@ -1076,7 +1078,8 @@ o_fetch_index_descr(ORelOids oids, OIndexType type, bool lock, bool *nested)
  *    descriptor mismatches during logical decoding and recovery.
  */
 OIndexDescr *
-o_fetch_index_descr_extended(ORelOids oids, OIndexType type, bool lock,
+o_fetch_index_descr_extended(ORelOids oids, OIndexType type,
+							 bool lock,
 							 OTableFetchContext ctx, OTableFetchContext base_ctx)
 {
 	OIndexDescr *index_descr = NULL;
@@ -1309,7 +1312,7 @@ o_find_shared_root_info(SharedRootInfoKey *key)
 }
 
 void
-o_insert_shared_root_placeholder(Oid datoid, Oid relnode)
+o_insert_shared_root_placeholder(Oid datoid, Oid relnode, Oid tablespace)
 {
 	OTuple		sharedRootInfoTuple;
 	SharedRootInfo sharedRootInfo = {0};
@@ -1321,6 +1324,7 @@ o_insert_shared_root_placeholder(Oid datoid, Oid relnode)
 	memset(&sharedRootInfo, 0, sizeof(sharedRootInfo));
 	sharedRootInfo.key.datoid = datoid;
 	sharedRootInfo.key.relnode = relnode;
+	sharedRootInfo.key.tablespace = tablespace;
 	sharedRootInfo.placeholder = true;
 	sharedRootInfo.rootInfo.metaPageBlkno = OInvalidInMemoryBlkno;
 	sharedRootInfo.rootInfo.rootPageBlkno = OInvalidInMemoryBlkno;
@@ -1331,6 +1335,66 @@ o_insert_shared_root_placeholder(Oid datoid, Oid relnode)
 	Assert(inserted);
 }
 
+/*
+ * Re-key a tree's in-memory checkpoint identity from old_tablespace to
+ * new_tablespace (ALTER DATABASE ... SET TABLESPACE).
+ *
+ * The tablespace is part of the SharedRootInfo / EvictedData key and of the
+ * seq_buf tags, and both are maintained autonomously (immediately visible to
+ * the checkpointer).  Unless they move with the tree, a checkpoint running
+ * before the ALTER commits would still find the tree under the source
+ * tablespace and flush its files back into the source directory after it was
+ * removed.  A tree is either resident (SharedRootInfo) or evicted
+ * (EvictedData), never both.
+ */
+void
+o_move_tree_meta(Oid datoid, Oid relnode, Oid old_tablespace,
+				 Oid new_tablespace)
+{
+	SharedRootInfoKey oldKey;
+	SharedRootInfo *shared;
+	EvictedTreeData *evicted;
+
+	/*
+	 * Move the tree's latest-checkpoint-number record so recovery finds the
+	 * moved tree's map/tmp files under the destination tablespace.
+	 */
+	o_move_latest_chkp_num(datoid, relnode, old_tablespace, new_tablespace);
+
+	oldKey.datoid = datoid;
+	oldKey.relnode = relnode;
+	oldKey.tablespace = old_tablespace;
+
+	shared = o_find_shared_root_info(&oldKey);
+	if (shared != NULL)
+	{
+		OTuple		tuple;
+		bool		ok PG_USED_FOR_ASSERTS_ONLY;
+
+		ok = o_drop_shared_root_info(datoid, relnode, old_tablespace);
+		Assert(ok);
+
+		shared->key.tablespace = new_tablespace;
+		tuple.formatFlags = 0;
+		tuple.data = (Pointer) shared;
+		ok = o_btree_autonomous_insert(get_sys_tree(SYS_TREES_SHARED_ROOT_INFO),
+									   tuple);
+		Assert(ok);
+		pfree(shared);
+		return;
+	}
+
+	evicted = read_evicted_data(datoid, relnode, old_tablespace, true);
+	if (evicted != NULL)
+	{
+		evicted->key.tablespace = new_tablespace;
+		evicted->freeBuf.tag.key.oids.spcoid = new_tablespace;
+		evicted->nextChkp.tag.key.oids.spcoid = new_tablespace;
+		evicted->tmpBuf.tag.key.oids.spcoid = new_tablespace;
+		insert_evicted_data(evicted);
+	}
+}
+
 void
 cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 {
@@ -1339,6 +1403,7 @@ cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 
 	key.datoid = ix_key.oids.datoid;
 	key.relnode = ix_key.oids.relnode;
+	key.tablespace = ix_key.oids.spcoid;
 
 	shared = o_find_shared_root_info(&key);
 
@@ -1346,7 +1411,8 @@ cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 	{
 		bool		drop_result PG_USED_FOR_ASSERTS_ONLY;
 
-		drop_result = o_drop_shared_root_info(key.datoid, key.relnode);
+		drop_result = o_drop_shared_root_info(key.datoid, key.relnode,
+											  key.tablespace);
 		Assert(drop_result);
 		if (!shared->placeholder)
 			o_btree_cleanup_pages(shared->rootInfo.rootPageBlkno,
@@ -1359,13 +1425,14 @@ cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 }
 
 bool
-o_drop_shared_root_info(Oid datoid, Oid relnode)
+o_drop_shared_root_info(Oid datoid, Oid relnode, Oid tablespace)
 {
 	SharedRootInfoKey key;
 	OTuple		key_tuple;
 
 	key.datoid = datoid;
 	key.relnode = relnode;
+	key.tablespace = tablespace;
 
 	if (drop_local_shared_root_info(&key))
 		return true;
@@ -1378,8 +1445,7 @@ o_drop_shared_root_info(Oid datoid, Oid relnode)
 }
 
 static OIndexDescr *
-get_index_descr(ORelOids ixOids, OIndexType ixType,
-				bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source)
+get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source)
 {
 	OIndexDescr *result;
 	OIndex	   *oIndex;
@@ -1392,8 +1458,19 @@ get_index_descr(ORelOids ixOids, OIndexType ixType,
 	Assert((found && result) || !found);
 
 	existed = found;
-	if (existed && (ctx.version == O_TABLE_INVALID_VERSION ||
-					result->version == ctx.version))
+
+	/*
+	 * The descriptor cache is keyed by (datoid, reloid, relnode) only, but
+	 * the tablespace (ORelOids.spcoid) is now part of the tree identity (file
+	 * location, seq_buf tags, OIndex key).  A cached descriptor built for a
+	 * different tablespace -- e.g. after ALTER DATABASE ... SET TABLESPACE
+	 * re-keyed the tree -- must be rebuilt so the caller (notably the
+	 * checkpointer) resolves the tree at the requested tablespace instead of
+	 * writing its files back into the old one.
+	 */
+	if (existed && result->desc.oids.spcoid == ixOids.spcoid &&
+		(ctx.version == O_TABLE_INVALID_VERSION ||
+		 result->version == ctx.version))
 		return result;
 
 	oIndex = o_indices_get_extended(ixOids, ixType, ctx);
@@ -1425,11 +1502,41 @@ get_index_descr(ORelOids ixOids, OIndexType ixType,
 	MemoryContextSwitchTo(mcxt);
 	index_btree_desc_init(&result->desc, result->compress, result->fillfactor,
 						  result->oids, oIndex->indexType,
-						  oIndex->table_persistence, oIndex->tablespace,
+						  oIndex->table_persistence, oIndex->indexOids.spcoid,
 						  oIndex->createOxid, result);
 	if (existed)
 		result->refcnt = refcnt;
 	free_o_index(oIndex);
+
+	return result;
+}
+
+/*
+ * Return an already-built index descriptor straight from the descriptor cache,
+ * or NULL when it is absent or was built for a different tablespace.  Unlike
+ * get_index_descr(), this NEVER reads the O_INDICES sys-tree (which would
+ * palloc a multi-kilobyte TOAST buffer) and never rebuilds the descriptor, so
+ * it is safe to call from a critical section -- e.g. the CHECK_PAGE_STATS
+ * diagnostic in unlock_check_page(), which runs while a page is locked.
+ */
+OIndexDescr *
+get_cached_index_descr(ORelOids oids)
+{
+	OIndexDescr *result;
+	bool		found;
+
+	result = hash_search(oIndexDescrHash, &oids, HASH_FIND, &found);
+	if (!found || result == NULL)
+		return NULL;
+
+	/*
+	 * The cache is keyed by (datoid, reloid, relnode); the tablespace
+	 * (spcoid) is part of the tree identity.  A descriptor cached for a
+	 * different tablespace is stale here (rebuilding it is exactly what we
+	 * must avoid), so treat it as a miss.
+	 */
+	if (result->desc.oids.spcoid != oids.spcoid)
+		return NULL;
 
 	return result;
 }
@@ -1441,7 +1548,8 @@ recreate_index_descr(OIndexDescr *descr)
 	int			refcnt;
 	MemoryContext mcxt;
 
-	oIndex = o_indices_get(descr->oids, descr->desc.type);
+	oIndex = o_indices_get(descr->oids,
+						   descr->desc.type);
 	if (!oIndex)
 	{
 		descr->valid = false;
@@ -1454,7 +1562,7 @@ recreate_index_descr(OIndexDescr *descr)
 	MemoryContextSwitchTo(mcxt);
 	index_btree_desc_init(&descr->desc, descr->compress, descr->fillfactor,
 						  descr->oids, oIndex->indexType,
-						  oIndex->table_persistence, oIndex->tablespace,
+						  oIndex->table_persistence, oIndex->indexOids.spcoid,
 						  oIndex->createOxid, descr);
 	descr->refcnt = refcnt;
 	free_o_index(oIndex);
@@ -2084,7 +2192,16 @@ o_tableam_descr_init(void)
 									 ALLOCSET_DEFAULT_SIZES);
 
 	MemSet(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(ORelOids);
+
+	/*
+	 * The descriptor caches are keyed by tree identity (datoid, reloid,
+	 * relnode) -- ORelOids.spcoid is intentionally excluded from the key so a
+	 * tree that changed tablespace keeps the same cache slot
+	 * (get_index_descr() rebuilds it in place on a spcoid mismatch).  spcoid
+	 * follows relnode in ORelOids, so offsetof(ORelOids, spcoid) covers
+	 * exactly the identity fields.
+	 */
+	ctl.keysize = offsetof(ORelOids, spcoid);
 	ctl.entrysize = sizeof(OTableDescr);
 	ctl.hcxt = descrCxt;
 	oTableDescrHash = hash_create("OrioleDB table descriptors", 8,
@@ -2092,7 +2209,7 @@ o_tableam_descr_init(void)
 								  HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
 	MemSet(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(ORelOids);
+	ctl.keysize = offsetof(ORelOids, spcoid);
 	ctl.entrysize = sizeof(OIndexDescr);
 	ctl.hcxt = descrCxt;
 	oIndexDescrHash = hash_create("OrioleDB index descriptors", 8,

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -61,8 +61,7 @@ typedef struct
 	Oid			righttype;
 } InvalidateComparatorUndoStackItem;
 
-static OIndexDescr *get_index_descr(ORelOids ixOids, OIndexType ixType,
-									bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source);
+static OIndexDescr *get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source);
 static bool o_table_descr_fill_indices(OTableDescr *descr, OTable *table, OSnapshot *snapshot);
 static void init_shared_root_info(PagePool *pool,
 								  SharedRootInfo *sharedRootInfo);
@@ -239,7 +238,7 @@ drop_local_shared_root_info(SharedRootInfoKey *key)
 }
 
 EvictedTreeData *
-read_evicted_data(Oid datoid, Oid relnode, bool delete)
+read_evicted_data(Oid datoid, Oid relnode, Oid tablespace, bool delete)
 {
 	SharedRootInfoKey key;
 	OTuple		keyTuple;
@@ -255,6 +254,7 @@ read_evicted_data(Oid datoid, Oid relnode, bool delete)
 
 	key.datoid = datoid;
 	key.relnode = relnode;
+	key.tablespace = tablespace;
 	keyTuple.formatFlags = 0;
 	keyTuple.data = (Pointer) &key;
 
@@ -385,6 +385,7 @@ o_btree_load_shmem_internal(BTreeDescr *desc, bool checkpoint)
 	memset(&key, 0, sizeof(SharedRootInfoKey));
 	key.datoid = desc->oids.datoid;
 	key.relnode = desc->oids.relnode;
+	key.tablespace = desc->oids.spcoid;
 
 	/*
 	 * evictable_tree_init() needs that.  Initialized it before we get one of
@@ -568,6 +569,7 @@ o_btree_try_use_shmem(BTreeDescr *desc)
 
 		key.datoid = desc->oids.datoid;
 		key.relnode = desc->oids.relnode;
+		key.tablespace = desc->oids.spcoid;
 
 		shared = o_find_shared_root_info(&key);
 		if (shared == NULL)
@@ -804,7 +806,7 @@ fill_table_descr_common_fields(OTableDescr *descr, OTable *o_table)
 	descr->refcnt = refcnt;
 	descr->oids = o_table->oids;
 	descr->version = o_table->version;
-	descr->tablespace = o_table->tablespace;
+	descr->oids.spcoid = o_table->oids.spcoid;
 	descr->tupdesc = o_table_tupdesc(o_table);
 	descr->oldTuple = MakeSingleTupleTableSlot(descr->tupdesc,
 											   &TTSOpsOrioleDB);
@@ -867,7 +869,7 @@ o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table)
 		index_btree_desc_init(&indexDescr->desc, indexDescr->compress,
 							  indexDescr->fillfactor, indexDescr->oids,
 							  index->indexType, index->table_persistence,
-							  index->tablespace, index->createOxid,
+							  index->indexOids.spcoid, index->createOxid,
 							  indexDescr);
 		free_o_index(index);
 		descr->indices[cur_ix] = indexDescr;
@@ -879,7 +881,7 @@ o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table)
 	index_btree_desc_init(&indexDescr->desc, indexDescr->compress,
 						  indexDescr->fillfactor, indexDescr->oids,
 						  index->indexType, index->table_persistence,
-						  index->tablespace, index->createOxid, indexDescr);
+						  index->indexOids.spcoid, index->createOxid, indexDescr);
 	free_o_index(index);
 	descr->toast = indexDescr;
 
@@ -891,7 +893,7 @@ o_fill_tmp_table_descr(OTableDescr *descr, OTable *o_table)
 		index_btree_desc_init(&indexDescr->desc, indexDescr->compress,
 							  indexDescr->fillfactor,
 							  indexDescr->oids, index->indexType,
-							  index->table_persistence, index->tablespace,
+							  index->table_persistence, index->indexOids.spcoid,
 							  index->createOxid, indexDescr);
 		free_o_index(index);
 		descr->bridge = indexDescr;
@@ -1076,7 +1078,8 @@ o_fetch_index_descr(ORelOids oids, OIndexType type, bool lock, bool *nested)
  *    descriptor mismatches during logical decoding and recovery.
  */
 OIndexDescr *
-o_fetch_index_descr_extended(ORelOids oids, OIndexType type, bool lock,
+o_fetch_index_descr_extended(ORelOids oids, OIndexType type,
+							 bool lock,
 							 OTableFetchContext ctx, OTableFetchContext base_ctx)
 {
 	OIndexDescr *index_descr = NULL;
@@ -1309,7 +1312,7 @@ o_find_shared_root_info(SharedRootInfoKey *key)
 }
 
 void
-o_insert_shared_root_placeholder(Oid datoid, Oid relnode)
+o_insert_shared_root_placeholder(Oid datoid, Oid relnode, Oid tablespace)
 {
 	OTuple		sharedRootInfoTuple;
 	SharedRootInfo sharedRootInfo = {0};
@@ -1321,6 +1324,7 @@ o_insert_shared_root_placeholder(Oid datoid, Oid relnode)
 	memset(&sharedRootInfo, 0, sizeof(sharedRootInfo));
 	sharedRootInfo.key.datoid = datoid;
 	sharedRootInfo.key.relnode = relnode;
+	sharedRootInfo.key.tablespace = tablespace;
 	sharedRootInfo.placeholder = true;
 	sharedRootInfo.rootInfo.metaPageBlkno = OInvalidInMemoryBlkno;
 	sharedRootInfo.rootInfo.rootPageBlkno = OInvalidInMemoryBlkno;
@@ -1331,6 +1335,66 @@ o_insert_shared_root_placeholder(Oid datoid, Oid relnode)
 	Assert(inserted);
 }
 
+/*
+ * Re-key a tree's in-memory checkpoint identity from old_tablespace to
+ * new_tablespace (ALTER DATABASE ... SET TABLESPACE).
+ *
+ * The tablespace is part of the SharedRootInfo / EvictedData key and of the
+ * seq_buf tags, and both are maintained autonomously (immediately visible to
+ * the checkpointer).  Unless they move with the tree, a checkpoint running
+ * before the ALTER commits would still find the tree under the source
+ * tablespace and flush its files back into the source directory after it was
+ * removed.  A tree is either resident (SharedRootInfo) or evicted
+ * (EvictedData), never both.
+ */
+void
+o_move_tree_meta(Oid datoid, Oid relnode, Oid old_tablespace,
+				 Oid new_tablespace)
+{
+	SharedRootInfoKey oldKey;
+	SharedRootInfo *shared;
+	EvictedTreeData *evicted;
+
+	/*
+	 * Move the tree's latest-checkpoint-number record so recovery finds the
+	 * moved tree's map/tmp files under the destination tablespace.
+	 */
+	o_move_latest_chkp_num(datoid, relnode, old_tablespace, new_tablespace);
+
+	oldKey.datoid = datoid;
+	oldKey.relnode = relnode;
+	oldKey.tablespace = old_tablespace;
+
+	shared = o_find_shared_root_info(&oldKey);
+	if (shared != NULL)
+	{
+		OTuple		tuple;
+		bool		ok PG_USED_FOR_ASSERTS_ONLY;
+
+		ok = o_drop_shared_root_info(datoid, relnode, old_tablespace);
+		Assert(ok);
+
+		shared->key.tablespace = new_tablespace;
+		tuple.formatFlags = 0;
+		tuple.data = (Pointer) shared;
+		ok = o_btree_autonomous_insert(get_sys_tree(SYS_TREES_SHARED_ROOT_INFO),
+									   tuple);
+		Assert(ok);
+		pfree(shared);
+		return;
+	}
+
+	evicted = read_evicted_data(datoid, relnode, old_tablespace, true);
+	if (evicted != NULL)
+	{
+		evicted->key.tablespace = new_tablespace;
+		evicted->freeBuf.tag.key.oids.spcoid = new_tablespace;
+		evicted->nextChkp.tag.key.oids.spcoid = new_tablespace;
+		evicted->tmpBuf.tag.key.oids.spcoid = new_tablespace;
+		insert_evicted_data(evicted);
+	}
+}
+
 void
 cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 {
@@ -1339,6 +1403,7 @@ cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 
 	key.datoid = ix_key.oids.datoid;
 	key.relnode = ix_key.oids.relnode;
+	key.tablespace = ix_key.oids.spcoid;
 
 	shared = o_find_shared_root_info(&key);
 
@@ -1346,7 +1411,8 @@ cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 	{
 		bool		drop_result PG_USED_FOR_ASSERTS_ONLY;
 
-		drop_result = o_drop_shared_root_info(key.datoid, key.relnode);
+		drop_result = o_drop_shared_root_info(key.datoid, key.relnode,
+											  key.tablespace);
 		Assert(drop_result);
 		if (!shared->placeholder)
 			o_btree_cleanup_pages(shared->rootInfo.rootPageBlkno,
@@ -1359,13 +1425,14 @@ cleanup_btree(OIndexKey ix_key, bool files, bool fsync)
 }
 
 bool
-o_drop_shared_root_info(Oid datoid, Oid relnode)
+o_drop_shared_root_info(Oid datoid, Oid relnode, Oid tablespace)
 {
 	SharedRootInfoKey key;
 	OTuple		key_tuple;
 
 	key.datoid = datoid;
 	key.relnode = relnode;
+	key.tablespace = tablespace;
 
 	if (drop_local_shared_root_info(&key))
 		return true;
@@ -1378,8 +1445,7 @@ o_drop_shared_root_info(Oid datoid, Oid relnode)
 }
 
 static OIndexDescr *
-get_index_descr(ORelOids ixOids, OIndexType ixType,
-				bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source)
+get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchContext ctx, void *o_table_source, OTableSource source)
 {
 	OIndexDescr *result;
 	OIndex	   *oIndex;
@@ -1392,8 +1458,19 @@ get_index_descr(ORelOids ixOids, OIndexType ixType,
 	Assert((found && result) || !found);
 
 	existed = found;
-	if (existed && (ctx.version == O_TABLE_INVALID_VERSION ||
-					result->version == ctx.version))
+
+	/*
+	 * The descriptor cache is keyed by (datoid, reloid, relnode) only, but
+	 * the tablespace (ORelOids.spcoid) is now part of the tree identity (file
+	 * location, seq_buf tags, OIndex key).  A cached descriptor built for a
+	 * different tablespace -- e.g. after ALTER DATABASE ... SET TABLESPACE
+	 * re-keyed the tree -- must be rebuilt so the caller (notably the
+	 * checkpointer) resolves the tree at the requested tablespace instead of
+	 * writing its files back into the old one.
+	 */
+	if (existed && result->desc.oids.spcoid == ixOids.spcoid &&
+		(ctx.version == O_TABLE_INVALID_VERSION ||
+		 result->version == ctx.version))
 		return result;
 
 	oIndex = o_indices_get_extended(ixOids, ixType, ctx);
@@ -1425,7 +1502,7 @@ get_index_descr(ORelOids ixOids, OIndexType ixType,
 	MemoryContextSwitchTo(mcxt);
 	index_btree_desc_init(&result->desc, result->compress, result->fillfactor,
 						  result->oids, oIndex->indexType,
-						  oIndex->table_persistence, oIndex->tablespace,
+						  oIndex->table_persistence, oIndex->indexOids.spcoid,
 						  oIndex->createOxid, result);
 	if (existed)
 		result->refcnt = refcnt;
@@ -1441,7 +1518,8 @@ recreate_index_descr(OIndexDescr *descr)
 	int			refcnt;
 	MemoryContext mcxt;
 
-	oIndex = o_indices_get(descr->oids, descr->desc.type);
+	oIndex = o_indices_get(descr->oids,
+						   descr->desc.type);
 	if (!oIndex)
 	{
 		descr->valid = false;
@@ -1454,7 +1532,7 @@ recreate_index_descr(OIndexDescr *descr)
 	MemoryContextSwitchTo(mcxt);
 	index_btree_desc_init(&descr->desc, descr->compress, descr->fillfactor,
 						  descr->oids, oIndex->indexType,
-						  oIndex->table_persistence, oIndex->tablespace,
+						  oIndex->table_persistence, oIndex->indexOids.spcoid,
 						  oIndex->createOxid, descr);
 	descr->refcnt = refcnt;
 	free_o_index(oIndex);
@@ -2084,7 +2162,16 @@ o_tableam_descr_init(void)
 									 ALLOCSET_DEFAULT_SIZES);
 
 	MemSet(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(ORelOids);
+
+	/*
+	 * The descriptor caches are keyed by tree identity (datoid, reloid,
+	 * relnode) -- ORelOids.spcoid is intentionally excluded from the key so a
+	 * tree that changed tablespace keeps the same cache slot
+	 * (get_index_descr() rebuilds it in place on a spcoid mismatch).  spcoid
+	 * follows relnode in ORelOids, so offsetof(ORelOids, spcoid) covers
+	 * exactly the identity fields.
+	 */
+	ctl.keysize = offsetof(ORelOids, spcoid);
 	ctl.entrysize = sizeof(OTableDescr);
 	ctl.hcxt = descrCxt;
 	oTableDescrHash = hash_create("OrioleDB table descriptors", 8,
@@ -2092,7 +2179,7 @@ o_tableam_descr_init(void)
 								  HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
 	MemSet(&ctl, 0, sizeof(ctl));
-	ctl.keysize = sizeof(ORelOids);
+	ctl.keysize = offsetof(ORelOids, spcoid);
 	ctl.entrysize = sizeof(OIndexDescr);
 	ctl.hcxt = descrCxt;
 	oIndexDescrHash = hash_create("OrioleDB index descriptors", 8,

--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -1670,6 +1670,7 @@ fetch_index_descr_by_oid(Oid relid)
 	tblOids.datoid = MyDatabaseId;
 	tblOids.reloid = rel->rd_rel->oid;
 	tblOids.relnode = rel->rd_rel->relfilenode;
+	tblOids.spcoid = InvalidOid;	/* looked up by reloid */
 
 	descr = o_fetch_table_descr(tblOids);
 

--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -216,12 +216,13 @@ print_unloaded_tree(StringInfoData *buf, BTreeDescr *td, const char *treeName,
 
 	memset(&prev_chkp_tag, 0, sizeof(prev_chkp_tag));
 	prev_chkp_tag.key.oids = td->oids;
-	prev_chkp_tag.key.tablespace = td->tablespace;
+	prev_chkp_tag.key.oids.spcoid = td->oids.spcoid;
 	prev_chkp_tag.num = checkpoint_state->lastCheckpointNumber;
 	prev_chkp_tag.type = 'm';
 
 	evicted_data = read_evicted_data(td->oids.datoid,
 									 td->oids.relnode,
+									 td->oids.spcoid,
 									 false);
 
 	/*
@@ -313,6 +314,7 @@ tree_structure(StringInfo buf,
 
 	key.datoid = td->oids.datoid;
 	key.relnode = td->oids.relnode;
+	key.tablespace = td->oids.spcoid;
 	sharedRootInfo = o_find_shared_root_info(&key);
 
 	if (sharedRootInfo != NULL && !sharedRootInfo->placeholder)
@@ -835,6 +837,7 @@ tree_bin_structure(StringInfo buf, OIndexDescr *id, bool print_bytes,
 
 	key.datoid = td->oids.datoid;
 	key.relnode = td->oids.relnode;
+	key.tablespace = td->oids.spcoid;
 	sharedRootInfo = o_find_shared_root_info(&key);
 
 	if (sharedRootInfo != NULL && !sharedRootInfo->placeholder)
@@ -1153,6 +1156,7 @@ orioledb_table_pages(PG_FUNCTION_ARGS)
 
 		key.datoid = td->oids.datoid;
 		key.relnode = td->oids.relnode;
+		key.tablespace = td->oids.spcoid;
 		sharedRootInfo = o_find_shared_root_info(&key);
 
 		if (sharedRootInfo == NULL || sharedRootInfo->placeholder)

--- a/src/tableam/func.c
+++ b/src/tableam/func.c
@@ -216,12 +216,13 @@ print_unloaded_tree(StringInfoData *buf, BTreeDescr *td, const char *treeName,
 
 	memset(&prev_chkp_tag, 0, sizeof(prev_chkp_tag));
 	prev_chkp_tag.key.oids = td->oids;
-	prev_chkp_tag.key.tablespace = td->tablespace;
+	prev_chkp_tag.key.oids.spcoid = td->oids.spcoid;
 	prev_chkp_tag.num = checkpoint_state->lastCheckpointNumber;
 	prev_chkp_tag.type = 'm';
 
 	evicted_data = read_evicted_data(td->oids.datoid,
 									 td->oids.relnode,
+									 td->oids.spcoid,
 									 false);
 
 	/*
@@ -313,6 +314,7 @@ tree_structure(StringInfo buf,
 
 	key.datoid = td->oids.datoid;
 	key.relnode = td->oids.relnode;
+	key.tablespace = td->oids.spcoid;
 	sharedRootInfo = o_find_shared_root_info(&key);
 
 	if (sharedRootInfo != NULL && !sharedRootInfo->placeholder)
@@ -835,6 +837,7 @@ tree_bin_structure(StringInfo buf, OIndexDescr *id, bool print_bytes,
 
 	key.datoid = td->oids.datoid;
 	key.relnode = td->oids.relnode;
+	key.tablespace = td->oids.spcoid;
 	sharedRootInfo = o_find_shared_root_info(&key);
 
 	if (sharedRootInfo != NULL && !sharedRootInfo->placeholder)
@@ -1153,6 +1156,7 @@ orioledb_table_pages(PG_FUNCTION_ARGS)
 
 		key.datoid = td->oids.datoid;
 		key.relnode = td->oids.relnode;
+		key.tablespace = td->oids.spcoid;
 		sharedRootInfo = o_find_shared_root_info(&key);
 
 		if (sharedRootInfo == NULL || sharedRootInfo->placeholder)
@@ -1666,6 +1670,7 @@ fetch_index_descr_by_oid(Oid relid)
 	tblOids.datoid = MyDatabaseId;
 	tblOids.reloid = rel->rd_rel->oid;
 	tblOids.relnode = rel->rd_rel->relfilenode;
+	tblOids.spcoid = InvalidOid;	/* looked up by reloid */
 
 	descr = o_fetch_table_descr(tblOids);
 

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -1416,6 +1416,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		tblOids.datoid = MyDatabaseId;
 		tblOids.reloid = tbl->rd_rel->oid;
 		tblOids.relnode = tbl->rd_rel->relfilenode;
+		tblOids.spcoid = InvalidOid;	/* looked up by reloid */
 
 		table_desc = o_fetch_table_descr(tblOids);
 		ixnum = find_tree_in_descr(table_desc, idxOids);

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -1355,7 +1355,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		}
 		else if (method == TABLE_SIZE)
 		{
-			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids, GET_PRIMARY(descr)->desc.tablespace))
+			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids))
 			{
 				o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
 				result += (uint64) TREE_NUM_LEAF_PAGES(&GET_PRIMARY(descr)->desc) *
@@ -1368,7 +1368,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		}
 		else if (method == TOAST_TABLE_SIZE)
 		{
-			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids, GET_PRIMARY(descr)->desc.tablespace))
+			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids))
 			{
 				o_btree_load_shmem(&descr->toast->desc);
 				result = (uint64) TREE_NUM_LEAF_PAGES(&descr->toast->desc) *
@@ -1377,7 +1377,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		}
 		else if (method == RELATION_SIZE || method == DEFAULT_SIZE)
 		{
-			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids, GET_PRIMARY(descr)->desc.tablespace))
+			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids))
 			{
 				o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
 				result = (uint64) TREE_NUM_LEAF_PAGES(&GET_PRIMARY(descr)->desc) *
@@ -1403,6 +1403,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		idxOids.datoid = MyDatabaseId;
 		idxOids.reloid = rel->rd_rel->oid;
 		idxOids.relnode = rel->rd_rel->relfilenode;
+		idxOids.spcoid = InvalidOid;	/* matched by reloid */
 
 		tbl = relation_open(rel->rd_index->indrelid, AccessShareLock);
 
@@ -1416,6 +1417,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		tblOids.datoid = MyDatabaseId;
 		tblOids.reloid = tbl->rd_rel->oid;
 		tblOids.relnode = tbl->rd_rel->relfilenode;
+		tblOids.spcoid = InvalidOid;	/* looked up by reloid */
 
 		table_desc = o_fetch_table_descr(tblOids);
 		ixnum = find_tree_in_descr(table_desc, idxOids);

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -1403,6 +1403,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		idxOids.datoid = MyDatabaseId;
 		idxOids.reloid = rel->rd_rel->oid;
 		idxOids.relnode = rel->rd_rel->relfilenode;
+		idxOids.spcoid = InvalidOid;	/* matched by reloid */
 
 		tbl = relation_open(rel->rd_index->indrelid, AccessShareLock);
 

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -1355,7 +1355,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		}
 		else if (method == TABLE_SIZE)
 		{
-			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids, GET_PRIMARY(descr)->desc.tablespace))
+			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids))
 			{
 				o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
 				result += (uint64) TREE_NUM_LEAF_PAGES(&GET_PRIMARY(descr)->desc) *
@@ -1368,7 +1368,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		}
 		else if (method == TOAST_TABLE_SIZE)
 		{
-			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids, GET_PRIMARY(descr)->desc.tablespace))
+			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids))
 			{
 				o_btree_load_shmem(&descr->toast->desc);
 				result = (uint64) TREE_NUM_LEAF_PAGES(&descr->toast->desc) *
@@ -1377,7 +1377,7 @@ orioledb_calculate_relation_size(Relation rel, ForkNumber forkNumber, uint8 meth
 		}
 		else if (method == RELATION_SIZE || method == DEFAULT_SIZE)
 		{
-			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids, GET_PRIMARY(descr)->desc.tablespace))
+			if (descr && tbl_data_exists(&GET_PRIMARY(descr)->oids))
 			{
 				o_btree_load_shmem(&GET_PRIMARY(descr)->desc);
 				result = (uint64) TREE_NUM_LEAF_PAGES(&GET_PRIMARY(descr)->desc) *

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -3046,7 +3046,7 @@ o_truncate_table(ORelOids oids, bool missingOK)
 
 	if (!invalidatedTable)
 	{
-		OIndexKey	key = {.oids = oids,.tablespace = o_table->tablespace};
+		OIndexKey	key = {.oids = oids};
 
 		cleanup_btree(key, true, !is_temp);
 		o_invalidate_oids(oids);

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -98,7 +98,7 @@ index_btree_desc_init(BTreeDescr *desc, OCompress compress, int fillfactor,
 		desc->ops = &secondaryOps;
 
 	desc->oids = oids;
-	desc->tablespace = tablespace;
+	desc->oids.spcoid = tablespace;
 	desc->arg = arg;
 	desc->compress = compress;
 	if (fillfactor >= BTREE_MIN_FILLFACTOR && fillfactor <= 100)

--- a/src/tuple/toast.c
+++ b/src/tuple/toast.c
@@ -232,6 +232,7 @@ o_detoast(struct varlena *attr)
 	oids.datoid = ote.datoid;
 	oids.reloid = ote.relid;
 	oids.relnode = ote.relnode;
+	oids.spcoid = InvalidOid;	/* looked up by reloid */
 	descr = o_fetch_table_descr(oids);
 
 	Assert(descr);

--- a/src/utils/page_pool.c
+++ b/src/utils/page_pool.c
@@ -321,6 +321,7 @@ o_ppool_free_page(PagePool *pool, OInMemoryBlkno blkno, bool haveLock)
 	page_block_reads(blkno);
 	O_PAGE_CHANGE_COUNT_INC(p);
 	ORelOidsSetInvalid(page_desc->oids);
+	page_desc->oids.spcoid = InvalidOid;
 	page_desc->type = 0;
 	page_desc->fileExtent.off = InvalidFileExtentOff;
 	page_desc->fileExtent.len = InvalidFileExtentLen;

--- a/src/utils/seq_buf.c
+++ b/src/utils/seq_buf.c
@@ -106,6 +106,7 @@ init_seq_buf(SeqBufDescPrivate *seqBufPrivate, SeqBufDescShared *shared,
 			OrioleDBPageDesc *page_desc = O_GET_IN_MEMORY_PAGEDESC(shared->pages[i]);
 
 			ORelOidsSetInvalid(page_desc->oids);
+			page_desc->oids.spcoid = InvalidOid;
 			page_desc->type = oIndexInvalid;
 		}
 
@@ -138,7 +139,7 @@ get_seq_buf_filename(SeqBufTag *tag)
 	char	   *typename;
 	char	   *db_prefix;
 
-	o_get_prefixes_for_tablespace(tag->key.oids.datoid, tag->key.tablespace,
+	o_get_prefixes_for_tablespace(tag->key.oids.datoid, tag->key.oids.spcoid,
 								  NULL, &db_prefix);
 	if (tag->type == 't')
 		typename = "tmp";
@@ -160,11 +161,13 @@ static bool
 seq_buf_tag_eq(SeqBufTag *t1, SeqBufTag *t2)
 {
 	/*
-	 * Tablespace is intentionally omitted: (datoid, relnode) already uniquely
-	 * identifies a btree regardless of which tablespace it lives in.
+	 * Tablespace is part of the identity: relfilenumber uniqueness is
+	 * enforced by PG only per-tablespace, so the same (datoid, relnode) can
+	 * name two different btrees living in different tablespaces.
 	 */
 	if (t1->key.oids.datoid == t2->key.oids.datoid &&
 		t1->key.oids.relnode == t2->key.oids.relnode &&
+		t1->key.oids.spcoid == t2->key.oids.spcoid &&
 		t1->num == t2->num &&
 		t1->type == t2->type)
 		return true;

--- a/test/expected/btree_sys_check.out
+++ b/test/expected/btree_sys_check.out
@@ -90,7 +90,7 @@ SELECT regexp_replace(
 		'g');
                            regexp_replace                            
 ---------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0               +
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
@@ -106,22 +106,22 @@ SELECT regexp_replace(
 		'g');
                                              regexp_replace                                              
 ---------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6568                                                +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6688                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                    +
      Leftmost, Rightmost                                                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ((NNN, NNN, NNN), 0, 1)            +
-     Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294)  +
-   Chunk 1: offset = 1, location = 600, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
-     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2108) +
-   Chunk 2: offset = 2, location = 2760, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 2: deleted, offset = 2768, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
-     Item 3: deleted, offset = 3104, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1201)+
-   Chunk 3: offset = 4, location = 4352, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 4: deleted, offset = 4360, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
-   Chunk 4: offset = 5, location = 4888, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 5: deleted, offset = 4896, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1395)+
-   Chunk 5: offset = 6, location = 6336, hikey location = 200                                           +
-     Item 6: deleted, offset = 6344, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
+     Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 302)  +
+   Chunk 1: offset = 1, location = 616, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
+     Item 1: deleted, offset = 624, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2132) +
+   Chunk 2: offset = 2, location = 2800, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 2: deleted, offset = 2808, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 302) +
+     Item 3: deleted, offset = 3160, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1217)+
+   Chunk 3: offset = 4, location = 4424, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 4: deleted, offset = 4432, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 496) +
+   Chunk 4: offset = 5, location = 4976, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 5: deleted, offset = 4984, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1411)+
+   Chunk 5: offset = 6, location = 6440, hikey location = 200                                           +
+     Item 6: deleted, offset = 6448, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 496) +
                                                                                                         +
  
 (1 row)
@@ -132,22 +132,21 @@ SELECT regexp_replace(
 		'\(\d+, \d+, \d+\)',
 		'(NNN, NNN, NNN)',
 		'g');
-                                        regexp_replace                                         
------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 5056                                      +
- state = free, datoid equal, relnode equal, ix_type = primary, clean                          +
-     Leftmost, Rightmost                                                                      +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 0)  +
-     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 698)                    +
-   Chunk 1: offset = 1, location = 1008, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0) +
-     Item 1: deleted, offset = 1016, tuple = ((1, (NNN, NNN, NNN), 0), 1046)                  +
-     Item 2: deleted, offset = 2112, tuple = ((1, (NNN, NNN, NNN), 0), 698)                   +
-   Chunk 2: offset = 3, location = 2856, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
-     Item 3: deleted, offset = 2864, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
-   Chunk 3: offset = 4, location = 3728, hikey location = 144                                 +
-     Item 4: deleted, offset = 3736, tuple = ((3, (NNN, NNN, NNN), 0), 698)                   +
-     Item 5: deleted, offset = 4480, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
-                                                                                              +
+                                           regexp_replace                                            
+-----------------------------------------------------------------------------------------------------
+ Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 5104                                            +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
+     Leftmost, Rightmost                                                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 1663, 0)  +
+     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 702)                    +
+   Chunk 1: offset = 1, location = 1016, hikey location = 104, hikey = (3, (NNN, NNN, NNN), 1663, 0)+
+     Item 1: deleted, offset = 1024, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 1050)                  +
+     Item 2: deleted, offset = 2128, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 702)                   +
+   Chunk 2: offset = 3, location = 2880, hikey location = 136                                       +
+     Item 3: deleted, offset = 2888, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 818)                   +
+     Item 4: deleted, offset = 3760, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 702)                   +
+     Item 5: deleted, offset = 4512, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 818)                   +
+                                                                                                    +
  
 (1 row)
 
@@ -657,7 +656,7 @@ SELECT regexp_replace(
 		'g');
                            regexp_replace                            
 ---------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0               +
  state = free, datoid equal, relnode equal, ix_type = primary, clean+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +

--- a/test/expected/btree_sys_check_1.out
+++ b/test/expected/btree_sys_check_1.out
@@ -90,7 +90,7 @@ SELECT regexp_replace(
 		'g');
                            regexp_replace                            
 ---------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0               +
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
@@ -106,22 +106,22 @@ SELECT regexp_replace(
 		'g');
                                              regexp_replace                                              
 ---------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6568                                                +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6688                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                    +
      Leftmost, Rightmost                                                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ((NNN, NNN, NNN), 0, 1)            +
-     Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294)  +
-   Chunk 1: offset = 1, location = 600, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
-     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2108) +
-   Chunk 2: offset = 2, location = 2760, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 2: deleted, offset = 2768, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
-     Item 3: deleted, offset = 3104, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1201)+
-   Chunk 3: offset = 4, location = 4352, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 4: deleted, offset = 4360, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
-   Chunk 4: offset = 5, location = 4888, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 5: deleted, offset = 4896, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1395)+
-   Chunk 5: offset = 6, location = 6336, hikey location = 200                                           +
-     Item 6: deleted, offset = 6344, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
+     Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 302)  +
+   Chunk 1: offset = 1, location = 616, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
+     Item 1: deleted, offset = 624, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2132) +
+   Chunk 2: offset = 2, location = 2800, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 2: deleted, offset = 2808, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 302) +
+     Item 3: deleted, offset = 3160, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1217)+
+   Chunk 3: offset = 4, location = 4424, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 4: deleted, offset = 4432, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 496) +
+   Chunk 4: offset = 5, location = 4976, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 5: deleted, offset = 4984, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1411)+
+   Chunk 5: offset = 6, location = 6440, hikey location = 200                                           +
+     Item 6: deleted, offset = 6448, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 496) +
                                                                                                         +
  
 (1 row)
@@ -132,22 +132,21 @@ SELECT regexp_replace(
 		'\(\d+, \d+, \d+\)',
 		'(NNN, NNN, NNN)',
 		'g');
-                                        regexp_replace                                         
------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 5056                                      +
- state = free, datoid equal, relnode equal, ix_type = primary, clean                          +
-     Leftmost, Rightmost                                                                      +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 0)  +
-     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 698)                    +
-   Chunk 1: offset = 1, location = 1008, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0) +
-     Item 1: deleted, offset = 1016, tuple = ((1, (NNN, NNN, NNN), 0), 1046)                  +
-     Item 2: deleted, offset = 2112, tuple = ((1, (NNN, NNN, NNN), 0), 698)                   +
-   Chunk 2: offset = 3, location = 2856, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
-     Item 3: deleted, offset = 2864, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
-   Chunk 3: offset = 4, location = 3728, hikey location = 144                                 +
-     Item 4: deleted, offset = 3736, tuple = ((3, (NNN, NNN, NNN), 0), 698)                   +
-     Item 5: deleted, offset = 4480, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
-                                                                                              +
+                                           regexp_replace                                            
+-----------------------------------------------------------------------------------------------------
+ Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 5104                                            +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
+     Leftmost, Rightmost                                                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 1663, 0)  +
+     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 702)                    +
+   Chunk 1: offset = 1, location = 1016, hikey location = 104, hikey = (3, (NNN, NNN, NNN), 1663, 0)+
+     Item 1: deleted, offset = 1024, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 1050)                  +
+     Item 2: deleted, offset = 2128, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 702)                   +
+   Chunk 2: offset = 3, location = 2880, hikey location = 136                                       +
+     Item 3: deleted, offset = 2888, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 818)                   +
+     Item 4: deleted, offset = 3760, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 702)                   +
+     Item 5: deleted, offset = 4512, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 818)                   +
+                                                                                                    +
  
 (1 row)
 
@@ -656,7 +655,7 @@ SELECT regexp_replace(
 		'g');
                            regexp_replace                            
 ---------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0               +
  state = free, datoid equal, relnode equal, ix_type = primary, clean+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +

--- a/test/expected/btree_sys_check_2.out
+++ b/test/expected/btree_sys_check_2.out
@@ -90,7 +90,7 @@ SELECT regexp_replace(
 		'g');
                            regexp_replace                            
 ---------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0               +
  state = free, datoid equal, relnode equal, ix_type = primary, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
@@ -106,22 +106,22 @@ SELECT regexp_replace(
 		'g');
                                              regexp_replace                                              
 ---------------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6568                                                +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 6688                                                +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                    +
      Leftmost, Rightmost                                                                                +
    Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ((NNN, NNN, NNN), 0, 1)            +
-     Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294)  +
-   Chunk 1: offset = 1, location = 600, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
-     Item 1: deleted, offset = 608, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2108) +
-   Chunk 2: offset = 2, location = 2760, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 2: deleted, offset = 2768, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 294) +
-     Item 3: deleted, offset = 3104, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1201)+
-   Chunk 3: offset = 4, location = 4352, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 4: deleted, offset = 4360, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 488) +
-   Chunk 4: offset = 5, location = 4888, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
-     Item 5: deleted, offset = 4896, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1395)+
-   Chunk 5: offset = 6, location = 6336, hikey location = 200                                           +
-     Item 6: deleted, offset = 6344, tuple = (((NNN, NNN, NNN), chunknum 0, version 2), dataLength 488) +
+     Item 0: deleted, offset = 264, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 302)  +
+   Chunk 1: offset = 1, location = 616, hikey location = 104, hikey = ((NNN, NNN, NNN), 0, 0)           +
+     Item 1: deleted, offset = 624, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 2132) +
+   Chunk 2: offset = 2, location = 2800, hikey location = 128, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 2: deleted, offset = 2808, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 302) +
+     Item 3: deleted, offset = 3160, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1217)+
+   Chunk 3: offset = 4, location = 4424, hikey location = 152, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 4: deleted, offset = 4432, tuple = (((NNN, NNN, NNN), chunknum 0, version 1), dataLength 496) +
+   Chunk 4: offset = 5, location = 4976, hikey location = 176, hikey = ((NNN, NNN, NNN), 0, 0)          +
+     Item 5: deleted, offset = 4984, tuple = (((NNN, NNN, NNN), chunknum 0, version 0), dataLength 1411)+
+   Chunk 5: offset = 6, location = 6440, hikey location = 200                                           +
+     Item 6: deleted, offset = 6448, tuple = (((NNN, NNN, NNN), chunknum 0, version 2), dataLength 496) +
                                                                                                         +
  
 (1 row)
@@ -132,22 +132,21 @@ SELECT regexp_replace(
 		'\(\d+, \d+, \d+\)',
 		'(NNN, NNN, NNN)',
 		'g');
-                                        regexp_replace                                         
------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 5056                                      +
- state = free, datoid equal, relnode equal, ix_type = primary, clean                          +
-     Leftmost, Rightmost                                                                      +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 0)  +
-     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 0), 698)                    +
-   Chunk 1: offset = 1, location = 1008, hikey location = 96, hikey = (3, (NNN, NNN, NNN), 0) +
-     Item 1: deleted, offset = 1016, tuple = ((1, (NNN, NNN, NNN), 0), 1046)                  +
-     Item 2: deleted, offset = 2112, tuple = ((1, (NNN, NNN, NNN), 0), 698)                   +
-   Chunk 2: offset = 3, location = 2856, hikey location = 120, hikey = (3, (NNN, NNN, NNN), 0)+
-     Item 3: deleted, offset = 2864, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
-   Chunk 3: offset = 4, location = 3728, hikey location = 144                                 +
-     Item 4: deleted, offset = 3736, tuple = ((3, (NNN, NNN, NNN), 0), 698)                   +
-     Item 5: deleted, offset = 4480, tuple = ((3, (NNN, NNN, NNN), 0), 814)                   +
-                                                                                              +
+                                           regexp_replace                                            
+-----------------------------------------------------------------------------------------------------
+ Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 5104                                            +
+ state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
+     Leftmost, Rightmost                                                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 1663, 0)  +
+     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 702)                    +
+   Chunk 1: offset = 1, location = 1016, hikey location = 104, hikey = (3, (NNN, NNN, NNN), 1663, 0)+
+     Item 1: deleted, offset = 1024, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 1050)                  +
+     Item 2: deleted, offset = 2128, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 702)                   +
+   Chunk 2: offset = 3, location = 2880, hikey location = 136                                       +
+     Item 3: deleted, offset = 2888, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 818)                   +
+     Item 4: deleted, offset = 3760, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 702)                   +
+     Item 5: deleted, offset = 4512, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 818)                   +
+                                                                                                    +
  
 (1 row)
 
@@ -652,7 +651,7 @@ SELECT regexp_replace(
 		'g');
                            regexp_replace                            
 ---------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0               +
  state = free, datoid equal, relnode equal, ix_type = primary, clean+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +


### PR DESCRIPTION
Two commits.

## 1. Add tablespace to tree identity via `ORelOids.spcoid`

OrioleDB keys a btree's on-disk identity by relfilenumber, but PostgreSQL only guarantees relfilenumber uniqueness **per-tablespace**. Two trees sharing a `(datoid, relnode)` in different tablespaces collided in the tree-identity layer (`SharedRootInfo` / seq_bufs / checkpoint files), corrupting the map/tmp checkpoint bookkeeping.

Tablespace becomes part of the tree identity as a new `ORelOids` field, `spcoid`, rather than a parallel `Oid tablespace` argument/field threaded next to every `ORelOids`:

- `ORelOidsSetFromRel()` resolves it (`InvalidOid → MyDatabaseTableSpace`); `ORelOidsSetInvalid()` clears it.
- `ORelOidsIsEqual()` still compares only `(datoid, reloid, relnode)` — reloid is already unique per relation, so that triple never suffers the collision. `spcoid` matters only for the reloid-omitting keys (sys trees, seq_buf), which compare it explicitly.
- Woven into the identity keys/comparators (`OIndexChunkKey`, `SharedRootInfoKey`, `o_index_chunk_cmp`, seq_buf tags, checkpoint tree ordering), undo/WAL records, and recovery/logical replay — all by carrying it inside `ORelOids.spcoid`, so struct-copy paths (undo items, recovery queue, page descriptors) propagate it for free.
- `ALTER DATABASE ... SET TABLESPACE` re-keys the moved trees' OIndex chunk, checkpoint-number record, and resident/evicted checkpoint metadata to the destination tablespace.
- Descriptor caches key on tree identity `(datoid, reloid, relnode)` only — `spcoid` is excluded from the hash key so a tree that changed tablespace keeps its cache slot and `get_index_descr()` rebuilds it in place, instead of leaking a duplicate descriptor.

Bumps `ORIOLEDB_BINARY_VERSION` (11), `ORIOLEDB_SYS_TREE_VERSION` (2), `ORIOLEDB_WAL_VERSION` (18); regenerates `btree_sys_check` expected output.

## 2. Reserve bridge-index relnode against relfilenumber reuse (SEQBUF_BADPAGE)

The bridge index self-assigns its relfilenumber via `GetNewRelFileNumber()` and has no pg_class row; that function's uniqueness probe is blind to trees kept in `orioledb_data/`, so on OID-counter regression PG can hand the same relnode to another relation in the same tablespace — the SEQBUF_BADPAGE `nextChkp` double-finalize. `o_bridge_new_relnode()` now creates a standard-path marker file so the probe sees the relnode; `o_bridge_drop_relnode_marker()` removes it once the bridge is durably dropped (from `btree_relnode_undo_callback`, recovery-safe via the undo item's `(datoid, spcoid, relnode)`). The marker is created only at the two sites where `bridge_oids` is durable.

## Testing

regress 48/48, isolation 32/32, testgres tablespace+recovery 57/57, index_bridging 4/4 (incl. `test_bridge_recovery`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)