### PR TITLE
[ORI-215] fix OIndexDescr panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/reindex_test.py \
 						test/t/s3_test.py \
 						test/t/schema_test.py \
+						test/t/seq_scan_resowner_test.py \
 						test/t/seq_scan_undo_test.py \
 						test/t/temp_local_pool_test.py \
 						test/t/toast_index_test.py \

--- a/include/btree/iterator.h
+++ b/include/btree/iterator.h
@@ -91,6 +91,7 @@ extern OTuple btree_iterate_all(BTreeIterator *it, void *end,
 								bool *scanEnd, BTreeLocationHint *hint,
 								BTreeLeafTuphdr **tupHdr);
 extern void btree_iterator_free(BTreeIterator *it);
+extern void btree_iterator_free_extended(BTreeIterator *it, bool fromResowner);
 
 extern OTuple o_btree_find_tuple_by_key_cb(BTreeDescr *desc, void *key,
 										   BTreeKeyType kind,

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -55,6 +55,15 @@ struct BTreeIterator
 {
 	OBTreeFindPageContext context;
 	OIndexDescr *oidescr;
+
+	/*
+     * Mirrors BTreeSeqScan.resowner
+     * Ensures scan cleanup on transaction abort or resource owner release.
+     * Iterator can be freed during transaction abort cleanup after
+     * CurrentResourceOwner is already pointing to
+     * TopTransactionResourceOwner, so we have to track it here.
+     */
+	ResourceOwner resowner;
 	OSnapshot	oSnapshot;
 	UndoIterator undoIt;
 	/* scan direction of current iterator: forward or backward */
@@ -317,9 +326,13 @@ o_btree_find_tuples_start(BTreeDescr *desc, void *key,
 	{
 		it->oidescr = (OIndexDescr *) desc->arg;
 		ResourceOwnerRememberOIndexDescr(CurrentResourceOwner, it->oidescr);
+		it->resowner = CurrentResourceOwner;
 	}
 	else
+	{
 		it->oidescr = NULL;
+		it->resowner = NULL;
+	}
 
 	it->combinedResult = have_current_undo(desc->undoType) && COMMITSEQNO_IS_NORMAL(read_o_snapshot->csn);
 	it->oSnapshot = *read_o_snapshot;
@@ -937,9 +950,13 @@ o_btree_iterator_create(BTreeDescr *desc, void *key, BTreeKeyType kind,
 	{
 		it->oidescr = (OIndexDescr *) desc->arg;
 		ResourceOwnerRememberOIndexDescr(CurrentResourceOwner, it->oidescr);
+		it->resowner = CurrentResourceOwner;
 	}
 	else
+	{
 		it->oidescr = NULL;
+		it->resowner = NULL;
+	}
 
 	it->combinedResult = have_current_undo(desc->undoType) && COMMITSEQNO_IS_NORMAL(o_snapshot->csn);
 	it->oSnapshot = *o_snapshot;
@@ -1340,13 +1357,35 @@ o_btree_iterator_fetch(BTreeIterator *it, CommitSeqNo *tupleCsn,
 
 /*
  * Free resouces associated with iterator.
+ *
+ * fromResowner is true when we are called (perhaps indirectly) from the
+ * release callback of the ResourceOwner that is being released.
  */
+void
+btree_iterator_free_extended(BTreeIterator *it, bool fromResowner)
+{
+	if (it->oidescr)
+	{
+		/*
+		 * It is unsafe to forget when called from a ResrouceOwner
+		 * release callback for the pinning owner.  We can only safely
+		 * forget when we are either:
+		 * - not invoked from a release callback
+		 * - not already in "releasing" state
+		 * NB There is no public interface for ResourceOwner "releasing" state
+		 * it->resowner == CurrentResourceOwner is set during the walk and
+		 * is the only signal we can use here
+		 */
+		if (!(fromResowner && it->resowner == CurrentResourceOwner))
+			ResourceOwnerForgetOIndexDescr(it->resowner, it->oidescr);
+	}
+	pfree(it);
+}
+
 void
 btree_iterator_free(BTreeIterator *it)
 {
-	if (it->oidescr)
-		ResourceOwnerForgetOIndexDescr(CurrentResourceOwner, it->oidescr);
-	pfree(it);
+	btree_iterator_free_extended(it, false);
 }
 
 /*

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -25,6 +25,7 @@
 #include "tableam/key_range.h"
 #include "transam/oxid.h"
 #include "transam/undo.h"
+#include "utils/antithesis.h"
 #include "utils/page_pool.h"
 #include "utils/stopevent.h"
 
@@ -57,12 +58,11 @@ struct BTreeIterator
 	OIndexDescr *oidescr;
 
 	/*
-     * Mirrors BTreeSeqScan.resowner
-     * Ensures scan cleanup on transaction abort or resource owner release.
-     * Iterator can be freed during transaction abort cleanup after
-     * CurrentResourceOwner is already pointing to
-     * TopTransactionResourceOwner, so we have to track it here.
-     */
+	 * Mirrors BTreeSeqScan.resowner Ensures scan cleanup on transaction abort
+	 * or resource owner release. Iterator can be freed during transaction
+	 * abort cleanup after CurrentResourceOwner is already pointing to
+	 * TopTransactionResourceOwner, so we have to track it here.
+	 */
 	ResourceOwner resowner;
 	OSnapshot	oSnapshot;
 	UndoIterator undoIt;
@@ -1366,15 +1366,26 @@ btree_iterator_free_extended(BTreeIterator *it, bool fromResowner)
 {
 	if (it->oidescr)
 	{
+		ANTITHESIS_ALWAYS(it->resowner != NULL,
+						  "BTreeIterator knows the ResourceOwner that pinned its OIndexDescr",
+						  NULL);
+
 		/*
-		 * It is unsafe to forget when called from a ResrouceOwner
-		 * release callback for the pinning owner.  We can only safely
-		 * forget when we are either:
-		 * - not invoked from a release callback
-		 * - not already in "releasing" state
-		 * NB There is no public interface for ResourceOwner "releasing" state
-		 * it->resowner == CurrentResourceOwner is set during the walk and
-		 * is the only signal we can use here
+		 * Durring transaction abort, cleanup sets CurrentResourceOwner to
+		 * TopTransactionResourceOwner before the iterator is freed. Always
+		 * using CurrentResourceOwner used to PANIC
+		 */
+		ANTITHESIS_SOMETIMES(it->resowner != CurrentResourceOwner,
+							 "BTreeIterator is freed while a ResourceOwner other than the pinning one is current",
+							 NULL);
+
+		/*
+		 * It is unsafe to forget when called from a ResrouceOwner release
+		 * callback for the pinning owner.  We can only safely forget when we
+		 * are either: - not invoked from a release callback - not already in
+		 * "releasing" state NB There is no public interface for ResourceOwner
+		 * "releasing" state it->resowner == CurrentResourceOwner is set
+		 * during the walk and is the only signal we can use here
 		 */
 		if (!(fromResowner && it->resowner == CurrentResourceOwner))
 			ResourceOwnerForgetOIndexDescr(it->resowner, it->oidescr);

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -2479,7 +2479,11 @@ free_btree_seq_scan_internal(BTreeSeqScan *scan, bool fromResowner)
 
 	if (scan->iter)
 	{
-		btree_iterator_free(scan->iter);
+		/*
+		 * Pass fromResowner down: like the dsm_detach above, the iterator must
+		 * not touch the ResourceOwner currently being released.
+		 */
+		btree_iterator_free_extended(scan->iter, fromResowner);
 		scan->iter = NULL;
 	}
 
@@ -2490,7 +2494,10 @@ free_btree_seq_scan_internal(BTreeSeqScan *scan, bool fromResowner)
 	}
 
 	if (!IS_SYS_TREE_OIDS(desc->oids))
-		((OIndexDescr *) desc->arg)->refcnt--;
+	{
+		OIndexDescr *indexDescr = (OIndexDescr *) desc->arg;
+		indexDescr->refcnt--;
+	}
 	scan->status = BTreeSeqScanFinished;
 
 	if (!fromResowner)

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -57,6 +57,7 @@
 #include "transam/oxid.h"
 #include "tableam/descr.h"
 #include "tuple/slot.h"
+#include "utils/antithesis.h"
 #include "utils/page_pool.h"
 #include "utils/resowner.h"
 #include "utils/sampling.h"
@@ -2487,11 +2488,19 @@ free_btree_seq_scan_internal(BTreeSeqScan *scan, bool fromResowner)
 		scan->dsmSeg = NULL;
 	}
 
+	/*
+	 * A sequential scan only holds an iterator in fallback mode
+	 * (scan_make_iterator())
+	 */
+	ANTITHESIS_SOMETIMES(scan->iter != NULL,
+						 "sequential scan is released while a fallback iterator is attached",
+						 NULL);
+
 	if (scan->iter)
 	{
 		/*
-		 * Pass fromResowner down: like the dsm_detach above, the iterator must
-		 * not touch the ResourceOwner currently being released.
+		 * Pass fromResowner down: like the dsm_detach above, the iterator
+		 * must not touch the ResourceOwner currently being released.
 		 */
 		btree_iterator_free_extended(scan->iter, fromResowner);
 		scan->iter = NULL;
@@ -2506,6 +2515,14 @@ free_btree_seq_scan_internal(BTreeSeqScan *scan, bool fromResowner)
 	if (!IS_SYS_TREE_OIDS(desc->oids))
 	{
 		OIndexDescr *indexDescr = (OIndexDescr *) desc->arg;
+
+		/*
+		 * The scan's own pin, taken in make_btree_seq_scan_internal(). A zero
+		 * refcnt here would mean some pin was dropped twice.
+		 */
+		ANTITHESIS_ALWAYS(indexDescr->refcnt > 0,
+						  "OIndexDescr refcnt is positive when a sequential scan drops its reference",
+						  NULL);
 		indexDescr->refcnt--;
 	}
 	scan->status = BTreeSeqScanFinished;

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -838,7 +838,15 @@ scan_make_iterator(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRangeHigh)
 {
 	MemoryContext mctx;
 
-	mctx = MemoryContextSwitchTo(scan->mctx);
+	/*
+	 * The iterator has to live as long as the scan does, so it goes into the
+	 * scan's own context rather than the executor's: on abort
+	 * AtAbort_Portals() deletes the portal's memory (scan->mctx included)
+	 * before undo_xact_callback() runs seq_scans_cleanup(), which would then
+	 * work through a freed iterator.  Tuples still come from the executor's
+	 * context, where the scan's caller expects them.
+	 */
+	mctx = MemoryContextSwitchTo(btree_seqscan_context);
 	if (!O_TUPLE_IS_NULL(keyRangeLow))
 	{
 		/*
@@ -856,6 +864,7 @@ scan_make_iterator(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRangeHigh)
 		scan->iter = o_btree_iterator_create(scan->desc, NULL, BTreeKeyNone,
 											 &scan->oSnapshot, ForwardScanDirection);
 	MemoryContextSwitchTo(mctx);
+	o_btree_iterator_set_tuple_ctx(scan->iter, scan->mctx);
 
 	BTREE_PAGE_LOCATOR_SET_INVALID(&scan->leafLoc);
 	scan->haveHistImg = false;
@@ -1538,6 +1547,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 				}
 				else
 				{
+					elog(DEBUG3, "scan_make_iterator 3");
 					scan_make_iterator(scan, scan->keyRangeLow.tuple, scan->keyRangeHigh.tuple);
 					Assert(scan->iter);
 					return true;

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -32,6 +32,7 @@
 #include "tableam/tree.h"
 #include "tuple/slot.h"
 #include "transam/undo.h"
+#include "utils/antithesis.h"
 #include "utils/page_pool.h"
 #include "utils/stopevent.h"
 
@@ -2662,6 +2663,9 @@ void
 ResourceOwnerForgetOIndexDescr(ResourceOwner owner, OIndexDescr *descr)
 {
 	ResourceOwnerForget(owner, PointerGetDatum(descr), &o_index_descr_resowner_desc);
+	ANTITHESIS_ALWAYS(descr->refcnt > 0,
+					  "OIndexDescr refcnt is positive when a ResourceOwner pin is forgotten",
+					  NULL);
 	descr->refcnt--;
 }
 
@@ -2670,6 +2674,14 @@ ResOwnerReleaseOIndexDescr(Datum res)
 {
 	OIndexDescr *descr = (OIndexDescr *) DatumGetPointer(res);
 
+	/*
+	 * Runs for a pin that was still remembered when its owner was released,
+	 * e.g. the descr of an iterator freed by this release, which The pin must
+	 * be dropped exactly once.
+	 */
+	ANTITHESIS_ALWAYS(descr->refcnt > 0,
+					  "OIndexDescr refcnt is positive when a ResourceOwner pin is released",
+					  NULL);
 	descr->refcnt--;
 }
 
@@ -2712,6 +2724,15 @@ ResOwnerReleaseOIndexDescrCallback(ResourceReleasePhase phase,
 		if (item->owner == CurrentResourceOwner)
 		{
 			*prev = item->next;
+
+			/*
+			 * Runs for a pin that was still remembered when its owner was
+			 * released, e.g. the descr of an iterator freed by this release,
+			 * which The pin must be dropped exactly once.
+			 */
+			ANTITHESIS_ALWAYS(item->descr->refcnt > 0,
+							  "OIndexDescr refcnt is positive when a ResourceOwner pin is released",
+							  NULL);
 			item->descr->refcnt--;
 			pfree(item);
 			item = *prev;
@@ -2755,6 +2776,9 @@ ResourceOwnerForgetOIndexDescr(ResourceOwner owner, OIndexDescr *descr)
 		{
 			*prev = item->next;
 			pfree(item);
+			ANTITHESIS_ALWAYS(descr->refcnt > 0,
+							  "OIndexDescr refcnt is positive when a ResourceOwner pin is forgotten",
+							  NULL);
 			descr->refcnt--;
 			return;
 		}

--- a/test/t/seq_scan_resowner_test.py
+++ b/test/t/seq_scan_resowner_test.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import unittest
+
+from testgres.connection import DatabaseError
+from testgres.enums import NodeStatus
+
+from .base_test import BaseTest
+
+
+class SeqScanResownerTest(BaseTest):
+	"""
+    Tests setup some edge cases for seq scan and transaction aborts and
+    asserts they are handled cleanly.
+
+	A sequential scan falling back to iterator mode (scan_make_iterator())
+	pins the index descriptor on the ResourceOwner that is current while the
+	iterator is built. Only the owner should ever drop the pin.
+
+	  * on transaction abort the scans are cleaned up from undo_xact_callback()
+	    after AtAbort_ResourceOwner() has already switched CurrentResourceOwner
+	    to TopTransactionResourceOwner. Dropping the pin with
+        CurrentResourceOwner raises an error
+	    "OrioleDB OIndexDescr...is not owned by resource owner TopTransaction"
+
+	  * on subtransaction abort the scan is released by the pinning owner's own
+	    release callback instead, where a forget is rejected
+
+	Both errors are raised inside the critical section of
+	free_btree_seq_scan_internal(), which promotes them to PANIC.
+	"""
+
+	N = 4000
+	BOOM_ID = 500
+
+	def setUp(self):
+		super().setUp()
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "shared_preload_libraries = orioledb\n"
+		    "orioledb.main_buffers = 8MB\n"
+		    "orioledb.debug_disable_pools_limit = true\n"
+		    "orioledb.debug_disable_bgwriter = true\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		node.safe_psql("""
+			CREATE TABLE o_scan_resowner (
+				id int PRIMARY KEY,
+				payload text
+			) USING orioledb;
+
+			INSERT INTO o_scan_resowner
+				SELECT g, repeat('x', 100) FROM generate_series(1, %d) g;
+
+			CREATE FUNCTION scan_probe(id int) RETURNS int AS $$
+			BEGIN
+				IF id = 1 THEN
+					-- The scan already holds its image of the internal page:
+					-- evicting the leaves invalidates every downlink it is
+					-- about to follow, so the remaining leaves are read
+					-- through fallback iterators.
+					PERFORM orioledb_evict_pages('o_scan_resowner'::regclass, 0);
+				ELSIF id = %d THEN
+					RAISE EXCEPTION 'boom';
+				END IF;
+				RETURN id;
+			END $$ LANGUAGE plpgsql;
+		""" % (self.N, self.BOOM_ID))
+
+	def _log(self):
+		with open(self.node.pg_log_file, errors='replace') as f:
+			return f.read()
+
+	def assertScanFellBackToIterator(self):
+		self.assertIn('scan_make_iterator', self._log(),
+		              "the sequential scan never fell back to an iterator")
+
+	def assertNoPanic(self):
+		self.assertEqual(self.node.status(), NodeStatus.Running,
+		                 "the backend did not survive the cleanup")
+		log = self._log()
+		for mark in ('PANIC', 'is not owned by resource owner',
+		             'after release started'):
+			self.assertNotIn(mark, log)
+
+	def test_xact_abort_with_fallback_iterator(self):
+		"""Transaction abort for seq scan with fallback iterator."""
+		with self.node.connect() as con:
+			con.execute("SET log_min_messages = 'debug3';")
+			with self.assertRaises(DatabaseError):
+				con.execute("""
+					DO $$
+					BEGIN
+						PERFORM scan_probe(id) FROM o_scan_resowner;
+					END $$;
+				""")
+			con.rollback()
+			self.assertEqual(
+			    con.execute("SELECT count(*) FROM o_scan_resowner;"),
+			    [(self.N, )])
+		self.assertScanFellBackToIterator()
+		self.assertNoPanic()
+
+	def test_plain_statement_abort_with_fallback_iterator(self):
+		"""
+        Transaction abort for seq scan with fallback iterator
+        while the scan is running.
+		"""
+		with self.node.connect() as con:
+			con.execute("SET log_min_messages = 'debug3';")
+			with self.assertRaises(DatabaseError):
+				con.execute("SELECT scan_probe(id) FROM o_scan_resowner;")
+			con.rollback()
+			self.assertEqual(
+			    con.execute("SELECT count(*) FROM o_scan_resowner;"),
+			    [(self.N, )])
+		self.assertScanFellBackToIterator()
+		self.assertNoPanic()
+
+	def test_subxact_abort_with_fallback_iterator(self):
+		"""
+		Subtransaction abort for a seq scan with fallback iterator: the
+		scan must ONLY be freed by the release callback of the owner
+        that pinned the descriptor.
+		"""
+		with self.node.connect() as con:
+			con.execute("SET log_min_messages = 'debug3';")
+			con.execute("""
+				DO $$
+				BEGIN
+					BEGIN
+						PERFORM scan_probe(id) FROM o_scan_resowner;
+					EXCEPTION WHEN others THEN
+						RAISE NOTICE 'boom caught';
+					END;
+				END $$;
+			""")
+			self.assertEqual(
+			    con.execute("SELECT count(*) FROM o_scan_resowner;"),
+			    [(self.N, )])
+			con.commit()
+		self.assertScanFellBackToIterator()
+		self.assertNoPanic()
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
# description

We are consistently seeing `SIGABRT` crashes on postgres processes in the Antithesis simulator in multiple workloads - [Jepsen](https://github.com/orioledb/orioledb/tree/pmbauer/add-initial-antithesis-workload/test/antithesis/jepsen) and [sk-recovery-race-chaos](https://github.com/orioledb/orioledb/tree/pmbauer/add-initial-antithesis-workload/test/antithesis/sk-recovery-race-chaos).

```
[        71.656] [            orioledb] [err] 2026-07-27 12:30:26.792 GMT [84] LOG:  orioledb bgwriter 0 is shut down
[        71.658] [            orioledb] [err] 2026-07-27 12:30:26.795 GMT [97] PANIC:  OrioleDB OIndexDescr 0x559880404ad0 is not owned by resource owner TopTransaction
[        71.659] [processes_terminated_with_signal] [inf] { "executable": "postgres", "signal": 6, "pid": 1916 }
```

# Cause

A sequential scan falling back to iterator mode (scan_make_iterator()) pins the index descriptor on the `ResourceOwner` that is current while the iterator is built. But only the owner should ever drop the pin.

There are some edge cases during transaction abort where the owner was forgotten.

* on transaction abort the scans are cleaned up from undo_xact_callback() after AtAbort_ResourceOwner() has already switched `CurrentResourceOwner` to `TopTransactionResourceOwner`. Asking postgres to drop the pin with `CurrentResourceOwner` as the iterator owner is an error.
* on subtransaction abort the scan is released by the pinning owner's own release callback instead; we have to be careful to not invoke forget as that will be rejected in that case too (see comments).
* Both errors are raised inside the critical section of `free_btree_seq_scan_internal()`, which promotes them to PANIC.

# triage process

The [Antithesis MVD debugger](https://supabase.antithesis.com/report/H6PBGP2i1Rx8jfQzn5Dwe_l5/8yLMrSx1sGcvAXysCvItz743a8eedOWdCGpFpGNgZsg.html?auth=v2.public.eyJuYmYiOiIyMDI2LTA3LTMxVDE0OjEwOjAyLjk0ODMwODY3N1oiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiOHlMTXJTeDFzR2N2QVh5c0N2SXR6NzQzYThlZWRPV2RDR3BGcEdOZ1pzZy5odG1sIiwicmVwb3J0X2lkIjoiSDZQQkdQMmkxUng4amZRem41RHdlX2w1In19fU4wimYUnwj3Rvldhc8QCFUsQdkF4Dh2gpU1ih_7pjwv-wGVmCdNvnCcbfUEmoFwGsxlehQyoC90AVBTtb97hAY) was key in discovering root cause.
With a debugging session launched at the point of the panic, we could rewind time, attach gbd, and extract a backtrace.

A subsequent Claude session and source examination helped explain the following:

```
[        28.281] [Thread debugging using libthread_db enabled]
[        28.281] Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[        28.357] 0x00007f7a2a06fa7a in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, req=0x7ffd1a45e088, rem=0x7ffd1a45e088) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
[        28.357] 
[        28.357] warning: 78	../sysdeps/unix/sysv/linux/clock_nanosleep.c: No such file or directory
[        28.383] Make breakpoint pending on future shared library load? (y or [n]) [answered N; input not from terminal]
[        28.393] Program received signal SIGABRT, Aborted.
[        28.393] __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
[        28.393] warning: 44	./nptl/pthread_kill.c: No such file or directory
[        28.418] 
[        28.418] Thread 1 (Thread 0x7f7a27f32740 (LWP 331) "postgres"):
[        28.418] #0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
[        28.418]         tid = <optimized out>
[        28.418]         ret = 0
[...]
[        28.418]         __private = <optimized out>
[        28.418]         __oldval = <optimized out>
[        28.418] #1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
[        28.418] No locals.
[        28.418] #2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
[        28.418] No locals.
[        28.418] #3  0x00007f7a29fc827e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
[        28.418]         ret = <optimized out>
[        28.418] #4  0x00007f7a29fab8ff in __GI_abort () at ./stdlib/abort.c:79
[        28.418]         save_stage = 1
[        28.418]         act = {__sigaction_handler = {sa_handler = 0x20, sa_sigaction = 0x20}, sa_mask = {__val = {0, 0, 0, 2314885530818453536, 2314885530818453536, 2314885530818453536, 2314885530818453536, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, sa_flags = 0, sa_restorer = 0x0}
[        28.418] #5  0x00005625d533d341 in errfinish (filename=<optimized out>, lineno=<optimized out>, funcname=0x5625d546a6df "ResourceOwnerForget") at elog.c:603
[        28.418]         edata = 0x5625d56f4908 <errordata+184>
[        28.418]         elevel = 23
[        28.418]         oldcontext = 0x5625d5966db0
[        28.418]         econtext = 0x0
[        28.418] #6  0x00005625d5373176 in ResourceOwnerForget (owner=<optimized out>, value=<optimized out>, kind=<optimized out>) at resowner.c:572
[        28.418] No locals.
[        28.418] #7  0x00007f7a27babdd8 in ResourceOwnerForgetOIndexDescr (owner=0x5625d5918598, descr=0x5625d58cf5d0) at src/tableam/descr.c:2644
[        28.418] No locals.
[        28.418] #8  0x00007f7a27b003fd in btree_iterator_free (it=0x5625d5a1ac58) at src/btree/iterator.c:1320
[        28.418] No locals.
[        28.418] #9  0x00007f7a27b19dae in free_btree_seq_scan_internal (scan=0x5625d5a297a8, fromResowner=false) at src/btree/scan.c:2441
[        28.418]         desc = 0x5625d58cf5f8
[        28.418] #10 0x00007f7a27b19f93 in seq_scans_cleanup () at src/btree/scan.c:2483
[        28.418]         scan = 0x5625d5a297a8
[        28.418] #11 0x00007f7a27be4c37 in undo_xact_callback (event=XACT_EVENT_ABORT, arg=<optimized out>) at src/transam/undo.c:2358
[        28.418]         logicalXidContext = {xid = 3577143068, useHeap = 37}
[        28.418]         oxid = 1859
[        28.418]         curProcData = 0x7f7a0519fd78
[        28.418]         xid1 = 0
[        28.418]         nsubxids = 0
[        28.418]         subxids = 0x0
[        28.418]         isParallelWorker = false
[        28.418]         heapXid = <optimized out>
[        28.418]         flushPos = <optimized out>
[        28.418]         i = <optimized out>
[        28.418]         csn = <optimized out>
[        28.418] #12 0x00005625d4e971bf in CallXactCallbacks (event=XACT_EVENT_ABORT) at xact.c:3833
[        28.418]         item = 0x0
[        28.418]         next = 0x0
[        28.418] #13 AbortTransaction () at xact.c:2940
[        28.418]         s = 0x5625d56e5048 <TopTransactionStateData>
[        28.418]         latestXid = <optimized out>
[        28.418]         is_parallel_worker = <optimized out>
[        28.418] #14 0x00005625d4e94e0b in AbortCurrentTransactionInternal () at xact.c:3501
[        28.418]         s = 0x5625d56e5048 <TopTransactionStateData>
[        28.418] #15 AbortCurrentTransaction () at xact.c:3430
[        28.418] No locals.
[        28.418] #16 0x00005625d51e3196 in PostgresMain (dbname=<optimized out>, username=<optimized out>) at postgres.c:4502
[        28.418]         local_sigjmp_buf = {{__jmpbuf = {140725044271568, 8933328088710569188, 94720494627184, 94720494472416, 94720494627192, 94720494573944, -8934248726579585820, -2904062346085475100}, __mask_was_saved = 1, __saved_mask = {__val = {4194304, 140725044271712, 140162667579410, 0, 3936, 9, 94720495781952, 15744, 94720494472416, 0, 94720490886129, 94720494627184, 3, 94720495781952, 94720494621368, 1}}}}
[        28.418]         send_ready_for_query = false
[        28.418]         idle_in_transaction_timeout_enabled = false
[        28.418]         idle_session_timeout_enabled = false
[        28.418] #17 0x00005625d51deb46 in BackendMain (startup_data=<optimized out>, startup_data_len=<optimized out>) at backend_startup.c:105
[        28.418]         bsdata = <optimized out>
[        28.418] #18 0x00005625d5133cf8 in postmaster_child_launch (child_type=child_type@entry=B_BACKEND, startup_data=startup_data@entry=0x7ffd1a465b20 "", startup_data_len=startup_data_len@entry=4, client_sock=client_sock@entry=0x7ffd1a465b40) at launch_backend.c:277
[        28.418]         pid = <optimized out>
[        28.418] #19 0x00005625d513853e in BackendStartup (client_sock=0x7ffd1a465b40) at postmaster.c:3566
[        28.418]         startup_data = {canAcceptConnections = CAC_OK}
[        28.418]         bn = 0x5625d59075e8
[        28.418]         pid = <optimized out>
[        28.418]         __errno_location = <optimized out>
[        28.418]         __errno_location = <optimized out>
[        28.418]         save_errno = <optimized out>
[        28.418]         __errno_location = <optimized out>
[        28.418]         __errno_location = <optimized out>
[        28.418] #20 ServerLoop () at postmaster.c:1662
[        28.418]         s = {sock = 11, raddr = {addr = {ss_family = 2, __ss_padding = "\341\372\nY\000\003", '\000' <repeats 15 times>, "\001", '\000' <repeats 32 times>, "`UUU)L\345\277\000\000\000\000\000\000\000\000\257î\356^\215\351?\000\000\000\000\000\000\000\000\351EH\233[I\362\277", '\000' <repeats 23 times>, __ss_align = 0}, salen = 16}}
[        28.418]         i = 0
[        28.418]         now = <optimized out>
[...]
[        28.418]         last_touch_time = 1785450715
[        28.418]         last_lockfile_recheck_time = 1785450715
[        28.418]         nevents = 1
[        28.418] #21 0x00005625d5135e5d in PostmasterMain (argc=argc@entry=3, argv=argv@entry=0x5625d58107b0) at postmaster.c:1360
[        28.418]         userDoption = <optimized out>
[        28.418]         listen_addr_saved = true
[        28.418]         output_config_variable = <optimized out>
[        28.418]         opt = <optimized out>
[        28.418]         status = <optimized out>
[        28.418] #22 0x00005625d504dc20 in main (argc=3, argv=0x5625d58107b0) at main.c:199
[        28.418]         do_check_root = <optimized out>
[        28.418] [Inferior 1 (process 331) detached]
```

# Fix

- https://github.com/orioledb/orioledb/pull/1006/changes/d08e9ffd6aa1b95f00d25864855417282e48aa9d regression tests
- https://github.com/orioledb/orioledb/pull/1006/changes/c0460a21d6fd81ecb1f057baba33936d09bc9001 record `resowner` in `BTreeIterator` (fallback path) similar to how we track in `BTreeSeqScan`, only forgetting pins when its safe to do so
- https://github.com/orioledb/orioledb/pull/1006/changes/041cb2edbbc77a42ff5336ef382ee4f07ce6bb8e fix a use-after-free case that popped up immediately after fixing the resowner bookkeeping
- https://github.com/orioledb/orioledb/pull/1006/changes/88644f13f207b2295adffbefb0dde1bc1da088bd Antithesis property assertions to validate the fix.

# impact

This graph of a 20 minute simulation run illustrates the frequency of these postgres process crashes.  These are worker crashes and not container crashes, but they happen frequently under our Jepsen test workload in an environment designed to simulate poor conditions.  It's not possible to extrapolate from this how prevalent the crash would be in a cloud environment, but the frequency on a short 20 min sim run on multiple unrelated workloads is strong signal it's only a matter of time before it would happen in prod.

<a href="https://supabase.antithesis.com/search?search=v5veyJxIjp7Im4iOnsiciI6eyJoIjpbeyJoIjpbeyJjIjpmYWxzZSwiZiI6ImdlbmVyYWwub3V0cHV0X3RleHQiLCJvIjoiY29udGFpbnMiLCJ2IjoiXCJleGVjdXRhYmxlXCI6IFwicG9zdGdyZXNcIiwgXCJzaWduYWxcIjogNiJ9XSwibyI6Im9yIn1dLCJvIjoiYW5kIn0sInQiOnsiZyI6ZmFsc2UsIm0iOiIifSwieSI6Im5vbmUifX0sInMiOiJhNmM2ZGNkNjkyZTcxZTMwZjJlMmNhNTcxOThkMGMxMy01OC0xMSJ9">
<img width="1944" height="1544" alt="CleanShot 2026-08-04 at 19 46 46@2x" src="https://github.com/user-attachments/assets/94a9ff68-e073-40f9-a0ed-7a51d9da88d5" /></a>

- blue-green dots: test finished
- purple dots: instances of SIGABRT

# fix validation

- [CI check run](https://github.com/orioledb/orioledb/actions/runs/30951461588) with only [the commit containing the regression test added](https://github.com/orioledb/orioledb/pull/1006/changes/d08e9ffd6aa1b95f00d25864855417282e48aa9d) consistently reproduces the failure.
- [This PR's check run with the fix](https://github.com/orioledb/orioledb/actions/runs/30960264723) where `seq_scan_resowner_test.py` tests pass.
- Antithesis - click links, then click the "search" button after the jump
   - [Test run before the fix (logs)](https://supabase.antithesis.com/search?search=v5veyJxIjp7Im4iOnsiciI6eyJoIjpbeyJoIjpbeyJjIjpmYWxzZSwiZiI6ImdlbmVyYWwub3V0cHV0X3RleHQiLCJvIjoiY29udGFpbnMiLCJ2IjoiUEFOSUM6ICBPcmlvbGVEQiBPSW5kZXhEZXNjciJ9XSwibyI6Im9yIn1dLCJvIjoiYW5kIn0sInQiOnsiZyI6ZmFsc2UsIm0iOiIifSwieSI6Im5vbmUifX0sInMiOiJlYmE4NzMwOGRmMmU0OThlZGQ2MzBlYWE2NGNkY2U1NS01OC0xMSJ9).
   - [Test run after the fix (logs)](https://supabase.antithesis.com/search?search=v5veyJxIjp7Im4iOnsiciI6eyJoIjpbeyJoIjpbeyJjIjpmYWxzZSwiZiI6ImdlbmVyYWwub3V0cHV0X3RleHQiLCJvIjoiY29udGFpbnMiLCJ2IjoiUEFOSUM6ICBPcmlvbGVEQiBPSW5kZXhEZXNjciJ9XSwibyI6Im9yIn1dLCJvIjoiYW5kIn0sInQiOnsiZyI6ZmFsc2UsIm0iOiIifSwieSI6Im5vbmUifX0sInMiOiIzYmRjMzkwMmE1ZWZmNmI1MmYwN2MzNTIwYWZhNjBjYi01OC0xMSJ9&report_name=&get_logs=false&get_logs_event_desc=)

Antithesis properties
<img width="2056" height="1626" alt="CleanShot 2026-08-04 at 20 10 38@2x" src="https://github.com/user-attachments/assets/95dd2aa1-9914-45c3-9a29-a699ffd23d22" />


<!-- start git-machete generated -->

# Based on PR #1005

## Chain of upstream PRs as of 2026-08-04

* PR #1005:
  `main` ← `pmbauer/antithesis-instrumentation`

  * **PR #1006 (THIS ONE)**:
    `pmbauer/antithesis-instrumentation` ← `pmbauer/ORI-215_fix_panic`

<!-- end git-machete generated -->
