### PR TITLE
Parallel index scan support (rebased onto rewind-removal)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  load_refind_page \
 				  merge \
 				  parallel_idx_scan \
+				  parallel_ordered_scan \
 				  partition_move \
 				  rightlink \
 				  rll \
@@ -230,6 +231,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/not_supported_yet_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \
+						test/t/parallel_ordered_scan_test.py \
 						test/t/recovery_heap_verdict_test.py \
 						test/t/recovery_heap_xid_binding_test.py \
 						test/t/recovery_item_rollback_test.py \

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  isol_serializable \
 				  load_refind_page \
 				  merge \
+				  parallel_idx_scan \
 				  partition_move \
 				  rightlink \
 				  rll \

--- a/ci/filter_regression_diff.py
+++ b/ci/filter_regression_diff.py
@@ -461,6 +461,13 @@ def compare_trees(src_tree: list, target_tree: list, test_name: str):
 		elif is_commutative_cond_eq(src_cur_value, target_cur[1]):
 			src_down = True
 			target_down = True
+		elif (test_name == 'aggregates'
+			  and src_cur_value == 'HashAggregate'
+			  and target_cur[1] == 'Group'):
+			# allvisfrac=1 makes IOS cheap enough that the planner picks
+			# an index-only scan path, enabling Group instead of HashAggregate
+			src_down = True
+			target_down = True
 		elif (src_cur_value == 'Unique'
 			  and target_cur[1] == 'HashAggregate'):
 			# As source output uses Unique, it may need to sort values after scan,
@@ -514,6 +521,13 @@ def compare_trees(src_tree: list, target_tree: list, test_name: str):
 				src_up = True
 				target_up = True
 			elif (src_cur_value.startswith('Index Only Scan')
+				and target_cur[1].startswith('Parallel Custom Scan')
+				and len(target_cur[2]) > 0
+				and target_cur[2][0].startswith('Forward index only scan')):
+				# Parallel Custom Scan replaces Parallel Index Only Scan
+				src_up = True
+				target_up = True
+			elif (src_cur_value.startswith('Index Only Scan')
 			      and target_cur[1].startswith('Seq Scan')):
 				src_up = True
 				target_up = True
@@ -540,6 +554,31 @@ def compare_trees(src_tree: list, target_tree: list, test_name: str):
 					target_down = True
 				else:
 					equal = False
+			elif (src_cur_value.startswith('Index Scan')
+				 and target_cur[1].startswith('Parallel Custom Scan')
+				 and len(target_cur[2]) > 0
+				 and target_cur[2][0].startswith('Forward index scan')):
+				# Parallel Custom Scan replaces Parallel Index Scan
+				if (len(src_cur[2]) == 0 and len(target_cur[2]) == 1) or is_conds_eq(src_cur[2][0], target_cur[2][1]):
+					src_down = True
+					target_down = True
+				else:
+					equal = False
+			elif (src_cur_value.startswith('Index Scan')
+				 and target_cur[1].startswith('Index Only Scan')):
+				# allvisfrac=1 makes index-only scan cheaper
+				src_up = True
+				target_up = True
+			elif (src_cur_value.startswith('Index Only Scan')
+				 and target_cur[1].startswith('Index Only Scan')):
+				# allvisfrac=1 may cause different index choice
+				src_up = True
+				target_up = True
+			elif (src_cur_value.startswith('Seq Scan')
+				 and target_cur[1].startswith('Index Only Scan')):
+				# allvisfrac=1 may make IOS cheaper than seq scan
+				src_up = True
+				target_up = True
 			elif re.sub(r"_\d+$", "", src_cur_value) == re.sub(r"_\d+$", "", target_cur[1]):
 				# lines differ only by auto-generated alias suffix (e.g. tinner_2 vs tinner_1)
 				src_down = True

--- a/doc/usage/getting-started.mdx
+++ b/doc/usage/getting-started.mdx
@@ -286,7 +286,7 @@ CREATE INDEX blog_post_title_idx ON blog_post USING btree(title) with (orioledb_
 OrioleDB is currently in the development stage. Therefore it has the following temporary limitations.
 
 1.  `pg_rewind` copies OrioleDB tables completely. Shortly OrioleDB will implement incremental copying of OrioleDB tables using `pg_rewind`.
-2.  OrioleDB supports parallel sequential scan, but not other types of scan.
+2.  OrioleDB supports parallel sequential scan and parallel index scan, but not other types of scan.
 3.  OrioleDB doesn't support prepared transactions.
 4.  OrioleDB support of non-btree indexes is experimental yet.
 5.  OrioleDB supports bitmap scan only for int4, int8 and ctid primary keys.

--- a/include/btree/scan.h
+++ b/include/btree/scan.h
@@ -16,6 +16,7 @@
 
 #include "btree/btree.h"
 #include "btree/page_contents.h"
+#include "tableam/key_range.h"
 
 #include "executor/tuptable.h"
 #include "utils/sampling.h"
@@ -71,6 +72,8 @@ extern OTuple btree_seq_scan_getnext(BTreeSeqScan *scan, MemoryContext mctx,
 extern OTuple btree_seq_scan_getnext_raw(BTreeSeqScan *scan, MemoryContext mctx,
 										 bool *end, BTreeLocationHint *hint);
 extern void free_btree_seq_scan(BTreeSeqScan *scan);
+extern void btree_seq_scan_set_range_filter(BTreeSeqScan *scan,
+											OBTreeKeyRange *scanRange);
 extern void seq_scans_cleanup(void);
 extern int	meta_page_get_num_seq_scans(OInMemoryBlkno metaPageBlkno);
 

--- a/include/btree/scan.h
+++ b/include/btree/scan.h
@@ -74,6 +74,8 @@ extern OTuple btree_seq_scan_getnext_raw(BTreeSeqScan *scan, MemoryContext mctx,
 extern void free_btree_seq_scan(BTreeSeqScan *scan);
 extern void btree_seq_scan_set_range_filter(BTreeSeqScan *scan,
 											OBTreeKeyRange *scanRange);
+extern void btree_seq_scan_set_ordered(BTreeSeqScan *scan, bool ordered,
+									   ScanDirection scanDir);
 extern void seq_scans_cleanup(void);
 extern int	meta_page_get_num_seq_scans(OInMemoryBlkno metaPageBlkno);
 

--- a/include/btree/scan.h
+++ b/include/btree/scan.h
@@ -74,6 +74,8 @@ extern OTuple btree_seq_scan_getnext_raw(BTreeSeqScan *scan, MemoryContext mctx,
 extern void free_btree_seq_scan(BTreeSeqScan *scan);
 extern void btree_seq_scan_set_range_filter(BTreeSeqScan *scan,
 											OBTreeKeyRange *scanRange);
+extern void btree_seq_scan_set_callbacks(BTreeSeqScan *scan,
+										 BTreeSeqScanCallbacks *cb, void *arg);
 extern void btree_seq_scan_set_ordered(BTreeSeqScan *scan, bool ordered,
 									   ScanDirection scanDir);
 extern void seq_scans_cleanup(void);

--- a/include/tableam/index_scan.h
+++ b/include/tableam/index_scan.h
@@ -19,6 +19,7 @@
 
 #include "access/nbtree.h"
 #include "access/sdir.h"
+#include "btree/scan.h"
 
 typedef struct OScanState
 {
@@ -59,6 +60,9 @@ typedef struct OScanState
 	/* used only by direct modify functions */
 	CmdType		cmd;
 	OSnapshot	oSnapshot;
+	/* Parallel index scan state (NULL for serial scans) */
+	ParallelOScanDesc pidxscan;
+	BTreeSeqScan *seqScan;
 } OScanState;
 
 typedef struct OIndexPlanState

--- a/include/tableam/index_scan.h
+++ b/include/tableam/index_scan.h
@@ -33,6 +33,8 @@ typedef struct OScanState
 	 */
 	bool		emptyScan;
 	ScanDirection scanDir;
+	/* parallel ordered (key-order) scan: read on-disk downlinks inline */
+	bool		ordered;
 	bool		addJunk;
 	/* is only current index can be used in scan */
 	bool		onlyCurIx;

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -3316,6 +3316,24 @@ btree_seq_scan_set_range_filter(BTreeSeqScan *scan,
 }
 
 /*
+ * Attach scan callbacks after construction.
+ *
+ * make_btree_seq_scan_cb() takes them up front, but a parallel scan is built
+ * by make_btree_seq_scan() and only then learns what it has to filter.  Only
+ * meaningful before the first getnext, and it deliberately does not turn on
+ * the partial-leaf (FETCH) walk: that is reserved for the non-parallel
+ * key-directed scan the constructor recognises.
+ */
+void
+btree_seq_scan_set_callbacks(BTreeSeqScan *scan,
+							 BTreeSeqScanCallbacks *cb, void *arg)
+{
+	Assert(!scan->initialized);
+	scan->cb = cb;
+	scan->arg = arg;
+}
+
+/*
  * Enable ordered (key-order) scanning.  Must be called before the first
  * getnext.  In ordered mode on-disk downlinks are read inline in key order
  * (see BTreeSeqScan.ordered).  Both forward and backward directions are

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1538,9 +1538,26 @@ check_downlink_in_scan_range(BTreeSeqScan *scan, OTuple keyRangeLow,
 }
 
 /*
+ * Does this side of the scan's qualification range constrain anything?
+ *
+ * The first unbounded key makes the whole bound infinite:
+ * o_idx_cmp_key_bound_to_tuple() answers on it without looking at the rest.
+ */
+static inline bool
+scan_range_side_is_open(OBTreeKeyBound *bound)
+{
+	return bound->nkeys == 0 ||
+		(bound->keys[0].flags & O_VALUE_BOUND_UNBOUNDED) != 0;
+}
+
+/*
  * Checks if a page's entire key range is within the scan's qualification
  * range.  When this returns true, every tuple on the page is guaranteed to
  * be in range, so per-tuple checks can be skipped entirely.
+ *
+ * A page unbounded on one side (the leftmost or the rightmost page of the
+ * tree) is still fully in range when the scan is unbounded on that side too,
+ * which is the common case for a one-sided qualification such as "id > 100".
  */
 static bool
 page_fully_in_scan_range(BTreeSeqScan *scan, OTuple keyRangeLow,
@@ -1561,8 +1578,8 @@ page_fully_in_scan_range(BTreeSeqScan *scan, OTuple keyRangeLow,
 		if (cmp < 0)
 			return false;
 	}
-	else
-		return false;			/* page starts at -infinity */
+	else if (!scan_range_side_is_open(&scanRange->low))
+		return false;			/* page starts at -infinity, the scan does not */
 
 	if (!O_TUPLE_IS_NULL(keyRangeHigh))
 	{
@@ -1574,8 +1591,8 @@ page_fully_in_scan_range(BTreeSeqScan *scan, OTuple keyRangeLow,
 		if (cmp > 0)
 			return false;
 	}
-	else
-		return false;			/* page ends at +infinity */
+	else if (!scan_range_side_is_open(&scanRange->high))
+		return false;			/* page ends at +infinity, the scan does not */
 
 	return true;
 }

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -227,6 +227,27 @@ struct BTreeSeqScan
 	OBTreeKeyRange *scanRange;
 
 	/*
+	 * Ordered (key-order) scan.  When set, on-disk downlinks are read inline
+	 * during the internal-page walk (in strict key order) instead of being
+	 * deferred to a physically-sorted disk phase, so every tuple this scan
+	 * emits is in scanDir order.  This lets a parallel scan feed Gather Merge
+	 * (each worker's stream is individually sorted) at the cost of losing the
+	 * sequential-I/O batching of the unordered path.  scanDir is Forward or
+	 * Backward.
+	 */
+	bool		ordered;
+	ScanDirection scanDir;
+#ifdef USE_ASSERT_CHECKING
+
+	/*
+	 * Last tuple emitted, to assert per-worker key monotonicity in ordered
+	 * mode.
+	 */
+	bool		haveOrderedPrev;
+	OFixedKey	orderedPrevKey;
+#endif
+
+	/*
 	 * Optimization flags for range-filtered scans.  pageFullyInRange is set
 	 * when the current page's key range is entirely within scanRange,
 	 * allowing per-tuple range checks to be skipped.  enteredRange is set
@@ -248,6 +269,8 @@ struct BTreeSeqScan
 static dlist_head listOfScans = DLIST_STATIC_INIT(listOfScans);
 
 static void scan_make_iterator(BTreeSeqScan *scan, OTuple startKey, OTuple keyRangeHigh);
+static bool get_prev_downlink_parallel(BTreeSeqScan *scan, uint64 *downlink,
+									   OFixedKey *keyRangeLow, OFixedKey *keyRangeHigh);
 static void get_next_key(BTreeSeqScan *scan, BTreePageItemLocator *intLoc, OFixedKey *nextKey, Page page);
 static void ResourceOwnerRememberBTreeSeqScan(ResourceOwner owner, BTreeSeqScan *scan);
 static void ResourceOwnerForgetBTreeSeqScan(ResourceOwner owner, BTreeSeqScan *scan);
@@ -1079,6 +1102,9 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 		bool		pageIsLoaded = scan->firstPageIsLoaded;
 		bool		prevIsLeftmostOrNone = true;
 
+		/* Ordered scanning is only ever generated as a parallel path. */
+		Assert(scan->scanDir == ForwardScanDirection);
+
 		while (true)
 		{
 
@@ -1278,6 +1304,11 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 	}
 	else
 	{
+		/* Parallel backward ordered walk (phase 2c). */
+		if (scan->scanDir == BackwardScanDirection)
+			return get_prev_downlink_parallel(scan, downlink,
+											  keyRangeLow, keyRangeHigh);
+
 		/* Parallel case */
 		while (true)
 		{
@@ -1572,6 +1603,32 @@ tuple_in_scan_range(BTreeSeqScan *scan, OTuple tuple)
 	if (!scanRange)
 		return 0;
 
+	if (scan->scanDir == BackwardScanDirection)
+	{
+		/*
+		 * Backward: tuples arrive in descending key order.  Skip tuples above
+		 * the high bound until we enter the range, then finish once we drop
+		 * below the low bound.
+		 */
+		if (!scan->enteredRange)
+		{
+			cmp = o_btree_cmp(scan->desc,
+							  &tuple, BTreeKeyLeafTuple,
+							  &scanRange->high, BTreeKeyBound);
+			if (cmp > 0)
+				return -1;
+			scan->enteredRange = true;
+		}
+
+		cmp = o_btree_cmp(scan->desc,
+						  &tuple, BTreeKeyLeafTuple,
+						  &scanRange->low, BTreeKeyBound);
+		if (cmp < 0)
+			return 1;
+
+		return 0;
+	}
+
 	if (!scan->enteredRange)
 	{
 		cmp = o_btree_cmp(scan->desc,
@@ -1589,6 +1646,335 @@ tuple_in_scan_range(BTreeSeqScan *scan, OTuple tuple)
 		return 1;
 
 	return 0;
+}
+
+/*
+ * Read one on-disk leaf page into scan->leafImg and apply undo down to the
+ * scan snapshot's CSN.  Shared by the deferred, physically-sorted disk phase
+ * (load_next_disk_leaf_page) and the inline ordered path (iterate_internal_
+ * page): both need the exact same physical read + undo replay.
+ */
+static void
+read_disk_leaf_into_img(BTreeSeqScan *scan, uint64 downlinkLoc, CommitSeqNo csn)
+{
+	FileExtent	extent;
+	OReadPageResult read_result;
+	BTreePageHeader *header;
+
+	read_result = read_page_from_disk(scan->desc, scan->leafImg, downlinkLoc,
+									  &extent);
+	header = (BTreePageHeader *) scan->leafImg;
+	if (header->csn >= csn)
+		read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
+							csn, NULL, BTreeKeyNone, NULL);
+
+	STOPEVENT(STOPEVENT_SCAN_DISK_PAGE,
+			  btree_page_stopevent_params(scan->desc, scan->leafImg));
+
+	if (read_result != OReadPageResultOk)
+	{
+		if (read_result == OReadPageResultChecksumFailed)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("invalid leaf page with file offset " UINT64_FORMAT " read from disk",
+							DOWNLINK_GET_DISK_OFF(downlinkLoc))));
+		else
+			elog(ERROR, "can not read leaf page from disk");
+	}
+}
+
+/*
+ * Position the leaf locator at the first tuple to emit for the current leaf,
+ * honoring scan direction: leftmost for a forward scan, rightmost (TAIL, then
+ * step back to the last valid item) for a backward scan.
+ */
+static inline void
+seq_leaf_locator_start(BTreeSeqScan *scan)
+{
+	if (scan->scanDir == BackwardScanDirection)
+		BTREE_PAGE_LOCATOR_LAST(scan->leafImg, &scan->leafLoc);
+	else
+		BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
+}
+
+/* Advance the leaf locator one tuple in scan direction. */
+static inline void
+seq_leaf_locator_advance(BTreeSeqScan *scan)
+{
+	if (scan->scanDir == BackwardScanDirection)
+		BTREE_PAGE_LOCATOR_PREV(scan->leafImg, &scan->leafLoc);
+	else
+		BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
+}
+
+/*
+ * Read the downlink at `loc` on internal `page` and its direction-independent
+ * key range [low, high) for a backward walk, WITHOUT advancing loc.  The
+ * leftmost item (offset 0) takes its low bound from the page's low key
+ * (pageLokey/havePageLokey; -infinity on the leftmost page).
+ */
+static void
+read_downlink_range_backward(BTreeSeqScan *scan, Page page,
+							 BTreePageItemLocator *loc,
+							 bool havePageLokey, OTuple pageLokey,
+							 uint64 *downlink, OFixedKey *keyRangeLow,
+							 OFixedKey *keyRangeHigh)
+{
+	BTreeNonLeafTuphdr *tuphdr;
+	OTuple		tuple;
+	BTreePageItemLocator next;
+
+	BTREE_PAGE_READ_INTERNAL_ITEM(tuphdr, tuple, page, loc);
+	*downlink = tuphdr->downlink;
+
+	if (BTREE_PAGE_LOCATOR_GET_OFFSET(page, loc) > 0)
+		copy_fixed_key(scan->desc, keyRangeLow, tuple);
+	else if (havePageLokey)
+		copy_fixed_key(scan->desc, keyRangeLow, pageLokey);
+	else
+		clear_fixed_key(keyRangeLow);
+
+	next = *loc;
+	BTREE_PAGE_LOCATOR_NEXT(page, &next);
+	if (BTREE_PAGE_LOCATOR_IS_VALID(page, &next))
+		copy_fixed_page_key(scan->desc, keyRangeHigh, page, &next);
+	else if (!O_PAGE_IS(page, RIGHTMOST))
+		copy_fixed_hikey(scan->desc, keyRangeHigh, page);
+	else
+		clear_fixed_key(keyRangeHigh);
+}
+
+/*
+ * Load the level-1 page that continues a backward walk into `page` (a shared
+ * parallel image, or scan->context.img when page == NULL for the serial
+ * walk), position *outLoc at its rightmost downlink, and report the page's own
+ * low key in *outLokey / *outHave.
+ *
+ *   - lokey NULL: descend to the rightmost level-1 page (walk start);
+ *   - otherwise: step one page left by re-descending to `lokey` as a
+ *     BTreeKeyPageHiKey (lands on the page whose hikey == lokey, i.e. the
+ *     immediate left sibling), mirroring the iterator's backward step.
+ *
+ * The low key is the level-1 page's own low key, which the KEEP_LOKEY descent
+ * establishes in context->lokey (LOKEY_EXISTS) at arbitrary tree depth: it is
+ * the nearest ancestor separator to the left of the descent path.  A leftmost
+ * descent (LOKEY_EXISTS unset) means the leftmost level-1 page (low bound
+ * -infinity).  Returns false when the tree is a single leaf page (no level-1
+ * page).
+ */
+static bool
+load_prev_internal_page(BTreeSeqScan *scan, OTuple lokey, Page page,
+						BTreePageItemLocator *outLoc, OffsetNumber *startOffset,
+						OFixedKey *outLokey, bool *outHave)
+{
+	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
+
+	BTREE_PAGE_FIND_UNSET(&scan->context, FETCH);
+	BTREE_PAGE_FIND_SET(&scan->context, IMAGE);
+	scan->context.flags |= BTREE_PAGE_FIND_DOWNLINK_LOCATION |
+		BTREE_PAGE_FIND_KEEP_LOKEY | BTREE_PAGE_FIND_KEEP_PARENT;
+
+	if (O_TUPLE_IS_NULL(lokey))
+		findResult = find_page(&scan->context, NULL, BTreeKeyRightmost, 1);
+	else
+		findResult = find_page(&scan->context, &lokey, BTreeKeyPageHiKey, 1);
+	Assert(findResult == OFindPageResultSuccess);
+
+	if (PAGE_GET_LEVEL(scan->context.img) != 1)
+	{
+		scan->isSingleLeafPage = true;
+		return false;			/* single leaf page (no level-1 page) */
+	}
+
+	/*
+	 * The KEEP_LOKEY descent to targetLevel == 1 stashes the target page's
+	 * own low key in context->lokey and sets LOKEY_EXISTS; a fully-leftmost
+	 * descent leaves it unset (low bound -infinity).  This is the recursive
+	 * lokey and works at any tree height.
+	 */
+	if (BTREE_PAGE_FIND_IS(&scan->context, LOKEY_EXISTS))
+	{
+		copy_fixed_key(scan->desc, outLokey, scan->context.lokey.tuple);
+		*outHave = true;
+	}
+	else
+	{
+		Assert(O_PAGE_IS(scan->context.img, LEFTMOST));
+		*outHave = false;
+	}
+
+	if (page)
+	{
+		Assert(scan->poscan);
+		memcpy(page, scan->context.img, ORIOLEDB_BLCKSZ);
+	}
+	else
+		page = scan->context.img;
+
+	BTREE_PAGE_LOCATOR_LAST(page, outLoc);
+	*startOffset = BTREE_PAGE_LOCATOR_GET_OFFSET(page, outLoc);
+	return true;
+}
+
+/*
+ * Parallel backward downlink generator (phase 2c): the mirror of the forward
+ * cooperative double-buffer walk.  CUR_PAGE is drained right-to-left; the
+ * NEXT_PAGE buffer is prefetched with the *previous* level-1 page (re-descent
+ * via the current page's low key, kept in the shared prevHikey field); the
+ * walk terminates at the LEFTMOST level-1 page.
+ */
+static bool
+get_prev_downlink_parallel(BTreeSeqScan *scan, uint64 *downlink,
+						   OFixedKey *keyRangeLow, OFixedKey *keyRangeHigh)
+{
+	ParallelOScanDesc poscan = scan->poscan;
+
+	while (true)
+	{
+		BTreeIntPageParallelData *curPage;
+		BTreeIntPageParallelData *nextPage;
+		BTreePageItemLocator loc;
+		OFixedKey	lk;
+		bool		haveLk;
+
+		SpinLockAcquire(&poscan->intpageAccess);
+		curPage = CUR_PAGE(poscan);
+		nextPage = NEXT_PAGE(poscan);
+
+		if (poscan->flags & O_PARALLEL_IS_SINGLE_LEAF_PAGE)
+		{
+			SpinLockRelease(&poscan->intpageAccess);
+			scan->haveHistImg = false;
+			BTREE_PAGE_LOCATOR_SET_INVALID(&scan->leafLoc);
+			return false;
+		}
+
+		if (curPage->status == OParallelScanPageInvalid)
+		{
+			OffsetNumber startOffset;
+			bool		loaded;
+
+			Assert(nextPage->status == OParallelScanPageInvalid);
+
+			if (poscan->flags & O_PARALLEL_FIRST_PAGE_LOADED)
+			{
+				/* Backward: the walk ends once the leftmost page is drained. */
+				Assert(O_PAGE_IS(nextPage->img, LEFTMOST));
+				SpinLockRelease(&poscan->intpageAccess);
+				return false;
+			}
+			curPage->status = OParallelScanPageInProgress;
+			LWLockAcquire(&poscan->intpageLoad, LW_EXCLUSIVE);
+			SpinLockRelease(&poscan->intpageAccess);
+
+			/* First page: rightmost descent (NULL step key). */
+			{
+				OTuple		nullKey;
+
+				O_TUPLE_SET_NULL(nullKey);
+				loaded = load_prev_internal_page(scan, nullKey, curPage->img,
+												 &loc, &startOffset, &lk, &haveLk);
+			}
+			if (!loaded)
+			{
+				SpinLockAcquire(&poscan->intpageAccess);
+				poscan->flags |= O_PARALLEL_IS_SINGLE_LEAF_PAGE;
+				clear_fixed_key(keyRangeLow);
+				clear_fixed_key(keyRangeHigh);
+				SpinLockRelease(&poscan->intpageAccess);
+				LWLockRelease(&poscan->intpageLoad);
+				return false;
+			}
+
+			SpinLockAcquire(&poscan->intpageAccess);
+			curPage->imgReadCsn = scan->context.imgReadCsn;
+			curPage->startOffset = startOffset;
+			curPage->offset = BTREE_PAGE_LOCATOR_GET_OFFSET(curPage->img, &loc);
+			if (haveLk)
+				copy_fixed_shmem_key(scan->desc, &curPage->prevHikey, lk.tuple);
+			else
+				clear_fixed_shmem_key(&curPage->prevHikey);
+			curPage->status = OParallelScanPageValid;
+			poscan->flags |= O_PARALLEL_FIRST_PAGE_LOADED;
+			SpinLockRelease(&poscan->intpageAccess);
+			LWLockRelease(&poscan->intpageLoad);
+			continue;
+		}
+		else if (curPage->status == OParallelScanPageInProgress)
+		{
+			SpinLockRelease(&poscan->intpageAccess);
+			if (LWLockAcquireOrWait(&poscan->intpageLoad, LW_EXCLUSIVE))
+				LWLockRelease(&poscan->intpageLoad);
+			continue;
+		}
+
+		/* Prefetch the previous level-1 page into NEXT_PAGE. */
+		if (nextPage->status == OParallelScanPageInvalid &&
+			!O_PAGE_IS(curPage->img, LEFTMOST))
+		{
+			OffsetNumber startOffset;
+			OFixedKey	stepKey;
+			bool		loaded PG_USED_FOR_ASSERTS_ONLY;
+			OTuple		curLokey = fixed_shmem_key_get_tuple(&curPage->prevHikey);
+
+			/* A non-leftmost page must carry its low key. */
+			Assert(!O_TUPLE_IS_NULL(curLokey));
+			copy_fixed_key(scan->desc, &stepKey, curLokey);
+			nextPage->status = OParallelScanPageInProgress;
+			LWLockAcquire(&poscan->intpageLoad, LW_EXCLUSIVE);
+			SpinLockRelease(&poscan->intpageAccess);
+
+			loaded = load_prev_internal_page(scan, stepKey.tuple, nextPage->img,
+											 &loc, &startOffset, &lk, &haveLk);
+			Assert(loaded);
+
+			SpinLockAcquire(&poscan->intpageAccess);
+			nextPage->imgReadCsn = scan->context.imgReadCsn;
+			nextPage->startOffset = startOffset;
+			nextPage->offset = BTREE_PAGE_LOCATOR_GET_OFFSET(nextPage->img, &loc);
+			if (haveLk)
+				copy_fixed_shmem_key(scan->desc, &nextPage->prevHikey, lk.tuple);
+			else
+				clear_fixed_shmem_key(&nextPage->prevHikey);
+			nextPage->status = OParallelScanPageValid;
+			SpinLockRelease(&poscan->intpageAccess);
+			LWLockRelease(&poscan->intpageLoad);
+			continue;
+		}
+
+		BTREE_PAGE_OFFSET_GET_LOCATOR(curPage->img, curPage->offset, &loc);
+
+		if (BTREE_PAGE_LOCATOR_IS_VALID(curPage->img, &loc))
+		{
+			OffsetNumber curOff = curPage->offset;
+			OTuple		curLokey = fixed_shmem_key_get_tuple(&curPage->prevHikey);
+
+			read_downlink_range_backward(scan, curPage->img, &loc,
+										 !O_TUPLE_IS_NULL(curLokey), curLokey,
+										 downlink, keyRangeLow, keyRangeHigh);
+
+			/*
+			 * Advance left.  Once offset 0 has been handed out, park the
+			 * shared offset past the end so the next visitor sees an
+			 * exhausted page and flips to NEXT_PAGE (OffsetNumber is
+			 * unsigned, so we cannot step below 0).
+			 */
+			curPage->offset = (curOff > 0) ? (curOff - 1)
+				: BTREE_PAGE_ITEMS_COUNT(curPage->img);
+			scan->context.imgReadCsn = curPage->imgReadCsn;
+
+			pg_atomic_fetch_add_u32(&poscan->downlinksWritersInProgress, 1);
+
+			SpinLockRelease(&poscan->intpageAccess);
+			return true;
+		}
+		else
+		{
+			curPage->status = OParallelScanPageInvalid;
+			poscan->flags ^= O_PARALLEL_CURRENT_PAGE;
+			SpinLockRelease(&poscan->intpageAccess);
+		}
+	}
 }
 
 
@@ -1615,20 +2001,42 @@ iterate_internal_page(BTreeSeqScan *scan)
 		if (scan->scanRange)
 		{
 			int			rangeCheck;
+			int			skipSide;
+			int			doneSide;
+
+			/*
+			 * In a backward scan downlinks arrive in descending key order, so
+			 * the roles of "before" and "after" the scan range are swapped:
+			 * downlinks above the range come first and must be skipped, while
+			 * the first downlink below the range means we are done.
+			 */
+			if (scan->scanDir == BackwardScanDirection)
+			{
+				skipSide = 1;	/* entirely after range: not reached yet */
+				doneSide = -1;	/* entirely before range: past it */
+			}
+			else
+			{
+				skipSide = -1;	/* entirely before range: not reached yet */
+				doneSide = 1;	/* entirely after range: past it */
+			}
 
 			rangeCheck = check_downlink_in_scan_range(scan,
 													  scan->keyRangeLow.tuple,
 													  scan->keyRangeHigh.tuple);
-			if (rangeCheck == -1)
+			if (rangeCheck == skipSide)
 			{
-				/* Downlink is entirely before scan range: skip it */
+				/*
+				 * Downlink is outside scan range on the not-reached side:
+				 * skip
+				 */
 				if (scan->poscan)
 					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
 				continue;
 			}
-			else if (rangeCheck == 1)
+			else if (rangeCheck == doneSide)
 			{
-				/* Downlink is entirely after scan range: we're done */
+				/* Downlink is past the scan range: we're done */
 				if (scan->poscan)
 					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
 				break;
@@ -1672,10 +2080,35 @@ iterate_internal_page(BTreeSeqScan *scan)
 		{
 			if (DOWNLINK_IS_ON_DISK(downlink))
 			{
-				add_on_disk_downlink(scan, downlink, scan->context.imgReadCsn,
-									 scan->pageFullyInRange);
 				if (scan->poscan)
 					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
+
+				if (scan->ordered)
+				{
+					/*
+					 * Ordered scan: read the on-disk leaf right here, in key
+					 * order, instead of deferring it to the physically-sorted
+					 * disk phase.  Set the leaf up exactly like an in-memory
+					 * leaf and return so btree_seq_scan_getnext_internal()
+					 * emits its tuples before advancing to the next downlink.
+					 * The downlink already passed the scan-range check above,
+					 * so no range-skip loop is needed here.
+					 */
+					read_disk_leaf_into_img(scan, downlink,
+											scan->context.imgReadCsn);
+					scan->leafPartial.isPartial = false;
+					scan->haveLastLeafKey = false;
+					scan->enteredRange = false;
+					seq_leaf_locator_start(scan);
+					scan->hint.blkno = OInvalidInMemoryBlkno;
+					scan->hint.pageChangeCount = InvalidOPageChangeCount;
+					O_TUPLE_SET_NULL(scan->nextKey.tuple);
+					load_first_historical_page(scan);
+					return true;
+				}
+
+				add_on_disk_downlink(scan, downlink, scan->context.imgReadCsn,
+									 scan->pageFullyInRange);
 			}
 			else if (DOWNLINK_IS_IN_MEMORY(downlink))
 			{
@@ -1746,7 +2179,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 
 					scan->hint.blkno = DOWNLINK_GET_IN_MEMORY_BLKNO(downlink);
 					scan->hint.pageChangeCount = DOWNLINK_GET_IN_MEMORY_CHANGECOUNT(downlink);
-					BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
+					seq_leaf_locator_start(scan);
 					O_TUPLE_SET_NULL(scan->nextKey.tuple);
 					load_first_historical_page(scan);
 					return true;
@@ -1794,9 +2227,6 @@ iterate_internal_page(BTreeSeqScan *scan)
 static bool
 load_next_disk_leaf_page(BTreeSeqScan *scan)
 {
-	FileExtent	extent;
-	OReadPageResult read_result;
-	BTreePageHeader *header;
 	BTreeSeqScanDiskDownlink downlink;
 	ParallelOScanDesc poscan = scan->poscan;
 
@@ -1830,29 +2260,7 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 			downlink = ((BTreeSeqScanDiskDownlink *) dsm_segment_address(scan->dsmSeg))[index];
 		}
 
-		read_result = read_page_from_disk(scan->desc,
-										  scan->leafImg,
-										  downlink.downlink,
-										  &extent);
-		header = (BTreePageHeader *) scan->leafImg;
-		if (header->csn >= downlink.csn)
-			read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
-								downlink.csn, NULL, BTreeKeyNone, NULL);
-
-		STOPEVENT(STOPEVENT_SCAN_DISK_PAGE,
-				  btree_page_stopevent_params(scan->desc,
-											  scan->leafImg));
-
-		if (read_result != OReadPageResultOk)
-		{
-			if (read_result == OReadPageResultChecksumFailed)
-				ereport(ERROR,
-						(errcode(ERRCODE_DATA_CORRUPTED),
-						 errmsg("invalid leaf page with file offset " UINT64_FORMAT " read from disk",
-								DOWNLINK_GET_DISK_OFF(downlink.downlink))));
-			else
-				elog(ERROR, "can not read leaf page from disk");
-		}
+		read_disk_leaf_into_img(scan, downlink.downlink, downlink.csn);
 
 		scan->downlinkIndex++;
 
@@ -2131,6 +2539,12 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 	scan->scanRange = NULL;
 	scan->pageFullyInRange = false;
 	scan->enteredRange = false;
+
+	scan->ordered = false;
+	scan->scanDir = ForwardScanDirection;
+#ifdef USE_ASSERT_CHECKING
+	scan->haveOrderedPrev = false;
+#endif
 
 	dlist_push_tail(&listOfScans, &scan->listNode);
 	scan->resowner = NULL;
@@ -2583,7 +2997,7 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 									 mctx,
 									 NULL,
 									 NULL);
-		BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
+		seq_leaf_locator_advance(scan);
 		if (!O_TUPLE_IS_NULL(tuple))
 		{
 			if (scan->scanRange && !scan->pageFullyInRange)
@@ -2627,7 +3041,35 @@ btree_seq_scan_getnext(BTreeSeqScan *scan, MemoryContext mctx,
 		tuple = btree_seq_scan_getnext_internal(scan, mctx, tupleCsn, hint);
 
 		if (!O_TUPLE_IS_NULL(tuple))
+		{
+#ifdef USE_ASSERT_CHECKING
+			/*
+			 * Ordered scan invariant: this backend must emit tuples in
+			 * scanDir key order (so a parallel worker's stream is
+			 * individually sorted for Gather Merge).  Assert non-decreasing
+			 * keys for a forward scan.
+			 */
+			if (scan->ordered)
+			{
+				if (scan->haveOrderedPrev)
+				{
+					int			cmp = o_btree_cmp(scan->desc,
+												  &scan->orderedPrevKey.tuple,
+												  BTreeKeyNonLeafKey,
+												  &tuple, BTreeKeyLeafTuple);
+
+					/* forward: prev <= cur; backward: prev >= cur */
+					if (scan->scanDir == BackwardScanDirection)
+						Assert(cmp >= 0);
+					else
+						Assert(cmp <= 0);
+				}
+				copy_fixed_key(scan->desc, &scan->orderedPrevKey, tuple);
+				scan->haveOrderedPrev = true;
+			}
+#endif
 			return tuple;
+		}
 	}
 	Assert(scan->status == BTreeSeqScanFinished);
 
@@ -2854,6 +3296,22 @@ btree_seq_scan_set_range_filter(BTreeSeqScan *scan,
 								OBTreeKeyRange *scanRange)
 {
 	scan->scanRange = scanRange;
+}
+
+/*
+ * Enable ordered (key-order) scanning.  Must be called before the first
+ * getnext.  In ordered mode on-disk downlinks are read inline in key order
+ * (see BTreeSeqScan.ordered).  Both forward and backward directions are
+ * supported, in both serial and parallel walks.
+ */
+void
+btree_seq_scan_set_ordered(BTreeSeqScan *scan, bool ordered,
+						   ScanDirection scanDir)
+{
+	Assert(scanDir == ForwardScanDirection ||
+		   scanDir == BackwardScanDirection);
+	scan->ordered = ordered;
+	scan->scanDir = scanDir;
 }
 
 /*

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -54,8 +54,8 @@
 #include "btree/scan.h"
 #include "btree/undo.h"
 #include "tableam/descr.h"
+#include "tableam/key_range.h"
 #include "transam/oxid.h"
-#include "tableam/descr.h"
 #include "tuple/slot.h"
 #include "utils/antithesis.h"
 #include "utils/page_pool.h"
@@ -77,6 +77,13 @@ typedef struct
 {
 	uint64		downlink;
 	CommitSeqNo csn;
+
+	/*
+	 * True when the downlink's key range is entirely within the scan's
+	 * qualification range (pre-computed during collection).  Lets the disk
+	 * phase skip per-tuple range checks without re-reading the hikey.
+	 */
+	bool		fullyInRange;
 } BTreeSeqScanDiskDownlink;
 
 struct BTreeSeqScan
@@ -215,6 +222,19 @@ struct BTreeSeqScan
 	 */
 	OFixedKey	iterKeyLow;
 	bool		firstPageIsLoaded;
+
+	/* Parallel index scan range filter */
+	OBTreeKeyRange *scanRange;
+
+	/*
+	 * Optimization flags for range-filtered scans.  pageFullyInRange is set
+	 * when the current page's key range is entirely within scanRange,
+	 * allowing per-tuple range checks to be skipped.  enteredRange is set
+	 * once the first tuple on the current page passes the low-bound check;
+	 * subsequent key-ordered tuples only need the high-bound check.
+	 */
+	bool		pageFullyInRange;
+	bool		enteredRange;
 
 	/* Private parallel worker info in a backend */
 	ParallelOScanDesc poscan;
@@ -659,7 +679,8 @@ load_next_internal_page(BTreeSeqScan *scan, OTuple prevHikey,
 }
 
 static void
-add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn)
+add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn,
+					 bool fullyInRange)
 {
 	ParallelOScanDesc poscan = scan->poscan;
 
@@ -674,6 +695,7 @@ add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn)
 		}
 		scan->diskDownlinks[scan->downlinksCount].downlink = downlink;
 		scan->diskDownlinks[scan->downlinksCount].csn = csn;
+		scan->diskDownlinks[scan->downlinksCount].fullyInRange = fullyInRange;
 		scan->downlinksCount++;
 	}
 	else
@@ -702,6 +724,7 @@ add_on_disk_downlink(BTreeSeqScan *scan, uint64 downlink, CommitSeqNo csn)
 				shared = (BTreeSeqScanDiskDownlink *) dsm_segment_address(scan->dsmSeg);
 				shared[index].downlink = downlink;
 				shared[index].csn = csn;
+				shared[index].fullyInRange = fullyInRange;
 				LWLockRelease(&poscan->downlinksPublish);
 				return;
 			}
@@ -1438,6 +1461,136 @@ check_in_memory_leaf_page(BTreeSeqScan *scan, OTuple keyRangeLow, OTuple keyRang
 	}
 }
 
+/*
+ * Checks if a downlink's key range overlaps the scan's key range filter.
+ * Returns:
+ *   -1 if the downlink range is entirely before the scan range (skip it)
+ *    0 if the downlink range overlaps the scan range (process it)
+ *    1 if the downlink range is entirely after the scan range (scan is done)
+ *
+ * The downlink's key range is [keyRangeLow, keyRangeHigh).  The scan's
+ * filter range is [scanLowBound, scanHighBound] with inclusivity encoded
+ * in OBTreeValueBound.flags.
+ */
+static int
+check_downlink_in_scan_range(BTreeSeqScan *scan, OTuple keyRangeLow,
+							 OTuple keyRangeHigh)
+{
+	OBTreeKeyRange *scanRange = scan->scanRange;
+
+	if (!scanRange)
+		return 0;
+
+	if (!O_TUPLE_IS_NULL(keyRangeHigh))
+	{
+		int			cmp;
+
+		cmp = o_btree_cmp(scan->desc,
+						  &keyRangeHigh, BTreeKeyNonLeafKey,
+						  &scanRange->low, BTreeKeyBound);
+		if (cmp < 0)
+			return -1;
+	}
+
+	if (!O_TUPLE_IS_NULL(keyRangeLow))
+	{
+		int			cmp;
+
+		cmp = o_btree_cmp(scan->desc,
+						  &keyRangeLow, BTreeKeyNonLeafKey,
+						  &scanRange->high, BTreeKeyBound);
+		if (cmp > 0)
+			return 1;
+	}
+
+	return 0;
+}
+
+/*
+ * Checks if a page's entire key range is within the scan's qualification
+ * range.  When this returns true, every tuple on the page is guaranteed to
+ * be in range, so per-tuple checks can be skipped entirely.
+ */
+static bool
+page_fully_in_scan_range(BTreeSeqScan *scan, OTuple keyRangeLow,
+						 OTuple keyRangeHigh)
+{
+	OBTreeKeyRange *scanRange = scan->scanRange;
+
+	if (!scanRange)
+		return false;
+
+	if (!O_TUPLE_IS_NULL(keyRangeLow))
+	{
+		int			cmp;
+
+		cmp = o_btree_cmp(scan->desc,
+						  &keyRangeLow, BTreeKeyNonLeafKey,
+						  &scanRange->low, BTreeKeyBound);
+		if (cmp < 0)
+			return false;
+	}
+	else
+		return false;			/* page starts at -infinity */
+
+	if (!O_TUPLE_IS_NULL(keyRangeHigh))
+	{
+		int			cmp;
+
+		cmp = o_btree_cmp(scan->desc,
+						  &keyRangeHigh, BTreeKeyNonLeafKey,
+						  &scanRange->high, BTreeKeyBound);
+		if (cmp > 0)
+			return false;
+	}
+	else
+		return false;			/* page ends at +infinity */
+
+	return true;
+}
+
+/*
+ * Checks if a leaf tuple is within the scan's qualification range.
+ * Returns:
+ *   -1 if the tuple is before the scan range (skip it)
+ *    0 if the tuple is within the scan range (return it)
+ *    1 if the tuple is after the scan range (scan is done)
+ *
+ * Inclusivity is encoded in OBTreeValueBound.flags, and o_btree_cmp
+ * incorporates it into the comparison result automatically.
+ *
+ * Uses the enteredRange optimization: once the first tuple on the current
+ * page passes the low-bound check, all subsequent key-ordered tuples only
+ * need the high-bound check.
+ */
+static int
+tuple_in_scan_range(BTreeSeqScan *scan, OTuple tuple)
+{
+	OBTreeKeyRange *scanRange = scan->scanRange;
+	int			cmp;
+
+	if (!scanRange)
+		return 0;
+
+	if (!scan->enteredRange)
+	{
+		cmp = o_btree_cmp(scan->desc,
+						  &tuple, BTreeKeyLeafTuple,
+						  &scanRange->low, BTreeKeyBound);
+		if (cmp < 0)
+			return -1;
+		scan->enteredRange = true;
+	}
+
+	cmp = o_btree_cmp(scan->desc,
+					  &tuple, BTreeKeyLeafTuple,
+					  &scanRange->high, BTreeKeyBound);
+	if (cmp > 0)
+		return 1;
+
+	return 0;
+}
+
 
 /*
  * Interates the internal page till we either:
@@ -1453,6 +1606,48 @@ iterate_internal_page(BTreeSeqScan *scan)
 	while (get_next_downlink(scan, &downlink, &scan->keyRangeLow, &scan->keyRangeHigh))
 	{
 		bool		valid_downlink = true;
+
+		/*
+		 * Check if this downlink's key range overlaps the scan's
+		 * qualification range.  Skip downlinks entirely before the scan
+		 * range; abort the loop when we're past it.
+		 */
+		if (scan->scanRange)
+		{
+			int			rangeCheck;
+
+			rangeCheck = check_downlink_in_scan_range(scan,
+													  scan->keyRangeLow.tuple,
+													  scan->keyRangeHigh.tuple);
+			if (rangeCheck == -1)
+			{
+				/* Downlink is entirely before scan range: skip it */
+				if (scan->poscan)
+					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
+				continue;
+			}
+			else if (rangeCheck == 1)
+			{
+				/* Downlink is entirely after scan range: we're done */
+				if (scan->poscan)
+					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
+				break;
+			}
+
+			/*
+			 * Downlink overlaps scan range.  Check if it is fully contained —
+			 * if so, per-tuple range checks can be skipped for all tuples on
+			 * this page.
+			 */
+			scan->pageFullyInRange =
+				page_fully_in_scan_range(scan,
+										 scan->keyRangeLow.tuple,
+										 scan->keyRangeHigh.tuple);
+		}
+		else
+			scan->pageFullyInRange = false;
+
+		scan->enteredRange = false;
 
 		if (scan->cb && scan->cb->isRangeValid)
 			valid_downlink = scan->cb->isRangeValid(scan->keyRangeLow.tuple, scan->keyRangeHigh.tuple,
@@ -1477,7 +1672,8 @@ iterate_internal_page(BTreeSeqScan *scan)
 		{
 			if (DOWNLINK_IS_ON_DISK(downlink))
 			{
-				add_on_disk_downlink(scan, downlink, scan->context.imgReadCsn);
+				add_on_disk_downlink(scan, downlink, scan->context.imgReadCsn,
+									 scan->pageFullyInRange);
 				if (scan->poscan)
 					pg_atomic_fetch_sub_u32(&scan->poscan->downlinksWritersInProgress, 1);
 			}
@@ -1604,52 +1800,87 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 	BTreeSeqScanDiskDownlink downlink;
 	ParallelOScanDesc poscan = scan->poscan;
 
-	if (!poscan)
+	/*
+	 * Loop to skip disk pages that are entirely before the scan range. Each
+	 * iteration claims and reads one page; if the page's hikey shows it is
+	 * before the qualification bounds, we advance and try again.
+	 */
+	do
 	{
-		if (scan->downlinkIndex >= scan->downlinksCount)
-			return false;
-
-		downlink = scan->diskDownlinks[scan->downlinkIndex];
-	}
-	else
-	{
-		uint64		index = pg_atomic_fetch_add_u64(&poscan->downlinkIndex, 1);
-
-		if (index >= pg_atomic_read_u64(&poscan->downlinksCount))
+		if (!poscan)
 		{
-			if (scan->dsmSeg)
-			{
-				dsm_detach(scan->dsmSeg);
-				scan->dsmSeg = NULL;
-			}
-			return false;
+			if (scan->downlinkIndex >= scan->downlinksCount)
+				return false;
+
+			downlink = scan->diskDownlinks[scan->downlinkIndex];
 		}
-		downlink = ((BTreeSeqScanDiskDownlink *) dsm_segment_address(scan->dsmSeg))[index];
-	}
-
-	read_result = read_page_from_disk(scan->desc,
-									  scan->leafImg,
-									  downlink.downlink,
-									  &extent);
-	header = (BTreePageHeader *) scan->leafImg;
-	if (header->csn >= downlink.csn)
-		read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
-							downlink.csn, NULL, BTreeKeyNone, NULL);
-
-	STOPEVENT(STOPEVENT_SCAN_DISK_PAGE,
-			  btree_page_stopevent_params(scan->desc,
-										  scan->leafImg));
-
-	if (read_result != OReadPageResultOk)
-	{
-		if (read_result == OReadPageResultChecksumFailed)
-			ereport(ERROR,
-					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("invalid leaf page with file offset " UINT64_FORMAT " read from disk",
-							DOWNLINK_GET_DISK_OFF(downlink.downlink))));
 		else
-			elog(ERROR, "can not read leaf page from disk");
-	}
+		{
+			uint64		index = pg_atomic_fetch_add_u64(&poscan->downlinkIndex, 1);
+
+			if (index >= pg_atomic_read_u64(&poscan->downlinksCount))
+			{
+				if (scan->dsmSeg)
+				{
+					dsm_detach(scan->dsmSeg);
+					scan->dsmSeg = NULL;
+				}
+				return false;
+			}
+			downlink = ((BTreeSeqScanDiskDownlink *) dsm_segment_address(scan->dsmSeg))[index];
+		}
+
+		read_result = read_page_from_disk(scan->desc,
+										  scan->leafImg,
+										  downlink.downlink,
+										  &extent);
+		header = (BTreePageHeader *) scan->leafImg;
+		if (header->csn >= downlink.csn)
+			read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
+								downlink.csn, NULL, BTreeKeyNone, NULL);
+
+		STOPEVENT(STOPEVENT_SCAN_DISK_PAGE,
+				  btree_page_stopevent_params(scan->desc,
+											  scan->leafImg));
+
+		if (read_result != OReadPageResultOk)
+		{
+			if (read_result == OReadPageResultChecksumFailed)
+				ereport(ERROR,
+						(errcode(ERRCODE_DATA_CORRUPTED),
+						 errmsg("invalid leaf page with file offset " UINT64_FORMAT " read from disk",
+								DOWNLINK_GET_DISK_OFF(downlink.downlink))));
+			else
+				elog(ERROR, "can not read leaf page from disk");
+		}
+
+		scan->downlinkIndex++;
+
+		/*
+		 * If a scan range filter is active, check whether this disk page's
+		 * key range overlaps the qualification bounds.  For a non-rightmost
+		 * page, the hikey is the upper bound of all tuples on the page.  If
+		 * hikey < scanLowKey, the page is entirely before the scan range;
+		 * skip it and try the next page.  (Rightmost pages have no hikey, so
+		 * we can't skip them here — tuple-level filtering will handle it.)
+		 */
+		if (scan->scanRange &&
+			!O_PAGE_IS(scan->leafImg, RIGHTMOST))
+		{
+			OTuple		hikey;
+			int			cmp;
+
+			BTREE_PAGE_GET_HIKEY(hikey, scan->leafImg);
+			cmp = o_btree_cmp(scan->desc,
+							  &hikey, BTreeKeyNonLeafKey,
+							  &scan->scanRange->low, BTreeKeyBound);
+			if (cmp < 0)
+				continue;		/* page entirely before scan range */
+		}
+
+		/* Page overlaps the scan range or no filter is active */
+		break;
+	} while (true);
 
 	/*
 	 * A disk leaf is read whole into the private leafImg, so any partial-read
@@ -1659,9 +1890,10 @@ load_next_disk_leaf_page(BTreeSeqScan *scan)
 	 */
 	scan->leafPartial.isPartial = false;
 	scan->haveLastLeafKey = false;
+	scan->pageFullyInRange = downlink.fullyInRange;
+	scan->enteredRange = false;
 
 	BTREE_PAGE_LOCATOR_FIRST(scan->leafImg, &scan->leafLoc);
-	scan->downlinkIndex++;
 	scan->hint.blkno = OInvalidInMemoryBlkno;
 	scan->hint.pageChangeCount = InvalidOPageChangeCount;
 	O_TUPLE_SET_NULL(scan->nextKey.tuple);
@@ -1895,6 +2127,10 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 	scan->checkpointNumberSet = false;
 	scan->haveHistImg = false;
 	BTREE_PAGE_LOCATOR_SET_INVALID(&scan->leafLoc);
+
+	scan->scanRange = NULL;
+	scan->pageFullyInRange = false;
+	scan->enteredRange = false;
 
 	dlist_push_tail(&listOfScans, &scan->listNode);
 	scan->resowner = NULL;
@@ -2238,6 +2474,20 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 			BTREE_PAGE_LOCATOR_NEXT(scan->histImg, &scan->histLoc);
 			if (!O_TUPLE_IS_NULL(tuple))
 			{
+				if (scan->scanRange && !scan->pageFullyInRange)
+				{
+					int			rangeCheck = tuple_in_scan_range(scan, tuple);
+
+					if (rangeCheck == -1)
+						continue;	/* tuple before scan range, skip */
+					if (rangeCheck == 1)
+					{
+						/* tuple past scan range, scan is done */
+						scan->status = BTreeSeqScanFinished;
+						O_TUPLE_SET_NULL(tuple);
+						return tuple;
+					}
+				}
 				if (hint)
 					*hint = scan->hint;
 				return tuple;
@@ -2336,6 +2586,20 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 		BTREE_PAGE_LOCATOR_NEXT(scan->leafImg, &scan->leafLoc);
 		if (!O_TUPLE_IS_NULL(tuple))
 		{
+			if (scan->scanRange && !scan->pageFullyInRange)
+			{
+				int			rangeCheck = tuple_in_scan_range(scan, tuple);
+
+				if (rangeCheck == -1)
+					continue;	/* tuple before scan range, skip */
+				if (rangeCheck == 1)
+				{
+					/* tuple past scan range, scan is done */
+					scan->status = BTreeSeqScanFinished;
+					O_TUPLE_SET_NULL(tuple);
+					return tuple;
+				}
+			}
 			if (hint)
 				*hint = scan->hint;
 			return tuple;
@@ -2583,6 +2847,13 @@ void
 free_btree_seq_scan(BTreeSeqScan *scan)
 {
 	free_btree_seq_scan_internal(scan, false);
+}
+
+void
+btree_seq_scan_set_range_filter(BTreeSeqScan *scan,
+								OBTreeKeyRange *scanRange)
+{
+	scan->scanRange = scanRange;
 }
 
 /*

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -145,7 +145,7 @@ orioledb_btree_handler(void)
 	amroutine->amstorage = false;
 	amroutine->amclusterable = true;
 	amroutine->ampredlocks = true;
-	amroutine->amcanparallel = false;
+	amroutine->amcanparallel = true;
 	amroutine->amcaninclude = true;
 	amroutine->amusemaintenanceworkmem = false;
 	amroutine->amsummarizing = false;

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -2141,12 +2141,6 @@ orioledb_get_relation_info_hook(PlannerInfo *root,
 					options = (OBTOptions *) index->rd_options;
 
 					/*
-					 * TODO: Remove when parallel index scan will be
-					 * implemented
-					 */
-					info->amcanparallel = false;
-
-					/*
 					 * Only the single-field uint64 encoding is enabled in the
 					 * planner for now.  The composite (fixed-key) path is
 					 * fully implemented and unit-tested, but choosing it well

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -572,6 +572,15 @@ switch_to_next_range(OIndexDescr *indexDescr, OScanState *ostate,
 	if (ostate->curKeyRangeIsLoaded)
 		result = o_bt_advance_array_keys_increment(ostate, ostate->scanDir);
 	else if (so->numArrayKeys)
+
+		/*
+		 * First range of an array scan: position the array keys at the
+		 * scan-direction start (last element for a backward scan, first for
+		 * forward).  Without this a backward scan starts on the smallest
+		 * element and the first o_bt_advance_array_keys_increment() rolls off
+		 * the low end, dropping every element but the smallest.  (PG17+ does
+		 * this in the branch above.)
+		 */
 		_bt_start_array_keys(scan, ostate->scanDir);
 #endif
 

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -62,6 +62,12 @@ init_index_scan_state(OPlanState *o_plan_state, OScanState *ostate,
 	pfree(scan);
 	scan = &ostate->scandesc;
 
+	/*
+	 * For parallel-aware index scans, the parallel state is managed through
+	 * OScanState.pidxscan rather than the standard IndexScanDescData
+	 * parallel_scan.  Leave parallel_scan NULL in that case since we don't
+	 * use the standard parallel index scan infrastructure.
+	 */
 	scan->parallel_scan = NULL;
 	scan->xs_temp_snap = false;
 #if PG_VERSION_NUM >= 180000
@@ -1036,6 +1042,162 @@ o_index_scan_getnext(OTableDescr *descr, OScanState *ostate,
 	return tup;
 }
 
+static BTreeSeqScan *
+o_exec_parallel_idx_scan_new_seqscan(OScanState *ostate,
+									 OIndexDescr *indexDescr)
+{
+	BTreeSeqScan *seqScan;
+
+	seqScan = make_btree_seq_scan(&indexDescr->desc,
+								  &ostate->oSnapshot,
+								  ostate->pidxscan);
+
+	if (!ostate->curKeyRange.empty)
+		btree_seq_scan_set_range_filter(seqScan, &ostate->curKeyRange);
+
+	return seqScan;
+}
+
+static void
+o_exec_parallel_idx_scan_load_keyrange(OScanState *ostate,
+									   OIndexDescr *indexDescr,
+									   MemoryContext tupleCxt)
+{
+	BTScanOpaque so = (BTScanOpaque) ostate->scandesc.opaque;
+	MemoryContext oldcontext;
+
+	if (ostate->curKeyRangeIsLoaded)
+		return;
+
+	ostate->curKeyRangeIsLoaded = true;
+
+	if (so->numArrayKeys)
+	{
+		/* punt if we have any unsatisfiable array keys */
+		if (so->numArrayKeys < 0)
+		{
+			ostate->curKeyRange.empty = true;
+			return;
+		}
+
+		_bt_start_array_keys(&ostate->scandesc, ostate->scanDir);
+	}
+	_bt_preprocess_keys(&ostate->scandesc);
+	ostate->numPrefixExactKeys =
+		o_adjust_num_prefix_exact_keys(so, ostate->numPrefixExactKeys);
+	ostate->curKeyRange.empty = true;
+
+	pgstat_count_index_scan(ostate->scandesc.indexRelation);
+#if PG_VERSION_NUM >= 180000
+
+	/*
+	 * Match upstream AMs (nbtsearch.c::_bt_first et al.) and bump the PG18
+	 * EXPLAIN ANALYZE "Index Searches" counter once per descent from root.
+	 * This is the same point at which we account a logical index scan for
+	 * pgstat.
+	 */
+	if (ostate->scandesc.instrument)
+		ostate->scandesc.instrument->nsearches++;
+#endif
+
+	oldcontext = MemoryContextSwitchTo(ostate->cxt);
+	ostate->exact = o_key_data_to_key_range(&ostate->curKeyRange,
+											so->keyData,
+											so->numberOfKeys,
+											(so->numArrayKeys > 0) ? so->arrayKeys : NULL,
+											0,
+											indexDescr->nonLeafTupdesc->natts,
+											indexDescr->fields);
+	MemoryContextSwitchTo(oldcontext);
+}
+
+static TupleTableSlot *
+o_exec_parallel_idx_scan(OScanState *ostate, ScanState *ss)
+{
+	OTableDescr *descr = relation_get_descr(ss->ss_currentRelation);
+	OIndexDescr *indexDescr = descr->indices[ostate->ixNum];
+	MemoryContext tupleCxt = ss->ss_ScanTupleSlot->tts_mcxt;
+
+	if (ostate->seqScan == NULL)
+	{
+		Assert(ostate->pidxscan != NULL);
+		Assert(ostate->scanDir == ForwardScanDirection);
+
+		o_exec_parallel_idx_scan_load_keyrange(ostate, indexDescr, tupleCxt);
+
+		if (ostate->curKeyRange.empty)
+			return ExecClearTuple(ss->ss_ScanTupleSlot);
+
+		ostate->seqScan = o_exec_parallel_idx_scan_new_seqscan(ostate,
+															   indexDescr);
+	}
+
+	while (true)
+	{
+		BTreeLocationHint hint = {OInvalidInMemoryBlkno, 0};
+		CommitSeqNo tupleCsn;
+		OTuple		tuple;
+		BTScanOpaque so = (BTScanOpaque) ostate->scandesc.opaque;
+
+		tuple = btree_seq_scan_getnext(ostate->seqScan, tupleCxt,
+									   &tupleCsn, &hint);
+
+		if (O_TUPLE_IS_NULL(tuple))
+			return ExecClearTuple(ss->ss_ScanTupleSlot);
+
+		if (!ostate->curKeyRange.empty)
+		{
+			/*
+			 * For parallel scans with SAOP, we use a union range covering all
+			 * array elements (see o_exec_parallel_idx_scan_load_keyrange
+			 * passing numPrefixExactKeys=0).  Filter each tuple against the
+			 * actual array elements by passing 0 here too, so that
+			 * is_tuple_valid checks every array key regardless of position.
+			 */
+			int			numPrefix = so->numArrayKeys > 0 ? 0 :
+				ostate->numPrefixExactKeys;
+
+			if (!is_tuple_valid(tuple, indexDescr, &ostate->curKeyRange,
+								so, numPrefix))
+				continue;
+		}
+
+		if (ostate->ixNum == PrimaryIndexNumber || ostate->onlyCurIx)
+		{
+			tts_orioledb_store_tuple(ss->ss_ScanTupleSlot, tuple,
+									 descr, tupleCsn, ostate->ixNum,
+									 true, &hint);
+		}
+		else
+		{
+			OBTreeKeyBound bound;
+			OTuple		ptup;
+			OIndexDescr *primary = GET_PRIMARY(descr);
+
+			o_fill_pindex_tuple_key_bound(&indexDescr->desc, tuple, &bound);
+
+			ptup = o_btree_find_tuple_by_key(&primary->desc,
+											 (Pointer) &bound, BTreeKeyBound,
+											 &ostate->oSnapshot, &tupleCsn,
+											 tupleCxt, NULL);
+			pfree(tuple.data);
+
+			if (O_TUPLE_IS_NULL(ptup))
+				continue;
+
+			tts_orioledb_store_tuple(ss->ss_ScanTupleSlot, ptup,
+									 descr, tupleCsn, PrimaryIndexNumber,
+									 true, NULL);
+		}
+
+		if (!o_exec_qual(ss->ps.ps_ExprContext,
+						 ss->ps.qual, ss->ss_ScanTupleSlot))
+			continue;
+
+		return ss->ss_ScanTupleSlot;
+	}
+}
+
 /* fetches next tuple for oIterateDirectModify */
 TupleTableSlot *
 o_exec_fetch(OScanState *ostate, ScanState *ss)
@@ -1046,6 +1208,9 @@ o_exec_fetch(OScanState *ostate, ScanState *ss)
 	bool		scan_primary = ostate->ixNum == PrimaryIndexNumber ||
 		!ostate->onlyCurIx;
 	MemoryContext tupleCxt = ss->ss_ScanTupleSlot->tts_mcxt;
+
+	if (ostate->pidxscan)
+		return o_exec_parallel_idx_scan(ostate, ss);
 
 	do
 	{

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -1045,11 +1045,171 @@ o_index_scan_getnext(OTableDescr *descr, OScanState *ostate,
 	return tup;
 }
 
+/*
+ * Downlink filter for a parallel scan over "col = ANY (array)".
+ *
+ * A parallel scan hands out level-1 downlinks, so it cannot turn an array
+ * into one descent per element the way the serial scan does (see
+ * switch_to_next_range()); its key range is the union
+ * [smallest element, largest element].  For a sparse array -- IN (1, 1000000)
+ * -- that union spans nearly the whole index, and every leaf in between would
+ * be read only to have all of its rows rejected by is_tuple_valid().
+ *
+ * A leaf whose key range holds no array element cannot hold a matching row,
+ * so it does not have to be read at all.  Rejecting those downlinks brings
+ * the pages read back to what the per-element scan reads, leaving only the
+ * level-1 internal chain -- a small fraction of the tree -- walked in full.
+ *
+ * This applies to an array on the index's leading column.  An array on a
+ * later column is interleaved with every value of the leading column, so page
+ * granularity buys nothing there and the union range stands.
+ */
+typedef struct
+{
+	OIndexDescr *indexDescr;
+	BTArrayKeyInfo *arrayKey;
+	OComparator *comparator;
+	bool		ascending;
+} OArrayDownlinkFilter;
+
+/*
+ * Compare an array element against a boundary value in index order (the order
+ * elem_values is sorted in), mirroring the membership test in
+ * is_tuple_valid().
+ */
+static inline int
+array_elem_cmp(OArrayDownlinkFilter *filter, Datum elem, Datum boundary)
+{
+	int			cmp = o_call_comparator(filter->comparator, elem, boundary);
+
+	return filter->ascending ? cmp : -cmp;
+}
+
+/*
+ * Does the key range [low, high) hold any array element?
+ *
+ * A NULL boundary is the corresponding infinity.  The test is on the leading
+ * key column alone, which makes it conservative on the high side -- high is
+ * an exclusive whole-key bound, while a leading value equal to high's leading
+ * value may still sort below it -- and conservative is the safe direction: it
+ * can admit a page with no match, never reject one with a match.
+ */
+static bool
+o_array_downlink_is_valid(OTuple low, OTuple high, void *arg)
+{
+	OArrayDownlinkFilter *filter = (OArrayDownlinkFilter *) arg;
+	OIndexDescr *id = filter->indexDescr;
+	BTArrayKeyInfo *arrayKey = filter->arrayKey;
+	int			attnum = OIndexKeyAttnumToTupleAttnum(BTreeKeyNonLeafKey, id, 1);
+	Datum		boundary;
+	bool		isnull;
+	int			lo = 0,
+				hi = arrayKey->num_elems - 1;
+
+	Assert(arrayKey->num_elems > 0);
+
+	/*
+	 * Find the first element at or after the low boundary.  Elements are
+	 * sorted in index order, so this is a binary search.
+	 */
+	if (!O_TUPLE_IS_NULL(low))
+	{
+		boundary = o_fastgetattr(low, attnum, id->nonLeafTupdesc,
+								 &id->nonLeafSpec, &isnull);
+
+		/* A NULL boundary sorts outside the elements; do not filter on it. */
+		if (isnull)
+			return true;
+
+		while (lo <= hi)
+		{
+			int			mid = lo + (hi - lo) / 2;
+
+			if (array_elem_cmp(filter, arrayKey->elem_values[mid], boundary) < 0)
+				lo = mid + 1;
+			else
+				hi = mid - 1;
+		}
+	}
+
+	/* Every element sorts below the page. */
+	if (lo >= arrayKey->num_elems)
+		return false;
+
+	if (O_TUPLE_IS_NULL(high))
+		return true;
+
+	boundary = o_fastgetattr(high, attnum, id->nonLeafTupdesc,
+							 &id->nonLeafSpec, &isnull);
+	if (isnull)
+		return true;
+
+	return array_elem_cmp(filter, arrayKey->elem_values[lo], boundary) <= 0;
+}
+
+static BTreeSeqScanCallbacks arrayDownlinkCallbacks = {
+	.isRangeValid = o_array_downlink_is_valid,
+	.getNextKey = NULL
+};
+
+/*
+ * Build the downlink filter, or return NULL when this scan cannot use one:
+ * no array on the leading column, or a leading skip array (PG18), whose
+ * elements are not enumerated.
+ */
+static OArrayDownlinkFilter *
+o_make_array_downlink_filter(OScanState *ostate, OIndexDescr *indexDescr)
+{
+	BTScanOpaque so = (BTScanOpaque) ostate->scandesc.opaque;
+	OIndexField *field = &indexDescr->fields[0];
+	OBTreeValueBound *bound = &ostate->curKeyRange.low.keys[0];
+	int			i;
+
+	if (so->numArrayKeys <= 0 || ostate->curKeyRange.empty)
+		return NULL;
+
+	for (i = 0; i < so->numArrayKeys; i++)
+	{
+		BTArrayKeyInfo *arrayKey = &so->arrayKeys[i];
+		ScanKey		key = so->keyData + arrayKey->scan_key;
+		OArrayDownlinkFilter *filter;
+
+		/* Only the leading index column gives page-level selectivity. */
+		if (key->sk_attno != 1)
+			continue;
+
+		/* A skip array does not enumerate its elements. */
+		if (arrayKey->num_elems <= 0)
+			continue;
+
+		/*
+		 * ostate->cxt outlives the scan it is attached to: a rescan frees the
+		 * scan before resetting the context (o_rescan_custom_scan()).
+		 */
+		filter = (OArrayDownlinkFilter *)
+			MemoryContextAlloc(ostate->cxt, sizeof(OArrayDownlinkFilter));
+		filter->indexDescr = indexDescr;
+		filter->arrayKey = arrayKey;
+		filter->ascending = field->ascending;
+
+		/* Same comparator choice as the per-tuple test in is_tuple_valid(). */
+		if (o_bound_is_coercible(bound, field))
+			filter->comparator = field->comparator;
+		else
+			filter->comparator = bound->comparator;
+
+		return filter;
+	}
+
+	return NULL;
+}
+
 static BTreeSeqScan *
 o_exec_parallel_idx_scan_new_seqscan(OScanState *ostate,
 									 OIndexDescr *indexDescr)
 {
 	BTreeSeqScan *seqScan;
+	OArrayDownlinkFilter *filter;
 
 	seqScan = make_btree_seq_scan(&indexDescr->desc,
 								  &ostate->oSnapshot,
@@ -1057,6 +1217,10 @@ o_exec_parallel_idx_scan_new_seqscan(OScanState *ostate,
 
 	if (!ostate->curKeyRange.empty)
 		btree_seq_scan_set_range_filter(seqScan, &ostate->curKeyRange);
+
+	filter = o_make_array_downlink_filter(ostate, indexDescr);
+	if (filter)
+		btree_seq_scan_set_callbacks(seqScan, &arrayDownlinkCallbacks, filter);
 
 	/*
 	 * An ordered parallel path reads on-disk downlinks inline in the plan's

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -1006,6 +1006,9 @@ o_index_scan_getnext(OTableDescr *descr, OScanState *ostate,
 		/*
 		 * if we should fetch tuple from primary and the current index is
 		 * secondary
+		 *
+		 * o_exec_parallel_idx_scan() repeats this lookup for the parallel
+		 * scan; keep the two in sync.
 		 */
 		if (ostate->ixNum != PrimaryIndexNumber)
 		{
@@ -1182,6 +1185,10 @@ o_exec_parallel_idx_scan(OScanState *ostate, ScanState *ss)
 			OTuple		ptup;
 			OIndexDescr *primary = GET_PRIMARY(descr);
 
+			/*
+			 * Same secondary-to-primary lookup that o_index_scan_getnext()
+			 * performs for the serial scan; keep the two in sync.
+			 */
 			o_fill_pindex_tuple_key_bound(&indexDescr->desc, tuple, &bound);
 
 			ptup = o_btree_find_tuple_by_key(&primary->desc,

--- a/src/tableam/index_scan.c
+++ b/src/tableam/index_scan.c
@@ -1055,6 +1055,13 @@ o_exec_parallel_idx_scan_new_seqscan(OScanState *ostate,
 	if (!ostate->curKeyRange.empty)
 		btree_seq_scan_set_range_filter(seqScan, &ostate->curKeyRange);
 
+	/*
+	 * An ordered parallel path reads on-disk downlinks inline in the plan's
+	 * scan direction so each worker emits a sorted stream (for Gather Merge).
+	 */
+	if (ostate->ordered)
+		btree_seq_scan_set_ordered(seqScan, true, ostate->scanDir);
+
 	return seqScan;
 }
 
@@ -1121,7 +1128,8 @@ o_exec_parallel_idx_scan(OScanState *ostate, ScanState *ss)
 	if (ostate->seqScan == NULL)
 	{
 		Assert(ostate->pidxscan != NULL);
-		Assert(ostate->scanDir == ForwardScanDirection);
+		Assert(ostate->scanDir == ForwardScanDirection ||
+			   ostate->scanDir == BackwardScanDirection);
 
 		o_exec_parallel_idx_scan_load_keyrange(ostate, indexDescr, tupleCxt);
 

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -184,6 +184,18 @@ o_find_ix_num(IndexPath *ix_path, OTableDescr *descr)
 }
 
 /*
+ * Index pages a scan on this path is expected to read.
+ *
+ * Both the worker estimate and the ordered-path penalty below are driven by
+ * this number, so they stay in step.
+ */
+static inline double
+o_index_path_pages(IndexPath *ipath)
+{
+	return (double) ipath->indexinfo->pages * ipath->indexselectivity;
+}
+
+/*
  * Estimate the number of parallel workers for a parallel index scan.
  */
 static int
@@ -209,7 +221,7 @@ o_estimate_parallel_workers(PlannerInfo *root, RelOptInfo *rel,
 	if (RecoveryInProgress())
 		return 0;
 
-	index_pages = (double) ipath->indexinfo->pages * ipath->indexselectivity;
+	index_pages = o_index_path_pages(ipath);
 
 	/*
 	 * For secondary index scans that need a primary index lookup, each
@@ -551,8 +563,7 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 								 * instead of the sequential disk phase,
 								 * spread over the workers.
 								 */
-								pages = ix_path->indexinfo->pages *
-									ix_path->indexselectivity;
+								pages = o_index_path_pages(ix_path);
 								penalty = pages *
 									Max(random_page_cost - seq_page_cost, 0.0) /
 									(parallel_workers + 1);

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -28,8 +28,10 @@
 #include "tuple/slot.h"
 #include "utils/stopevent.h"
 
+#include "access/nbtree.h"
 #include "access/relation.h"
 #include "access/table.h"
+#include "access/xlog.h"
 #include "common/hashfn.h"
 #include "executor/executor.h"
 #include "executor/nodeIndexscan.h"
@@ -92,6 +94,15 @@ static void o_explain_custom_scan(CustomScanState *node, List *ancestors,
 								  ExplainState *es);
 static Node *o_create_custom_scan_state(CustomScan *cscan);
 
+static Size o_idx_scan_estimate_dsm(CustomScanState *node,
+									ParallelContext *pcxt);
+static void o_idx_scan_init_dsm(CustomScanState *node,
+								ParallelContext *pcxt, void *coordinate);
+static void o_idx_scan_init_worker(CustomScanState *node,
+								   shm_toc *toc, void *coordinate);
+static void o_idx_scan_reinit_dsm(CustomScanState *node,
+								  ParallelContext *pcxt, void *coordinate);
+
 static CustomPathMethods o_path_methods =
 {
 	.CustomName = "o_path",
@@ -121,6 +132,23 @@ static CustomExecMethods o_scan_exec_methods =
 	o_explain_custom_scan
 };
 
+static CustomExecMethods o_parallel_idx_scan_exec_methods =
+{
+	"o_exec_parallel_idx_scan",
+	o_begin_custom_scan,
+	o_exec_custom_scan,
+	o_end_custom_scan,
+	o_rescan_custom_scan,
+	NULL,
+	NULL,
+	o_idx_scan_estimate_dsm,
+	o_idx_scan_init_dsm,
+	o_idx_scan_reinit_dsm,
+	o_idx_scan_init_worker,
+	NULL,
+	o_explain_custom_scan
+};
+
 /* No existing callers */
 bool
 is_o_custom_scan(CustomScan *scan)
@@ -132,7 +160,66 @@ is_o_custom_scan(CustomScan *scan)
 bool
 is_o_custom_scan_state(CustomScanState *scan)
 {
-	return scan->methods == &o_scan_exec_methods;
+	return scan->methods == &o_scan_exec_methods ||
+		scan->methods == &o_parallel_idx_scan_exec_methods;
+}
+
+/*
+ * Find the OrioleDB index number for an IndexPath's target index.
+ * Returns -1 if the index is not an OrioleDB index.
+ */
+static OIndexNumber
+o_find_ix_num(IndexPath *ix_path, OTableDescr *descr)
+{
+	OIndexNumber ix_num;
+
+	for (ix_num = 0; ix_num < descr->nIndices; ix_num++)
+	{
+		if (descr->indices[ix_num]->oids.reloid == ix_path->indexinfo->indexoid)
+			return ix_num;
+	}
+	return -1;
+}
+
+/*
+ * Estimate the number of parallel workers for a parallel index scan.
+ */
+static int
+o_estimate_parallel_workers(PlannerInfo *root, RelOptInfo *rel,
+							IndexPath *ipath, bool is_primary)
+{
+	double		index_pages;
+	double		heap_pages;
+
+	if (ipath->indexscandir != ForwardScanDirection)
+		return 0;
+
+	if (!ipath->path.parallel_safe)
+		return 0;
+
+	/* Parallel index scan not supported during recovery */
+	if (RecoveryInProgress())
+		return 0;
+
+	index_pages = (double) ipath->indexinfo->pages * ipath->indexselectivity;
+
+	/*
+	 * For secondary index scans that need a primary index lookup, each
+	 * matching tuple incurs a random I/O to the primary index.  Factor this
+	 * in via the heap_pages parameter so compute_parallel_worker() doesn't
+	 * over-parallelise when the per-tuple cost dominates.
+	 *
+	 * For primary index scans and index-only scans, the heap (primary index)
+	 * is not accessed during the scan phase, so pass -1 to indicate no heap
+	 * component.
+	 */
+	if (!is_primary && ipath->path.pathtype != T_IndexOnlyScan)
+		heap_pages = ceil(ipath->indexselectivity * Max(rel->pages, 1));
+	else
+		heap_pages = -1;
+
+	return compute_parallel_worker(rel, heap_pages, index_pages,
+								   max_parallel_workers_per_gather);
 }
 
 static Path *
@@ -376,14 +463,75 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 			{
 				Path	   *path = list_nth(rel->partial_pathlist, i);
 
-				/*
-				 * TODO: Remove when parallel bitmap heap scan will be
-				 * implemented
-				 */
-				if (!IsA(path, Path))
-					rel->partial_pathlist = list_delete_nth_cell(rel->partial_pathlist, i);
+				if (IsA(path, IndexPath))
+				{
+					IndexPath  *ix_path = (IndexPath *) path;
+					OIndexNumber ix_num = o_find_ix_num(ix_path, descr);
+
+					/*
+					 * Transform OrioleDB IndexPath entries into CustomPath
+					 * entries so they can run as parallel-aware index scans.
+					 * Only forward scans are supported.
+					 */
+					if (ix_num >= 0 &&
+						ix_path->indexscandir == ForwardScanDirection)
+					{
+						Path	   *custom_path;
+						int			parallel_workers;
+
+						parallel_workers = o_estimate_parallel_workers(root,
+																	   rel,
+																	   ix_path,
+																	   ix_num == PrimaryIndexNumber);
+						if (parallel_workers > 0)
+						{
+							custom_path = transform_path(path, descr);
+							custom_path->parallel_aware = true;
+							custom_path->parallel_workers = parallel_workers;
+
+							/*
+							 * Parallel index scan does not guarantee
+							 * per-worker sorted output: disk-phase downlinks
+							 * are sorted by physical location (not key order)
+							 * and the boundary between in-memory and disk
+							 * phases breaks key ordering across phases. Clear
+							 * pathkeys so the planner uses Gather + Sort
+							 * instead of Gather Merge.
+							 */
+							custom_path->pathkeys = NIL;
+
+							rel->partial_pathlist =
+								list_delete_nth_cell(rel->partial_pathlist, i);
+							rel->partial_pathlist =
+								list_insert_nth(rel->partial_pathlist, i,
+												custom_path);
+							i++;
+						}
+						else
+						{
+							rel->partial_pathlist =
+								list_delete_nth_cell(rel->partial_pathlist, i);
+						}
+					}
+					else
+					{
+						rel->partial_pathlist =
+							list_delete_nth_cell(rel->partial_pathlist, i);
+					}
+				}
+				else if (!IsA(path, Path))
+				{
+					/*
+					 * TODO: Remove when parallel bitmap heap scan will be
+					 * implemented
+					 */
+					rel->partial_pathlist =
+						list_delete_nth_cell(rel->partial_pathlist, i);
+				}
 				else
+				{
 					i++;
+				}
 			}
 		}
 
@@ -517,7 +665,6 @@ o_create_custom_scan_state(CustomScan *cscan)
 	Plan	   *custom_plan;
 
 	node->type = T_CustomScanState;
-	ocstate->css.methods = &o_scan_exec_methods;
 	ocstate->css.slotOps = &TTSOpsOrioleDB;
 
 	Assert(cscan->custom_plans);
@@ -537,6 +684,11 @@ o_create_custom_scan_state(CustomScan *cscan)
 		ix_plan_state->ostate.curKeyRange.empty = true;
 		ix_plan_state->ostate.curKeyRange.low.n_row_keys = 0;
 		ix_plan_state->ostate.curKeyRange.high.n_row_keys = 0;
+
+		if (cscan->scan.plan.parallel_aware)
+			ocstate->css.methods = &o_parallel_idx_scan_exec_methods;
+		else
+			ocstate->css.methods = &o_scan_exec_methods;
 
 		if (IsA(custom_plan, IndexScan))
 		{
@@ -579,6 +731,9 @@ o_create_custom_scan_state(CustomScan *cscan)
 		Assert(false);
 	}
 	ocstate->o_plan_state->type = plan_tag;
+
+	if (ocstate->css.methods == NULL)
+		ocstate->css.methods = &o_scan_exec_methods;
 
 	return node;
 }
@@ -819,6 +974,12 @@ o_rescan_custom_scan(CustomScanState *node)
 		OIndexPlanState *ix_plan_state =
 			(OIndexPlanState *) ocstate->o_plan_state;
 
+		if (ix_plan_state->ostate.seqScan != NULL)
+		{
+			free_btree_seq_scan(ix_plan_state->ostate.seqScan);
+			ix_plan_state->ostate.seqScan = NULL;
+		}
+
 		if (ix_plan_state->iss_NumRuntimeKeys != 0)
 		{
 			ExprContext *econtext = ix_plan_state->iss_RuntimeContext;
@@ -832,6 +993,21 @@ o_rescan_custom_scan(CustomScanState *node)
 
 		btrescan(&ix_plan_state->ostate.scandesc, ix_plan_state->iss_ScanKeys,
 				 ix_plan_state->iss_NumScanKeys, NULL, 0);
+
+		/*
+		 * btrescan() copies scan keys to scan->keyData but leaves
+		 * so->numberOfKeys = 0, expecting the caller to run
+		 * _bt_preprocess_keys() to populate so->keyData/numberOfKeys/qual_ok.
+		 * Do NOT call it here: both execution entry points already do so at
+		 * their start -- the serial path in o_index_scan_getnext() and the
+		 * parallel path in o_exec_parallel_idx_scan_load_keyrange().  On
+		 * PG17+ a second _bt_preprocess_keys() before _bt_start_array_keys()
+		 * has run takes the "numberOfKeys > 0" fast path, whose
+		 * _bt_verify_keys_with_arraykeys() assertion fires because a
+		 * SEARCHARRAY key's sk_argument still points at the array rather than
+		 * elem_values[cur_elem] (crash in bitmap_scan on the "col = ANY(...)"
+		 * queries under a cassert build).
+		 */
 
 		if (ix_plan_state->ostate.iterator != NULL)
 		{
@@ -881,6 +1057,11 @@ o_end_custom_scan(CustomScanState *node)
 
 		ix_plan_state = (OIndexPlanState *) ocstate->o_plan_state;
 
+		if (ix_plan_state->ostate.seqScan != NULL)
+		{
+			free_btree_seq_scan(ix_plan_state->ostate.seqScan);
+			ix_plan_state->ostate.seqScan = NULL;
+		}
 		if (ix_plan_state->ostate.iterator != NULL)
 			btree_iterator_free(ix_plan_state->ostate.iterator);
 		MemoryContextDelete(ix_plan_state->ostate.cxt);
@@ -1175,4 +1356,56 @@ o_explain_custom_scan(CustomScanState *node, List *ancestors, ExplainState *es)
 	}
 	if (is_explain_analyze(ocstate->o_plan_state->plan_state))
 		eanalyze_counters_explain(descr, &ocstate->eaCounters, es);
+}
+
+/*
+ * Parallel index scan DSM callbacks.
+ */
+
+static Size
+o_idx_scan_estimate_dsm(CustomScanState *node, ParallelContext *pcxt)
+{
+	return MAXALIGN(sizeof(ParallelOScanDescData));
+}
+
+static void
+o_idx_scan_init_dsm(CustomScanState *node, ParallelContext *pcxt,
+					void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OIndexPlanState *ix_plan_state =
+		(OIndexPlanState *) ocstate->o_plan_state;
+	ParallelOScanDesc poscan = (ParallelOScanDesc) coordinate;
+
+	orioledb_parallelscan_initialize_inner(&poscan->phs_base);
+
+	ix_plan_state->ostate.pidxscan = poscan;
+
+	node->pscan_len = sizeof(ParallelOScanDescData);
+}
+
+static void
+o_idx_scan_init_worker(CustomScanState *node, shm_toc *toc,
+					   void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OIndexPlanState *ix_plan_state =
+		(OIndexPlanState *) ocstate->o_plan_state;
+	ParallelOScanDesc poscan = (ParallelOScanDesc) coordinate;
+
+	ix_plan_state->ostate.pidxscan = poscan;
+}
+
+static void
+o_idx_scan_reinit_dsm(CustomScanState *node, ParallelContext *pcxt,
+					  void *coordinate)
+{
+	OCustomScanState *ocstate = (OCustomScanState *) node;
+	OIndexPlanState *ix_plan_state =
+		(OIndexPlanState *) ocstate->o_plan_state;
+	ParallelOScanDesc poscan = (ParallelOScanDesc) coordinate;
+
+	orioledb_parallelscan_initialize_inner(&poscan->phs_base);
+
+	ix_plan_state->ostate.seqScan = NULL;
 }

--- a/src/tableam/scan.c
+++ b/src/tableam/scan.c
@@ -72,6 +72,8 @@ typedef struct OIndexPath
 	OPath		o_path;
 	ScanDirection scandir;
 	OIndexNumber ix_num;
+	/* ordered (key-order) parallel scan: reads on-disk downlinks inline */
+	bool		ordered;
 } OIndexPath;
 
 typedef struct OBitmapHeapPath
@@ -191,7 +193,13 @@ o_estimate_parallel_workers(PlannerInfo *root, RelOptInfo *rel,
 	double		index_pages;
 	double		heap_pages;
 
-	if (ipath->indexscandir != ForwardScanDirection)
+	/*
+	 * Only forward and backward index scans are supported; a backward scan
+	 * runs the ordered backward engine (the caller only keeps the ordered
+	 * variant of a backward path).
+	 */
+	if (ipath->indexscandir != ForwardScanDirection &&
+		ipath->indexscandir != BackwardScanDirection)
 		return 0;
 
 	if (!ipath->path.parallel_safe)
@@ -223,7 +231,7 @@ o_estimate_parallel_workers(PlannerInfo *root, RelOptInfo *rel,
 }
 
 static Path *
-transform_path(Path *src_path, OTableDescr *descr)
+transform_path(Path *src_path, OTableDescr *descr, bool ordered)
 {
 	CustomPath *result;
 
@@ -252,6 +260,7 @@ transform_path(Path *src_path, OTableDescr *descr)
 		new_path->o_path.type = O_IndexPath;
 		new_path->ix_num = PrimaryIndexNumber;
 		new_path->scandir = ForwardScanDirection;
+		new_path->ordered = ordered;
 		result->custom_private = list_make1(new_path);
 	}
 	else if (IsA(src_path, IndexPath))
@@ -272,6 +281,7 @@ transform_path(Path *src_path, OTableDescr *descr)
 		new_path->o_path.type = O_IndexPath;
 		new_path->ix_num = ix_num;
 		new_path->scandir = ix_path->indexscandir;
+		new_path->ordered = ordered;
 		result->custom_private = list_make1(new_path);
 	}
 	else if (IsA(src_path, BitmapHeapPath))
@@ -447,7 +457,8 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 
 					if (replace)
 					{
-						Path	   *custom_path = transform_path(path, descr);
+						Path	   *custom_path = transform_path(path, descr,
+																 false);
 
 						rel->pathlist = list_delete_nth_cell(rel->pathlist, i);
 
@@ -471,46 +482,89 @@ orioledb_set_rel_pathlist_hook(PlannerInfo *root, RelOptInfo *rel,
 					/*
 					 * Transform OrioleDB IndexPath entries into CustomPath
 					 * entries so they can run as parallel-aware index scans.
-					 * Only forward scans are supported.
+					 * We can emit two variants:
+					 *
+					 * - Unordered (forward only): the default parallel index
+					 * scan does not guarantee per-worker sorted output --
+					 * disk-phase downlinks are sorted by physical location
+					 * and the in-memory/disk phase boundary breaks key order
+					 * -- so drop pathkeys and let the planner use Gather (+
+					 * Sort if an ordering is needed).  This is the cheapest
+					 * variant.
+					 *
+					 * - Ordered (forward and backward): reads on-disk
+					 * downlinks inline in key order, so each worker emits a
+					 * sorted stream and the planner can use Gather Merge.
+					 * Reading disk leaves inline forgoes the physically
+					 * sorted disk phase, so its cost is penalised; the
+					 * planner then prefers the unordered variant unless the
+					 * ordering pays for itself.  A backward index path exists
+					 * only to provide descending order, so only its ordered
+					 * variant is useful.
 					 */
 					if (ix_num >= 0 &&
-						ix_path->indexscandir == ForwardScanDirection)
+						(ix_path->indexscandir == ForwardScanDirection ||
+						 ix_path->indexscandir == BackwardScanDirection))
 					{
-						Path	   *custom_path;
 						int			parallel_workers;
 
 						parallel_workers = o_estimate_parallel_workers(root,
 																	   rel,
 																	   ix_path,
 																	   ix_num == PrimaryIndexNumber);
+
+						/* The original IndexPath is always replaced. */
+						rel->partial_pathlist =
+							list_delete_nth_cell(rel->partial_pathlist, i);
+
 						if (parallel_workers > 0)
 						{
-							custom_path = transform_path(path, descr);
-							custom_path->parallel_aware = true;
-							custom_path->parallel_workers = parallel_workers;
+							int			ninserted = 0;
 
-							/*
-							 * Parallel index scan does not guarantee
-							 * per-worker sorted output: disk-phase downlinks
-							 * are sorted by physical location (not key order)
-							 * and the boundary between in-memory and disk
-							 * phases breaks key ordering across phases. Clear
-							 * pathkeys so the planner uses Gather + Sort
-							 * instead of Gather Merge.
-							 */
-							custom_path->pathkeys = NIL;
+							if (ix_path->indexscandir == ForwardScanDirection)
+							{
+								Path	   *unordered;
 
-							rel->partial_pathlist =
-								list_delete_nth_cell(rel->partial_pathlist, i);
-							rel->partial_pathlist =
-								list_insert_nth(rel->partial_pathlist, i,
-												custom_path);
-							i++;
-						}
-						else
-						{
-							rel->partial_pathlist =
-								list_delete_nth_cell(rel->partial_pathlist, i);
+								unordered = transform_path(path, descr, false);
+								unordered->parallel_aware = true;
+								unordered->parallel_workers = parallel_workers;
+								unordered->pathkeys = NIL;
+								rel->partial_pathlist =
+									list_insert_nth(rel->partial_pathlist,
+													i + ninserted, unordered);
+								ninserted++;
+							}
+
+							if (ix_path->path.pathkeys != NIL)
+							{
+								Path	   *ordered;
+								double		pages;
+								Cost		penalty;
+
+								ordered = transform_path(path, descr, true);
+								ordered->parallel_aware = true;
+								ordered->parallel_workers = parallel_workers;
+
+								/*
+								 * Penalise the inline on-disk reads: roughly
+								 * one random access per selected index page
+								 * instead of the sequential disk phase,
+								 * spread over the workers.
+								 */
+								pages = ix_path->indexinfo->pages *
+									ix_path->indexselectivity;
+								penalty = pages *
+									Max(random_page_cost - seq_page_cost, 0.0) /
+									(parallel_workers + 1);
+								ordered->total_cost += penalty;
+
+								rel->partial_pathlist =
+									list_insert_nth(rel->partial_pathlist,
+													i + ninserted, ordered);
+								ninserted++;
+							}
+
+							i += ninserted;
 						}
 					}
 					else
@@ -616,10 +670,11 @@ o_plan_custom_path(PlannerInfo *root, RelOptInfo *rel,
 		custom_scan->custom_exprs = NIL;
 		custom_scan->custom_private =
 		/* cppcheck-suppress unknownEvaluationOrder */
-			list_make4(makeInteger(O_IndexPlan),
+			list_make5(makeInteger(O_IndexPlan),
 					   makeInteger(ix_path->ix_num),
 					   makeInteger(ix_path->scandir),
-					   makeInteger(onlyCurIx));
+					   makeInteger(onlyCurIx),
+					   makeInteger(ix_path->ordered));
 	}
 	else
 	{
@@ -679,6 +734,8 @@ o_create_custom_scan_state(CustomScan *cscan)
 
 		ix_plan_state->ostate.ixNum = intVal(lsecond(cscan->custom_private));
 		ix_plan_state->ostate.scanDir = intVal(lthird(cscan->custom_private));
+		ix_plan_state->ostate.ordered =
+			intVal(list_nth(cscan->custom_private, 4));
 		ix_plan_state->ostate.iterator = NULL;
 		ix_plan_state->ostate.curKeyRangeIsLoaded = false;
 		ix_plan_state->ostate.curKeyRange.empty = true;

--- a/test/expected/createas.out
+++ b/test/expected/createas.out
@@ -433,10 +433,10 @@ Indexes:
     "o_test_matview_ix1" btree (item_id DESC)
     "o_test_matview_ix2" btree (quantity2)
 View definition:
- SELECT "*VALUES*".column1 AS order_id,
-    "*VALUES*".column2 AS item_id,
-    "*VALUES*".column3 AS quantity2,
-    "*VALUES*".column4 AS price
+ SELECT column1 AS order_id,
+    column2 AS item_id,
+    column3 AS quantity2,
+    column4 AS price
    FROM (VALUES (100,1,'a'::text,nextval('o_matview_seq'::regclass)), (100,3,'b'::text,nextval('o_matview_seq'::regclass))) "*VALUES*";
 
 EXPLAIN (COSTS OFF) SELECT * FROM o_test_matview ORDER BY quantity2;

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -193,14 +193,12 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                     QUERY PLAN                      
------------------------------------------------------
+                 QUERY PLAN                  
+---------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Bitmap heap scan
-   Recheck Cond: ((key >= 100) AND (key <= 110))
-   ->  Bitmap Index Scan on o_test52_pkey
-         Index Cond: ((key >= 100) AND (key <= 110))
-(5 rows)
+   Forward index only scan of: o_test52_pkey
+   Conds: ((key >= 100) AND (key <= 110))
+(3 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -219,14 +217,12 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 
 SET enable_seqscan = off;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                       QUERY PLAN                        
----------------------------------------------------------
+                  QUERY PLAN                  
+----------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Bitmap heap scan
-   Recheck Cond: ((value >= 200) AND (value <= 210))
-   ->  Bitmap Index Scan on o_test52_pkey
-         Index Cond: ((value >= 200) AND (value <= 210))
-(5 rows)
+   Forward index only scan of: o_test52_pkey
+   Conds: ((value >= 200) AND (value <= 210))
+(3 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -7975,16 +7971,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(7 rows)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8004,19 +7996,13 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
-         ->  BitmapOr
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
-(10 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((val_1 > 0) AND (val_2 > 0))
+(4 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8036,16 +8022,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(7 rows)
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8066,20 +8048,13 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-         Bitmap heap scan
-         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
-         ->  BitmapOr
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
-(11 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((val_1 > 0) AND (val_2 > 0))
+(4 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8100,16 +8075,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(7 rows)
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8160,16 +8131,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(7 rows)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8251,14 +8218,12 @@ SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Bitmap heap scan
-   Recheck Cond: (val_1 < 2)
-   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
-         Index Cond: (val_1 < 2)
-(5 rows)
+   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
+   Conds: (val_1 < 2)
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8619,17 +8584,13 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Sort
-   Sort Key: i, j, k
-   ->  Custom Scan (o_scan) on o_test_saop
-         Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-         Bitmap heap scan
-         Recheck Cond: (i < ANY ('{3,4,5}'::integer[]))
-         ->  Bitmap Index Scan on o_test_saop_pkey
-               Index Cond: (i < ANY ('{3,4,5}'::integer[]))
-(8 rows)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_saop
+   Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+   Forward index only scan of: o_test_saop_pkey
+   Conds: (i < ANY ('{3,4,5}'::integer[]))
+(4 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8708,17 +8669,13 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Sort
-   Sort Key: i, j, k
-   ->  Custom Scan (o_scan) on o_test_saop
-         Filter: (j = ANY ('{1,3}'::integer[]))
-         Bitmap heap scan
-         Recheck Cond: (i < ANY ('{1,2}'::integer[]))
-         ->  Bitmap Index Scan on o_test_saop_pkey
-               Index Cond: (i < ANY ('{1,2}'::integer[]))
-(8 rows)
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (o_scan) on o_test_saop
+   Filter: (j = ANY ('{1,3}'::integer[]))
+   Forward index only scan of: o_test_saop_pkey
+   Conds: (i < ANY ('{1,2}'::integer[]))
+(4 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -11,7 +11,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 16
+ 18
 (1 row)
 
 SELECT orioledb_parallel_debug_start();
@@ -958,69 +958,69 @@ SELECT count(*) FROM o_test65;
     60
 (1 row)
 
-SELECT id, val FROM o_test65;
+SELECT id, val FROM o_test65 ORDER BY id;
  id | val 
 ----+-----
- 60 | 61
- 59 | 60
- 58 | 59
- 57 | 58
- 56 | 57
- 55 | 56
- 54 | 55
- 53 | 54
- 52 | 53
- 51 | 52
- 50 | 51
- 49 | 50
- 48 | 49
- 47 | 48
- 46 | 47
- 45 | 46
- 44 | 45
- 43 | 44
- 42 | 43
- 41 | 42
- 40 | 41
- 39 | 40
- 38 | 39
- 37 | 38
- 36 | 37
- 35 | 36
- 34 | 35
- 33 | 34
- 32 | 33
- 31 | 32
- 30 | 31
- 29 | 30
- 28 | 29
- 27 | 28
- 26 | 27
- 25 | 26
- 24 | 25
- 23 | 24
- 22 | 23
- 21 | 22
- 20 | 21
- 19 | 20
- 18 | 19
- 17 | 18
- 16 | 17
- 15 | 16
- 14 | 15
- 13 | 14
- 12 | 13
- 11 | 12
- 10 | 11
-  9 | 10
-  8 | 9
-  7 | 8
-  6 | 7
-  5 | 6
-  4 | 5
-  3 | 4
-  2 | 3
   1 | 2
+  2 | 3
+  3 | 4
+  4 | 5
+  5 | 6
+  6 | 7
+  7 | 8
+  8 | 9
+  9 | 10
+ 10 | 11
+ 11 | 12
+ 12 | 13
+ 13 | 14
+ 14 | 15
+ 15 | 16
+ 16 | 17
+ 17 | 18
+ 18 | 19
+ 19 | 20
+ 20 | 21
+ 21 | 22
+ 22 | 23
+ 23 | 24
+ 24 | 25
+ 25 | 26
+ 26 | 27
+ 27 | 28
+ 28 | 29
+ 29 | 30
+ 30 | 31
+ 31 | 32
+ 32 | 33
+ 33 | 34
+ 34 | 35
+ 35 | 36
+ 36 | 37
+ 37 | 38
+ 38 | 39
+ 39 | 40
+ 40 | 41
+ 41 | 42
+ 42 | 43
+ 43 | 44
+ 44 | 45
+ 45 | 46
+ 46 | 47
+ 47 | 48
+ 48 | 49
+ 49 | 50
+ 50 | 51
+ 51 | 52
+ 52 | 53
+ 53 | 54
+ 54 | 55
+ 55 | 56
+ 56 | 57
+ 57 | 58
+ 58 | 59
+ 59 | 60
+ 60 | 61
 (60 rows)
 
 SET enable_seqscan = off;
@@ -1855,13 +1855,11 @@ SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idv = '22';
 
 -- Test Result node processing
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idi = 1;
-                      QUERY PLAN                       
--------------------------------------------------------
+        QUERY PLAN        
+--------------------------
  Result
    One-Time Filter: false
-   ->  Index Only Scan using o_test66_reg1 on o_test66
-         Index Cond: (idi = 2)
-(4 rows)
+(2 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idi = 1;
  idi | idv 
@@ -2097,12 +2095,11 @@ SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                    QUERY PLAN                     
----------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Index Only Scan using o_test66_reg1 on o_test66
-   Index Cond: (idi = ANY ('{2,4}'::integer[]))
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi = ANY ('{2,4}'::integer[])) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -2249,12 +2246,11 @@ SELECT idi, idv FROM o_test66 WHERE idi < 3 AND idv = '22';
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22');
-                    QUERY PLAN                     
----------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Index Only Scan using o_test66_reg1 on o_test66
-   Index Cond: (idi > 1)
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22');
  idi | idv 
@@ -2266,12 +2262,11 @@ SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22');
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
-                    QUERY PLAN                     
----------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Index Only Scan using o_test66_reg1 on o_test66
-   Index Cond: (idi > 1)
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
  idi | idv 
@@ -2959,12 +2954,11 @@ SELECT idi, idv FROM o_test67 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test67 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                    QUERY PLAN                     
----------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Index Only Scan using o_test67_reg1 on o_test67
-   Index Cond: (idi = ANY ('{2,4}'::integer[]))
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi = ANY ('{2,4}'::integer[])) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test67 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -3105,12 +3099,11 @@ SELECT idi, idv FROM o_test67 WHERE idi < 3 AND idv = '22';
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test67 WHERE idi > 1 AND idv IN ('12', '22');
-                    QUERY PLAN                     
----------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Index Only Scan using o_test67_reg1 on o_test67
-   Index Cond: (idi > 1)
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test67 WHERE idi > 1 AND idv IN ('12', '22');
  idi | idv 
@@ -3798,12 +3791,11 @@ SELECT idi, idv FROM o_test68 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test68 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                    QUERY PLAN                     
----------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Index Only Scan using o_test68_reg1 on o_test68
-   Index Cond: (idi = ANY ('{2,4}'::integer[]))
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi = ANY ('{2,4}'::integer[])) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test68 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -3944,12 +3936,11 @@ SELECT idi, idv FROM o_test68 WHERE idi < 3 AND idv = '22';
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22');
-                    QUERY PLAN                     
----------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Index Only Scan using o_test68_reg1 on o_test68
-   Index Cond: (idi > 1)
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22');
  idi | idv 
@@ -3961,12 +3952,11 @@ SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22');
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
-                        QUERY PLAN                        
-----------------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Index Only Scan Backward using o_test68_reg1 on o_test68
-   Index Cond: (idi > 1)
-   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
-(3 rows)
+   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
  idi | idv 
@@ -4652,12 +4642,11 @@ SELECT idi, idv FROM o_test69 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test69 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                   QUERY PLAN                    
--------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Index Only Scan using o_test69_reg1 on o_test69
-   Index Cond: (idv = ANY ('{12,22}'::text[]))
-   Filter: (idi = ANY ('{2,4}'::integer[]))
-(3 rows)
+   Index Cond: ((idv = ANY ('{12,22}'::text[])) AND (idi = ANY ('{2,4}'::integer[])))
+(2 rows)
 
 SELECT idi, idv FROM o_test69 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -5685,11 +5674,11 @@ SELECT * FROM o_test_partial_idx_update;
   1 |  100500 |  0
 (1 row)
 
-EXPLAIN SELECT * FROM o_test_partial_idx_update
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5699,11 +5688,11 @@ SELECT * FROM o_test_partial_idx_update WHERE user_id=100500 and am > 0;
 (0 rows)
 
 SET enable_bitmapscan = off;
-EXPLAIN SELECT * FROM o_test_partial_idx_update
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5735,6 +5724,10 @@ INSERT INTO o_test_unique_as_pkey (key, val, val2)
 Indexes:
     "o_test_unique_as_pkey_pkey" PRIMARY KEY, btree (key, val)
     "o_test_unique_as_pkey_ix1" UNIQUE, btree (val, key)
+Not-null constraints:
+    "o_test_unique_as_pkey_key_not_null" NOT NULL "key"
+    "o_test_unique_as_pkey_val_not_null" NOT NULL "val"
+    "o_test_unique_as_pkey_val2_not_null" NOT NULL "val2"
 
 SELECT orioledb_tbl_indices('o_test_unique_as_pkey'::regclass);
               orioledb_tbl_indices              
@@ -5781,6 +5774,10 @@ Indexes:
     "o_test_unique_as_pkey_pkey" PRIMARY KEY, btree (key, val)
     "o_test_unique_as_pkey_ix1" UNIQUE, btree (val, key)
     "o_test_unique_as_pkey_ix2" UNIQUE, btree (val, key)
+Not-null constraints:
+    "o_test_unique_as_pkey_key_not_null" NOT NULL "key"
+    "o_test_unique_as_pkey_val_not_null" NOT NULL "val"
+    "o_test_unique_as_pkey_val2_not_null" NOT NULL "val2"
 
 SELECT orioledb_tbl_indices('o_test_unique_as_pkey'::regclass);
               orioledb_tbl_indices              
@@ -6081,6 +6078,9 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
+Not-null constraints:
+    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
+    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 \d+ o_test_reuse_multiple_indices_ix1
       Index "indices.o_test_reuse_multiple_indices_ix1"
@@ -6358,6 +6358,9 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
+Not-null constraints:
+    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
+    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 EXPLAIN (COSTS OFF)
 	SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
@@ -6376,10 +6379,10 @@ SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
  f
 (5 rows)
 
-EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=8)
+EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6438,10 +6441,10 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  
 (1 row)
 
-EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=9)
+EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6469,6 +6472,9 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
+Not-null constraints:
+    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
+    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 \d+ o_test_reuse_multiple_indices_ix1
       Index "indices.o_test_reuse_multiple_indices_ix1"
@@ -6867,6 +6873,9 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
+Not-null constraints:
+    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
+    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 \d+ o_test_reuse_multiple_indices_ix1
       Index "indices.o_test_reuse_multiple_indices_ix1"
@@ -6950,6 +6959,8 @@ Indexes:
     "o_test_include_like_ix1" btree (key)
     "o_test_include_like_ix2" btree (value)
     "o_test_include_like_ix_include" UNIQUE, btree (val2) INCLUDE (value)
+Not-null constraints:
+    "o_test_include_like_key_not_null" NOT NULL "key"
 
 CREATE TABLE IF NOT EXISTS o_test_include_like_like
 	(LIKE o_test_include_like INCLUDING INDEXES INCLUDING CONSTRAINTS)
@@ -6992,6 +7003,8 @@ Indexes:
     "o_test_include_like_like_key_idx" btree (key)
     "o_test_include_like_like_val2_value_idx" UNIQUE, btree (val2) INCLUDE (value)
     "o_test_include_like_like_value_idx" btree (value)
+Not-null constraints:
+    "o_test_include_like_key_not_null" NOT NULL "key"
 
 DROP TABLE o_test_include_like_like;
 ALTER TABLE o_test_include_like DROP CONSTRAINT o_test_include_like_pkey;
@@ -7032,6 +7045,8 @@ Indexes:
     "o_test_include_like_ix1" btree (key)
     "o_test_include_like_ix2" btree (value)
     "o_test_include_like_ix_include" UNIQUE, btree (val2) INCLUDE (value)
+Not-null constraints:
+    "o_test_include_like_key_not_null" NOT NULL "key"
 
 CREATE TABLE IF NOT EXISTS o_test_include_like_like
 	(LIKE o_test_include_like INCLUDING INDEXES INCLUDING CONSTRAINTS)
@@ -7073,6 +7088,8 @@ Indexes:
     "o_test_include_like_like_key_idx" btree (key)
     "o_test_include_like_like_val2_value_idx" UNIQUE, btree (val2) INCLUDE (value)
     "o_test_include_like_like_value_idx" btree (value)
+Not-null constraints:
+    "o_test_include_like_key_not_null" NOT NULL "key"
 
 DROP TABLE o_test_include_like_like;
 -- Test that fields also added when we create table like postgres table
@@ -7098,6 +7115,8 @@ Indexes:
     "pg_test_include_like_ix1" btree (key)
     "pg_test_include_like_ix2" btree (value)
     "pg_test_include_like_ix_include" UNIQUE, btree (val2) INCLUDE (value)
+Not-null constraints:
+    "pg_test_include_like_key_not_null" NOT NULL "key"
 
 CREATE TABLE IF NOT EXISTS o_test_include_like_like
 	(LIKE pg_test_include_like INCLUDING INDEXES INCLUDING CONSTRAINTS)
@@ -7140,6 +7159,8 @@ Indexes:
     "o_test_include_like_like_key_idx" btree (key)
     "o_test_include_like_like_val2_value_idx" UNIQUE, btree (val2) INCLUDE (value)
     "o_test_include_like_like_value_idx" btree (value)
+Not-null constraints:
+    "pg_test_include_like_key_not_null" NOT NULL "key"
 
 DROP TABLE o_test_include_like_like;
 CREATE TABLE o_test_partial_unique(
@@ -7338,6 +7359,11 @@ CREATE INDEX o_test_pkey_mixed_ix1
 Indexes:
     "o_test_pkey_mixed_pkey" PRIMARY KEY, btree (pk1, pk2, pk3, pk4)
     "o_test_pkey_mixed_ix1" btree (f1, f2, pk1, f3) INCLUDE (i1, pk4, i2)
+Not-null constraints:
+    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
+    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
+    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
+    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 SELECT orioledb_tbl_indices('o_test_pkey_mixed'::regclass);
@@ -7375,6 +7401,11 @@ Indexes:
     "o_test_pkey_mixed_pkey" PRIMARY KEY, btree (pk1, pk2, pk3, pk4)
     "o_test_pkey_mixed_ix1" btree (f1, f2, pk1, f3) INCLUDE (i1, pk4, i2)
     "o_test_pkey_mixed_uniq1" UNIQUE, btree (f2, f1, pk1, f3) INCLUDE (i1, pk4, i2)
+Not-null constraints:
+    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
+    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
+    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
+    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 -- f2 f1 pk1 f3 i1 pk4 i2 pk2 pk3
@@ -7419,6 +7450,11 @@ Indexes:
     "o_test_pkey_mixed_ix1" btree (f1, f2, pk1, f3) INCLUDE (i1, pk4, i2)
     "o_test_pkey_mixed_ix3" btree (f3, f2, pk4, f1, pk4) INCLUDE (pk3)
     "o_test_pkey_mixed_uniq1" UNIQUE, btree (f2, f1, pk1, f3) INCLUDE (i1, pk4, i2)
+Not-null constraints:
+    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
+    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
+    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
+    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 -- f2 f1 pk1 f3 i1 pk4 i2 pk2 pk3
@@ -7470,6 +7506,11 @@ Indexes:
     "o_test_pkey_mixed_ix3" btree (f3, f2, pk4, f1, pk4) INCLUDE (pk3)
     "o_test_pkey_mixed_ix4" btree (i1, f1, pk4, f2, pk4) INCLUDE (pk3, i2)
     "o_test_pkey_mixed_uniq1" UNIQUE, btree (f2, f1, pk1, f3) INCLUDE (i1, pk4, i2)
+Not-null constraints:
+    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
+    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
+    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
+    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 -- f2 f1 pk1 f3 i1 pk4 i2 pk2 pk3
@@ -7650,6 +7691,8 @@ CREATE TABLE o_test_pkey_include_box
  f2     | integer |           |          |         | plain   |              | 
 Indexes:
     "o_test_pkey_include_box_pkey" PRIMARY KEY, btree (pk1) INCLUDE (pk2)
+Not-null constraints:
+    "o_test_pkey_include_box_pk1_not_null" NOT NULL "pk1"
 
 SELECT orioledb_tbl_indices('o_test_pkey_include_box'::regclass);
               orioledb_tbl_indices              
@@ -7797,6 +7840,8 @@ Indexes:
     "o_test_include_box_with_pkey_pkey" PRIMARY KEY, btree (val_1)
     "o_test_include_box_with_pkey_ix1" UNIQUE, btree (val_2) INCLUDE (val_4)
     "o_test_include_box_with_pkey_ix2" UNIQUE, btree (val_3)
+Not-null constraints:
+    "o_test_include_box_with_pkey_val_1_not_null" NOT NULL "val_1"
 
 SELECT orioledb_tbl_indices('o_test_include_box_with_pkey'::regclass);
                orioledb_tbl_indices                
@@ -8106,12 +8151,12 @@ EXPLAIN (COSTS OFF)
    ->  Custom Scan (o_scan) on o_test_row_searchkey
          Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2)))
          Bitmap heap scan
-         Recheck Cond: (((val_1 = 2) AND (val_2 < 3)) OR (val_1 < 2))
+         Recheck Cond: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
          ->  BitmapOr
                ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_2 < 3))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
                      Index Cond: (val_1 < 2)
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 < 3))
 (11 rows)
 
 SELECT * FROM o_test_row_searchkey
@@ -8164,12 +8209,12 @@ EXPLAIN (COSTS OFF)
    ->  Custom Scan (o_scan) on o_test_row_searchkey
          Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2)))
          Bitmap heap scan
-         Recheck Cond: (((val_1 = 2) AND (val_2 <= 3)) OR (val_1 < 2))
+         Recheck Cond: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 <= 3)))
          ->  BitmapOr
                ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_2 <= 3))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
                      Index Cond: (val_1 < 2)
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_2 <= 3))
 (11 rows)
 
 SELECT * FROM o_test_row_searchkey
@@ -8464,6 +8509,8 @@ CREATE INDEX o_test_pkey_include_same_fields_ix1
 Indexes:
     "o_test_pkey_include_same_fields_pkey" PRIMARY KEY, btree (val_1) INCLUDE (val_2, val_2)
     "o_test_pkey_include_same_fields_ix1" btree (val_1) INCLUDE (val_2, val_2)
+Not-null constraints:
+    "o_test_pkey_include_same_fields_val_1_not_null" NOT NULL "val_1"
 
 SELECT orioledb_tbl_indices('o_test_pkey_include_same_fields'::regclass);
               orioledb_tbl_indices              
@@ -8584,12 +8631,12 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_saop
-   Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+   Filter: (k > ALL ('{7,8}'::integer[]))
    Forward index only scan of: o_test_saop_pkey
-   Conds: (i < ANY ('{3,4,5}'::integer[]))
+   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
 (4 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
@@ -8614,13 +8661,12 @@ SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) ORDER BY i, j, k;
-                   QUERY PLAN                   
-------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_saop
-   Filter: (k = ANY ('{3,5}'::integer[]))
    Forward index only scan of: o_test_saop_pkey
-   Conds: (i = ANY ('{1,3}'::integer[]))
-(4 rows)
+   Conds: ((i = ANY ('{1,3}'::integer[])) AND (k = ANY ('{3,5}'::integer[])))
+(3 rows)
 
 SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) ORDER BY i, j, k;
  i | j | k 
@@ -8669,13 +8715,12 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                   QUERY PLAN                   
-------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_saop
-   Filter: (j = ANY ('{1,3}'::integer[]))
    Forward index only scan of: o_test_saop_pkey
-   Conds: (i < ANY ('{1,2}'::integer[]))
-(4 rows)
+   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+(3 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 
@@ -8781,10 +8826,11 @@ SELECT conname, contype, conindid::regclass
 FROM pg_constraint
 WHERE conrelid = 'o_test_add_index_constraint'::regclass
 ORDER BY conname;
-  conname  | contype | conindid  
------------+---------+-----------
- o_test_pk | p       | o_test_pk
-(1 row)
+                 conname                 | contype | conindid  
+-----------------------------------------+---------+-----------
+ o_test_add_index_constraint_id_not_null | n       | -
+ o_test_pk                               | p       | o_test_pk
+(2 rows)
 
 -- Test constraint enforcement
 INSERT INTO o_test_add_index_constraint VALUES (4, 'four');  -- Should succeed
@@ -8798,10 +8844,11 @@ SELECT conname, contype, conindid::regclass
 FROM pg_constraint
 WHERE conrelid = 'o_test_add_index_constraint'::regclass
 ORDER BY conname;
-  conname  | contype | conindid  
------------+---------+-----------
- o_test_pk | p       | o_test_pk
-(1 row)
+                 conname                 | contype | conindid  
+-----------------------------------------+---------+-----------
+ o_test_add_index_constraint_id_not_null | n       | -
+ o_test_pk                               | p       | o_test_pk
+(2 rows)
 
 -- Test AT_AddIndexConstraint: Add UNIQUE constraint using existing index
 ALTER TABLE o_test_add_index_constraint
@@ -8812,11 +8859,12 @@ SELECT conname, contype, conindid::regclass
 FROM pg_constraint
 WHERE conrelid = 'o_test_add_index_constraint'::regclass
 ORDER BY conname;
-  conname  | contype | conindid  
------------+---------+-----------
- o_test_pk | p       | o_test_pk
- o_test_uq | u       | o_test_uq
-(2 rows)
+                 conname                 | contype | conindid  
+-----------------------------------------+---------+-----------
+ o_test_add_index_constraint_id_not_null | n       | -
+ o_test_pk                               | p       | o_test_pk
+ o_test_uq                               | u       | o_test_uq
+(3 rows)
 
 -- Test UNIQUE constraint enforcement
 INSERT INTO o_test_add_index_constraint VALUES (5, 'five');  -- Should succeed
@@ -8982,7 +9030,8 @@ EXPLAIN (COSTS OFF)
                       QUERY PLAN                       
 -------------------------------------------------------
  Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
-(1 row)
+   Disabled: true
+(2 rows)
 
 SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
  val_1 
@@ -8999,7 +9048,8 @@ EXPLAIN (COSTS OFF)
                       QUERY PLAN                       
 -------------------------------------------------------
  Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
-(1 row)
+   Disabled: true
+(2 rows)
 
 SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
  val_1 | val_2 
@@ -9022,7 +9072,8 @@ EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
                       QUERY PLAN                       
 -------------------------------------------------------
  Index Only Scan using o_ios_pk_dup_ix on o_ios_pk_dup
-(1 row)
+   Disabled: true
+(2 rows)
 
 SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
  a |   b   
@@ -9049,7 +9100,8 @@ EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
                          QUERY PLAN                          
 -------------------------------------------------------------
  Index Only Scan using o_ios_pk_sk_dup_ix on o_ios_pk_sk_dup
-(1 row)
+   Disabled: true
+(2 rows)
 
 SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
  a | b  |  c  
@@ -9077,7 +9129,8 @@ EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_include ORDER BY b;
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Index Only Scan using o_ios_pk_include_ix on o_ios_pk_include
-(1 row)
+   Disabled: true
+(2 rows)
 
 SELECT a, b FROM o_ios_pk_include ORDER BY b;
  a | b  
@@ -9101,7 +9154,8 @@ EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Index Only Scan using o_ios_sk_include_ix on o_ios_sk_include
-(1 row)
+   Disabled: true
+(2 rows)
 
 SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
  a | b  |  c  
@@ -9117,6 +9171,151 @@ DROP TABLE o_ios_sk_include;
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_indexscan;
+-- amnblocks: INSERT -> CREATE INDEX (no ANALYZE)
+CREATE TABLE o_test_amnblocks1 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_amnblocks1 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_amnblocks1_k ON o_test_amnblocks1(k);
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks1
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks1_k on o_test_amnblocks1
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks1_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks1;
+-- amnblocks: INSERT -> CREATE INDEX -> ANALYZE
+CREATE TABLE o_test_amnblocks2 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_amnblocks2 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_amnblocks2_k ON o_test_amnblocks2(k);
+ANALYZE o_test_amnblocks2;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks2
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks2_k on o_test_amnblocks2
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks2_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks2;
+-- amnblocks: CREATE INDEX -> INSERT -> ANALYZE
+CREATE TABLE o_test_amnblocks3 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+CREATE INDEX o_test_amnblocks3_k ON o_test_amnblocks3(k);
+INSERT INTO o_test_amnblocks3 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+ANALYZE o_test_amnblocks3;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks3
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks3_k on o_test_amnblocks3
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks3_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks3;
+-- amnblocks: VACUUM ANALYZE updates pg_class.relpages
+CREATE TABLE o_test_amnblocks4 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+CREATE INDEX o_test_amnblocks4_k ON o_test_amnblocks4(k);
+INSERT INTO o_test_amnblocks4 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+VACUUM ANALYZE o_test_amnblocks4;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks4
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks4_k on o_test_amnblocks4
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks4_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks4;
+-- allvisfrac: IOS preferred even with low correlation (random insert order)
+-- With allvisfrac=1.0 the IOS heap-fetch cost drops to 0 so IOS wins
+-- over bitmap even when csquared is near 0.
+CREATE TABLE o_test_allvisfrac (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_allvisfrac
+	SELECT i, (i * 7919) % 10000, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_allvisfrac_k ON o_test_allvisfrac(k);
+ANALYZE o_test_allvisfrac;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_allvisfrac
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_allvisfrac_k on o_test_allvisfrac
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+RESET enable_seqscan;
+DROP TABLE o_test_allvisfrac;
 -- Skip scan tests below exercise PG18's _bt_preprocess_keys synthesizing a
 -- skip array on the leading column.  On PG16/PG17 there are no skip arrays;
 -- skip the whole block instead of maintaining version-specific expected
@@ -9143,11 +9342,27 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT x, y FROM o_test_skip_leading_int WHERE y = 42 ORDER BY x, y;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Index Only Scan using o_test_skip_leading_int_idx on o_test_skip_leading_int
+   Index Cond: (y = 42)
+(2 rows)
+
 SELECT x, y FROM o_test_skip_leading_int WHERE y = 42 ORDER BY x, y;
+ x | y  
+---+----
+ 2 | 42
+(1 row)
+
 -- Multiple matching y values across distinct x: every distinct x is
 -- visited exactly once by the skip-array driver.
 SELECT count(*), count(DISTINCT x) FROM o_test_skip_leading_int
 	WHERE y IN (42, 84, 126);
+ count | count 
+-------+-------
+     3 |     3
+(1 row)
+
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_leading_int;
@@ -9168,7 +9383,18 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT x, y FROM o_test_skip_leading_text WHERE y = 42 ORDER BY x, y;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Index Only Scan using o_test_skip_leading_text_idx on o_test_skip_leading_text
+   Index Cond: (y = 42)
+(2 rows)
+
 SELECT x, y FROM o_test_skip_leading_text WHERE y = 42 ORDER BY x, y;
+ x | y  
+---+----
+ C | 42
+(1 row)
+
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_leading_text;
@@ -9188,7 +9414,18 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT x, y FROM o_test_skip_backward WHERE y = 42 ORDER BY x DESC, y DESC;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Index Only Scan Backward using o_test_skip_backward_idx on o_test_skip_backward
+   Index Cond: (y = 42)
+(2 rows)
+
 SELECT x, y FROM o_test_skip_backward WHERE y = 42 ORDER BY x DESC, y DESC;
+ x | y  
+---+----
+ 2 | 42
+(1 row)
+
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_backward;
@@ -9209,6 +9446,11 @@ ANALYZE o_test_skip_multirow;
 SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 SELECT count(*), count(DISTINCT x) FROM o_test_skip_multirow WHERE y = 42;
+ count | count 
+-------+-------
+    30 |    10
+(1 row)
+
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_multirow;
@@ -9230,7 +9472,17 @@ ANALYZE o_test_skip_nullable;
 SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 SELECT x, y FROM o_test_skip_nullable WHERE y = 25;
+ x | y  
+---+----
+ 0 | 25
+(1 row)
+
 SELECT x, y FROM o_test_skip_nullable WHERE y = 102;
+ x |  y  
+---+-----
+   | 102
+(1 row)
+
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_nullable;
@@ -9250,6 +9502,11 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 SELECT count(*), count(DISTINCT x) FROM o_test_skip_bounded
 	WHERE x < 5 AND y IN (2, 3, 4);
+ count | count 
+-------+-------
+    15 |     5
+(1 row)
+
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_bounded;

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -193,12 +193,14 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                 QUERY PLAN                  
----------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -217,12 +219,14 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 
 SET enable_seqscan = off;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -958,69 +962,69 @@ SELECT count(*) FROM o_test65;
     60
 (1 row)
 
-SELECT id, val FROM o_test65 ORDER BY id;
+SELECT id, val FROM o_test65;
  id | val 
 ----+-----
-  1 | 2
-  2 | 3
-  3 | 4
-  4 | 5
-  5 | 6
-  6 | 7
-  7 | 8
-  8 | 9
-  9 | 10
- 10 | 11
- 11 | 12
- 12 | 13
- 13 | 14
- 14 | 15
- 15 | 16
- 16 | 17
- 17 | 18
- 18 | 19
- 19 | 20
- 20 | 21
- 21 | 22
- 22 | 23
- 23 | 24
- 24 | 25
- 25 | 26
- 26 | 27
- 27 | 28
- 28 | 29
- 29 | 30
- 30 | 31
- 31 | 32
- 32 | 33
- 33 | 34
- 34 | 35
- 35 | 36
- 36 | 37
- 37 | 38
- 38 | 39
- 39 | 40
- 40 | 41
- 41 | 42
- 42 | 43
- 43 | 44
- 44 | 45
- 45 | 46
- 46 | 47
- 47 | 48
- 48 | 49
- 49 | 50
- 50 | 51
- 51 | 52
- 52 | 53
- 53 | 54
- 54 | 55
- 55 | 56
- 56 | 57
- 57 | 58
- 58 | 59
- 59 | 60
  60 | 61
+ 59 | 60
+ 58 | 59
+ 57 | 58
+ 56 | 57
+ 55 | 56
+ 54 | 55
+ 53 | 54
+ 52 | 53
+ 51 | 52
+ 50 | 51
+ 49 | 50
+ 48 | 49
+ 47 | 48
+ 46 | 47
+ 45 | 46
+ 44 | 45
+ 43 | 44
+ 42 | 43
+ 41 | 42
+ 40 | 41
+ 39 | 40
+ 38 | 39
+ 37 | 38
+ 36 | 37
+ 35 | 36
+ 34 | 35
+ 33 | 34
+ 32 | 33
+ 31 | 32
+ 30 | 31
+ 29 | 30
+ 28 | 29
+ 27 | 28
+ 26 | 27
+ 25 | 26
+ 24 | 25
+ 23 | 24
+ 22 | 23
+ 21 | 22
+ 20 | 21
+ 19 | 20
+ 18 | 19
+ 17 | 18
+ 16 | 17
+ 15 | 16
+ 14 | 15
+ 13 | 14
+ 12 | 13
+ 11 | 12
+ 10 | 11
+  9 | 10
+  8 | 9
+  7 | 8
+  6 | 7
+  5 | 6
+  4 | 5
+  3 | 4
+  2 | 3
+  1 | 2
 (60 rows)
 
 SET enable_seqscan = off;
@@ -5685,11 +5689,11 @@ SELECT * FROM o_test_partial_idx_update;
   1 |  100500 |  0
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
+EXPLAIN SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5699,11 +5703,11 @@ SELECT * FROM o_test_partial_idx_update WHERE user_id=100500 and am > 0;
 (0 rows)
 
 SET enable_bitmapscan = off;
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
+EXPLAIN SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -6376,10 +6380,10 @@ SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
  f
 (5 rows)
 
-EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
+EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=8)
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6438,10 +6442,10 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
+EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=9)
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -7971,12 +7975,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -7996,13 +8004,19 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(10 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8022,12 +8036,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8048,13 +8066,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8075,12 +8100,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(3 rows)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8131,12 +8160,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(3 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8218,12 +8251,14 @@ SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
-   Conds: (val_1 < 2)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (val_1 < 2)
+   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
+         Index Cond: (val_1 < 2)
+(5 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8584,13 +8619,17 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: (i < ANY ('{3,4,5}'::integer[]))
-(4 rows)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+         Bitmap heap scan
+         Recheck Cond: (i < ANY ('{3,4,5}'::integer[]))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: (i < ANY ('{3,4,5}'::integer[]))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8669,13 +8708,17 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                   QUERY PLAN                   
-------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: (j = ANY ('{1,3}'::integer[]))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: (i < ANY ('{1,2}'::integer[]))
-(4 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: (j = ANY ('{1,3}'::integer[]))
+         Bitmap heap scan
+         Recheck Cond: (i < ANY ('{1,2}'::integer[]))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: (i < ANY ('{1,2}'::integer[]))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 
@@ -9117,151 +9160,6 @@ DROP TABLE o_ios_sk_include;
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_indexscan;
--- amnblocks: INSERT -> CREATE INDEX (no ANALYZE)
-CREATE TABLE o_test_amnblocks1 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_amnblocks1 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_amnblocks1_k ON o_test_amnblocks1(k);
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks1
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks1_k on o_test_amnblocks1
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks1_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks1;
--- amnblocks: INSERT -> CREATE INDEX -> ANALYZE
-CREATE TABLE o_test_amnblocks2 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_amnblocks2 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_amnblocks2_k ON o_test_amnblocks2(k);
-ANALYZE o_test_amnblocks2;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks2
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks2_k on o_test_amnblocks2
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks2_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks2;
--- amnblocks: CREATE INDEX -> INSERT -> ANALYZE
-CREATE TABLE o_test_amnblocks3 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-CREATE INDEX o_test_amnblocks3_k ON o_test_amnblocks3(k);
-INSERT INTO o_test_amnblocks3 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-ANALYZE o_test_amnblocks3;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks3
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks3_k on o_test_amnblocks3
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks3_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks3;
--- amnblocks: VACUUM ANALYZE updates pg_class.relpages
-CREATE TABLE o_test_amnblocks4 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-CREATE INDEX o_test_amnblocks4_k ON o_test_amnblocks4(k);
-INSERT INTO o_test_amnblocks4 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-VACUUM ANALYZE o_test_amnblocks4;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks4
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks4_k on o_test_amnblocks4
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks4_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks4;
--- allvisfrac: IOS preferred even with low correlation (random insert order)
--- With allvisfrac=1.0 the IOS heap-fetch cost drops to 0 so IOS wins
--- over bitmap even when csquared is near 0.
-CREATE TABLE o_test_allvisfrac (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_allvisfrac
-	SELECT i, (i * 7919) % 10000, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_allvisfrac_k ON o_test_allvisfrac(k);
-ANALYZE o_test_allvisfrac;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_allvisfrac
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_allvisfrac_k on o_test_allvisfrac
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-RESET enable_seqscan;
-DROP TABLE o_test_allvisfrac;
 -- Skip scan tests below exercise PG18's _bt_preprocess_keys synthesizing a
 -- skip array on the leading column.  On PG16/PG17 there are no skip arrays;
 -- skip the whole block instead of maintaining version-specific expected

--- a/test/expected/indices.out
+++ b/test/expected/indices.out
@@ -9297,6 +9297,49 @@ RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_bounded;
 \endif
+-- A backward scan over an array (SAOP) key must cover every element, not just
+-- the one the forward scan would start at.
+CREATE TABLE o_test_array_backward (
+	a int NOT NULL,
+	b int NOT NULL
+) USING orioledb;
+CREATE INDEX o_test_array_backward_idx ON o_test_array_backward(a);
+INSERT INTO o_test_array_backward SELECT a, a FROM generate_series(1, 1000) a;
+ANALYZE o_test_array_backward;
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+  a   
+------
+ 1000
+    1
+(2 rows)
+
+SELECT a FROM o_test_array_backward WHERE a IN (1, 500, 1000) ORDER BY a DESC;
+  a   
+------
+ 1000
+  500
+    1
+(3 rows)
+
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a;
+  a   
+------
+    1
+ 1000
+(2 rows)
+
+SELECT a, b FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+    1 |    1
+(2 rows)
+
+RESET enable_bitmapscan;
+RESET enable_seqscan;
+DROP TABLE o_test_array_backward;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -193,14 +193,12 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                     QUERY PLAN                      
------------------------------------------------------
+                 QUERY PLAN                  
+---------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Bitmap heap scan
-   Recheck Cond: ((key >= 100) AND (key <= 110))
-   ->  Bitmap Index Scan on o_test52_pkey
-         Index Cond: ((key >= 100) AND (key <= 110))
-(5 rows)
+   Forward index only scan of: o_test52_pkey
+   Conds: ((key >= 100) AND (key <= 110))
+(3 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -219,14 +217,12 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 
 SET enable_seqscan = off;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                       QUERY PLAN                        
----------------------------------------------------------
+                  QUERY PLAN                  
+----------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Bitmap heap scan
-   Recheck Cond: ((value >= 200) AND (value <= 210))
-   ->  Bitmap Index Scan on o_test52_pkey
-         Index Cond: ((value >= 200) AND (value <= 210))
-(5 rows)
+   Forward index only scan of: o_test52_pkey
+   Conds: ((value >= 200) AND (value <= 210))
+(3 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -7964,16 +7960,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(7 rows)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -7993,19 +7985,13 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
-         ->  BitmapOr
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
-(10 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((val_1 > 0) AND (val_2 > 0))
+(4 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8025,16 +8011,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(7 rows)
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8055,20 +8037,13 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-         Bitmap heap scan
-         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
-         ->  BitmapOr
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
-(11 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((val_1 > 0) AND (val_2 > 0))
+(4 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8089,16 +8064,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(7 rows)
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8149,16 +8120,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(7 rows)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8240,14 +8207,12 @@ SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Bitmap heap scan
-   Recheck Cond: (val_1 < 2)
-   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
-         Index Cond: (val_1 < 2)
-(5 rows)
+   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
+   Conds: (val_1 < 2)
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8608,17 +8573,13 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: i, j, k
-   ->  Custom Scan (o_scan) on o_test_saop
-         Filter: (k > ALL ('{7,8}'::integer[]))
-         Bitmap heap scan
-         Recheck Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-         ->  Bitmap Index Scan on o_test_saop_pkey
-               Index Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-(8 rows)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_saop
+   Filter: (k > ALL ('{7,8}'::integer[]))
+   Forward index only scan of: o_test_saop_pkey
+   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+(4 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8696,16 +8657,12 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: i, j, k
-   ->  Custom Scan (o_scan) on o_test_saop
-         Bitmap heap scan
-         Recheck Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-         ->  Bitmap Index Scan on o_test_saop_pkey
-               Index Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-(7 rows)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_saop
+   Forward index only scan of: o_test_saop_pkey
+   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+(3 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -9284,6 +9284,49 @@ RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_bounded;
 \endif
+-- A backward scan over an array (SAOP) key must cover every element, not just
+-- the one the forward scan would start at.
+CREATE TABLE o_test_array_backward (
+	a int NOT NULL,
+	b int NOT NULL
+) USING orioledb;
+CREATE INDEX o_test_array_backward_idx ON o_test_array_backward(a);
+INSERT INTO o_test_array_backward SELECT a, a FROM generate_series(1, 1000) a;
+ANALYZE o_test_array_backward;
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+  a   
+------
+ 1000
+    1
+(2 rows)
+
+SELECT a FROM o_test_array_backward WHERE a IN (1, 500, 1000) ORDER BY a DESC;
+  a   
+------
+ 1000
+  500
+    1
+(3 rows)
+
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a;
+  a   
+------
+    1
+ 1000
+(2 rows)
+
+SELECT a, b FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+    1 |    1
+(2 rows)
+
+RESET enable_bitmapscan;
+RESET enable_seqscan;
+DROP TABLE o_test_array_backward;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -11,7 +11,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 17
+ 16
 (1 row)
 
 SELECT orioledb_parallel_debug_start();
@@ -958,69 +958,69 @@ SELECT count(*) FROM o_test65;
     60
 (1 row)
 
-SELECT id, val FROM o_test65;
+SELECT id, val FROM o_test65 ORDER BY id;
  id | val 
 ----+-----
- 60 | 61
- 59 | 60
- 58 | 59
- 57 | 58
- 56 | 57
- 55 | 56
- 54 | 55
- 53 | 54
- 52 | 53
- 51 | 52
- 50 | 51
- 49 | 50
- 48 | 49
- 47 | 48
- 46 | 47
- 45 | 46
- 44 | 45
- 43 | 44
- 42 | 43
- 41 | 42
- 40 | 41
- 39 | 40
- 38 | 39
- 37 | 38
- 36 | 37
- 35 | 36
- 34 | 35
- 33 | 34
- 32 | 33
- 31 | 32
- 30 | 31
- 29 | 30
- 28 | 29
- 27 | 28
- 26 | 27
- 25 | 26
- 24 | 25
- 23 | 24
- 22 | 23
- 21 | 22
- 20 | 21
- 19 | 20
- 18 | 19
- 17 | 18
- 16 | 17
- 15 | 16
- 14 | 15
- 13 | 14
- 12 | 13
- 11 | 12
- 10 | 11
-  9 | 10
-  8 | 9
-  7 | 8
-  6 | 7
-  5 | 6
-  4 | 5
-  3 | 4
-  2 | 3
   1 | 2
+  2 | 3
+  3 | 4
+  4 | 5
+  5 | 6
+  6 | 7
+  7 | 8
+  8 | 9
+  9 | 10
+ 10 | 11
+ 11 | 12
+ 12 | 13
+ 13 | 14
+ 14 | 15
+ 15 | 16
+ 16 | 17
+ 17 | 18
+ 18 | 19
+ 19 | 20
+ 20 | 21
+ 21 | 22
+ 22 | 23
+ 23 | 24
+ 24 | 25
+ 25 | 26
+ 26 | 27
+ 27 | 28
+ 28 | 29
+ 29 | 30
+ 30 | 31
+ 31 | 32
+ 32 | 33
+ 33 | 34
+ 34 | 35
+ 35 | 36
+ 36 | 37
+ 37 | 38
+ 38 | 39
+ 39 | 40
+ 40 | 41
+ 41 | 42
+ 42 | 43
+ 43 | 44
+ 44 | 45
+ 45 | 46
+ 46 | 47
+ 47 | 48
+ 48 | 49
+ 49 | 50
+ 50 | 51
+ 51 | 52
+ 52 | 53
+ 53 | 54
+ 54 | 55
+ 55 | 56
+ 56 | 57
+ 57 | 58
+ 58 | 59
+ 59 | 60
+ 60 | 61
 (60 rows)
 
 SET enable_seqscan = off;
@@ -1855,11 +1855,13 @@ SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idv = '22';
 
 -- Test Result node processing
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idi = 1;
-        QUERY PLAN        
---------------------------
+                      QUERY PLAN                       
+-------------------------------------------------------
  Result
    One-Time Filter: false
-(2 rows)
+   ->  Index Only Scan using o_test66_reg1 on o_test66
+         Index Cond: (idi = 2)
+(4 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idi = 1;
  idi | idv 
@@ -2095,11 +2097,12 @@ SELECT idi, idv FROM o_test66 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan using o_test66_reg1 on o_test66
-   Index Cond: ((idi = ANY ('{2,4}'::integer[])) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi = ANY ('{2,4}'::integer[]))
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -2246,11 +2249,12 @@ SELECT idi, idv FROM o_test66 WHERE idi < 3 AND idv = '22';
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22');
-                          QUERY PLAN                           
----------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan using o_test66_reg1 on o_test66
-   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi > 1)
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22');
  idi | idv 
@@ -2262,11 +2266,12 @@ SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22');
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
-                          QUERY PLAN                           
----------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan using o_test66_reg1 on o_test66
-   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi > 1)
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test66 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
  idi | idv 
@@ -2954,11 +2959,12 @@ SELECT idi, idv FROM o_test67 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test67 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan using o_test67_reg1 on o_test67
-   Index Cond: ((idi = ANY ('{2,4}'::integer[])) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi = ANY ('{2,4}'::integer[]))
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test67 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -3099,11 +3105,12 @@ SELECT idi, idv FROM o_test67 WHERE idi < 3 AND idv = '22';
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test67 WHERE idi > 1 AND idv IN ('12', '22');
-                          QUERY PLAN                           
----------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan using o_test67_reg1 on o_test67
-   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi > 1)
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test67 WHERE idi > 1 AND idv IN ('12', '22');
  idi | idv 
@@ -3791,11 +3798,12 @@ SELECT idi, idv FROM o_test68 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test68 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan using o_test68_reg1 on o_test68
-   Index Cond: ((idi = ANY ('{2,4}'::integer[])) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi = ANY ('{2,4}'::integer[]))
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test68 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -3936,11 +3944,12 @@ SELECT idi, idv FROM o_test68 WHERE idi < 3 AND idv = '22';
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22');
-                          QUERY PLAN                           
----------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan using o_test68_reg1 on o_test68
-   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi > 1)
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22');
  idi | idv 
@@ -3952,11 +3961,12 @@ SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22');
 (4 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
-                          QUERY PLAN                           
----------------------------------------------------------------
+                        QUERY PLAN                        
+----------------------------------------------------------
  Index Only Scan Backward using o_test68_reg1 on o_test68
-   Index Cond: ((idi > 1) AND (idv = ANY ('{12,22}'::text[])))
-(2 rows)
+   Index Cond: (idi > 1)
+   Filter: ((idv)::text = ANY ('{12,22}'::text[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test68 WHERE idi > 1 AND idv IN ('12', '22') ORDER BY idi;
  idi | idv 
@@ -4642,11 +4652,12 @@ SELECT idi, idv FROM o_test69 WHERE idi = 2 AND idv IN ('12', '22');
 (2 rows)
 
 EXPLAIN (COSTS off) SELECT idi, idv FROM o_test69 WHERE idi IN (2, 4) AND idv IN ('12', '22');
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Index Only Scan using o_test69_reg1 on o_test69
-   Index Cond: ((idv = ANY ('{12,22}'::text[])) AND (idi = ANY ('{2,4}'::integer[])))
-(2 rows)
+   Index Cond: (idv = ANY ('{12,22}'::text[]))
+   Filter: (idi = ANY ('{2,4}'::integer[]))
+(3 rows)
 
 SELECT idi, idv FROM o_test69 WHERE idi IN (2, 4) AND idv IN ('12', '22');
  idi | idv 
@@ -5674,11 +5685,11 @@ SELECT * FROM o_test_partial_idx_update;
   1 |  100500 |  0
 (1 row)
 
-EXPLAIN SELECT * FROM o_test_partial_idx_update
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5688,11 +5699,11 @@ SELECT * FROM o_test_partial_idx_update WHERE user_id=100500 and am > 0;
 (0 rows)
 
 SET enable_bitmapscan = off;
-EXPLAIN SELECT * FROM o_test_partial_idx_update
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -6365,10 +6376,10 @@ SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
  f
 (5 rows)
 
-EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=8)
+EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6427,10 +6438,10 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  
 (1 row)
 
-EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=9)
+EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -8573,12 +8584,12 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_saop
-   Filter: (k > ALL ('{7,8}'::integer[]))
+   Filter: ((k > ALL ('{7,8}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
    Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+   Conds: (i < ANY ('{3,4,5}'::integer[]))
 (4 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
@@ -8603,12 +8614,13 @@ SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) ORDER BY i, j, k;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  Custom Scan (o_scan) on o_test_saop
+   Filter: (k = ANY ('{3,5}'::integer[]))
    Forward index only scan of: o_test_saop_pkey
-   Conds: ((i = ANY ('{1,3}'::integer[])) AND (k = ANY ('{3,5}'::integer[])))
-(3 rows)
+   Conds: (i = ANY ('{1,3}'::integer[]))
+(4 rows)
 
 SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) ORDER BY i, j, k;
  i | j | k 
@@ -8657,12 +8669,13 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                   QUERY PLAN                   
+------------------------------------------------
  Custom Scan (o_scan) on o_test_saop
+   Filter: (j = ANY ('{1,3}'::integer[]))
    Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-(3 rows)
+   Conds: (i < ANY ('{1,2}'::integer[]))
+(4 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 
@@ -9104,6 +9117,151 @@ DROP TABLE o_ios_sk_include;
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_indexscan;
+-- amnblocks: INSERT -> CREATE INDEX (no ANALYZE)
+CREATE TABLE o_test_amnblocks1 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_amnblocks1 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_amnblocks1_k ON o_test_amnblocks1(k);
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks1
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks1_k on o_test_amnblocks1
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks1_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks1;
+-- amnblocks: INSERT -> CREATE INDEX -> ANALYZE
+CREATE TABLE o_test_amnblocks2 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_amnblocks2 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_amnblocks2_k ON o_test_amnblocks2(k);
+ANALYZE o_test_amnblocks2;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks2
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks2_k on o_test_amnblocks2
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks2_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks2;
+-- amnblocks: CREATE INDEX -> INSERT -> ANALYZE
+CREATE TABLE o_test_amnblocks3 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+CREATE INDEX o_test_amnblocks3_k ON o_test_amnblocks3(k);
+INSERT INTO o_test_amnblocks3 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+ANALYZE o_test_amnblocks3;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks3
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks3_k on o_test_amnblocks3
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks3_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks3;
+-- amnblocks: VACUUM ANALYZE updates pg_class.relpages
+CREATE TABLE o_test_amnblocks4 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+CREATE INDEX o_test_amnblocks4_k ON o_test_amnblocks4(k);
+INSERT INTO o_test_amnblocks4 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+VACUUM ANALYZE o_test_amnblocks4;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks4
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks4_k on o_test_amnblocks4
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks4_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks4;
+-- allvisfrac: IOS preferred even with low correlation (random insert order)
+-- With allvisfrac=1.0 the IOS heap-fetch cost drops to 0 so IOS wins
+-- over bitmap even when csquared is near 0.
+CREATE TABLE o_test_allvisfrac (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_allvisfrac
+	SELECT i, (i * 7919) % 10000, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_allvisfrac_k ON o_test_allvisfrac(k);
+ANALYZE o_test_allvisfrac;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_allvisfrac
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_allvisfrac_k on o_test_allvisfrac
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+RESET enable_seqscan;
+DROP TABLE o_test_allvisfrac;
 -- Skip scan tests below exercise PG18's _bt_preprocess_keys synthesizing a
 -- skip array on the leading column.  On PG16/PG17 there are no skip arrays;
 -- skip the whole block instead of maintaining version-specific expected

--- a/test/expected/indices_1.out
+++ b/test/expected/indices_1.out
@@ -193,12 +193,14 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                 QUERY PLAN                  
----------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -217,12 +219,14 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 
 SET enable_seqscan = off;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -958,69 +962,69 @@ SELECT count(*) FROM o_test65;
     60
 (1 row)
 
-SELECT id, val FROM o_test65 ORDER BY id;
+SELECT id, val FROM o_test65;
  id | val 
 ----+-----
-  1 | 2
-  2 | 3
-  3 | 4
-  4 | 5
-  5 | 6
-  6 | 7
-  7 | 8
-  8 | 9
-  9 | 10
- 10 | 11
- 11 | 12
- 12 | 13
- 13 | 14
- 14 | 15
- 15 | 16
- 16 | 17
- 17 | 18
- 18 | 19
- 19 | 20
- 20 | 21
- 21 | 22
- 22 | 23
- 23 | 24
- 24 | 25
- 25 | 26
- 26 | 27
- 27 | 28
- 28 | 29
- 29 | 30
- 30 | 31
- 31 | 32
- 32 | 33
- 33 | 34
- 34 | 35
- 35 | 36
- 36 | 37
- 37 | 38
- 38 | 39
- 39 | 40
- 40 | 41
- 41 | 42
- 42 | 43
- 43 | 44
- 44 | 45
- 45 | 46
- 46 | 47
- 47 | 48
- 48 | 49
- 49 | 50
- 50 | 51
- 51 | 52
- 52 | 53
- 53 | 54
- 54 | 55
- 55 | 56
- 56 | 57
- 57 | 58
- 58 | 59
- 59 | 60
  60 | 61
+ 59 | 60
+ 58 | 59
+ 57 | 58
+ 56 | 57
+ 55 | 56
+ 54 | 55
+ 53 | 54
+ 52 | 53
+ 51 | 52
+ 50 | 51
+ 49 | 50
+ 48 | 49
+ 47 | 48
+ 46 | 47
+ 45 | 46
+ 44 | 45
+ 43 | 44
+ 42 | 43
+ 41 | 42
+ 40 | 41
+ 39 | 40
+ 38 | 39
+ 37 | 38
+ 36 | 37
+ 35 | 36
+ 34 | 35
+ 33 | 34
+ 32 | 33
+ 31 | 32
+ 30 | 31
+ 29 | 30
+ 28 | 29
+ 27 | 28
+ 26 | 27
+ 25 | 26
+ 24 | 25
+ 23 | 24
+ 22 | 23
+ 21 | 22
+ 20 | 21
+ 19 | 20
+ 18 | 19
+ 17 | 18
+ 16 | 17
+ 15 | 16
+ 14 | 15
+ 13 | 14
+ 12 | 13
+ 11 | 12
+ 10 | 11
+  9 | 10
+  8 | 9
+  7 | 8
+  6 | 7
+  5 | 6
+  4 | 5
+  3 | 4
+  2 | 3
+  1 | 2
 (60 rows)
 
 SET enable_seqscan = off;
@@ -5674,11 +5678,11 @@ SELECT * FROM o_test_partial_idx_update;
   1 |  100500 |  0
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
+EXPLAIN SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5688,11 +5692,11 @@ SELECT * FROM o_test_partial_idx_update WHERE user_id=100500 and am > 0;
 (0 rows)
 
 SET enable_bitmapscan = off;
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
+EXPLAIN SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -6365,10 +6369,10 @@ SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
  f
 (5 rows)
 
-EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
+EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=8)
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6427,10 +6431,10 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
+EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=9)
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -7960,12 +7964,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -7985,13 +7993,19 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(10 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8011,12 +8025,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8037,13 +8055,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8064,12 +8089,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(3 rows)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8120,12 +8149,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(3 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8207,12 +8240,14 @@ SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
-   Conds: (val_1 < 2)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (val_1 < 2)
+   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
+         Index Cond: (val_1 < 2)
+(5 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8573,13 +8608,17 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: (k > ALL ('{7,8}'::integer[]))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-(4 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: (k > ALL ('{7,8}'::integer[]))
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8657,12 +8696,16 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-(3 rows)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+(7 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 
@@ -9104,151 +9147,6 @@ DROP TABLE o_ios_sk_include;
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_indexscan;
--- amnblocks: INSERT -> CREATE INDEX (no ANALYZE)
-CREATE TABLE o_test_amnblocks1 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_amnblocks1 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_amnblocks1_k ON o_test_amnblocks1(k);
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks1
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks1_k on o_test_amnblocks1
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks1_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks1;
--- amnblocks: INSERT -> CREATE INDEX -> ANALYZE
-CREATE TABLE o_test_amnblocks2 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_amnblocks2 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_amnblocks2_k ON o_test_amnblocks2(k);
-ANALYZE o_test_amnblocks2;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks2
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks2_k on o_test_amnblocks2
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks2_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks2;
--- amnblocks: CREATE INDEX -> INSERT -> ANALYZE
-CREATE TABLE o_test_amnblocks3 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-CREATE INDEX o_test_amnblocks3_k ON o_test_amnblocks3(k);
-INSERT INTO o_test_amnblocks3 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-ANALYZE o_test_amnblocks3;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks3
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks3_k on o_test_amnblocks3
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks3_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks3;
--- amnblocks: VACUUM ANALYZE updates pg_class.relpages
-CREATE TABLE o_test_amnblocks4 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-CREATE INDEX o_test_amnblocks4_k ON o_test_amnblocks4(k);
-INSERT INTO o_test_amnblocks4 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-VACUUM ANALYZE o_test_amnblocks4;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks4
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks4_k on o_test_amnblocks4
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks4_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks4;
--- allvisfrac: IOS preferred even with low correlation (random insert order)
--- With allvisfrac=1.0 the IOS heap-fetch cost drops to 0 so IOS wins
--- over bitmap even when csquared is near 0.
-CREATE TABLE o_test_allvisfrac (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_allvisfrac
-	SELECT i, (i * 7919) % 10000, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_allvisfrac_k ON o_test_allvisfrac(k);
-ANALYZE o_test_allvisfrac;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_allvisfrac
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_allvisfrac_k on o_test_allvisfrac
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-RESET enable_seqscan;
-DROP TABLE o_test_allvisfrac;
 -- Skip scan tests below exercise PG18's _bt_preprocess_keys synthesizing a
 -- skip array on the leading column.  On PG16/PG17 there are no skip arrays;
 -- skip the whole block instead of maintaining version-specific expected

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -193,14 +193,12 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                     QUERY PLAN                      
------------------------------------------------------
+                 QUERY PLAN                  
+---------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Bitmap heap scan
-   Recheck Cond: ((key >= 100) AND (key <= 110))
-   ->  Bitmap Index Scan on o_test52_pkey
-         Index Cond: ((key >= 100) AND (key <= 110))
-(5 rows)
+   Forward index only scan of: o_test52_pkey
+   Conds: ((key >= 100) AND (key <= 110))
+(3 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -219,14 +217,12 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 
 SET enable_seqscan = off;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                       QUERY PLAN                        
----------------------------------------------------------
+                  QUERY PLAN                  
+----------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Bitmap heap scan
-   Recheck Cond: ((value >= 200) AND (value <= 210))
-   ->  Bitmap Index Scan on o_test52_pkey
-         Index Cond: ((value >= 200) AND (value <= 210))
-(5 rows)
+   Forward index only scan of: o_test52_pkey
+   Conds: ((value >= 200) AND (value <= 210))
+(3 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -8020,16 +8016,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(7 rows)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8049,19 +8041,13 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: (((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)))
-         ->  BitmapOr
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
-(10 rows)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((val_1 > 0) AND (val_2 > 0))
+(4 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8081,16 +8067,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(7 rows)
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8111,20 +8093,13 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-         Bitmap heap scan
-         Recheck Cond: (((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)))
-         ->  BitmapOr
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
-(11 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((val_1 > 0) AND (val_2 > 0))
+(4 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8145,16 +8120,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(7 rows)
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8205,16 +8176,12 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: val_1, val_2
-   ->  Custom Scan (o_scan) on o_test_row_searchkey
-         Bitmap heap scan
-         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(7 rows)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_row_searchkey
+   Forward index only scan of: o_test_row_searchkey_pkey
+   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8296,14 +8263,12 @@ SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Bitmap heap scan
-   Recheck Cond: (val_1 < 2)
-   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
-         Index Cond: (val_1 < 2)
-(5 rows)
+   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
+   Conds: (val_1 < 2)
+(3 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8666,17 +8631,13 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: i, j, k
-   ->  Custom Scan (o_scan) on o_test_saop
-         Filter: (k > ALL ('{7,8}'::integer[]))
-         Bitmap heap scan
-         Recheck Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-         ->  Bitmap Index Scan on o_test_saop_pkey
-               Index Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-(8 rows)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_saop
+   Filter: (k > ALL ('{7,8}'::integer[]))
+   Forward index only scan of: o_test_saop_pkey
+   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+(4 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8754,16 +8715,12 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: i, j, k
-   ->  Custom Scan (o_scan) on o_test_saop
-         Bitmap heap scan
-         Recheck Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-         ->  Bitmap Index Scan on o_test_saop_pkey
-               Index Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-(7 rows)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Custom Scan (o_scan) on o_test_saop
+   Forward index only scan of: o_test_saop_pkey
+   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+(3 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -9409,6 +9409,49 @@ RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_bounded;
 \endif
+-- A backward scan over an array (SAOP) key must cover every element, not just
+-- the one the forward scan would start at.
+CREATE TABLE o_test_array_backward (
+	a int NOT NULL,
+	b int NOT NULL
+) USING orioledb;
+CREATE INDEX o_test_array_backward_idx ON o_test_array_backward(a);
+INSERT INTO o_test_array_backward SELECT a, a FROM generate_series(1, 1000) a;
+ANALYZE o_test_array_backward;
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+  a   
+------
+ 1000
+    1
+(2 rows)
+
+SELECT a FROM o_test_array_backward WHERE a IN (1, 500, 1000) ORDER BY a DESC;
+  a   
+------
+ 1000
+  500
+    1
+(3 rows)
+
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a;
+  a   
+------
+    1
+ 1000
+(2 rows)
+
+SELECT a, b FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+    1 |    1
+(2 rows)
+
+RESET enable_bitmapscan;
+RESET enable_seqscan;
+DROP TABLE o_test_array_backward;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -193,12 +193,14 @@ SELECT orioledb_tbl_indices('o_test52'::regclass);
 
 INSERT INTO o_test52 SELECT 100 + i, 200 + i FROM generate_series(1, 100) AS i;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
-                 QUERY PLAN                  
----------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((key >= 100) AND (key <= 110))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((key >= 100) AND (key <= 110))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((key >= 100) AND (key <= 110))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
  key | value 
@@ -217,12 +219,14 @@ SELECT * FROM o_test52 WHERE key BETWEEN 100 and 110;
 
 SET enable_seqscan = off;
 EXPLAIN (COSTS off) SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
-                  QUERY PLAN                  
-----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Custom Scan (o_scan) on o_test52
-   Forward index only scan of: o_test52_pkey
-   Conds: ((value >= 200) AND (value <= 210))
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: ((value >= 200) AND (value <= 210))
+   ->  Bitmap Index Scan on o_test52_pkey
+         Index Cond: ((value >= 200) AND (value <= 210))
+(5 rows)
 
 SELECT * FROM o_test52 WHERE value BETWEEN 200 and 210;
  key | value 
@@ -958,69 +962,69 @@ SELECT count(*) FROM o_test65;
     60
 (1 row)
 
-SELECT id, val FROM o_test65 ORDER BY id;
+SELECT id, val FROM o_test65;
  id | val 
 ----+-----
-  1 | 2
-  2 | 3
-  3 | 4
-  4 | 5
-  5 | 6
-  6 | 7
-  7 | 8
-  8 | 9
-  9 | 10
- 10 | 11
- 11 | 12
- 12 | 13
- 13 | 14
- 14 | 15
- 15 | 16
- 16 | 17
- 17 | 18
- 18 | 19
- 19 | 20
- 20 | 21
- 21 | 22
- 22 | 23
- 23 | 24
- 24 | 25
- 25 | 26
- 26 | 27
- 27 | 28
- 28 | 29
- 29 | 30
- 30 | 31
- 31 | 32
- 32 | 33
- 33 | 34
- 34 | 35
- 35 | 36
- 36 | 37
- 37 | 38
- 38 | 39
- 39 | 40
- 40 | 41
- 41 | 42
- 42 | 43
- 43 | 44
- 44 | 45
- 45 | 46
- 46 | 47
- 47 | 48
- 48 | 49
- 49 | 50
- 50 | 51
- 51 | 52
- 52 | 53
- 53 | 54
- 54 | 55
- 55 | 56
- 56 | 57
- 57 | 58
- 58 | 59
- 59 | 60
  60 | 61
+ 59 | 60
+ 58 | 59
+ 57 | 58
+ 56 | 57
+ 55 | 56
+ 54 | 55
+ 53 | 54
+ 52 | 53
+ 51 | 52
+ 50 | 51
+ 49 | 50
+ 48 | 49
+ 47 | 48
+ 46 | 47
+ 45 | 46
+ 44 | 45
+ 43 | 44
+ 42 | 43
+ 41 | 42
+ 40 | 41
+ 39 | 40
+ 38 | 39
+ 37 | 38
+ 36 | 37
+ 35 | 36
+ 34 | 35
+ 33 | 34
+ 32 | 33
+ 31 | 32
+ 30 | 31
+ 29 | 30
+ 28 | 29
+ 27 | 28
+ 26 | 27
+ 25 | 26
+ 24 | 25
+ 23 | 24
+ 22 | 23
+ 21 | 22
+ 20 | 21
+ 19 | 20
+ 18 | 19
+ 17 | 18
+ 16 | 17
+ 15 | 16
+ 14 | 15
+ 13 | 14
+ 12 | 13
+ 11 | 12
+ 10 | 11
+  9 | 10
+  8 | 9
+  7 | 8
+  6 | 7
+  5 | 6
+  4 | 5
+  3 | 4
+  2 | 3
+  1 | 2
 (60 rows)
 
 SET enable_seqscan = off;
@@ -5674,11 +5678,11 @@ SELECT * FROM o_test_partial_idx_update;
   1 |  100500 |  0
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
+EXPLAIN SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5688,11 +5692,11 @@ SELECT * FROM o_test_partial_idx_update WHERE user_id=100500 and am > 0;
 (0 rows)
 
 SET enable_bitmapscan = off;
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
+EXPLAIN SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -6379,10 +6383,10 @@ SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
  f
 (5 rows)
 
-EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
+EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=8)
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6441,10 +6445,10 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
+EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=9)
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -8016,12 +8020,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8041,13 +8049,19 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: (((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 < 3) AND (val_2 > 0))
+(10 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3))) AND
@@ -8067,12 +8081,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
-(3 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (val_1 > 0) AND (val_2 > 0))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND val_1 > 0 AND val_2 > 0
@@ -8093,13 +8111,20 @@ EXPLAIN (COSTS OFF)
 		WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
 			  val_1 > 0 AND val_2 > 0
 			ORDER BY val_1, val_2;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((val_1 > 0) AND (val_2 > 0))
-(4 rows)
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Filter: ((val_1 < 2) OR ((val_1 = 2) AND ((val_2 < 3) OR (val_2 = 3))))
+         Bitmap heap scan
+         Recheck Cond: (((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0)) OR ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 < 2) AND (val_1 > 0) AND (val_2 > 0))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: ((val_1 = 2) AND (val_1 > 0) AND (val_2 > 0))
+(11 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1 < 2 OR (val_1 = 2 AND (val_2 < 3 OR val_2 = 3))) AND
@@ -8120,12 +8145,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
 			ORDER BY val_1, val_2;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
-(3 rows)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) < ROW(2, 3)) AND (ROW(val_1, val_2) > ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) < (2, 3) AND (val_1, val_2) > (1, 2)
@@ -8176,12 +8205,16 @@ EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey
 		WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
 			ORDER BY val_1, val_2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_row_searchkey
-   Forward index only scan of: o_test_row_searchkey_pkey
-   Conds: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
-(3 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: val_1, val_2
+   ->  Custom Scan (o_scan) on o_test_row_searchkey
+         Bitmap heap scan
+         Recheck Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+         ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+               Index Cond: ((ROW(val_1, val_2) <= ROW(2, 3)) AND (ROW(val_1, val_2) >= ROW(1, 2)))
+(7 rows)
 
 SELECT * FROM o_test_row_searchkey
 	WHERE (val_1, val_2) <= (2, 3) AND (val_1, val_2) >= (1, 2)
@@ -8263,12 +8296,14 @@ SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_row_searchkey_pkey_include
 		WHERE (val_1) < (2);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_row_searchkey_pkey_include
-   Forward index only scan of: o_test_row_searchkey_pkey_include_pkey
-   Conds: (val_1 < 2)
-(3 rows)
+   Bitmap heap scan
+   Recheck Cond: (val_1 < 2)
+   ->  Bitmap Index Scan on o_test_row_searchkey_pkey_include_pkey
+         Index Cond: (val_1 < 2)
+(5 rows)
 
 SELECT * FROM o_test_row_searchkey_pkey_include
 	WHERE (val_1) < (2);
@@ -8631,13 +8666,17 @@ INSERT INTO o_test_saop
 SET enable_seqscan = off;
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Filter: (k > ALL ('{7,8}'::integer[]))
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
-(4 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Filter: (k > ALL ('{7,8}'::integer[]))
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{3,4,5}'::integer[])) AND (j = ANY ('{3,4,5}'::integer[])))
+(8 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[3, 4, 5]) AND j = ANY(ARRAY[3, 4, 5]) AND k > ALL(ARRAY[7, 8]) ORDER BY i, j, k;
  i | j | k 
@@ -8715,12 +8754,16 @@ SELECT * FROM o_test_saop WHERE i = ANY(ARRAY[1, 3]) AND k = ANY(ARRAY[3, 5]) OR
 
 EXPLAIN (COSTS OFF)
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_saop
-   Forward index only scan of: o_test_saop_pkey
-   Conds: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
-(3 rows)
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: i, j, k
+   ->  Custom Scan (o_scan) on o_test_saop
+         Bitmap heap scan
+         Recheck Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+         ->  Bitmap Index Scan on o_test_saop_pkey
+               Index Cond: ((i < ANY ('{1,2}'::integer[])) AND (j = ANY ('{1,3}'::integer[])))
+(7 rows)
 
 SELECT * FROM o_test_saop WHERE i < ANY(ARRAY[1, 2]) AND j = ANY(ARRAY[1, 3]) ORDER BY i, j, k;
  i | j | k 
@@ -9171,151 +9214,6 @@ DROP TABLE o_ios_sk_include;
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_indexscan;
--- amnblocks: INSERT -> CREATE INDEX (no ANALYZE)
-CREATE TABLE o_test_amnblocks1 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_amnblocks1 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_amnblocks1_k ON o_test_amnblocks1(k);
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks1
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks1_k on o_test_amnblocks1
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks1_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks1;
--- amnblocks: INSERT -> CREATE INDEX -> ANALYZE
-CREATE TABLE o_test_amnblocks2 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_amnblocks2 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_amnblocks2_k ON o_test_amnblocks2(k);
-ANALYZE o_test_amnblocks2;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks2
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks2_k on o_test_amnblocks2
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks2_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks2;
--- amnblocks: CREATE INDEX -> INSERT -> ANALYZE
-CREATE TABLE o_test_amnblocks3 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-CREATE INDEX o_test_amnblocks3_k ON o_test_amnblocks3(k);
-INSERT INTO o_test_amnblocks3 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-ANALYZE o_test_amnblocks3;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks3
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks3_k on o_test_amnblocks3
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks3_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks3;
--- amnblocks: VACUUM ANALYZE updates pg_class.relpages
-CREATE TABLE o_test_amnblocks4 (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-CREATE INDEX o_test_amnblocks4_k ON o_test_amnblocks4(k);
-INSERT INTO o_test_amnblocks4 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
-VACUUM ANALYZE o_test_amnblocks4;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_amnblocks4
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_amnblocks4_k on o_test_amnblocks4
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-SELECT relpages > 0 AS idx_pages_ok FROM pg_class
-	WHERE relname = 'o_test_amnblocks4_k';
- idx_pages_ok 
---------------
- t
-(1 row)
-
-RESET enable_seqscan;
-DROP TABLE o_test_amnblocks4;
--- allvisfrac: IOS preferred even with low correlation (random insert order)
--- With allvisfrac=1.0 the IOS heap-fetch cost drops to 0 so IOS wins
--- over bitmap even when csquared is near 0.
-CREATE TABLE o_test_allvisfrac (
-	id int8 NOT NULL PRIMARY KEY,
-	k int8 NOT NULL,
-	c char(120) NOT NULL DEFAULT '',
-	pad char(60) NOT NULL DEFAULT ''
-) USING orioledb;
-INSERT INTO o_test_allvisfrac
-	SELECT i, (i * 7919) % 10000, '', '' FROM generate_series(1, 10000) i;
-CREATE INDEX o_test_allvisfrac_k ON o_test_allvisfrac(k);
-ANALYZE o_test_allvisfrac;
-SET enable_seqscan = off;
-EXPLAIN (COSTS off)
-	SELECT k FROM o_test_allvisfrac
-		WHERE k IN (1000, 2000, 3000, 4000, 5000,
-					6000, 7000, 8000, 9000, 10000);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Index Only Scan using o_test_allvisfrac_k on o_test_allvisfrac
-   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
-(2 rows)
-
-RESET enable_seqscan;
-DROP TABLE o_test_allvisfrac;
 -- Skip scan tests below exercise PG18's _bt_preprocess_keys synthesizing a
 -- skip array on the leading column.  On PG16/PG17 there are no skip arrays;
 -- skip the whole block instead of maintaining version-specific expected

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -11,7 +11,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 18
+ 17
 (1 row)
 
 SELECT orioledb_parallel_debug_start();
@@ -958,69 +958,69 @@ SELECT count(*) FROM o_test65;
     60
 (1 row)
 
-SELECT id, val FROM o_test65;
+SELECT id, val FROM o_test65 ORDER BY id;
  id | val 
 ----+-----
- 60 | 61
- 59 | 60
- 58 | 59
- 57 | 58
- 56 | 57
- 55 | 56
- 54 | 55
- 53 | 54
- 52 | 53
- 51 | 52
- 50 | 51
- 49 | 50
- 48 | 49
- 47 | 48
- 46 | 47
- 45 | 46
- 44 | 45
- 43 | 44
- 42 | 43
- 41 | 42
- 40 | 41
- 39 | 40
- 38 | 39
- 37 | 38
- 36 | 37
- 35 | 36
- 34 | 35
- 33 | 34
- 32 | 33
- 31 | 32
- 30 | 31
- 29 | 30
- 28 | 29
- 27 | 28
- 26 | 27
- 25 | 26
- 24 | 25
- 23 | 24
- 22 | 23
- 21 | 22
- 20 | 21
- 19 | 20
- 18 | 19
- 17 | 18
- 16 | 17
- 15 | 16
- 14 | 15
- 13 | 14
- 12 | 13
- 11 | 12
- 10 | 11
-  9 | 10
-  8 | 9
-  7 | 8
-  6 | 7
-  5 | 6
-  4 | 5
-  3 | 4
-  2 | 3
   1 | 2
+  2 | 3
+  3 | 4
+  4 | 5
+  5 | 6
+  6 | 7
+  7 | 8
+  8 | 9
+  9 | 10
+ 10 | 11
+ 11 | 12
+ 12 | 13
+ 13 | 14
+ 14 | 15
+ 15 | 16
+ 16 | 17
+ 17 | 18
+ 18 | 19
+ 19 | 20
+ 20 | 21
+ 21 | 22
+ 22 | 23
+ 23 | 24
+ 24 | 25
+ 25 | 26
+ 26 | 27
+ 27 | 28
+ 28 | 29
+ 29 | 30
+ 30 | 31
+ 31 | 32
+ 32 | 33
+ 33 | 34
+ 34 | 35
+ 35 | 36
+ 36 | 37
+ 37 | 38
+ 38 | 39
+ 39 | 40
+ 40 | 41
+ 41 | 42
+ 42 | 43
+ 43 | 44
+ 44 | 45
+ 45 | 46
+ 46 | 47
+ 47 | 48
+ 48 | 49
+ 49 | 50
+ 50 | 51
+ 51 | 52
+ 52 | 53
+ 53 | 54
+ 54 | 55
+ 55 | 56
+ 56 | 57
+ 57 | 58
+ 58 | 59
+ 59 | 60
+ 60 | 61
 (60 rows)
 
 SET enable_seqscan = off;
@@ -5674,11 +5674,11 @@ SELECT * FROM o_test_partial_idx_update;
   1 |  100500 |  0
 (1 row)
 
-EXPLAIN SELECT * FROM o_test_partial_idx_update
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5688,11 +5688,11 @@ SELECT * FROM o_test_partial_idx_update WHERE user_id=100500 and am > 0;
 (0 rows)
 
 SET enable_bitmapscan = off;
-EXPLAIN SELECT * FROM o_test_partial_idx_update
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_partial_idx_update
 	WHERE user_id=100500 and am > 0;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update  (cost=0.15..4.19 rows=2 width=24)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Index Only Scan using o_test_partial_idx_update_idx1 on o_test_partial_idx_update
    Index Cond: ((user_id = 100500) AND (am > 0))
 (2 rows)
 
@@ -5724,10 +5724,6 @@ INSERT INTO o_test_unique_as_pkey (key, val, val2)
 Indexes:
     "o_test_unique_as_pkey_pkey" PRIMARY KEY, btree (key, val)
     "o_test_unique_as_pkey_ix1" UNIQUE, btree (val, key)
-Not-null constraints:
-    "o_test_unique_as_pkey_key_not_null" NOT NULL "key"
-    "o_test_unique_as_pkey_val_not_null" NOT NULL "val"
-    "o_test_unique_as_pkey_val2_not_null" NOT NULL "val2"
 
 SELECT orioledb_tbl_indices('o_test_unique_as_pkey'::regclass);
               orioledb_tbl_indices              
@@ -5774,10 +5770,6 @@ Indexes:
     "o_test_unique_as_pkey_pkey" PRIMARY KEY, btree (key, val)
     "o_test_unique_as_pkey_ix1" UNIQUE, btree (val, key)
     "o_test_unique_as_pkey_ix2" UNIQUE, btree (val, key)
-Not-null constraints:
-    "o_test_unique_as_pkey_key_not_null" NOT NULL "key"
-    "o_test_unique_as_pkey_val_not_null" NOT NULL "val"
-    "o_test_unique_as_pkey_val2_not_null" NOT NULL "val2"
 
 SELECT orioledb_tbl_indices('o_test_unique_as_pkey'::regclass);
               orioledb_tbl_indices              
@@ -6078,9 +6070,6 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
-Not-null constraints:
-    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
-    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 \d+ o_test_reuse_multiple_indices_ix1
       Index "indices.o_test_reuse_multiple_indices_ix1"
@@ -6358,9 +6347,6 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
-Not-null constraints:
-    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
-    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 EXPLAIN (COSTS OFF)
 	SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
@@ -6379,10 +6365,10 @@ SELECT chr(ASCII('a') + val_5 / 1000) FROM o_test_reuse_multiple_indices;
  f
 (5 rows)
 
-EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=8)
+EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6441,10 +6427,10 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  
 (1 row)
 
-EXPLAIN SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
- Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices  (cost=0.13..4.21 rows=5 width=9)
+EXPLAIN (COSTS OFF) SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_reuse_multiple_indices_ix4 on o_test_reuse_multiple_indices
 (1 row)
 
 SELECT val_1, val_5 FROM o_test_reuse_multiple_indices ORDER BY val_5;
@@ -6472,9 +6458,6 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
-Not-null constraints:
-    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
-    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 \d+ o_test_reuse_multiple_indices_ix1
       Index "indices.o_test_reuse_multiple_indices_ix1"
@@ -6873,9 +6856,6 @@ Indexes:
     "o_test_reuse_multiple_indices_ix2" btree (val_3 DESC, val_2 DESC)
     "o_test_reuse_multiple_indices_ix3" btree (val_4) INCLUDE (val_2)
     "o_test_reuse_multiple_indices_ix4" btree (val_5) INCLUDE (val_1, val_2)
-Not-null constraints:
-    "o_test_reuse_multiple_indices_val_1_not_null" NOT NULL "val_1"
-    "o_test_reuse_multiple_indices_val_2_not_null" NOT NULL "val_2"
 
 \d+ o_test_reuse_multiple_indices_ix1
       Index "indices.o_test_reuse_multiple_indices_ix1"
@@ -6959,8 +6939,6 @@ Indexes:
     "o_test_include_like_ix1" btree (key)
     "o_test_include_like_ix2" btree (value)
     "o_test_include_like_ix_include" UNIQUE, btree (val2) INCLUDE (value)
-Not-null constraints:
-    "o_test_include_like_key_not_null" NOT NULL "key"
 
 CREATE TABLE IF NOT EXISTS o_test_include_like_like
 	(LIKE o_test_include_like INCLUDING INDEXES INCLUDING CONSTRAINTS)
@@ -7003,8 +6981,6 @@ Indexes:
     "o_test_include_like_like_key_idx" btree (key)
     "o_test_include_like_like_val2_value_idx" UNIQUE, btree (val2) INCLUDE (value)
     "o_test_include_like_like_value_idx" btree (value)
-Not-null constraints:
-    "o_test_include_like_key_not_null" NOT NULL "key"
 
 DROP TABLE o_test_include_like_like;
 ALTER TABLE o_test_include_like DROP CONSTRAINT o_test_include_like_pkey;
@@ -7045,8 +7021,6 @@ Indexes:
     "o_test_include_like_ix1" btree (key)
     "o_test_include_like_ix2" btree (value)
     "o_test_include_like_ix_include" UNIQUE, btree (val2) INCLUDE (value)
-Not-null constraints:
-    "o_test_include_like_key_not_null" NOT NULL "key"
 
 CREATE TABLE IF NOT EXISTS o_test_include_like_like
 	(LIKE o_test_include_like INCLUDING INDEXES INCLUDING CONSTRAINTS)
@@ -7088,8 +7062,6 @@ Indexes:
     "o_test_include_like_like_key_idx" btree (key)
     "o_test_include_like_like_val2_value_idx" UNIQUE, btree (val2) INCLUDE (value)
     "o_test_include_like_like_value_idx" btree (value)
-Not-null constraints:
-    "o_test_include_like_key_not_null" NOT NULL "key"
 
 DROP TABLE o_test_include_like_like;
 -- Test that fields also added when we create table like postgres table
@@ -7115,8 +7087,6 @@ Indexes:
     "pg_test_include_like_ix1" btree (key)
     "pg_test_include_like_ix2" btree (value)
     "pg_test_include_like_ix_include" UNIQUE, btree (val2) INCLUDE (value)
-Not-null constraints:
-    "pg_test_include_like_key_not_null" NOT NULL "key"
 
 CREATE TABLE IF NOT EXISTS o_test_include_like_like
 	(LIKE pg_test_include_like INCLUDING INDEXES INCLUDING CONSTRAINTS)
@@ -7159,8 +7129,6 @@ Indexes:
     "o_test_include_like_like_key_idx" btree (key)
     "o_test_include_like_like_val2_value_idx" UNIQUE, btree (val2) INCLUDE (value)
     "o_test_include_like_like_value_idx" btree (value)
-Not-null constraints:
-    "pg_test_include_like_key_not_null" NOT NULL "key"
 
 DROP TABLE o_test_include_like_like;
 CREATE TABLE o_test_partial_unique(
@@ -7359,11 +7327,6 @@ CREATE INDEX o_test_pkey_mixed_ix1
 Indexes:
     "o_test_pkey_mixed_pkey" PRIMARY KEY, btree (pk1, pk2, pk3, pk4)
     "o_test_pkey_mixed_ix1" btree (f1, f2, pk1, f3) INCLUDE (i1, pk4, i2)
-Not-null constraints:
-    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
-    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
-    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
-    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 SELECT orioledb_tbl_indices('o_test_pkey_mixed'::regclass);
@@ -7401,11 +7364,6 @@ Indexes:
     "o_test_pkey_mixed_pkey" PRIMARY KEY, btree (pk1, pk2, pk3, pk4)
     "o_test_pkey_mixed_ix1" btree (f1, f2, pk1, f3) INCLUDE (i1, pk4, i2)
     "o_test_pkey_mixed_uniq1" UNIQUE, btree (f2, f1, pk1, f3) INCLUDE (i1, pk4, i2)
-Not-null constraints:
-    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
-    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
-    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
-    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 -- f2 f1 pk1 f3 i1 pk4 i2 pk2 pk3
@@ -7450,11 +7408,6 @@ Indexes:
     "o_test_pkey_mixed_ix1" btree (f1, f2, pk1, f3) INCLUDE (i1, pk4, i2)
     "o_test_pkey_mixed_ix3" btree (f3, f2, pk4, f1, pk4) INCLUDE (pk3)
     "o_test_pkey_mixed_uniq1" UNIQUE, btree (f2, f1, pk1, f3) INCLUDE (i1, pk4, i2)
-Not-null constraints:
-    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
-    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
-    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
-    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 -- f2 f1 pk1 f3 i1 pk4 i2 pk2 pk3
@@ -7506,11 +7459,6 @@ Indexes:
     "o_test_pkey_mixed_ix3" btree (f3, f2, pk4, f1, pk4) INCLUDE (pk3)
     "o_test_pkey_mixed_ix4" btree (i1, f1, pk4, f2, pk4) INCLUDE (pk3, i2)
     "o_test_pkey_mixed_uniq1" UNIQUE, btree (f2, f1, pk1, f3) INCLUDE (i1, pk4, i2)
-Not-null constraints:
-    "o_test_pkey_mixed_pk1_not_null" NOT NULL "pk1"
-    "o_test_pkey_mixed_pk2_not_null" NOT NULL "pk2"
-    "o_test_pkey_mixed_pk3_not_null" NOT NULL "pk3"
-    "o_test_pkey_mixed_pk4_not_null" NOT NULL "pk4"
 
 -- f1 f2 pk1 f3 i1 pk4 i2 pk2 pk3
 -- f2 f1 pk1 f3 i1 pk4 i2 pk2 pk3
@@ -7691,8 +7639,6 @@ CREATE TABLE o_test_pkey_include_box
  f2     | integer |           |          |         | plain   |              | 
 Indexes:
     "o_test_pkey_include_box_pkey" PRIMARY KEY, btree (pk1) INCLUDE (pk2)
-Not-null constraints:
-    "o_test_pkey_include_box_pk1_not_null" NOT NULL "pk1"
 
 SELECT orioledb_tbl_indices('o_test_pkey_include_box'::regclass);
               orioledb_tbl_indices              
@@ -7840,8 +7786,6 @@ Indexes:
     "o_test_include_box_with_pkey_pkey" PRIMARY KEY, btree (val_1)
     "o_test_include_box_with_pkey_ix1" UNIQUE, btree (val_2) INCLUDE (val_4)
     "o_test_include_box_with_pkey_ix2" UNIQUE, btree (val_3)
-Not-null constraints:
-    "o_test_include_box_with_pkey_val_1_not_null" NOT NULL "val_1"
 
 SELECT orioledb_tbl_indices('o_test_include_box_with_pkey'::regclass);
                orioledb_tbl_indices                
@@ -8151,12 +8095,12 @@ EXPLAIN (COSTS OFF)
    ->  Custom Scan (o_scan) on o_test_row_searchkey
          Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 > 2)))
          Bitmap heap scan
-         Recheck Cond: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 < 3)))
+         Recheck Cond: (((val_1 = 2) AND (val_2 < 3)) OR (val_1 < 2))
          ->  BitmapOr
                ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: (val_1 < 2)
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
                      Index Cond: ((val_1 = 2) AND (val_2 < 3))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
 (11 rows)
 
 SELECT * FROM o_test_row_searchkey
@@ -8209,12 +8153,12 @@ EXPLAIN (COSTS OFF)
    ->  Custom Scan (o_scan) on o_test_row_searchkey
          Filter: ((val_1 > 1) OR ((val_1 = 1) AND (val_2 >= 2)))
          Bitmap heap scan
-         Recheck Cond: ((val_1 < 2) OR ((val_1 = 2) AND (val_2 <= 3)))
+         Recheck Cond: (((val_1 = 2) AND (val_2 <= 3)) OR (val_1 < 2))
          ->  BitmapOr
                ->  Bitmap Index Scan on o_test_row_searchkey_pkey
-                     Index Cond: (val_1 < 2)
-               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
                      Index Cond: ((val_1 = 2) AND (val_2 <= 3))
+               ->  Bitmap Index Scan on o_test_row_searchkey_pkey
+                     Index Cond: (val_1 < 2)
 (11 rows)
 
 SELECT * FROM o_test_row_searchkey
@@ -8509,8 +8453,6 @@ CREATE INDEX o_test_pkey_include_same_fields_ix1
 Indexes:
     "o_test_pkey_include_same_fields_pkey" PRIMARY KEY, btree (val_1) INCLUDE (val_2, val_2)
     "o_test_pkey_include_same_fields_ix1" btree (val_1) INCLUDE (val_2, val_2)
-Not-null constraints:
-    "o_test_pkey_include_same_fields_val_1_not_null" NOT NULL "val_1"
 
 SELECT orioledb_tbl_indices('o_test_pkey_include_same_fields'::regclass);
               orioledb_tbl_indices              
@@ -8826,11 +8768,10 @@ SELECT conname, contype, conindid::regclass
 FROM pg_constraint
 WHERE conrelid = 'o_test_add_index_constraint'::regclass
 ORDER BY conname;
-                 conname                 | contype | conindid  
------------------------------------------+---------+-----------
- o_test_add_index_constraint_id_not_null | n       | -
- o_test_pk                               | p       | o_test_pk
-(2 rows)
+  conname  | contype | conindid  
+-----------+---------+-----------
+ o_test_pk | p       | o_test_pk
+(1 row)
 
 -- Test constraint enforcement
 INSERT INTO o_test_add_index_constraint VALUES (4, 'four');  -- Should succeed
@@ -8844,11 +8785,10 @@ SELECT conname, contype, conindid::regclass
 FROM pg_constraint
 WHERE conrelid = 'o_test_add_index_constraint'::regclass
 ORDER BY conname;
-                 conname                 | contype | conindid  
------------------------------------------+---------+-----------
- o_test_add_index_constraint_id_not_null | n       | -
- o_test_pk                               | p       | o_test_pk
-(2 rows)
+  conname  | contype | conindid  
+-----------+---------+-----------
+ o_test_pk | p       | o_test_pk
+(1 row)
 
 -- Test AT_AddIndexConstraint: Add UNIQUE constraint using existing index
 ALTER TABLE o_test_add_index_constraint
@@ -8859,12 +8799,11 @@ SELECT conname, contype, conindid::regclass
 FROM pg_constraint
 WHERE conrelid = 'o_test_add_index_constraint'::regclass
 ORDER BY conname;
-                 conname                 | contype | conindid  
------------------------------------------+---------+-----------
- o_test_add_index_constraint_id_not_null | n       | -
- o_test_pk                               | p       | o_test_pk
- o_test_uq                               | u       | o_test_uq
-(3 rows)
+  conname  | contype | conindid  
+-----------+---------+-----------
+ o_test_pk | p       | o_test_pk
+ o_test_uq | u       | o_test_uq
+(2 rows)
 
 -- Test UNIQUE constraint enforcement
 INSERT INTO o_test_add_index_constraint VALUES (5, 'five');  -- Should succeed
@@ -9030,8 +8969,7 @@ EXPLAIN (COSTS OFF)
                       QUERY PLAN                       
 -------------------------------------------------------
  Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
-   Disabled: true
-(2 rows)
+(1 row)
 
 SELECT val_1 FROM o_ios_sk_dup ORDER BY val_1;
  val_1 
@@ -9048,8 +8986,7 @@ EXPLAIN (COSTS OFF)
                       QUERY PLAN                       
 -------------------------------------------------------
  Index Only Scan using o_ios_sk_dup_ix on o_ios_sk_dup
-   Disabled: true
-(2 rows)
+(1 row)
 
 SELECT val_1, val_2 FROM o_ios_sk_dup ORDER BY val_1;
  val_1 | val_2 
@@ -9072,8 +9009,7 @@ EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
                       QUERY PLAN                       
 -------------------------------------------------------
  Index Only Scan using o_ios_pk_dup_ix on o_ios_pk_dup
-   Disabled: true
-(2 rows)
+(1 row)
 
 SELECT a, b FROM o_ios_pk_dup ORDER BY a, b;
  a |   b   
@@ -9100,8 +9036,7 @@ EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
                          QUERY PLAN                          
 -------------------------------------------------------------
  Index Only Scan using o_ios_pk_sk_dup_ix on o_ios_pk_sk_dup
-   Disabled: true
-(2 rows)
+(1 row)
 
 SELECT a, b, c FROM o_ios_pk_sk_dup ORDER BY a, b;
  a | b  |  c  
@@ -9129,8 +9064,7 @@ EXPLAIN (COSTS OFF) SELECT a, b FROM o_ios_pk_include ORDER BY b;
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Index Only Scan using o_ios_pk_include_ix on o_ios_pk_include
-   Disabled: true
-(2 rows)
+(1 row)
 
 SELECT a, b FROM o_ios_pk_include ORDER BY b;
  a | b  
@@ -9154,8 +9088,7 @@ EXPLAIN (COSTS OFF) SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Index Only Scan using o_ios_sk_include_ix on o_ios_sk_include
-   Disabled: true
-(2 rows)
+(1 row)
 
 SELECT a, b, c FROM o_ios_sk_include ORDER BY b;
  a | b  |  c  
@@ -9171,6 +9104,151 @@ DROP TABLE o_ios_sk_include;
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 RESET enable_indexscan;
+-- amnblocks: INSERT -> CREATE INDEX (no ANALYZE)
+CREATE TABLE o_test_amnblocks1 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_amnblocks1 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_amnblocks1_k ON o_test_amnblocks1(k);
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks1
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks1_k on o_test_amnblocks1
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks1_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks1;
+-- amnblocks: INSERT -> CREATE INDEX -> ANALYZE
+CREATE TABLE o_test_amnblocks2 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_amnblocks2 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_amnblocks2_k ON o_test_amnblocks2(k);
+ANALYZE o_test_amnblocks2;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks2
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks2_k on o_test_amnblocks2
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks2_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks2;
+-- amnblocks: CREATE INDEX -> INSERT -> ANALYZE
+CREATE TABLE o_test_amnblocks3 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+CREATE INDEX o_test_amnblocks3_k ON o_test_amnblocks3(k);
+INSERT INTO o_test_amnblocks3 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+ANALYZE o_test_amnblocks3;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks3
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks3_k on o_test_amnblocks3
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks3_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks3;
+-- amnblocks: VACUUM ANALYZE updates pg_class.relpages
+CREATE TABLE o_test_amnblocks4 (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+CREATE INDEX o_test_amnblocks4_k ON o_test_amnblocks4(k);
+INSERT INTO o_test_amnblocks4 SELECT i, i, '', '' FROM generate_series(1, 10000) i;
+VACUUM ANALYZE o_test_amnblocks4;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_amnblocks4
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_amnblocks4_k on o_test_amnblocks4
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+SELECT relpages > 0 AS idx_pages_ok FROM pg_class
+	WHERE relname = 'o_test_amnblocks4_k';
+ idx_pages_ok 
+--------------
+ t
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_test_amnblocks4;
+-- allvisfrac: IOS preferred even with low correlation (random insert order)
+-- With allvisfrac=1.0 the IOS heap-fetch cost drops to 0 so IOS wins
+-- over bitmap even when csquared is near 0.
+CREATE TABLE o_test_allvisfrac (
+	id int8 NOT NULL PRIMARY KEY,
+	k int8 NOT NULL,
+	c char(120) NOT NULL DEFAULT '',
+	pad char(60) NOT NULL DEFAULT ''
+) USING orioledb;
+INSERT INTO o_test_allvisfrac
+	SELECT i, (i * 7919) % 10000, '', '' FROM generate_series(1, 10000) i;
+CREATE INDEX o_test_allvisfrac_k ON o_test_allvisfrac(k);
+ANALYZE o_test_allvisfrac;
+SET enable_seqscan = off;
+EXPLAIN (COSTS off)
+	SELECT k FROM o_test_allvisfrac
+		WHERE k IN (1000, 2000, 3000, 4000, 5000,
+					6000, 7000, 8000, 9000, 10000);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_allvisfrac_k on o_test_allvisfrac
+   Index Cond: (k = ANY ('{1000,2000,3000,4000,5000,6000,7000,8000,9000,10000}'::bigint[]))
+(2 rows)
+
+RESET enable_seqscan;
+DROP TABLE o_test_allvisfrac;
 -- Skip scan tests below exercise PG18's _bt_preprocess_keys synthesizing a
 -- skip array on the leading column.  On PG16/PG17 there are no skip arrays;
 -- skip the whole block instead of maintaining version-specific expected
@@ -9197,27 +9275,11 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT x, y FROM o_test_skip_leading_int WHERE y = 42 ORDER BY x, y;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Index Only Scan using o_test_skip_leading_int_idx on o_test_skip_leading_int
-   Index Cond: (y = 42)
-(2 rows)
-
 SELECT x, y FROM o_test_skip_leading_int WHERE y = 42 ORDER BY x, y;
- x | y  
----+----
- 2 | 42
-(1 row)
-
 -- Multiple matching y values across distinct x: every distinct x is
 -- visited exactly once by the skip-array driver.
 SELECT count(*), count(DISTINCT x) FROM o_test_skip_leading_int
 	WHERE y IN (42, 84, 126);
- count | count 
--------+-------
-     3 |     3
-(1 row)
-
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_leading_int;
@@ -9238,18 +9300,7 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT x, y FROM o_test_skip_leading_text WHERE y = 42 ORDER BY x, y;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Index Only Scan using o_test_skip_leading_text_idx on o_test_skip_leading_text
-   Index Cond: (y = 42)
-(2 rows)
-
 SELECT x, y FROM o_test_skip_leading_text WHERE y = 42 ORDER BY x, y;
- x | y  
----+----
- C | 42
-(1 row)
-
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_leading_text;
@@ -9269,18 +9320,7 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 SELECT x, y FROM o_test_skip_backward WHERE y = 42 ORDER BY x DESC, y DESC;
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Index Only Scan Backward using o_test_skip_backward_idx on o_test_skip_backward
-   Index Cond: (y = 42)
-(2 rows)
-
 SELECT x, y FROM o_test_skip_backward WHERE y = 42 ORDER BY x DESC, y DESC;
- x | y  
----+----
- 2 | 42
-(1 row)
-
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_backward;
@@ -9301,11 +9341,6 @@ ANALYZE o_test_skip_multirow;
 SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 SELECT count(*), count(DISTINCT x) FROM o_test_skip_multirow WHERE y = 42;
- count | count 
--------+-------
-    30 |    10
-(1 row)
-
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_multirow;
@@ -9327,17 +9362,7 @@ ANALYZE o_test_skip_nullable;
 SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 SELECT x, y FROM o_test_skip_nullable WHERE y = 25;
- x | y  
----+----
- 0 | 25
-(1 row)
-
 SELECT x, y FROM o_test_skip_nullable WHERE y = 102;
- x |  y  
----+-----
-   | 102
-(1 row)
-
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_nullable;
@@ -9357,11 +9382,6 @@ SET enable_seqscan = OFF;
 SET enable_bitmapscan = OFF;
 SELECT count(*), count(DISTINCT x) FROM o_test_skip_bounded
 	WHERE x < 5 AND y IN (2, 3, 4);
- count | count 
--------+-------
-    15 |     5
-(1 row)
-
 RESET enable_bitmapscan;
 RESET enable_seqscan;
 DROP TABLE o_test_skip_bounded;

--- a/test/expected/parallel_idx_scan.out
+++ b/test/expected/parallel_idx_scan.out
@@ -1,0 +1,372 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2_setup s2_begin_rr s2_count_all s1_insert s2_count_all s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_insert: 
+	INSERT INTO o_par_idx_scan
+		SELECT i, i % 100 FROM generate_series(10001, 11000) AS i;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rr s2_count_all s1_delete s2_count_all s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_delete: 
+	DELETE FROM o_par_idx_scan WHERE id BETWEEN 5001 AND 6000;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rr s2_count_all s1_update s2_count_all s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_update: 
+	UPDATE o_par_idx_scan SET val = val + 1000 WHERE id <= 500;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rr s2_count_range s1_insert s2_count_range s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_range: 
+	SELECT count(*) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 5000;
+count
+-----
+ 5000
+(1 row)
+
+step s1_insert: 
+	INSERT INTO o_par_idx_scan
+		SELECT i, i % 100 FROM generate_series(10001, 11000) AS i;
+step s2_count_range: 
+	SELECT count(*) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 5000;
+count
+-----
+ 5000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rr s2_count_range s1_delete s2_count_range s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_range: 
+	SELECT count(*) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 5000;
+count
+-----
+ 5000
+(1 row)
+
+step s1_delete: 
+	DELETE FROM o_par_idx_scan WHERE id BETWEEN 5001 AND 6000;
+step s2_count_range: 
+	SELECT count(*) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 5000;
+count
+-----
+ 5000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rr s2_count_range s1_update s2_count_range s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_range: 
+	SELECT count(*) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 5000;
+count
+-----
+ 5000
+(1 row)
+
+step s1_update: 
+	UPDATE o_par_idx_scan SET val = val + 1000 WHERE id <= 500;
+step s2_count_range: 
+	SELECT count(*) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 5000;
+count
+-----
+ 5000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rr s2_count_val s1_update s2_count_val s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_val: 
+	SELECT count(*) FROM o_par_idx_scan WHERE val = 0;
+count
+-----
+  100
+(1 row)
+
+step s1_update: 
+	UPDATE o_par_idx_scan SET val = val + 1000 WHERE id <= 500;
+step s2_count_val: 
+	SELECT count(*) FROM o_par_idx_scan WHERE val = 0;
+count
+-----
+  100
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rc s2_count_all s1_begin_rc s1_insert s1_commit s2_count_all s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s1_insert: 
+	INSERT INTO o_par_idx_scan
+		SELECT i, i % 100 FROM generate_series(10001, 11000) AS i;
+step s1_commit: COMMIT;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+11000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rc s2_count_all s1_begin_rc s1_delete s1_commit s2_count_all s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s1_delete: 
+	DELETE FROM o_par_idx_scan WHERE id BETWEEN 5001 AND 6000;
+step s1_commit: COMMIT;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+ 9000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rc s2_count_all s1_begin_rc s1_update s1_commit s2_count_all s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s1_update: 
+	UPDATE o_par_idx_scan SET val = val + 1000 WHERE id <= 500;
+step s1_commit: COMMIT;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rc s2_count_all s1_begin_rc s1_insert s1_rollback s2_count_all s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_begin_rc: 
+	BEGIN ISOLATION LEVEL READ COMMITTED;
+step s1_insert: 
+	INSERT INTO o_par_idx_scan
+		SELECT i, i % 100 FROM generate_series(10001, 11000) AS i;
+step s1_rollback: ROLLBACK;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s2_setup s2_begin_rr s2_sum_val s1_update s2_sum_val s2_commit
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_sum_val: 
+	SELECT sum(val) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 1000;
+  sum
+-----
+49500
+(1 row)
+
+step s1_update: 
+	UPDATE o_par_idx_scan SET val = val + 1000 WHERE id <= 500;
+step s2_sum_val: 
+	SELECT sum(val) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 1000;
+  sum
+-----
+49500
+(1 row)
+
+step s2_commit: COMMIT;
+
+starting permutation: s1_begin_rr s2_setup s2_begin_rr s2_count_all s1_insert s2_count_all s1_commit s2_commit
+step s1_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_setup: 
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4;
+step s2_begin_rr: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_insert: 
+	INSERT INTO o_par_idx_scan
+		SELECT i, i % 100 FROM generate_series(10001, 11000) AS i;
+step s2_count_all: 
+	SELECT count(*) FROM o_par_idx_scan;
+count
+-----
+10000
+(1 row)
+
+step s1_commit: COMMIT;
+step s2_commit: COMMIT;

--- a/test/expected/parallel_ordered_scan.out
+++ b/test/expected/parallel_ordered_scan.out
@@ -1,0 +1,298 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan_desc s2_insert_mid s2_checkpoint s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_bitmapscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan_desc: 
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) o) t; <waiting ...>
+step s2_insert_mid: 
+	INSERT INTO o_ord SELECT i, i % 97
+		FROM generate_series(1000000, 1030000) i
+		WHERE i % 3 = 0;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan_desc: <... completed>
+count| min|  max|sorted
+-----+----+-----+------
+20001|5000|25000|t     
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan_desc s2_delete_mid s2_checkpoint s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_bitmapscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan_desc: 
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) o) t; <waiting ...>
+step s2_delete_mid: 
+	DELETE FROM o_ord WHERE id BETWEEN 8000 AND 20000;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan_desc: <... completed>
+count| min|  max|sorted
+-----+----+-----+------
+20001|5000|25000|t     
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan_desc s2_update s2_evict s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_bitmapscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan_desc: 
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) o) t; <waiting ...>
+step s2_update: 
+	UPDATE o_ord SET val = val + 1 WHERE id BETWEEN 5000 AND 25000;
+step s2_evict: 
+	SELECT orioledb_evict_pages('o_ord'::regclass::oid, 0);
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan_desc: <... completed>
+count| min|  max|sorted
+-----+----+-----+------
+20001|5000|25000|t     
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rr s1_scan_asc s2_insert_mid s2_delete_mid s2_checkpoint s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_bitmapscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+step s1_scan_asc: 
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id >= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id) o) t; <waiting ...>
+step s2_insert_mid: 
+	INSERT INTO o_ord SELECT i, i % 97
+		FROM generate_series(1000000, 1030000) i
+		WHERE i % 3 = 0;
+step s2_delete_mid: 
+	DELETE FROM o_ord WHERE id BETWEEN 8000 AND 20000;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan_asc: <... completed>
+count| min|  max|sorted
+-----+----+-----+------
+20001|5000|25000|t     
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_begin_rc s1_scan_desc s2_delete_mid s2_reset s1_commit
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_bitmapscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_begin_rc: BEGIN ISOLATION LEVEL READ COMMITTED;
+step s1_scan_desc: 
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) o) t; <waiting ...>
+step s2_delete_mid: 
+	DELETE FROM o_ord WHERE id BETWEEN 8000 AND 20000;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan_desc: <... completed>
+count| min|  max|sorted
+-----+----+-----+------
+20001|5000|25000|t     
+(1 row)
+
+step s1_commit: COMMIT;
+
+starting permutation: s2_arm s1_setup s1_scan_desc s2_update s2_checkpoint s2_reset
+orioledb_evict_pages
+--------------------
+                    
+(1 row)
+
+step s2_arm: 
+	SELECT pg_stopevent_set('scan_disk_page', 'true');
+pg_stopevent_set
+----------------
+                
+(1 row)
+
+step s1_setup: 
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_bitmapscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3;
+step s1_scan_desc: 
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) o) t; <waiting ...>
+step s2_update: 
+	UPDATE o_ord SET val = val + 1 WHERE id BETWEEN 5000 AND 25000;
+step s2_checkpoint: CHECKPOINT;
+step s2_reset: 
+	SELECT pg_stopevent_reset('scan_disk_page');
+pg_stopevent_reset
+------------------
+t                 
+(1 row)
+
+step s1_scan_desc: <... completed>
+count| min|  max|sorted
+-----+----+-----+------
+20001|5000|25000|t     
+(1 row)
+

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -419,6 +419,7 @@ RESET parallel_setup_cost;
 RESET min_parallel_table_scan_size;
 RESET parallel_leader_participation;
 BEGIN;
+SET LOCAL enable_indexonlyscan = off;
 CREATE TABLE o_test_parallel_bitmap_scan (
 	val_1 int
 ) USING orioledb;

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1195,6 +1195,84 @@ SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
              20000
 (1 row)
 
+-- Sparse SAOP list: the union range between the smallest and the largest
+-- element covers the whole index, so the scan has to reject the leaves that
+-- hold no element rather than read and filter them.
+CREATE TABLE o_test_parallel_saop_sparse (
+	id SERIAL PRIMARY KEY,
+	val INT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop_sparse (val)
+	SELECT (g % 10) + 1 FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_sparse_idx
+	ON o_test_parallel_saop_sparse (val);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop_sparse
+                     Forward index scan of: o_test_parallel_saop_sparse_idx
+                     Conds: (val = ANY ('{1,10}'::integer[]))
+(7 rows)
+
+SELECT count(*) AS parallel_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ parallel_saop_sparse 
+----------------------
+                20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ serial_saop_sparse 
+--------------------
+              20000
+(1 row)
+
+-- The same on a DESC index: elements are ordered the other way round, so the
+-- page-level membership test has to compare in index order.
+DROP INDEX o_test_parallel_saop_sparse_idx;
+CREATE INDEX o_test_parallel_saop_sparse_desc_idx
+	ON o_test_parallel_saop_sparse (val DESC);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop_sparse
+                     Forward index scan of: o_test_parallel_saop_sparse_desc_idx
+                     Conds: (val = ANY ('{1,10}'::integer[]))
+(7 rows)
+
+SELECT count(*) AS parallel_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ parallel_saop_desc 
+--------------------
+              20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ serial_saop_desc 
+------------------
+            20000
+(1 row)
+
+DROP TABLE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
 -- SAOP with full row lookup through secondary index
 SET LOCAL enable_indexonlyscan = off;
 SET LOCAL max_parallel_workers_per_gather = 2;

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1274,8 +1274,115 @@ SELECT o_test1.i, substring(o_test1.t, 1,2) FROM o_test1
 DROP TABLE o_test1;
 DROP TABLE o_test2;
 COMMIT;
+-- Parallel ordered (key-order) index scan: forward and backward.  An ordered
+-- path reads on-disk downlinks inline so each worker emits a sorted stream that
+-- Gather Merge combines; ORDER BY / ORDER BY DESC should use Gather Merge, and
+-- the result must match the serial scan exactly.
+BEGIN;
+CREATE TABLE o_test_ordered_scan (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_ordered_scan
+	SELECT g, g % 777 FROM generate_series(1, 60000) g;
+ANALYZE o_test_ordered_scan;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- An always-true but per-row-expensive filter (sqrt) makes the parallel
+-- ordered path cheaper than the naturally-ordered serial index scan, so the
+-- planner picks Gather Merge deterministically.
+-- Plan shape: ORDER BY ascending uses Gather Merge over a forward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 3
+   ->  Parallel Custom Scan (o_scan) on o_test_ordered_scan
+         Filter: (sqrt((val)::double precision) >= '0'::double precision)
+         Forward index scan of: o_test_ordered_scan_pkey
+         Conds: ((id >= 10000) AND (id <= 50000))
+(6 rows)
+
+-- Plan shape: ORDER BY DESC uses Gather Merge over a backward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 3
+   ->  Parallel Custom Scan (o_scan) on o_test_ordered_scan
+         Filter: (sqrt((val)::double precision) >= '0'::double precision)
+         Backward index scan of: o_test_ordered_scan_pkey
+         Conds: ((id >= 10000) AND (id <= 50000))
+(6 rows)
+
+-- Correctness: ascending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id >= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id) s) t;
+ count |  min  |  max  | sorted 
+-------+-------+-------+--------
+ 40001 | 10000 | 50000 | t
+(1 row)
+
+-- Correctness: descending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) s) t;
+ count |  min  |  max  | sorted 
+-------+-------+-------+--------
+ 40001 | 10000 | 50000 | t
+(1 row)
+
+-- Serial vs parallel equivalence (descending), whole ordered vector
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id) AS serial_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+                                           serial_desc                                            
+--------------------------------------------------------------------------------------------------
+ {1010,1009,1008,1007,1006,1005,1004,1003,1002,1001,1000,999,998,997,996,995,994,993,992,991,990}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT array_agg(id) AS parallel_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+                                          parallel_desc                                           
+--------------------------------------------------------------------------------------------------
+ {1010,1009,1008,1007,1006,1005,1004,1003,1002,1001,1000,999,998,997,996,995,994,993,992,991,990}
+(1 row)
+
+-- Full ordered scan (no range), descending
+SELECT count(*), min(id), max(id) FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE sqrt(val::float8) >= 0 ORDER BY id DESC) s;
+ count | min |  max  
+-------+-----+-------
+ 60000 |   1 | 60000
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to 19 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1294,6 +1401,7 @@ drop cascades to table o_test_parallelscan_reinitialize2
 drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
+drop cascades to table o_test_ordered_scan
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -815,55 +815,6 @@ SELECT * FROM o_test_parallel_join
 
 COMMIT;
 BEGIN;
-CREATE TABLE o_test_no_parallel_index_scan (
-  val_1 INT PRIMARY KEY,
-  val_2 text
-) USING orioledb;
-INSERT INTO o_test_no_parallel_index_scan VALUES (1, 'a'), (2, 'b');
-SET LOCAL max_parallel_workers_per_gather = 1;
-SET LOCAL parallel_setup_cost = 0;
-SET LOCAL parallel_tuple_cost = 0;
-SET LOCAL min_parallel_table_scan_size = 1;
-SET LOCAL min_parallel_index_scan_size = 1;
-SET LOCAL enable_seqscan = off;
-SET LOCAL enable_bitmapscan = off;
--- Parallel Index Only Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF) SELECT val_1 FROM o_test_no_parallel_index_scan;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_no_parallel_index_scan
-   Forward index only scan of: o_test_no_parallel_index_scan_pkey
-(2 rows)
-
-SELECT val_1 FROM o_test_no_parallel_index_scan;
- val_1 
--------
-     1
-     2
-(2 rows)
-
-SET LOCAL enable_indexonlyscan = off;
--- Parallel Index Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF)
-	SELECT array_agg(val_1), array_agg(val_2)
-		FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (o_scan) on o_test_no_parallel_index_scan
-         Forward index scan of: o_test_no_parallel_index_scan_pkey
-         Conds: (val_1 > 0)
-(4 rows)
-
-SELECT array_agg(val_1), array_agg(val_2)
-	FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
- array_agg | array_agg 
------------+-----------
- {1,2}     | {a,b}
-(1 row)
-
-COMMIT;
-BEGIN;
 SET LOCAL parallel_setup_cost = 0;
 SET LOCAL min_parallel_table_scan_size = 1;
 CREATE TABLE o_test_no_parallel_bitmap_scan (
@@ -959,6 +910,308 @@ SELECT * FROM o_test_no_parallel_bitmap_scan WHERE val_1 <@ int4range(10,50);
 
 COMMIT;
 BEGIN;
+-- Parallel index range scan on primary index
+CREATE TABLE o_test_parallel_index_range (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+INSERT INTO o_test_parallel_index_range (val, name)
+	SELECT g, 'name_' || g FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_index_range_val_idx
+	ON o_test_parallel_index_range (val);
+ANALYZE o_test_parallel_index_range;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- Range scan on primary key
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range
+		WHERE id BETWEEN 1000 AND 5000;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather
+   Workers Planned: 2
+   ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+         Forward index only scan of: o_test_parallel_index_range_pkey
+         Conds: ((id >= 1000) AND (id <= 5000))
+(5 rows)
+
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE id BETWEEN 1000 AND 5000;
+ count 
+-------
+  4001
+(1 row)
+
+-- Range scan: serial vs parallel equivalence
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+ serial_count 
+--------------
+         4001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+ parallel_count 
+----------------
+           4001
+(1 row)
+
+-- Parallel index scan with aggregation on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+                     Forward index only scan of: o_test_parallel_index_range_val_idx
+                     Conds: (val > 50000)
+(7 rows)
+
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+ count 
+-------
+ 50000
+(1 row)
+
+-- Serial vs parallel equivalence on primary index range
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+                                            serial_ids                                            
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+                                           parallel_ids                                           
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+-- Plan shape: primary index range scan
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE id > 50000;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+                     Forward index only scan of: o_test_parallel_index_range_pkey
+                     Conds: (id > 50000)
+(7 rows)
+
+-- Plan shape: index-only scan on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT val FROM o_test_parallel_index_range
+		WHERE val BETWEEN 100 AND 200;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_parallel_index_range_val_idx on o_test_parallel_index_range
+   Index Cond: ((val >= 100) AND (val <= 200))
+(2 rows)
+
+-- Plan shape: full index scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather
+   Workers Planned: 2
+   ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+         Forward index only scan of: o_test_parallel_index_range_val_idx
+(4 rows)
+
+-- Edge case: empty result set
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE val BETWEEN 999900 AND 999999;
+ count 
+-------
+     0
+(1 row)
+
+-- Edge case: single row result
+SELECT id, val FROM o_test_parallel_index_range WHERE id = 42;
+ id | val 
+----+-----
+ 42 |  42
+(1 row)
+
+-- Edge case: full table scan via index
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 0;
+ count  
+--------
+ 100000
+(1 row)
+
+-- Filter on non-index column: serial vs parallel equivalence
+-- Tests that generic Filter conditions (not convertible to scan keys)
+-- are correctly applied in parallel index scans
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+ serial_filter_count 
+---------------------
+               50000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+ parallel_filter_count 
+-----------------------
+                 50000
+(1 row)
+
+-- Parallel index scan with ORDER BY
+SELECT count(*) FROM (
+	SELECT id FROM o_test_parallel_index_range
+		WHERE val BETWEEN 1000 AND 2000 ORDER BY id
+) sub;
+ count 
+-------
+  1001
+(1 row)
+
+-- Secondary index parallel scan: index-only
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ serial_val_count 
+------------------
+             1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ parallel_val_count 
+--------------------
+               1001
+(1 row)
+
+-- Secondary index parallel scan: full row lookup
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ serial_full_count 
+-------------------
+              1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ parallel_full_count 
+---------------------
+                1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+                                            serial_ids                                            
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+                                           parallel_ids                                           
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+DROP TABLE o_test_parallel_index_range;
+-- Parallel index scan with SAOP (ScalarArrayOpExpr) on secondary index
+-- Uses repeating val values (low cardinality) so planner picks parallel
+CREATE TABLE o_test_parallel_saop (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop (val, name)
+	SELECT (g % 100) + 1, 'name_' || g FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_val_idx
+	ON o_test_parallel_saop (val);
+ANALYZE o_test_parallel_saop;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- SAOP literal IN-list: plan shape
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop
+		WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop
+                     Forward index scan of: o_test_parallel_saop_val_idx
+                     Conds: (val = ANY ('{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}'::integer[]))
+(7 rows)
+
+-- SAOP literal IN-list: parallel result
+SELECT count(*) FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ count 
+-------
+ 20000
+(1 row)
+
+-- SAOP literal IN-list: serial result
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ serial_saop_count 
+-------------------
+             20000
+(1 row)
+
+-- SAOP with full row lookup through secondary index
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ parallel_saop_full 
+--------------------
+              20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ serial_saop_full 
+------------------
+            20000
+(1 row)
+
+DROP TABLE o_test_parallel_saop;
+COMMIT;
+BEGIN;
 CREATE TABLE o_test1(i int, t text) USING orioledb;
 CREATE TABLE o_test2(i int, t text) USING orioledb;
 INSERT INTO o_test1 SELECT x, repeat('a', 500) FROM generate_series(1,10) as x;
@@ -1022,7 +1275,7 @@ DROP TABLE o_test1;
 DROP TABLE o_test2;
 COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1040,7 +1293,6 @@ drop cascades to table o_test_parallelscan_reinitialize1
 drop cascades to table o_test_parallelscan_reinitialize2
 drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
-drop cascades to table o_test_no_parallel_index_scan
 drop cascades to table o_test_no_parallel_bitmap_scan
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -5,7 +5,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 16
+ 18
 (1 row)
 
 SET min_parallel_table_scan_size = 1;
@@ -433,12 +433,15 @@ SELECT orioledb_parallel_debug_start();
 
 EXPLAIN (COSTS OFF)
 	SELECT count(*) FROM o_test_parallel_bitmap_scan WHERE val_1 < 5;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
-   ->  Index Only Scan using ind_1 on o_test_parallel_bitmap_scan
-         Index Cond: (val_1 < 5)
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test_parallel_bitmap_scan
+         Bitmap heap scan
+         Recheck Cond: (val_1 < 5)
+         ->  Bitmap Index Scan on ind_1
+               Index Cond: (val_1 < 5)
+(6 rows)
 
 SELECT count(*) FROM o_test_parallel_bitmap_scan WHERE val_1 < 5;
  count 
@@ -607,14 +610,15 @@ EXPLAIN (COSTS OFF)
 				WHERE ot1.val_1 = 1;
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Nested Loop
-   ->  Seq Scan on o_test_parallel_seq_rescan1 ot1
-         Filter: (val_1 = 1)
-   ->  Gather
-         Workers Planned: 1
+ Gather
+   Workers Planned: 1
+   ->  Nested Loop
          ->  Parallel Seq Scan on o_test_parallel_seq_rescan2 ot2
                Filter: (val_1 = 1)
-(7 rows)
+         ->  Materialize
+               ->  Seq Scan on o_test_parallel_seq_rescan1 ot1
+                     Filter: (val_1 = 1)
+(8 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v, ot2.val_2 ot2v
 	FROM o_test_parallel_seq_rescan1 ot1
@@ -667,6 +671,7 @@ EXPLAIN (COSTS OFF)
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Sort
+   Disabled: true
    Sort Key: ot1.val_2, ot2.val_2, ot3.val_2
    ->  Nested Loop
          ->  Nested Loop
@@ -682,7 +687,7 @@ EXPLAIN (COSTS OFF)
                Workers Planned: 1
                ->  Parallel Seq Scan on o_test_parallel_seq_rescan_multiple_joins3 ot3
                      Filter: (val_1 = 1)
-(16 rows)
+(17 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v, ot2.val_2 ot2v, ot3.val_2 ot3v
 	FROM o_test_parallel_seq_rescan_multiple_joins1 ot1
@@ -735,15 +740,16 @@ EXPLAIN (COSTS OFF)
 				WHERE ot1.val_1 % 1000 = 1 AND ot2.val_1 = any(array[1]);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
- Nested Loop
-   Join Filter: (ot1.val_1 = ot2.val_1)
-   ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
-         Filter: ((val_1 % 1000) = 1)
-   ->  Gather
-         Workers Planned: 3
+ Gather
+   Workers Planned: 3
+   ->  Nested Loop
+         Join Filter: (ot1.val_1 = ot2.val_1)
          ->  Parallel Seq Scan on o_test_parallelscan_reinitialize2 ot2
                Filter: (val_1 = ANY ('{1}'::integer[]))
-(8 rows)
+         ->  Materialize
+               ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
+                     Filter: ((val_1 % 1000) = 1)
+(9 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
 	FROM o_test_parallelscan_reinitialize1 ot1
@@ -753,14 +759,14 @@ SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
  val_1 | ot1v2 | ot2v2 
 -------+-------+-------
      1 |     1 |     1
-     1 |     1 |     2
      1 |     2 |     1
-     1 |     2 |     2
      1 |     3 |     1
-     1 |     3 |     2
      1 |     4 |     1
-     1 |     4 |     2
      1 |     5 |     1
+     1 |     1 |     2
+     1 |     2 |     2
+     1 |     3 |     2
+     1 |     4 |     2
      1 |     5 |     2
 (10 rows)
 
@@ -791,18 +797,16 @@ SET LOCAL enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_parallel_join
 		JOIN o_test_parallel_join2 USING (val_1, val_2);
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop
-   Join Filter: ((o_test_parallel_join.val_1 = o_test_parallel_join2.val_1) AND (o_test_parallel_join.val_2 = o_test_parallel_join2.val_2))
-   ->  Gather
-         Workers Planned: 2
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather
+   Workers Planned: 2
+   ->  Nested Loop
          ->  Parallel Seq Scan on o_test_parallel_join
-   ->  Materialize
-         ->  Gather
-               Workers Planned: 2
-               ->  Parallel Seq Scan on o_test_parallel_join2
-(9 rows)
+         ->  Custom Scan (o_scan) on o_test_parallel_join2
+               Forward index only scan of: o_test_parallel_join2_pkey
+               Conds: ((val_1 = o_test_parallel_join.val_1) AND (val_2 = o_test_parallel_join.val_2))
+(7 rows)
 
 SELECT * FROM o_test_parallel_join
 	JOIN o_test_parallel_join2 USING (val_1, val_2);
@@ -845,7 +849,7 @@ EXPLAIN (COSTS OFF)
 --------------------------------------------------------------------------------------------------
  Aggregate
    ->  Index Only Scan using o_test_no_parallel_bitmap_scan_ix1 on o_test_no_parallel_bitmap_scan
-         Filter: (val_1 <@ '[10,50)'::int4range)
+         Index Cond: ((val_1 >= 10) AND (val_1 < 50))
 (3 rows)
 
 SELECT count(*) FROM o_test_no_parallel_bitmap_scan WHERE val_1 <@ int4range(10,50);
@@ -860,7 +864,7 @@ EXPLAIN (COSTS OFF)
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Index Only Scan using o_test_no_parallel_bitmap_scan_ix1 on o_test_no_parallel_bitmap_scan
-   Filter: (val_1 <@ '[10,50)'::int4range)
+   Index Cond: ((val_1 >= 10) AND (val_1 < 50))
 (2 rows)
 
 SELECT * FROM o_test_no_parallel_bitmap_scan WHERE val_1 <@ int4range(10,50);

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -419,6 +419,7 @@ RESET parallel_setup_cost;
 RESET min_parallel_table_scan_size;
 RESET parallel_leader_participation;
 BEGIN;
+SET LOCAL enable_indexonlyscan = off;
 CREATE TABLE o_test_parallel_bitmap_scan (
 	val_1 int
 ) USING orioledb;

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1194,6 +1194,84 @@ SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
              20000
 (1 row)
 
+-- Sparse SAOP list: the union range between the smallest and the largest
+-- element covers the whole index, so the scan has to reject the leaves that
+-- hold no element rather than read and filter them.
+CREATE TABLE o_test_parallel_saop_sparse (
+	id SERIAL PRIMARY KEY,
+	val INT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop_sparse (val)
+	SELECT (g % 10) + 1 FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_sparse_idx
+	ON o_test_parallel_saop_sparse (val);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop_sparse
+                     Forward index scan of: o_test_parallel_saop_sparse_idx
+                     Conds: (val = ANY ('{1,10}'::integer[]))
+(7 rows)
+
+SELECT count(*) AS parallel_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ parallel_saop_sparse 
+----------------------
+                20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ serial_saop_sparse 
+--------------------
+              20000
+(1 row)
+
+-- The same on a DESC index: elements are ordered the other way round, so the
+-- page-level membership test has to compare in index order.
+DROP INDEX o_test_parallel_saop_sparse_idx;
+CREATE INDEX o_test_parallel_saop_sparse_desc_idx
+	ON o_test_parallel_saop_sparse (val DESC);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop_sparse
+                     Forward index scan of: o_test_parallel_saop_sparse_desc_idx
+                     Conds: (val = ANY ('{1,10}'::integer[]))
+(7 rows)
+
+SELECT count(*) AS parallel_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ parallel_saop_desc 
+--------------------
+              20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ serial_saop_desc 
+------------------
+            20000
+(1 row)
+
+DROP TABLE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
 -- SAOP with full row lookup through secondary index
 SET LOCAL enable_indexonlyscan = off;
 SET LOCAL max_parallel_workers_per_gather = 2;

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -5,7 +5,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 17
+ 16
 (1 row)
 
 SET min_parallel_table_scan_size = 1;
@@ -433,12 +433,15 @@ SELECT orioledb_parallel_debug_start();
 
 EXPLAIN (COSTS OFF)
 	SELECT count(*) FROM o_test_parallel_bitmap_scan WHERE val_1 < 5;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
-   ->  Index Only Scan using ind_1 on o_test_parallel_bitmap_scan
-         Index Cond: (val_1 < 5)
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test_parallel_bitmap_scan
+         Bitmap heap scan
+         Recheck Cond: (val_1 < 5)
+         ->  Bitmap Index Scan on ind_1
+               Index Cond: (val_1 < 5)
+(6 rows)
 
 SELECT count(*) FROM o_test_parallel_bitmap_scan WHERE val_1 < 5;
  count 
@@ -845,7 +848,7 @@ EXPLAIN (COSTS OFF)
 --------------------------------------------------------------------------------------------------
  Aggregate
    ->  Index Only Scan using o_test_no_parallel_bitmap_scan_ix1 on o_test_no_parallel_bitmap_scan
-         Index Cond: ((val_1 >= 10) AND (val_1 < 50))
+         Filter: (val_1 <@ '[10,50)'::int4range)
 (3 rows)
 
 SELECT count(*) FROM o_test_no_parallel_bitmap_scan WHERE val_1 <@ int4range(10,50);
@@ -860,7 +863,7 @@ EXPLAIN (COSTS OFF)
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Index Only Scan using o_test_no_parallel_bitmap_scan_ix1 on o_test_no_parallel_bitmap_scan
-   Index Cond: ((val_1 >= 10) AND (val_1 < 50))
+   Filter: (val_1 <@ '[10,50)'::int4range)
 (2 rows)
 
 SELECT * FROM o_test_no_parallel_bitmap_scan WHERE val_1 <@ int4range(10,50);

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1274,8 +1274,115 @@ SELECT o_test1.i, substring(o_test1.t, 1,2) FROM o_test1
 DROP TABLE o_test1;
 DROP TABLE o_test2;
 COMMIT;
+-- Parallel ordered (key-order) index scan: forward and backward.  An ordered
+-- path reads on-disk downlinks inline so each worker emits a sorted stream that
+-- Gather Merge combines; ORDER BY / ORDER BY DESC should use Gather Merge, and
+-- the result must match the serial scan exactly.
+BEGIN;
+CREATE TABLE o_test_ordered_scan (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_ordered_scan
+	SELECT g, g % 777 FROM generate_series(1, 60000) g;
+ANALYZE o_test_ordered_scan;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- An always-true but per-row-expensive filter (sqrt) makes the parallel
+-- ordered path cheaper than the naturally-ordered serial index scan, so the
+-- planner picks Gather Merge deterministically.
+-- Plan shape: ORDER BY ascending uses Gather Merge over a forward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 3
+   ->  Parallel Custom Scan (o_scan) on o_test_ordered_scan
+         Filter: (sqrt((val)::double precision) >= '0'::double precision)
+         Forward index scan of: o_test_ordered_scan_pkey
+         Conds: ((id >= 10000) AND (id <= 50000))
+(6 rows)
+
+-- Plan shape: ORDER BY DESC uses Gather Merge over a backward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 3
+   ->  Parallel Custom Scan (o_scan) on o_test_ordered_scan
+         Filter: (sqrt((val)::double precision) >= '0'::double precision)
+         Backward index scan of: o_test_ordered_scan_pkey
+         Conds: ((id >= 10000) AND (id <= 50000))
+(6 rows)
+
+-- Correctness: ascending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id >= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id) s) t;
+ count |  min  |  max  | sorted 
+-------+-------+-------+--------
+ 40001 | 10000 | 50000 | t
+(1 row)
+
+-- Correctness: descending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) s) t;
+ count |  min  |  max  | sorted 
+-------+-------+-------+--------
+ 40001 | 10000 | 50000 | t
+(1 row)
+
+-- Serial vs parallel equivalence (descending), whole ordered vector
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id) AS serial_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+                                           serial_desc                                            
+--------------------------------------------------------------------------------------------------
+ {1010,1009,1008,1007,1006,1005,1004,1003,1002,1001,1000,999,998,997,996,995,994,993,992,991,990}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT array_agg(id) AS parallel_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+                                          parallel_desc                                           
+--------------------------------------------------------------------------------------------------
+ {1010,1009,1008,1007,1006,1005,1004,1003,1002,1001,1000,999,998,997,996,995,994,993,992,991,990}
+(1 row)
+
+-- Full ordered scan (no range), descending
+SELECT count(*), min(id), max(id) FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE sqrt(val::float8) >= 0 ORDER BY id DESC) s;
+ count | min |  max  
+-------+-----+-------
+ 60000 |   1 | 60000
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to 19 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1294,6 +1401,7 @@ drop cascades to table o_test_parallelscan_reinitialize2
 drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
+drop cascades to table o_test_ordered_scan
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -815,55 +815,6 @@ SELECT * FROM o_test_parallel_join
 
 COMMIT;
 BEGIN;
-CREATE TABLE o_test_no_parallel_index_scan (
-  val_1 INT PRIMARY KEY,
-  val_2 text
-) USING orioledb;
-INSERT INTO o_test_no_parallel_index_scan VALUES (1, 'a'), (2, 'b');
-SET LOCAL max_parallel_workers_per_gather = 1;
-SET LOCAL parallel_setup_cost = 0;
-SET LOCAL parallel_tuple_cost = 0;
-SET LOCAL min_parallel_table_scan_size = 1;
-SET LOCAL min_parallel_index_scan_size = 1;
-SET LOCAL enable_seqscan = off;
-SET LOCAL enable_bitmapscan = off;
--- Parallel Index Only Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF) SELECT val_1 FROM o_test_no_parallel_index_scan;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_no_parallel_index_scan
-   Forward index only scan of: o_test_no_parallel_index_scan_pkey
-(2 rows)
-
-SELECT val_1 FROM o_test_no_parallel_index_scan;
- val_1 
--------
-     1
-     2
-(2 rows)
-
-SET LOCAL enable_indexonlyscan = off;
--- Parallel Index Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF)
-	SELECT array_agg(val_1), array_agg(val_2)
-		FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (o_scan) on o_test_no_parallel_index_scan
-         Forward index scan of: o_test_no_parallel_index_scan_pkey
-         Conds: (val_1 > 0)
-(4 rows)
-
-SELECT array_agg(val_1), array_agg(val_2)
-	FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
- array_agg | array_agg 
------------+-----------
- {1,2}     | {a,b}
-(1 row)
-
-COMMIT;
-BEGIN;
 SET LOCAL parallel_setup_cost = 0;
 SET LOCAL min_parallel_table_scan_size = 1;
 CREATE TABLE o_test_no_parallel_bitmap_scan (
@@ -959,6 +910,308 @@ SELECT * FROM o_test_no_parallel_bitmap_scan WHERE val_1 <@ int4range(10,50);
 
 COMMIT;
 BEGIN;
+-- Parallel index range scan on primary index
+CREATE TABLE o_test_parallel_index_range (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+INSERT INTO o_test_parallel_index_range (val, name)
+	SELECT g, 'name_' || g FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_index_range_val_idx
+	ON o_test_parallel_index_range (val);
+ANALYZE o_test_parallel_index_range;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- Range scan on primary key
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range
+		WHERE id BETWEEN 1000 AND 5000;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather
+   Workers Planned: 2
+   ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+         Forward index only scan of: o_test_parallel_index_range_pkey
+         Conds: ((id >= 1000) AND (id <= 5000))
+(5 rows)
+
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE id BETWEEN 1000 AND 5000;
+ count 
+-------
+  4001
+(1 row)
+
+-- Range scan: serial vs parallel equivalence
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+ serial_count 
+--------------
+         4001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+ parallel_count 
+----------------
+           4001
+(1 row)
+
+-- Parallel index scan with aggregation on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+                     Forward index only scan of: o_test_parallel_index_range_val_idx
+                     Conds: (val > 50000)
+(7 rows)
+
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+ count 
+-------
+ 50000
+(1 row)
+
+-- Serial vs parallel equivalence on primary index range
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+                                            serial_ids                                            
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+                                           parallel_ids                                           
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+-- Plan shape: primary index range scan
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE id > 50000;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+                     Forward index only scan of: o_test_parallel_index_range_pkey
+                     Conds: (id > 50000)
+(7 rows)
+
+-- Plan shape: index-only scan on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT val FROM o_test_parallel_index_range
+		WHERE val BETWEEN 100 AND 200;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_parallel_index_range_val_idx on o_test_parallel_index_range
+   Index Cond: ((val >= 100) AND (val <= 200))
+(2 rows)
+
+-- Plan shape: full index scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather
+   Workers Planned: 2
+   ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+         Forward index only scan of: o_test_parallel_index_range_val_idx
+(4 rows)
+
+-- Edge case: empty result set
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE val BETWEEN 999900 AND 999999;
+ count 
+-------
+     0
+(1 row)
+
+-- Edge case: single row result
+SELECT id, val FROM o_test_parallel_index_range WHERE id = 42;
+ id | val 
+----+-----
+ 42 |  42
+(1 row)
+
+-- Edge case: full table scan via index
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 0;
+ count  
+--------
+ 100000
+(1 row)
+
+-- Filter on non-index column: serial vs parallel equivalence
+-- Tests that generic Filter conditions (not convertible to scan keys)
+-- are correctly applied in parallel index scans
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+ serial_filter_count 
+---------------------
+               50000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+ parallel_filter_count 
+-----------------------
+                 50000
+(1 row)
+
+-- Parallel index scan with ORDER BY
+SELECT count(*) FROM (
+	SELECT id FROM o_test_parallel_index_range
+		WHERE val BETWEEN 1000 AND 2000 ORDER BY id
+) sub;
+ count 
+-------
+  1001
+(1 row)
+
+-- Secondary index parallel scan: index-only
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ serial_val_count 
+------------------
+             1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ parallel_val_count 
+--------------------
+               1001
+(1 row)
+
+-- Secondary index parallel scan: full row lookup
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ serial_full_count 
+-------------------
+              1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ parallel_full_count 
+---------------------
+                1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+                                            serial_ids                                            
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+                                           parallel_ids                                           
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+DROP TABLE o_test_parallel_index_range;
+-- Parallel index scan with SAOP (ScalarArrayOpExpr) on secondary index
+-- Uses repeating val values (low cardinality) so planner picks parallel
+CREATE TABLE o_test_parallel_saop (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop (val, name)
+	SELECT (g % 100) + 1, 'name_' || g FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_val_idx
+	ON o_test_parallel_saop (val);
+ANALYZE o_test_parallel_saop;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- SAOP literal IN-list: plan shape
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop
+		WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop
+                     Forward index scan of: o_test_parallel_saop_val_idx
+                     Conds: (val = ANY ('{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}'::integer[]))
+(7 rows)
+
+-- SAOP literal IN-list: parallel result
+SELECT count(*) FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ count 
+-------
+ 20000
+(1 row)
+
+-- SAOP literal IN-list: serial result
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ serial_saop_count 
+-------------------
+             20000
+(1 row)
+
+-- SAOP with full row lookup through secondary index
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ parallel_saop_full 
+--------------------
+              20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ serial_saop_full 
+------------------
+            20000
+(1 row)
+
+DROP TABLE o_test_parallel_saop;
+COMMIT;
+BEGIN;
 CREATE TABLE o_test1(i int, t text) USING orioledb;
 CREATE TABLE o_test2(i int, t text) USING orioledb;
 INSERT INTO o_test1 SELECT x, repeat('a', 500) FROM generate_series(1,10) as x;
@@ -1022,7 +1275,7 @@ DROP TABLE o_test1;
 DROP TABLE o_test2;
 COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1040,7 +1293,6 @@ drop cascades to table o_test_parallelscan_reinitialize1
 drop cascades to table o_test_parallelscan_reinitialize2
 drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
-drop cascades to table o_test_no_parallel_index_scan
 drop cascades to table o_test_no_parallel_bitmap_scan
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -1194,6 +1194,84 @@ SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
              20000
 (1 row)
 
+-- Sparse SAOP list: the union range between the smallest and the largest
+-- element covers the whole index, so the scan has to reject the leaves that
+-- hold no element rather than read and filter them.
+CREATE TABLE o_test_parallel_saop_sparse (
+	id SERIAL PRIMARY KEY,
+	val INT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop_sparse (val)
+	SELECT (g % 10) + 1 FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_sparse_idx
+	ON o_test_parallel_saop_sparse (val);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop_sparse
+                     Forward index scan of: o_test_parallel_saop_sparse_idx
+                     Conds: (val = ANY ('{1,10}'::integer[]))
+(7 rows)
+
+SELECT count(*) AS parallel_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ parallel_saop_sparse 
+----------------------
+                20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ serial_saop_sparse 
+--------------------
+              20000
+(1 row)
+
+-- The same on a DESC index: elements are ordered the other way round, so the
+-- page-level membership test has to compare in index order.
+DROP INDEX o_test_parallel_saop_sparse_idx;
+CREATE INDEX o_test_parallel_saop_sparse_desc_idx
+	ON o_test_parallel_saop_sparse (val DESC);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop_sparse
+                     Forward index scan of: o_test_parallel_saop_sparse_desc_idx
+                     Conds: (val = ANY ('{1,10}'::integer[]))
+(7 rows)
+
+SELECT count(*) AS parallel_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ parallel_saop_desc 
+--------------------
+              20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+ serial_saop_desc 
+------------------
+            20000
+(1 row)
+
+DROP TABLE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
 -- SAOP with full row lookup through secondary index
 SET LOCAL enable_indexonlyscan = off;
 SET LOCAL max_parallel_workers_per_gather = 2;

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -5,7 +5,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 18
+ 17
 (1 row)
 
 SET min_parallel_table_scan_size = 1;
@@ -433,12 +433,15 @@ SELECT orioledb_parallel_debug_start();
 
 EXPLAIN (COSTS OFF)
 	SELECT count(*) FROM o_test_parallel_bitmap_scan WHERE val_1 < 5;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  Aggregate
-   ->  Index Only Scan using ind_1 on o_test_parallel_bitmap_scan
-         Index Cond: (val_1 < 5)
-(3 rows)
+   ->  Custom Scan (o_scan) on o_test_parallel_bitmap_scan
+         Bitmap heap scan
+         Recheck Cond: (val_1 < 5)
+         ->  Bitmap Index Scan on ind_1
+               Index Cond: (val_1 < 5)
+(6 rows)
 
 SELECT count(*) FROM o_test_parallel_bitmap_scan WHERE val_1 < 5;
  count 
@@ -607,15 +610,14 @@ EXPLAIN (COSTS OFF)
 				WHERE ot1.val_1 = 1;
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   ->  Nested Loop
+ Nested Loop
+   ->  Seq Scan on o_test_parallel_seq_rescan1 ot1
+         Filter: (val_1 = 1)
+   ->  Gather
+         Workers Planned: 1
          ->  Parallel Seq Scan on o_test_parallel_seq_rescan2 ot2
                Filter: (val_1 = 1)
-         ->  Materialize
-               ->  Seq Scan on o_test_parallel_seq_rescan1 ot1
-                     Filter: (val_1 = 1)
-(8 rows)
+(7 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v, ot2.val_2 ot2v
 	FROM o_test_parallel_seq_rescan1 ot1
@@ -668,7 +670,6 @@ EXPLAIN (COSTS OFF)
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Sort
-   Disabled: true
    Sort Key: ot1.val_2, ot2.val_2, ot3.val_2
    ->  Nested Loop
          ->  Nested Loop
@@ -684,7 +685,7 @@ EXPLAIN (COSTS OFF)
                Workers Planned: 1
                ->  Parallel Seq Scan on o_test_parallel_seq_rescan_multiple_joins3 ot3
                      Filter: (val_1 = 1)
-(17 rows)
+(16 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v, ot2.val_2 ot2v, ot3.val_2 ot3v
 	FROM o_test_parallel_seq_rescan_multiple_joins1 ot1
@@ -737,16 +738,15 @@ EXPLAIN (COSTS OFF)
 				WHERE ot1.val_1 % 1000 = 1 AND ot2.val_1 = any(array[1]);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
- Gather
-   Workers Planned: 3
-   ->  Nested Loop
-         Join Filter: (ot1.val_1 = ot2.val_1)
+ Nested Loop
+   Join Filter: (ot1.val_1 = ot2.val_1)
+   ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
+         Filter: ((val_1 % 1000) = 1)
+   ->  Gather
+         Workers Planned: 3
          ->  Parallel Seq Scan on o_test_parallelscan_reinitialize2 ot2
                Filter: (val_1 = ANY ('{1}'::integer[]))
-         ->  Materialize
-               ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
-                     Filter: ((val_1 % 1000) = 1)
-(9 rows)
+(8 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
 	FROM o_test_parallelscan_reinitialize1 ot1
@@ -756,14 +756,14 @@ SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
  val_1 | ot1v2 | ot2v2 
 -------+-------+-------
      1 |     1 |     1
-     1 |     2 |     1
-     1 |     3 |     1
-     1 |     4 |     1
-     1 |     5 |     1
      1 |     1 |     2
+     1 |     2 |     1
      1 |     2 |     2
+     1 |     3 |     1
      1 |     3 |     2
+     1 |     4 |     1
      1 |     4 |     2
+     1 |     5 |     1
      1 |     5 |     2
 (10 rows)
 
@@ -794,16 +794,18 @@ SET LOCAL enable_bitmapscan = OFF;
 EXPLAIN (COSTS OFF)
 	SELECT * FROM o_test_parallel_join
 		JOIN o_test_parallel_join2 USING (val_1, val_2);
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 2
-   ->  Nested Loop
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   Join Filter: ((o_test_parallel_join.val_1 = o_test_parallel_join2.val_1) AND (o_test_parallel_join.val_2 = o_test_parallel_join2.val_2))
+   ->  Gather
+         Workers Planned: 2
          ->  Parallel Seq Scan on o_test_parallel_join
-         ->  Custom Scan (o_scan) on o_test_parallel_join2
-               Forward index only scan of: o_test_parallel_join2_pkey
-               Conds: ((val_1 = o_test_parallel_join.val_1) AND (val_2 = o_test_parallel_join.val_2))
-(7 rows)
+   ->  Materialize
+         ->  Gather
+               Workers Planned: 2
+               ->  Parallel Seq Scan on o_test_parallel_join2
+(9 rows)
 
 SELECT * FROM o_test_parallel_join
 	JOIN o_test_parallel_join2 USING (val_1, val_2);

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -737,15 +737,16 @@ EXPLAIN (COSTS OFF)
 				WHERE ot1.val_1 % 1000 = 1 AND ot2.val_1 = any(array[1]);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
- Nested Loop
-   Join Filter: (ot1.val_1 = ot2.val_1)
-   ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
-         Filter: ((val_1 % 1000) = 1)
-   ->  Gather
-         Workers Planned: 3
+ Gather
+   Workers Planned: 3
+   ->  Nested Loop
+         Join Filter: (ot1.val_1 = ot2.val_1)
          ->  Parallel Seq Scan on o_test_parallelscan_reinitialize2 ot2
                Filter: (val_1 = ANY ('{1}'::integer[]))
-(8 rows)
+         ->  Materialize
+               ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
+                     Filter: ((val_1 % 1000) = 1)
+(9 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
 	FROM o_test_parallelscan_reinitialize1 ot1
@@ -755,14 +756,14 @@ SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
  val_1 | ot1v2 | ot2v2 
 -------+-------+-------
      1 |     1 |     1
-     1 |     1 |     2
      1 |     2 |     1
-     1 |     2 |     2
      1 |     3 |     1
-     1 |     3 |     2
      1 |     4 |     1
-     1 |     4 |     2
      1 |     5 |     1
+     1 |     1 |     2
+     1 |     2 |     2
+     1 |     3 |     2
+     1 |     4 |     2
      1 |     5 |     2
 (10 rows)
 
@@ -1274,8 +1275,115 @@ SELECT o_test1.i, substring(o_test1.t, 1,2) FROM o_test1
 DROP TABLE o_test1;
 DROP TABLE o_test2;
 COMMIT;
+-- Parallel ordered (key-order) index scan: forward and backward.  An ordered
+-- path reads on-disk downlinks inline so each worker emits a sorted stream that
+-- Gather Merge combines; ORDER BY / ORDER BY DESC should use Gather Merge, and
+-- the result must match the serial scan exactly.
+BEGIN;
+CREATE TABLE o_test_ordered_scan (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_ordered_scan
+	SELECT g, g % 777 FROM generate_series(1, 60000) g;
+ANALYZE o_test_ordered_scan;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- An always-true but per-row-expensive filter (sqrt) makes the parallel
+-- ordered path cheaper than the naturally-ordered serial index scan, so the
+-- planner picks Gather Merge deterministically.
+-- Plan shape: ORDER BY ascending uses Gather Merge over a forward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 3
+   ->  Parallel Custom Scan (o_scan) on o_test_ordered_scan
+         Filter: (sqrt((val)::double precision) >= '0'::double precision)
+         Forward index scan of: o_test_ordered_scan_pkey
+         Conds: ((id >= 10000) AND (id <= 50000))
+(6 rows)
+
+-- Plan shape: ORDER BY DESC uses Gather Merge over a backward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 3
+   ->  Parallel Custom Scan (o_scan) on o_test_ordered_scan
+         Filter: (sqrt((val)::double precision) >= '0'::double precision)
+         Backward index scan of: o_test_ordered_scan_pkey
+         Conds: ((id >= 10000) AND (id <= 50000))
+(6 rows)
+
+-- Correctness: ascending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id >= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id) s) t;
+ count |  min  |  max  | sorted 
+-------+-------+-------+--------
+ 40001 | 10000 | 50000 | t
+(1 row)
+
+-- Correctness: descending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) s) t;
+ count |  min  |  max  | sorted 
+-------+-------+-------+--------
+ 40001 | 10000 | 50000 | t
+(1 row)
+
+-- Serial vs parallel equivalence (descending), whole ordered vector
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id) AS serial_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+                                           serial_desc                                            
+--------------------------------------------------------------------------------------------------
+ {1010,1009,1008,1007,1006,1005,1004,1003,1002,1001,1000,999,998,997,996,995,994,993,992,991,990}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT array_agg(id) AS parallel_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+                                          parallel_desc                                           
+--------------------------------------------------------------------------------------------------
+ {1010,1009,1008,1007,1006,1005,1004,1003,1002,1001,1000,999,998,997,996,995,994,993,992,991,990}
+(1 row)
+
+-- Full ordered scan (no range), descending
+SELECT count(*), min(id), max(id) FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE sqrt(val::float8) >= 0 ORDER BY id DESC) s;
+ count | min |  max  
+-------+-----+-------
+ 60000 |   1 | 60000
+(1 row)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to 19 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1294,6 +1402,7 @@ drop cascades to table o_test_parallelscan_reinitialize2
 drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
 drop cascades to table o_test_no_parallel_bitmap_scan
+drop cascades to table o_test_ordered_scan
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -419,6 +419,7 @@ RESET parallel_setup_cost;
 RESET min_parallel_table_scan_size;
 RESET parallel_leader_participation;
 BEGIN;
+SET LOCAL enable_indexonlyscan = off;
 CREATE TABLE o_test_parallel_bitmap_scan (
 	val_1 int
 ) USING orioledb;
@@ -736,16 +737,15 @@ EXPLAIN (COSTS OFF)
 				WHERE ot1.val_1 % 1000 = 1 AND ot2.val_1 = any(array[1]);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
- Gather
-   Workers Planned: 3
-   ->  Nested Loop
-         Join Filter: (ot1.val_1 = ot2.val_1)
+ Nested Loop
+   Join Filter: (ot1.val_1 = ot2.val_1)
+   ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
+         Filter: ((val_1 % 1000) = 1)
+   ->  Gather
+         Workers Planned: 3
          ->  Parallel Seq Scan on o_test_parallelscan_reinitialize2 ot2
                Filter: (val_1 = ANY ('{1}'::integer[]))
-         ->  Materialize
-               ->  Seq Scan on o_test_parallelscan_reinitialize1 ot1
-                     Filter: ((val_1 % 1000) = 1)
-(9 rows)
+(8 rows)
 
 SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
 	FROM o_test_parallelscan_reinitialize1 ot1
@@ -755,14 +755,14 @@ SELECT ot1.val_1, ot1.val_2 ot1v2, ot2.val_2 ot2v2
  val_1 | ot1v2 | ot2v2 
 -------+-------+-------
      1 |     1 |     1
-     1 |     2 |     1
-     1 |     3 |     1
-     1 |     4 |     1
-     1 |     5 |     1
      1 |     1 |     2
+     1 |     2 |     1
      1 |     2 |     2
+     1 |     3 |     1
      1 |     3 |     2
+     1 |     4 |     1
      1 |     4 |     2
+     1 |     5 |     1
      1 |     5 |     2
 (10 rows)
 

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -815,55 +815,6 @@ SELECT * FROM o_test_parallel_join
 
 COMMIT;
 BEGIN;
-CREATE TABLE o_test_no_parallel_index_scan (
-  val_1 INT PRIMARY KEY,
-  val_2 text
-) USING orioledb;
-INSERT INTO o_test_no_parallel_index_scan VALUES (1, 'a'), (2, 'b');
-SET LOCAL max_parallel_workers_per_gather = 1;
-SET LOCAL parallel_setup_cost = 0;
-SET LOCAL parallel_tuple_cost = 0;
-SET LOCAL min_parallel_table_scan_size = 1;
-SET LOCAL min_parallel_index_scan_size = 1;
-SET LOCAL enable_seqscan = off;
-SET LOCAL enable_bitmapscan = off;
--- Parallel Index Only Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF) SELECT val_1 FROM o_test_no_parallel_index_scan;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Custom Scan (o_scan) on o_test_no_parallel_index_scan
-   Forward index only scan of: o_test_no_parallel_index_scan_pkey
-(2 rows)
-
-SELECT val_1 FROM o_test_no_parallel_index_scan;
- val_1 
--------
-     1
-     2
-(2 rows)
-
-SET LOCAL enable_indexonlyscan = off;
--- Parallel Index Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF)
-	SELECT array_agg(val_1), array_agg(val_2)
-		FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (o_scan) on o_test_no_parallel_index_scan
-         Forward index scan of: o_test_no_parallel_index_scan_pkey
-         Conds: (val_1 > 0)
-(4 rows)
-
-SELECT array_agg(val_1), array_agg(val_2)
-	FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
- array_agg | array_agg 
------------+-----------
- {1,2}     | {a,b}
-(1 row)
-
-COMMIT;
-BEGIN;
 SET LOCAL parallel_setup_cost = 0;
 SET LOCAL min_parallel_table_scan_size = 1;
 CREATE TABLE o_test_no_parallel_bitmap_scan (
@@ -959,6 +910,308 @@ SELECT * FROM o_test_no_parallel_bitmap_scan WHERE val_1 <@ int4range(10,50);
 
 COMMIT;
 BEGIN;
+-- Parallel index range scan on primary index
+CREATE TABLE o_test_parallel_index_range (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+INSERT INTO o_test_parallel_index_range (val, name)
+	SELECT g, 'name_' || g FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_index_range_val_idx
+	ON o_test_parallel_index_range (val);
+ANALYZE o_test_parallel_index_range;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- Range scan on primary key
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range
+		WHERE id BETWEEN 1000 AND 5000;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather
+   Workers Planned: 2
+   ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+         Forward index only scan of: o_test_parallel_index_range_pkey
+         Conds: ((id >= 1000) AND (id <= 5000))
+(5 rows)
+
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE id BETWEEN 1000 AND 5000;
+ count 
+-------
+  4001
+(1 row)
+
+-- Range scan: serial vs parallel equivalence
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+ serial_count 
+--------------
+         4001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+ parallel_count 
+----------------
+           4001
+(1 row)
+
+-- Parallel index scan with aggregation on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+                     Forward index only scan of: o_test_parallel_index_range_val_idx
+                     Conds: (val > 50000)
+(7 rows)
+
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+ count 
+-------
+ 50000
+(1 row)
+
+-- Serial vs parallel equivalence on primary index range
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+                                            serial_ids                                            
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+                                           parallel_ids                                           
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+-- Plan shape: primary index range scan
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE id > 50000;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+                     Forward index only scan of: o_test_parallel_index_range_pkey
+                     Conds: (id > 50000)
+(7 rows)
+
+-- Plan shape: index-only scan on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT val FROM o_test_parallel_index_range
+		WHERE val BETWEEN 100 AND 200;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Index Only Scan using o_test_parallel_index_range_val_idx on o_test_parallel_index_range
+   Index Cond: ((val >= 100) AND (val <= 200))
+(2 rows)
+
+-- Plan shape: full index scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather
+   Workers Planned: 2
+   ->  Parallel Custom Scan (o_scan) on o_test_parallel_index_range
+         Forward index only scan of: o_test_parallel_index_range_val_idx
+(4 rows)
+
+-- Edge case: empty result set
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE val BETWEEN 999900 AND 999999;
+ count 
+-------
+     0
+(1 row)
+
+-- Edge case: single row result
+SELECT id, val FROM o_test_parallel_index_range WHERE id = 42;
+ id | val 
+----+-----
+ 42 |  42
+(1 row)
+
+-- Edge case: full table scan via index
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 0;
+ count  
+--------
+ 100000
+(1 row)
+
+-- Filter on non-index column: serial vs parallel equivalence
+-- Tests that generic Filter conditions (not convertible to scan keys)
+-- are correctly applied in parallel index scans
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+ serial_filter_count 
+---------------------
+               50000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+ parallel_filter_count 
+-----------------------
+                 50000
+(1 row)
+
+-- Parallel index scan with ORDER BY
+SELECT count(*) FROM (
+	SELECT id FROM o_test_parallel_index_range
+		WHERE val BETWEEN 1000 AND 2000 ORDER BY id
+) sub;
+ count 
+-------
+  1001
+(1 row)
+
+-- Secondary index parallel scan: index-only
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ serial_val_count 
+------------------
+             1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ parallel_val_count 
+--------------------
+               1001
+(1 row)
+
+-- Secondary index parallel scan: full row lookup
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ serial_full_count 
+-------------------
+              1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+ parallel_full_count 
+---------------------
+                1001
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+                                            serial_ids                                            
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+                                           parallel_ids                                           
+--------------------------------------------------------------------------------------------------
+ {990,991,992,993,994,995,996,997,998,999,1000,1001,1002,1003,1004,1005,1006,1007,1008,1009,1010}
+(1 row)
+
+DROP TABLE o_test_parallel_index_range;
+-- Parallel index scan with SAOP (ScalarArrayOpExpr) on secondary index
+-- Uses repeating val values (low cardinality) so planner picks parallel
+CREATE TABLE o_test_parallel_saop (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop (val, name)
+	SELECT (g % 100) + 1, 'name_' || g FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_val_idx
+	ON o_test_parallel_saop (val);
+ANALYZE o_test_parallel_saop;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+-- SAOP literal IN-list: plan shape
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop
+		WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Custom Scan (o_scan) on o_test_parallel_saop
+                     Forward index scan of: o_test_parallel_saop_val_idx
+                     Conds: (val = ANY ('{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}'::integer[]))
+(7 rows)
+
+-- SAOP literal IN-list: parallel result
+SELECT count(*) FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ count 
+-------
+ 20000
+(1 row)
+
+-- SAOP literal IN-list: serial result
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ serial_saop_count 
+-------------------
+             20000
+(1 row)
+
+-- SAOP with full row lookup through secondary index
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ parallel_saop_full 
+--------------------
+              20000
+(1 row)
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+ serial_saop_full 
+------------------
+            20000
+(1 row)
+
+DROP TABLE o_test_parallel_saop;
+COMMIT;
+BEGIN;
 CREATE TABLE o_test1(i int, t text) USING orioledb;
 CREATE TABLE o_test2(i int, t text) USING orioledb;
 INSERT INTO o_test1 SELECT x, repeat('a', 500) FROM generate_series(1,10) as x;
@@ -1022,7 +1275,7 @@ DROP TABLE o_test1;
 DROP TABLE o_test2;
 COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 19 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1040,7 +1293,6 @@ drop cascades to table o_test_parallelscan_reinitialize1
 drop cascades to table o_test_parallelscan_reinitialize2
 drop cascades to table o_test_parallel_join
 drop cascades to table o_test_parallel_join2
-drop cascades to table o_test_no_parallel_index_scan
 drop cascades to table o_test_no_parallel_bitmap_scan
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects

--- a/test/expected/partial.out
+++ b/test/expected/partial.out
@@ -1,7 +1,7 @@
 CREATE SCHEMA partial;
 SET SESSION search_path = 'partial';
 CREATE EXTENSION orioledb;
-CREATE FUNCTION my_cmp_plpgsql(a int, b int) RETURNS int AS $$
+CREATE FUNCTION partial.my_cmp_plpgsql(a int, b int) RETURNS int AS $$
 DECLARE
 	a_tr int := (a::bit(5) & X'A8'::bit(5))::int;
 	b_tr int := (b::bit(5) & X'A8'::bit(5))::int;
@@ -9,54 +9,54 @@ BEGIN
 	RETURN btint4cmp(a_tr, b_tr);
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
-CREATE FUNCTION my_cmp_sql(a int, b int) RETURNS int AS $$
+CREATE FUNCTION partial.my_cmp_sql(a int, b int) RETURNS int AS $$
 	SELECT btint4cmp((a::bit(5) & X'A8'::bit(5))::int,
 					(b::bit(5) & X'A8'::bit(5))::int);
 $$ LANGUAGE SQL IMMUTABLE;
-CREATE FUNCTION my_cmp_sql_sql(a int, b int) RETURNS int AS $$
+CREATE FUNCTION partial.my_cmp_sql_sql(a int, b int) RETURNS int AS $$
 	SELECT extract(epoch from current_timestamp)::integer +
-		   my_cmp_sql(a, b);
+		   partial.my_cmp_sql(a, b);
 $$ LANGUAGE SQL IMMUTABLE;
-CREATE FUNCTION my_cmp_sql_plpgsql(a int, b int) RETURNS int AS $$
-	SELECT my_cmp_plpgsql(a, b);
+CREATE FUNCTION partial.my_cmp_sql_plpgsql(a int, b int) RETURNS int AS $$
+	SELECT partial.my_cmp_plpgsql(a, b);
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_cmp_sql_sql_sql(a int, b int) RETURNS int AS $$
-	SELECT my_cmp_sql_sql(a, b);
+	SELECT partial.my_cmp_sql_sql(a, b);
 $$ LANGUAGE SQL IMMUTABLE;
-CREATE FUNCTION my_cmp_sql_sql_plpgsql(a int, b int) RETURNS int AS $$
-	SELECT my_cmp_sql_plpgsql(a, b);
+CREATE FUNCTION partial.my_cmp_sql_sql_plpgsql(a int, b int) RETURNS int AS $$
+	SELECT partial.my_cmp_sql_plpgsql(a, b);
 $$ LANGUAGE SQL IMMUTABLE;
-CREATE FUNCTION my_cmp_sql_body(a int, b int) RETURNS int
+CREATE FUNCTION partial.my_cmp_sql_body(a int, b int) RETURNS int
 	LANGUAGE SQL IMMUTABLE
 BEGIN ATOMIC
 	SELECT btint4cmp((a::bit(5) & X'A8'::bit(5))::int,
 					(b::bit(5) & X'A8'::bit(5))::int);
 END;
-CREATE FUNCTION my_cmp_inter(a int, b int) RETURNS int
+CREATE FUNCTION partial.my_cmp_inter(a int, b int) RETURNS int
 	AS 'btint4cmp'
 	LANGUAGE internal;
-CREATE FUNCTION my_c_func(a int, b int)
+CREATE FUNCTION partial.my_c_func(a int, b int)
 	RETURNS int8
 	AS 'orioledb', 'orioledb_compression_max_level'
 	LANGUAGE C STRICT IMMUTABLE;
 CREATE FUNCTION my_eq_p_p(a int, b int) RETURNS bool AS $$
 BEGIN
-	RETURN my_cmp_plpgsql(a, b) = 0;
+	RETURN partial.my_cmp_plpgsql(a, b) = 0;
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 CREATE FUNCTION my_eq_p_s(a int, b int) RETURNS bool AS $$
 BEGIN
-	RETURN my_cmp_sql(a, b) = 0;
+	RETURN partial.my_cmp_sql(a, b) = 0;
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 CREATE FUNCTION my_eq_p_sb(a int, b int) RETURNS bool AS $$
 BEGIN
-	RETURN my_cmp_sql_body(a, b) = 0;
+	RETURN partial.my_cmp_sql_body(a, b) = 0;
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 CREATE FUNCTION my_eq_p_i(a int, b int) RETURNS bool AS $$
 BEGIN
-	RETURN my_cmp_inter(a, b) = 0;
+	RETURN partial.my_cmp_inter(a, b) = 0;
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 CREATE FUNCTION my_eq_p_b(a int, b int) RETURNS bool AS $$
@@ -66,54 +66,54 @@ END
 $$ LANGUAGE plpgsql IMMUTABLE;
 CREATE FUNCTION my_eq_p_c(a int, b int) RETURNS bool AS $$
 BEGIN
-	RETURN ((a % (my_c_func(a, b) - 20)) -
-			(b % (my_c_func(a, b) - 20))) = 0;
+	RETURN ((a % (partial.my_c_func(a, b) - 20)) -
+			(b % (partial.my_c_func(a, b) - 20))) = 0;
 END
 $$ LANGUAGE plpgsql IMMUTABLE;
 CREATE FUNCTION my_eq_s_p(a int, b int) RETURNS bool AS $$
-	SELECT my_cmp_plpgsql(a, b) = 0;
+	SELECT partial.my_cmp_plpgsql(a, b) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_s_s(a int, b int) RETURNS bool AS $$
-	SELECT my_cmp_sql(a, b) = 0;
+	SELECT partial.my_cmp_sql(a, b) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_s_s_s_s(a int, b int) RETURNS bool AS $$
-	SELECT my_cmp_sql_sql_sql(a, b) = 0;
+	SELECT partial.my_cmp_sql_sql_sql(a, b) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_s_s_s_p(a int, b int) RETURNS bool AS $$
-	SELECT my_cmp_sql_sql_plpgsql(a, b) = 0;
+	SELECT partial.my_cmp_sql_sql_plpgsql(a, b) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_s_sb(a int, b int) RETURNS bool AS $$
-	SELECT my_cmp_sql_body(a, b) = 0;
+	SELECT partial.my_cmp_sql_body(a, b) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_s_i(a int, b int) RETURNS bool AS $$
-	SELECT my_cmp_inter(a, b) = 0;
+	SELECT partial.my_cmp_inter(a, b) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_s_b(a int, b int) RETURNS bool AS $$
 	SELECT btint4cmp(a, b) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_s_c(a int, b int) RETURNS bool AS $$
-	SELECT ((a % (my_c_func(a, b) - 20)) -
-			(b % (my_c_func(a, b) - 20))) = 0;
+	SELECT ((a % (partial.my_c_func(a, b) - 20)) -
+			(b % (partial.my_c_func(a, b) - 20))) = 0;
 $$ LANGUAGE SQL IMMUTABLE;
 CREATE FUNCTION my_eq_sb_p(a int, b int) RETURNS bool
 	LANGUAGE SQL IMMUTABLE
 BEGIN ATOMIC
-	SELECT my_cmp_plpgsql(a, b) = 0;
+	SELECT partial.my_cmp_plpgsql(a, b) = 0;
 END;
 CREATE FUNCTION my_eq_sb_s(a int, b int) RETURNS bool
 	LANGUAGE SQL IMMUTABLE
 BEGIN ATOMIC
-	SELECT my_cmp_sql(a, b) = 0;
+	SELECT partial.my_cmp_sql(a, b) = 0;
 END;
 CREATE FUNCTION my_eq_sb_sb(a int, b int) RETURNS bool
 	LANGUAGE SQL IMMUTABLE
 BEGIN ATOMIC
-	SELECT my_cmp_sql_body(a, b) = 0;
+	SELECT partial.my_cmp_sql_body(a, b) = 0;
 END;
 CREATE FUNCTION my_eq_sb_i(a int, b int) RETURNS bool
 	LANGUAGE SQL IMMUTABLE
 BEGIN ATOMIC
-	SELECT my_cmp_inter(a, b) = 0;
+	SELECT partial.my_cmp_inter(a, b) = 0;
 END;
 CREATE FUNCTION my_eq_sb_b(a int, b int) RETURNS bool
 	LANGUAGE SQL IMMUTABLE
@@ -123,8 +123,8 @@ END;
 CREATE FUNCTION my_eq_sb_c(a int, b int) RETURNS bool
 	LANGUAGE SQL IMMUTABLE
 BEGIN ATOMIC
-	SELECT ((a % (my_c_func(a, b) - 20)) -
-			(b % (my_c_func(a, b) - 20))) = 0;
+	SELECT ((a % (partial.my_c_func(a, b) - 20)) -
+			(b % (partial.my_c_func(a, b) - 20))) = 0;
 END;
 CREATE FUNCTION my_eq_i(a int, b int) RETURNS bool
 	AS 'int4eq'
@@ -204,7 +204,7 @@ CREATE INDEX o_test_sql_func_ix_i ON
 CREATE INDEX o_test_sql_func_ix_b ON
 	o_test_sql_func(val) WHERE (int4eq(val % 4, 3));
 CREATE INDEX o_test_sql_func_ix_c ON
-	o_test_sql_func(val) WHERE ((val % (my_c_func(val,
+	o_test_sql_func(val) WHERE ((val % (partial.my_c_func(val,
 														   val + 1) - 18)) =
 								0);
 CREATE SEQUENCE o_test_sql_func_seq;

--- a/test/expected/primary_key.out
+++ b/test/expected/primary_key.out
@@ -5,7 +5,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 16
+ 18
 (1 row)
 
 -- Test for integer primary key
@@ -423,8 +423,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key >  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key > 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -451,8 +452,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key >  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key >= 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -480,8 +482,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key >= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key > 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -508,8 +511,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key >= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key >= 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -537,8 +541,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key <  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key > 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -566,8 +571,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key <  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key >= 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -596,8 +602,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key <= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key > 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -625,8 +632,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key <= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key >= 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -655,8 +663,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key >  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key < 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -671,8 +680,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key >  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key <= 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -688,8 +698,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key >= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key < 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -704,8 +715,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key >= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key <= 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -721,8 +733,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key <  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key < 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -736,8 +749,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key <  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key <= 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -752,8 +766,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key <= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key < 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -767,8 +782,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key <= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key <= 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -781,12 +797,12 @@ SELECT * FROM o_pk1 WHERE key <= 10 OR  key <= 19 AND payload LIKE '%7*%';
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1
 WHERE key >  10 AND key <  19 AND key = (SELECT i FROM generate_series(13,13) AS i);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Custom Scan (o_scan) on o_pk1
    Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key < 19) AND (key = $0))
-   InitPlan 1 (returns $0)
+   Conds: ((key > 10) AND (key < 19) AND (key = (InitPlan 1).col1))
+   InitPlan 1
      ->  Function Scan on generate_series i
 (5 rows)
 
@@ -799,13 +815,14 @@ WHERE key >  10 AND key <  19 AND key = (SELECT i FROM generate_series(13,13) AS
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1
 WHERE key <  10 OR  key >  19 OR key = (SELECT i FROM generate_series(13,13) AS i);
-                     QUERY PLAN                     
-----------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Seq Scan on o_pk1
-   Filter: ((key < 10) OR (key > 19) OR (key = $0))
-   InitPlan 1 (returns $0)
+   Disabled: true
+   Filter: ((key < 10) OR (key > 19) OR (key = (InitPlan 1).col1))
+   InitPlan 1
      ->  Function Scan on generate_series i
-(4 rows)
+(5 rows)
 
 SELECT * FROM o_pk1
 WHERE key <  10 OR  key >  19 OR key = (SELECT i FROM generate_series(13,13) AS i);
@@ -878,8 +895,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4]);
                 QUERY PLAN                
 ------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: (key = ALL ('{4}'::integer[]))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4]);
  key | payload 
@@ -891,8 +909,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10]);
                  QUERY PLAN                  
 ---------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: (key = ALL ('{4,10}'::integer[]))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10]);
  key | payload 
@@ -903,8 +922,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10, NULL]);
                     QUERY PLAN                    
 --------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: (key = ALL ('{4,10,NULL}'::integer[]))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10, NULL]);
  key | payload 
@@ -961,8 +981,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4]);
                 QUERY PLAN                
 ------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: (key < ALL ('{4}'::integer[]))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4]);
  key | payload 
@@ -974,8 +995,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,10]);
                  QUERY PLAN                  
 ---------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: (key < ALL ('{4,10}'::integer[]))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,10]);
  key | payload 
@@ -987,8 +1009,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,5, NULL]);
                    QUERY PLAN                    
 -------------------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: (key < ALL ('{4,5,NULL}'::integer[]))
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,5, NULL]);
  key | payload 
@@ -1000,8 +1023,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = 1.0;
             QUERY PLAN            
 ----------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key)::numeric = 1.0)
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key = 1.0;
  key | payload 
@@ -1013,8 +1037,9 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10.0;
              QUERY PLAN             
 ------------------------------------
  Seq Scan on o_pk1
+   Disabled: true
    Filter: ((key)::numeric <= 10.0)
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10.0;
  key | payload 
@@ -2093,8 +2118,9 @@ EXPLAIN (COSTS off) SELECT id, value FROM o_pk2 WHERE id <= 71 OR id > 91;
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
  Seq Scan on o_pk2
+   Disabled: true
    Filter: ((id <= '71'::double precision) OR (id > '91'::double precision))
-(2 rows)
+(3 rows)
 
 SELECT id, value FROM o_pk2 WHERE id <= 71 OR id > 91;
  id  |   value   
@@ -2371,8 +2397,9 @@ EXPLAIN (COSTS off) SELECT id, value FROM o_pk2 WHERE id >= 71 OR id < 19;
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
  Seq Scan on o_pk2
+   Disabled: true
    Filter: ((id >= '71'::double precision) OR (id < '19'::double precision))
-(2 rows)
+(3 rows)
 
 SELECT id, value FROM o_pk2 WHERE id >= 71 OR id < 19;
  id  |   value   
@@ -2646,14 +2673,12 @@ sql/composite_pk_quals: No such file or directory
 -- translate index attnum -> table attnum so PKs whose column order
 -- differs from the table column order still filter correctly.
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                     QUERY PLAN                     
-----------------------------------------------------
- Sort
-   Sort Key: id1, id2
-   ->  Custom Scan (o_scan) on o_pk3
-         Forward index only scan of: o_pk3_pkey
-         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(5 rows)
+                  QUERY PLAN                  
+----------------------------------------------
+ Custom Scan (o_scan) on o_pk3
+   Forward index only scan of: o_pk3_pkey
+   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2669,14 +2694,12 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
-                     QUERY PLAN                     
-----------------------------------------------------
- Sort
-   Sort Key: id1, id2
-   ->  Custom Scan (o_scan) on o_pk3
-         Forward index only scan of: o_pk3_pkey
-         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(5 rows)
+                  QUERY PLAN                  
+----------------------------------------------
+ Custom Scan (o_scan) on o_pk3
+   Forward index only scan of: o_pk3_pkey
+   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -2692,13 +2715,12 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                  QUERY PLAN                   
------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_pk3
-   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
    Forward index only scan of: o_pk3_pkey
-   Conds: (id1 = '2'::double precision)
-(4 rows)
+   Conds: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2800,14 +2822,12 @@ SELECT id1, id2 FROM o_pk3;
 \i 'sql/composite_pk_quals'
 sql/composite_pk_quals: No such file or directory
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                     QUERY PLAN                     
-----------------------------------------------------
- Sort
-   Sort Key: id1, id2
-   ->  Custom Scan (o_scan) on o_pk3
-         Forward index only scan of: o_pk3_pkey
-         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(5 rows)
+                  QUERY PLAN                  
+----------------------------------------------
+ Custom Scan (o_scan) on o_pk3
+   Forward index only scan of: o_pk3_pkey
+   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2823,14 +2843,12 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
-                     QUERY PLAN                     
-----------------------------------------------------
- Sort
-   Sort Key: id1, id2
-   ->  Custom Scan (o_scan) on o_pk3
-         Forward index only scan of: o_pk3_pkey
-         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(5 rows)
+                  QUERY PLAN                  
+----------------------------------------------
+ Custom Scan (o_scan) on o_pk3
+   Forward index only scan of: o_pk3_pkey
+   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -2846,13 +2864,12 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                  QUERY PLAN                   
------------------------------------------------
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_pk3
-   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
    Forward index only scan of: o_pk3_pkey
-   Conds: (id1 = '2'::double precision)
-(4 rows)
+   Conds: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2882,73 +2899,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3;
+SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
  id1 |   id2    
 -----+----------
-   1 | xyyyy
-   1 | xyyy
-   1 | xyy
-   1 | xy
-   1 | xxyyyy
-   1 | xxyyy
-   1 | xxyy
-   1 | xxy
-   1 | xxxyyyy
-   1 | xxxyyy
-   1 | xxxyy
-   1 | xxxy
-   1 | xxxxyyyy
-   1 | xxxxyyy
-   1 | xxxxyy
    1 | xxxxy
-   2 | xyyyy
-   2 | xyyy
-   2 | xyy
-   2 | xy
-   2 | xxyyyy
-   2 | xxyyy
-   2 | xxyy
-   2 | xxy
-   2 | xxxyyyy
-   2 | xxxyyy
-   2 | xxxyy
-   2 | xxxy
-   2 | xxxxyyyy
-   2 | xxxxyyy
-   2 | xxxxyy
+   1 | xxxxyy
+   1 | xxxxyyy
+   1 | xxxxyyyy
+   1 | xxxy
+   1 | xxxyy
+   1 | xxxyyy
+   1 | xxxyyyy
+   1 | xxy
+   1 | xxyy
+   1 | xxyyy
+   1 | xxyyyy
+   1 | xy
+   1 | xyy
+   1 | xyyy
+   1 | xyyyy
    2 | xxxxy
-   3 | xyyyy
-   3 | xyyy
-   3 | xyy
-   3 | xy
-   3 | xxyyyy
-   3 | xxyyy
-   3 | xxyy
-   3 | xxy
-   3 | xxxyyyy
-   3 | xxxyyy
-   3 | xxxyy
-   3 | xxxy
-   3 | xxxxyyyy
-   3 | xxxxyyy
-   3 | xxxxyy
+   2 | xxxxyy
+   2 | xxxxyyy
+   2 | xxxxyyyy
+   2 | xxxy
+   2 | xxxyy
+   2 | xxxyyy
+   2 | xxxyyyy
+   2 | xxy
+   2 | xxyy
+   2 | xxyyy
+   2 | xxyyyy
+   2 | xy
+   2 | xyy
+   2 | xyyy
+   2 | xyyyy
    3 | xxxxy
-   4 | xyyyy
-   4 | xyyy
-   4 | xyy
-   4 | xy
-   4 | xxyyyy
-   4 | xxyyy
-   4 | xxyy
-   4 | xxy
-   4 | xxxyyyy
-   4 | xxxyyy
-   4 | xxxyy
-   4 | xxxy
-   4 | xxxxyyyy
-   4 | xxxxyyy
-   4 | xxxxyy
+   3 | xxxxyy
+   3 | xxxxyyy
+   3 | xxxxyyyy
+   3 | xxxy
+   3 | xxxyy
+   3 | xxxyyy
+   3 | xxxyyyy
+   3 | xxy
+   3 | xxyy
+   3 | xxyyy
+   3 | xxyyyy
+   3 | xy
+   3 | xyy
+   3 | xyyy
+   3 | xyyyy
    4 | xxxxy
+   4 | xxxxyy
+   4 | xxxxyyy
+   4 | xxxxyyyy
+   4 | xxxy
+   4 | xxxyy
+   4 | xxxyyy
+   4 | xxxyyyy
+   4 | xxy
+   4 | xxyy
+   4 | xxyyy
+   4 | xxyyyy
+   4 | xy
+   4 | xyy
+   4 | xyyy
+   4 | xyyyy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -2956,11 +2973,12 @@ sql/composite_pk_quals: No such file or directory
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
                        QUERY PLAN                        
 ---------------------------------------------------------
- Sort
+ Incremental Sort
    Sort Key: id1, id2
+   Presorted Key: id1
    ->  Index Only Scan using o_pk3_idx on o_pk3
          Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(4 rows)
+(5 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2978,11 +2996,12 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
                        QUERY PLAN                        
 ---------------------------------------------------------
- Sort
+ Incremental Sort
    Sort Key: id1, id2
+   Presorted Key: id1
    ->  Index Only Scan using o_pk3_idx on o_pk3
          Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(4 rows)
+(5 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -2998,12 +3017,11 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                    QUERY PLAN                     
----------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Index Only Scan Backward using o_pk3_idx on o_pk3
-   Index Cond: (id1 = '2'::double precision)
-   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(3 rows)
+   Index Cond: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
+(2 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -3033,85 +3051,83 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3;
+SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
  id1 |   id2    
 -----+----------
-   4 | xyyyy
-   4 | xyyy
-   4 | xyy
-   4 | xy
-   4 | xxyyyy
-   4 | xxyyy
-   4 | xxyy
-   4 | xxy
-   4 | xxxyyyy
-   4 | xxxyyy
-   4 | xxxyy
-   4 | xxxy
-   4 | xxxxyyyy
-   4 | xxxxyyy
-   4 | xxxxyy
-   4 | xxxxy
-   3 | xyyyy
-   3 | xyyy
-   3 | xyy
-   3 | xy
-   3 | xxyyyy
-   3 | xxyyy
-   3 | xxyy
-   3 | xxy
-   3 | xxxyyyy
-   3 | xxxyyy
-   3 | xxxyy
-   3 | xxxy
-   3 | xxxxyyyy
-   3 | xxxxyyy
-   3 | xxxxyy
-   3 | xxxxy
-   2 | xyyyy
-   2 | xyyy
-   2 | xyy
-   2 | xy
-   2 | xxyyyy
-   2 | xxyyy
-   2 | xxyy
-   2 | xxy
-   2 | xxxyyyy
-   2 | xxxyyy
-   2 | xxxyy
-   2 | xxxy
-   2 | xxxxyyyy
-   2 | xxxxyyy
-   2 | xxxxyy
-   2 | xxxxy
-   1 | xyyyy
-   1 | xyyy
-   1 | xyy
-   1 | xy
-   1 | xxyyyy
-   1 | xxyyy
-   1 | xxyy
-   1 | xxy
-   1 | xxxyyyy
-   1 | xxxyyy
-   1 | xxxyy
-   1 | xxxy
-   1 | xxxxyyyy
-   1 | xxxxyyy
-   1 | xxxxyy
    1 | xxxxy
+   1 | xxxxyy
+   1 | xxxxyyy
+   1 | xxxxyyyy
+   1 | xxxy
+   1 | xxxyy
+   1 | xxxyyy
+   1 | xxxyyyy
+   1 | xxy
+   1 | xxyy
+   1 | xxyyy
+   1 | xxyyyy
+   1 | xy
+   1 | xyy
+   1 | xyyy
+   1 | xyyyy
+   2 | xxxxy
+   2 | xxxxyy
+   2 | xxxxyyy
+   2 | xxxxyyyy
+   2 | xxxy
+   2 | xxxyy
+   2 | xxxyyy
+   2 | xxxyyyy
+   2 | xxy
+   2 | xxyy
+   2 | xxyyy
+   2 | xxyyyy
+   2 | xy
+   2 | xyy
+   2 | xyyy
+   2 | xyyyy
+   3 | xxxxy
+   3 | xxxxyy
+   3 | xxxxyyy
+   3 | xxxxyyyy
+   3 | xxxy
+   3 | xxxyy
+   3 | xxxyyy
+   3 | xxxyyyy
+   3 | xxy
+   3 | xxyy
+   3 | xxyyy
+   3 | xxyyyy
+   3 | xy
+   3 | xyy
+   3 | xyyy
+   3 | xyyyy
+   4 | xxxxy
+   4 | xxxxyy
+   4 | xxxxyyy
+   4 | xxxxyyyy
+   4 | xxxy
+   4 | xxxyy
+   4 | xxxyyy
+   4 | xxxyyyy
+   4 | xxy
+   4 | xxyy
+   4 | xxyyy
+   4 | xxyyyy
+   4 | xy
+   4 | xyy
+   4 | xyyy
+   4 | xyyyy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
 sql/composite_pk_quals: No such file or directory
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                       QUERY PLAN                        
----------------------------------------------------------
- Sort
-   Sort Key: id1, id2
-   ->  Index Only Scan using o_pk3_idx on o_pk3
-         Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(4 rows)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Index Only Scan Backward using o_pk3_idx on o_pk3
+   Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(2 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -3127,13 +3143,11 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
-                       QUERY PLAN                        
----------------------------------------------------------
- Sort
-   Sort Key: id1, id2
-   ->  Index Only Scan using o_pk3_idx on o_pk3
-         Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(4 rows)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Index Only Scan Backward using o_pk3_idx on o_pk3
+   Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(2 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -3149,12 +3163,11 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                    QUERY PLAN                     
----------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Index Only Scan Backward using o_pk3_idx on o_pk3
-   Index Cond: (id1 = '2'::double precision)
-   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(3 rows)
+   Index Cond: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
+(2 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -3250,12 +3263,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::time
    Index Cond: ((dt = 'Mon Mar 01 00:00:00 2021'::timestamp without time zone) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp ORDER BY dt;
  i |            dt            
 ---+--------------------------
- 2 | Sat May 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Mon Mar 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Sat May 01 00:00:00 2021
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date;
@@ -3265,12 +3278,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date
    Index Cond: ((dt = '03-01-2021'::date) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date ORDER BY dt;
  i |            dt            
 ---+--------------------------
- 2 | Sat May 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Mon Mar 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Sat May 01 00:00:00 2021
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/expected/primary_key.out
+++ b/test/expected/primary_key.out
@@ -2882,73 +2882,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
+SELECT id1, id2 FROM o_pk3;
  id1 |   id2    
 -----+----------
-   1 | xxxxy
-   1 | xxxxyy
-   1 | xxxxyyy
-   1 | xxxxyyyy
-   1 | xxxy
-   1 | xxxyy
-   1 | xxxyyy
-   1 | xxxyyyy
-   1 | xxy
-   1 | xxyy
-   1 | xxyyy
-   1 | xxyyyy
-   1 | xy
-   1 | xyy
-   1 | xyyy
    1 | xyyyy
-   2 | xxxxy
-   2 | xxxxyy
-   2 | xxxxyyy
-   2 | xxxxyyyy
-   2 | xxxy
-   2 | xxxyy
-   2 | xxxyyy
-   2 | xxxyyyy
-   2 | xxy
-   2 | xxyy
-   2 | xxyyy
-   2 | xxyyyy
-   2 | xy
-   2 | xyy
-   2 | xyyy
+   1 | xyyy
+   1 | xyy
+   1 | xy
+   1 | xxyyyy
+   1 | xxyyy
+   1 | xxyy
+   1 | xxy
+   1 | xxxyyyy
+   1 | xxxyyy
+   1 | xxxyy
+   1 | xxxy
+   1 | xxxxyyyy
+   1 | xxxxyyy
+   1 | xxxxyy
+   1 | xxxxy
    2 | xyyyy
-   3 | xxxxy
-   3 | xxxxyy
-   3 | xxxxyyy
-   3 | xxxxyyyy
-   3 | xxxy
-   3 | xxxyy
-   3 | xxxyyy
-   3 | xxxyyyy
-   3 | xxy
-   3 | xxyy
-   3 | xxyyy
-   3 | xxyyyy
-   3 | xy
-   3 | xyy
-   3 | xyyy
+   2 | xyyy
+   2 | xyy
+   2 | xy
+   2 | xxyyyy
+   2 | xxyyy
+   2 | xxyy
+   2 | xxy
+   2 | xxxyyyy
+   2 | xxxyyy
+   2 | xxxyy
+   2 | xxxy
+   2 | xxxxyyyy
+   2 | xxxxyyy
+   2 | xxxxyy
+   2 | xxxxy
    3 | xyyyy
-   4 | xxxxy
-   4 | xxxxyy
-   4 | xxxxyyy
-   4 | xxxxyyyy
-   4 | xxxy
-   4 | xxxyy
-   4 | xxxyyy
-   4 | xxxyyyy
-   4 | xxy
-   4 | xxyy
-   4 | xxyyy
-   4 | xxyyyy
-   4 | xy
-   4 | xyy
-   4 | xyyy
+   3 | xyyy
+   3 | xyy
+   3 | xy
+   3 | xxyyyy
+   3 | xxyyy
+   3 | xxyy
+   3 | xxy
+   3 | xxxyyyy
+   3 | xxxyyy
+   3 | xxxyy
+   3 | xxxy
+   3 | xxxxyyyy
+   3 | xxxxyyy
+   3 | xxxxyy
+   3 | xxxxy
    4 | xyyyy
+   4 | xyyy
+   4 | xyy
+   4 | xy
+   4 | xxyyyy
+   4 | xxyyy
+   4 | xxyy
+   4 | xxy
+   4 | xxxyyyy
+   4 | xxxyyy
+   4 | xxxyy
+   4 | xxxy
+   4 | xxxxyyyy
+   4 | xxxxyyy
+   4 | xxxxyy
+   4 | xxxxy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3033,73 +3033,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
+SELECT id1, id2 FROM o_pk3;
  id1 |   id2    
 -----+----------
-   1 | xxxxy
-   1 | xxxxyy
-   1 | xxxxyyy
-   1 | xxxxyyyy
-   1 | xxxy
-   1 | xxxyy
-   1 | xxxyyy
-   1 | xxxyyyy
-   1 | xxy
-   1 | xxyy
-   1 | xxyyy
-   1 | xxyyyy
-   1 | xy
-   1 | xyy
-   1 | xyyy
-   1 | xyyyy
-   2 | xxxxy
-   2 | xxxxyy
-   2 | xxxxyyy
-   2 | xxxxyyyy
-   2 | xxxy
-   2 | xxxyy
-   2 | xxxyyy
-   2 | xxxyyyy
-   2 | xxy
-   2 | xxyy
-   2 | xxyyy
-   2 | xxyyyy
-   2 | xy
-   2 | xyy
-   2 | xyyy
-   2 | xyyyy
-   3 | xxxxy
-   3 | xxxxyy
-   3 | xxxxyyy
-   3 | xxxxyyyy
-   3 | xxxy
-   3 | xxxyy
-   3 | xxxyyy
-   3 | xxxyyyy
-   3 | xxy
-   3 | xxyy
-   3 | xxyyy
-   3 | xxyyyy
-   3 | xy
-   3 | xyy
-   3 | xyyy
-   3 | xyyyy
-   4 | xxxxy
-   4 | xxxxyy
-   4 | xxxxyyy
-   4 | xxxxyyyy
-   4 | xxxy
-   4 | xxxyy
-   4 | xxxyyy
-   4 | xxxyyyy
-   4 | xxy
-   4 | xxyy
-   4 | xxyyy
-   4 | xxyyyy
-   4 | xy
-   4 | xyy
-   4 | xyyy
    4 | xyyyy
+   4 | xyyy
+   4 | xyy
+   4 | xy
+   4 | xxyyyy
+   4 | xxyyy
+   4 | xxyy
+   4 | xxy
+   4 | xxxyyyy
+   4 | xxxyyy
+   4 | xxxyy
+   4 | xxxy
+   4 | xxxxyyyy
+   4 | xxxxyyy
+   4 | xxxxyy
+   4 | xxxxy
+   3 | xyyyy
+   3 | xyyy
+   3 | xyy
+   3 | xy
+   3 | xxyyyy
+   3 | xxyyy
+   3 | xxyy
+   3 | xxy
+   3 | xxxyyyy
+   3 | xxxyyy
+   3 | xxxyy
+   3 | xxxy
+   3 | xxxxyyyy
+   3 | xxxxyyy
+   3 | xxxxyy
+   3 | xxxxy
+   2 | xyyyy
+   2 | xyyy
+   2 | xyy
+   2 | xy
+   2 | xxyyyy
+   2 | xxyyy
+   2 | xxyy
+   2 | xxy
+   2 | xxxyyyy
+   2 | xxxyyy
+   2 | xxxyy
+   2 | xxxy
+   2 | xxxxyyyy
+   2 | xxxxyyy
+   2 | xxxxyy
+   2 | xxxxy
+   1 | xyyyy
+   1 | xyyy
+   1 | xyy
+   1 | xy
+   1 | xxyyyy
+   1 | xxyyy
+   1 | xxyy
+   1 | xxy
+   1 | xxxyyyy
+   1 | xxxyyy
+   1 | xxxyy
+   1 | xxxy
+   1 | xxxxyyyy
+   1 | xxxxyyy
+   1 | xxxxyy
+   1 | xxxxy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3250,12 +3250,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::time
    Index Cond: ((dt = 'Mon Mar 01 00:00:00 2021'::timestamp without time zone) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp ORDER BY dt;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp;
  i |            dt            
 ---+--------------------------
- 2 | Mon Mar 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Sat May 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Mon Mar 01 00:00:00 2021
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date;
@@ -3265,12 +3265,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date
    Index Cond: ((dt = '03-01-2021'::date) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date ORDER BY dt;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date;
  i |            dt            
 ---+--------------------------
- 2 | Mon Mar 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Sat May 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Mon Mar 01 00:00:00 2021
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/expected/primary_key_1.out
+++ b/test/expected/primary_key_1.out
@@ -2872,73 +2872,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
+SELECT id1, id2 FROM o_pk3;
  id1 |   id2    
 -----+----------
-   1 | xxxxy
-   1 | xxxxyy
-   1 | xxxxyyy
-   1 | xxxxyyyy
-   1 | xxxy
-   1 | xxxyy
-   1 | xxxyyy
-   1 | xxxyyyy
-   1 | xxy
-   1 | xxyy
-   1 | xxyyy
-   1 | xxyyyy
-   1 | xy
-   1 | xyy
-   1 | xyyy
    1 | xyyyy
-   2 | xxxxy
-   2 | xxxxyy
-   2 | xxxxyyy
-   2 | xxxxyyyy
-   2 | xxxy
-   2 | xxxyy
-   2 | xxxyyy
-   2 | xxxyyyy
-   2 | xxy
-   2 | xxyy
-   2 | xxyyy
-   2 | xxyyyy
-   2 | xy
-   2 | xyy
-   2 | xyyy
+   1 | xyyy
+   1 | xyy
+   1 | xy
+   1 | xxyyyy
+   1 | xxyyy
+   1 | xxyy
+   1 | xxy
+   1 | xxxyyyy
+   1 | xxxyyy
+   1 | xxxyy
+   1 | xxxy
+   1 | xxxxyyyy
+   1 | xxxxyyy
+   1 | xxxxyy
+   1 | xxxxy
    2 | xyyyy
-   3 | xxxxy
-   3 | xxxxyy
-   3 | xxxxyyy
-   3 | xxxxyyyy
-   3 | xxxy
-   3 | xxxyy
-   3 | xxxyyy
-   3 | xxxyyyy
-   3 | xxy
-   3 | xxyy
-   3 | xxyyy
-   3 | xxyyyy
-   3 | xy
-   3 | xyy
-   3 | xyyy
+   2 | xyyy
+   2 | xyy
+   2 | xy
+   2 | xxyyyy
+   2 | xxyyy
+   2 | xxyy
+   2 | xxy
+   2 | xxxyyyy
+   2 | xxxyyy
+   2 | xxxyy
+   2 | xxxy
+   2 | xxxxyyyy
+   2 | xxxxyyy
+   2 | xxxxyy
+   2 | xxxxy
    3 | xyyyy
-   4 | xxxxy
-   4 | xxxxyy
-   4 | xxxxyyy
-   4 | xxxxyyyy
-   4 | xxxy
-   4 | xxxyy
-   4 | xxxyyy
-   4 | xxxyyyy
-   4 | xxy
-   4 | xxyy
-   4 | xxyyy
-   4 | xxyyyy
-   4 | xy
-   4 | xyy
-   4 | xyyy
+   3 | xyyy
+   3 | xyy
+   3 | xy
+   3 | xxyyyy
+   3 | xxyyy
+   3 | xxyy
+   3 | xxy
+   3 | xxxyyyy
+   3 | xxxyyy
+   3 | xxxyy
+   3 | xxxy
+   3 | xxxxyyyy
+   3 | xxxxyyy
+   3 | xxxxyy
+   3 | xxxxy
    4 | xyyyy
+   4 | xyyy
+   4 | xyy
+   4 | xy
+   4 | xxyyyy
+   4 | xxyyy
+   4 | xxyy
+   4 | xxy
+   4 | xxxyyyy
+   4 | xxxyyy
+   4 | xxxyy
+   4 | xxxy
+   4 | xxxxyyyy
+   4 | xxxxyyy
+   4 | xxxxyy
+   4 | xxxxy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3024,73 +3024,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
+SELECT id1, id2 FROM o_pk3;
  id1 |   id2    
 -----+----------
-   1 | xxxxy
-   1 | xxxxyy
-   1 | xxxxyyy
-   1 | xxxxyyyy
-   1 | xxxy
-   1 | xxxyy
-   1 | xxxyyy
-   1 | xxxyyyy
-   1 | xxy
-   1 | xxyy
-   1 | xxyyy
-   1 | xxyyyy
-   1 | xy
-   1 | xyy
-   1 | xyyy
-   1 | xyyyy
-   2 | xxxxy
-   2 | xxxxyy
-   2 | xxxxyyy
-   2 | xxxxyyyy
-   2 | xxxy
-   2 | xxxyy
-   2 | xxxyyy
-   2 | xxxyyyy
-   2 | xxy
-   2 | xxyy
-   2 | xxyyy
-   2 | xxyyyy
-   2 | xy
-   2 | xyy
-   2 | xyyy
-   2 | xyyyy
-   3 | xxxxy
-   3 | xxxxyy
-   3 | xxxxyyy
-   3 | xxxxyyyy
-   3 | xxxy
-   3 | xxxyy
-   3 | xxxyyy
-   3 | xxxyyyy
-   3 | xxy
-   3 | xxyy
-   3 | xxyyy
-   3 | xxyyyy
-   3 | xy
-   3 | xyy
-   3 | xyyy
-   3 | xyyyy
-   4 | xxxxy
-   4 | xxxxyy
-   4 | xxxxyyy
-   4 | xxxxyyyy
-   4 | xxxy
-   4 | xxxyy
-   4 | xxxyyy
-   4 | xxxyyyy
-   4 | xxy
-   4 | xxyy
-   4 | xxyyy
-   4 | xxyyyy
-   4 | xy
-   4 | xyy
-   4 | xyyy
    4 | xyyyy
+   4 | xyyy
+   4 | xyy
+   4 | xy
+   4 | xxyyyy
+   4 | xxyyy
+   4 | xxyy
+   4 | xxy
+   4 | xxxyyyy
+   4 | xxxyyy
+   4 | xxxyy
+   4 | xxxy
+   4 | xxxxyyyy
+   4 | xxxxyyy
+   4 | xxxxyy
+   4 | xxxxy
+   3 | xyyyy
+   3 | xyyy
+   3 | xyy
+   3 | xy
+   3 | xxyyyy
+   3 | xxyyy
+   3 | xxyy
+   3 | xxy
+   3 | xxxyyyy
+   3 | xxxyyy
+   3 | xxxyy
+   3 | xxxy
+   3 | xxxxyyyy
+   3 | xxxxyyy
+   3 | xxxxyy
+   3 | xxxxy
+   2 | xyyyy
+   2 | xyyy
+   2 | xyy
+   2 | xy
+   2 | xxyyyy
+   2 | xxyyy
+   2 | xxyy
+   2 | xxy
+   2 | xxxyyyy
+   2 | xxxyyy
+   2 | xxxyy
+   2 | xxxy
+   2 | xxxxyyyy
+   2 | xxxxyyy
+   2 | xxxxyy
+   2 | xxxxy
+   1 | xyyyy
+   1 | xyyy
+   1 | xyy
+   1 | xy
+   1 | xxyyyy
+   1 | xxyyy
+   1 | xxyy
+   1 | xxy
+   1 | xxxyyyy
+   1 | xxxyyy
+   1 | xxxyy
+   1 | xxxy
+   1 | xxxxyyyy
+   1 | xxxxyyy
+   1 | xxxxyy
+   1 | xxxxy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3236,12 +3236,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::time
    Index Cond: ((dt = 'Mon Mar 01 00:00:00 2021'::timestamp without time zone) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp ORDER BY dt;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp;
  i |            dt            
 ---+--------------------------
- 2 | Mon Mar 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Sat May 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Mon Mar 01 00:00:00 2021
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date;
@@ -3251,12 +3251,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date
    Index Cond: ((dt = '03-01-2021'::date) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date ORDER BY dt;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date;
  i |            dt            
 ---+--------------------------
- 2 | Mon Mar 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Sat May 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Mon Mar 01 00:00:00 2021
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/expected/primary_key_1.out
+++ b/test/expected/primary_key_1.out
@@ -5,7 +5,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 17
+ 16
 (1 row)
 
 -- Test for integer primary key
@@ -781,12 +781,12 @@ SELECT * FROM o_pk1 WHERE key <= 10 OR  key <= 19 AND payload LIKE '%7*%';
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1
 WHERE key >  10 AND key <  19 AND key = (SELECT i FROM generate_series(13,13) AS i);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                     QUERY PLAN                      
+-----------------------------------------------------
  Custom Scan (o_scan) on o_pk1
    Forward index scan of: o_pk1_pkey
-   Conds: ((key > 10) AND (key < 19) AND (key = (InitPlan 1).col1))
-   InitPlan 1
+   Conds: ((key > 10) AND (key < 19) AND (key = $0))
+   InitPlan 1 (returns $0)
      ->  Function Scan on generate_series i
 (5 rows)
 
@@ -799,11 +799,11 @@ WHERE key >  10 AND key <  19 AND key = (SELECT i FROM generate_series(13,13) AS
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk1
 WHERE key <  10 OR  key >  19 OR key = (SELECT i FROM generate_series(13,13) AS i);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                     QUERY PLAN                     
+----------------------------------------------------
  Seq Scan on o_pk1
-   Filter: ((key < 10) OR (key > 19) OR (key = (InitPlan 1).col1))
-   InitPlan 1
+   Filter: ((key < 10) OR (key > 19) OR (key = $0))
+   InitPlan 1 (returns $0)
      ->  Function Scan on generate_series i
 (4 rows)
 
@@ -2646,12 +2646,14 @@ sql/composite_pk_quals: No such file or directory
 -- translate index attnum -> table attnum so PKs whose column order
 -- differs from the table column order still filter correctly.
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                  QUERY PLAN                  
-----------------------------------------------
- Custom Scan (o_scan) on o_pk3
-   Forward index only scan of: o_pk3_pkey
-   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(3 rows)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Sort
+   Sort Key: id1, id2
+   ->  Custom Scan (o_scan) on o_pk3
+         Forward index only scan of: o_pk3_pkey
+         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(5 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2667,12 +2669,14 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
-                  QUERY PLAN                  
-----------------------------------------------
- Custom Scan (o_scan) on o_pk3
-   Forward index only scan of: o_pk3_pkey
-   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(3 rows)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Sort
+   Sort Key: id1, id2
+   ->  Custom Scan (o_scan) on o_pk3
+         Forward index only scan of: o_pk3_pkey
+         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(5 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -2688,12 +2692,13 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                  QUERY PLAN                   
+-----------------------------------------------
  Custom Scan (o_scan) on o_pk3
+   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
    Forward index only scan of: o_pk3_pkey
-   Conds: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
-(3 rows)
+   Conds: (id1 = '2'::double precision)
+(4 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2795,12 +2800,14 @@ SELECT id1, id2 FROM o_pk3;
 \i 'sql/composite_pk_quals'
 sql/composite_pk_quals: No such file or directory
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                  QUERY PLAN                  
-----------------------------------------------
- Custom Scan (o_scan) on o_pk3
-   Forward index only scan of: o_pk3_pkey
-   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(3 rows)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Sort
+   Sort Key: id1, id2
+   ->  Custom Scan (o_scan) on o_pk3
+         Forward index only scan of: o_pk3_pkey
+         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(5 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2816,12 +2823,14 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
-                  QUERY PLAN                  
-----------------------------------------------
- Custom Scan (o_scan) on o_pk3
-   Forward index only scan of: o_pk3_pkey
-   Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(3 rows)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Sort
+   Sort Key: id1, id2
+   ->  Custom Scan (o_scan) on o_pk3
+         Forward index only scan of: o_pk3_pkey
+         Conds: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(5 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -2837,12 +2846,13 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                  QUERY PLAN                   
+-----------------------------------------------
  Custom Scan (o_scan) on o_pk3
+   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
    Forward index only scan of: o_pk3_pkey
-   Conds: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
-(3 rows)
+   Conds: (id1 = '2'::double precision)
+(4 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2872,73 +2882,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3;
+SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
  id1 |   id2    
 -----+----------
-   1 | xyyyy
-   1 | xyyy
-   1 | xyy
-   1 | xy
-   1 | xxyyyy
-   1 | xxyyy
-   1 | xxyy
-   1 | xxy
-   1 | xxxyyyy
-   1 | xxxyyy
-   1 | xxxyy
-   1 | xxxy
-   1 | xxxxyyyy
-   1 | xxxxyyy
-   1 | xxxxyy
    1 | xxxxy
-   2 | xyyyy
-   2 | xyyy
-   2 | xyy
-   2 | xy
-   2 | xxyyyy
-   2 | xxyyy
-   2 | xxyy
-   2 | xxy
-   2 | xxxyyyy
-   2 | xxxyyy
-   2 | xxxyy
-   2 | xxxy
-   2 | xxxxyyyy
-   2 | xxxxyyy
-   2 | xxxxyy
+   1 | xxxxyy
+   1 | xxxxyyy
+   1 | xxxxyyyy
+   1 | xxxy
+   1 | xxxyy
+   1 | xxxyyy
+   1 | xxxyyyy
+   1 | xxy
+   1 | xxyy
+   1 | xxyyy
+   1 | xxyyyy
+   1 | xy
+   1 | xyy
+   1 | xyyy
+   1 | xyyyy
    2 | xxxxy
-   3 | xyyyy
-   3 | xyyy
-   3 | xyy
-   3 | xy
-   3 | xxyyyy
-   3 | xxyyy
-   3 | xxyy
-   3 | xxy
-   3 | xxxyyyy
-   3 | xxxyyy
-   3 | xxxyy
-   3 | xxxy
-   3 | xxxxyyyy
-   3 | xxxxyyy
-   3 | xxxxyy
+   2 | xxxxyy
+   2 | xxxxyyy
+   2 | xxxxyyyy
+   2 | xxxy
+   2 | xxxyy
+   2 | xxxyyy
+   2 | xxxyyyy
+   2 | xxy
+   2 | xxyy
+   2 | xxyyy
+   2 | xxyyyy
+   2 | xy
+   2 | xyy
+   2 | xyyy
+   2 | xyyyy
    3 | xxxxy
-   4 | xyyyy
-   4 | xyyy
-   4 | xyy
-   4 | xy
-   4 | xxyyyy
-   4 | xxyyy
-   4 | xxyy
-   4 | xxy
-   4 | xxxyyyy
-   4 | xxxyyy
-   4 | xxxyy
-   4 | xxxy
-   4 | xxxxyyyy
-   4 | xxxxyyy
-   4 | xxxxyy
+   3 | xxxxyy
+   3 | xxxxyyy
+   3 | xxxxyyyy
+   3 | xxxy
+   3 | xxxyy
+   3 | xxxyyy
+   3 | xxxyyyy
+   3 | xxy
+   3 | xxyy
+   3 | xxyyy
+   3 | xxyyyy
+   3 | xy
+   3 | xyy
+   3 | xyyy
+   3 | xyyyy
    4 | xxxxy
+   4 | xxxxyy
+   4 | xxxxyyy
+   4 | xxxxyyyy
+   4 | xxxy
+   4 | xxxyy
+   4 | xxxyyy
+   4 | xxxyyyy
+   4 | xxy
+   4 | xxyy
+   4 | xxyyy
+   4 | xxyyyy
+   4 | xy
+   4 | xyy
+   4 | xyyy
+   4 | xyyyy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -2946,12 +2956,11 @@ sql/composite_pk_quals: No such file or directory
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
                        QUERY PLAN                        
 ---------------------------------------------------------
- Incremental Sort
+ Sort
    Sort Key: id1, id2
-   Presorted Key: id1
    ->  Index Only Scan using o_pk3_idx on o_pk3
          Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(5 rows)
+(4 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -2969,12 +2978,11 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
                        QUERY PLAN                        
 ---------------------------------------------------------
- Incremental Sort
+ Sort
    Sort Key: id1, id2
-   Presorted Key: id1
    ->  Index Only Scan using o_pk3_idx on o_pk3
          Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(5 rows)
+(4 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -2990,11 +2998,12 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan Backward using o_pk3_idx on o_pk3
-   Index Cond: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
-(2 rows)
+   Index Cond: (id1 = '2'::double precision)
+   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -3024,83 +3033,85 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3;
+SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
  id1 |   id2    
 -----+----------
-   4 | xyyyy
-   4 | xyyy
-   4 | xyy
-   4 | xy
-   4 | xxyyyy
-   4 | xxyyy
-   4 | xxyy
-   4 | xxy
-   4 | xxxyyyy
-   4 | xxxyyy
-   4 | xxxyy
-   4 | xxxy
-   4 | xxxxyyyy
-   4 | xxxxyyy
-   4 | xxxxyy
-   4 | xxxxy
-   3 | xyyyy
-   3 | xyyy
-   3 | xyy
-   3 | xy
-   3 | xxyyyy
-   3 | xxyyy
-   3 | xxyy
-   3 | xxy
-   3 | xxxyyyy
-   3 | xxxyyy
-   3 | xxxyy
-   3 | xxxy
-   3 | xxxxyyyy
-   3 | xxxxyyy
-   3 | xxxxyy
-   3 | xxxxy
-   2 | xyyyy
-   2 | xyyy
-   2 | xyy
-   2 | xy
-   2 | xxyyyy
-   2 | xxyyy
-   2 | xxyy
-   2 | xxy
-   2 | xxxyyyy
-   2 | xxxyyy
-   2 | xxxyy
-   2 | xxxy
-   2 | xxxxyyyy
-   2 | xxxxyyy
-   2 | xxxxyy
-   2 | xxxxy
-   1 | xyyyy
-   1 | xyyy
-   1 | xyy
-   1 | xy
-   1 | xxyyyy
-   1 | xxyyy
-   1 | xxyy
-   1 | xxy
-   1 | xxxyyyy
-   1 | xxxyyy
-   1 | xxxyy
-   1 | xxxy
-   1 | xxxxyyyy
-   1 | xxxxyyy
-   1 | xxxxyy
    1 | xxxxy
+   1 | xxxxyy
+   1 | xxxxyyy
+   1 | xxxxyyyy
+   1 | xxxy
+   1 | xxxyy
+   1 | xxxyyy
+   1 | xxxyyyy
+   1 | xxy
+   1 | xxyy
+   1 | xxyyy
+   1 | xxyyyy
+   1 | xy
+   1 | xyy
+   1 | xyyy
+   1 | xyyyy
+   2 | xxxxy
+   2 | xxxxyy
+   2 | xxxxyyy
+   2 | xxxxyyyy
+   2 | xxxy
+   2 | xxxyy
+   2 | xxxyyy
+   2 | xxxyyyy
+   2 | xxy
+   2 | xxyy
+   2 | xxyyy
+   2 | xxyyyy
+   2 | xy
+   2 | xyy
+   2 | xyyy
+   2 | xyyyy
+   3 | xxxxy
+   3 | xxxxyy
+   3 | xxxxyyy
+   3 | xxxxyyyy
+   3 | xxxy
+   3 | xxxyy
+   3 | xxxyyy
+   3 | xxxyyyy
+   3 | xxy
+   3 | xxyy
+   3 | xxyyy
+   3 | xxyyyy
+   3 | xy
+   3 | xyy
+   3 | xyyy
+   3 | xyyyy
+   4 | xxxxy
+   4 | xxxxyy
+   4 | xxxxyyy
+   4 | xxxxyyyy
+   4 | xxxy
+   4 | xxxyy
+   4 | xxxyyy
+   4 | xxxyyyy
+   4 | xxy
+   4 | xxyy
+   4 | xxyyy
+   4 | xxyyyy
+   4 | xy
+   4 | xyy
+   4 | xyyy
+   4 | xyyyy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
 sql/composite_pk_quals: No such file or directory
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                    QUERY PLAN                     
----------------------------------------------------
- Index Only Scan Backward using o_pk3_idx on o_pk3
-   Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(2 rows)
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Sort
+   Sort Key: id1, id2
+   ->  Index Only Scan using o_pk3_idx on o_pk3
+         Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(4 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -3116,11 +3127,13 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
-                    QUERY PLAN                     
----------------------------------------------------
- Index Only Scan Backward using o_pk3_idx on o_pk3
-   Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
-(2 rows)
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Sort
+   Sort Key: id1, id2
+   ->  Index Only Scan using o_pk3_idx on o_pk3
+         Index Cond: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(4 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
  id1 |  id2  
@@ -3136,11 +3149,12 @@ SELECT id1, id2 FROM o_pk3 WHERE id2 IN ('xyy', 'xxyyy') ORDER BY id1, id2;
 (8 rows)
 
 EXPLAIN (COSTS off) SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Index Only Scan Backward using o_pk3_idx on o_pk3
-   Index Cond: ((id1 = '2'::double precision) AND (id2 = ANY ('{xyy,xxyyy}'::text[])))
-(2 rows)
+   Index Cond: (id1 = '2'::double precision)
+   Filter: (id2 = ANY ('{xyy,xxyyy}'::text[]))
+(3 rows)
 
 SELECT id1, id2 FROM o_pk3 WHERE id1 = 2 AND id2 = ANY ('{xyy, xxyyy}'::text[]) ORDER BY id1, id2;
  id1 |  id2  
@@ -3236,12 +3250,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::time
    Index Cond: ((dt = 'Mon Mar 01 00:00:00 2021'::timestamp without time zone) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp ORDER BY dt;
  i |            dt            
 ---+--------------------------
- 2 | Sat May 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Mon Mar 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Sat May 01 00:00:00 2021
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date;
@@ -3251,12 +3265,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date
    Index Cond: ((dt = '03-01-2021'::date) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date ORDER BY dt;
  i |            dt            
 ---+--------------------------
- 2 | Sat May 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Mon Mar 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Sat May 01 00:00:00 2021
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/expected/primary_key_2.out
+++ b/test/expected/primary_key_2.out
@@ -5,7 +5,7 @@ SELECT split_part(setting, '.', 1) major_version
 	FROM pg_settings WHERE name = 'server_version';
  major_version 
 ---------------
- 18
+ 17
 (1 row)
 
 -- Test for integer primary key
@@ -423,9 +423,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key >  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key > 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -452,9 +451,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key >  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key >= 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -482,9 +480,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key >= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key > 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -511,9 +508,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key >= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key >= 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -541,9 +537,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key <  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key > 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -571,9 +566,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key <  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key >= 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -602,9 +596,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >  10 OR  key <= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key > 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >  10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -632,9 +625,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key >= 10 OR  key <= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key >= 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key >= 10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -663,9 +655,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key >  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key < 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -680,9 +671,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key >  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key <= 10) OR ((key > 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key >  19 AND payload LIKE '%7*%';
  key | payload 
@@ -698,9 +688,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key >= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key < 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -715,9 +704,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key >= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key <= 10) OR ((key >= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key >= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -733,9 +721,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key <  19 AND payloa
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key < 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -749,9 +736,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key <  19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key <= 10) OR ((key < 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key <  19 AND payload LIKE '%7*%';
  key | payload 
@@ -766,9 +752,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <  10 OR  key <= 19 AND payloa
                               QUERY PLAN                               
 -----------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key < 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <  10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -782,9 +767,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10 OR  key <= 19 AND payloa
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key <= 10) OR ((key <= 19) AND (payload ~~ '%7*%'::text)))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10 OR  key <= 19 AND payload LIKE '%7*%';
  key | payload 
@@ -818,11 +802,10 @@ WHERE key <  10 OR  key >  19 OR key = (SELECT i FROM generate_series(13,13) AS 
                             QUERY PLAN                             
 -------------------------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key < 10) OR (key > 19) OR (key = (InitPlan 1).col1))
    InitPlan 1
      ->  Function Scan on generate_series i
-(5 rows)
+(4 rows)
 
 SELECT * FROM o_pk1
 WHERE key <  10 OR  key >  19 OR key = (SELECT i FROM generate_series(13,13) AS i);
@@ -895,9 +878,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4]);
                 QUERY PLAN                
 ------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: (key = ALL ('{4}'::integer[]))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4]);
  key | payload 
@@ -909,9 +891,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10]);
                  QUERY PLAN                  
 ---------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: (key = ALL ('{4,10}'::integer[]))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10]);
  key | payload 
@@ -922,9 +903,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10, NULL]);
                     QUERY PLAN                    
 --------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: (key = ALL ('{4,10,NULL}'::integer[]))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key = ALL (ARRAY[4,10, NULL]);
  key | payload 
@@ -981,9 +961,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4]);
                 QUERY PLAN                
 ------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: (key < ALL ('{4}'::integer[]))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4]);
  key | payload 
@@ -995,9 +974,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,10]);
                  QUERY PLAN                  
 ---------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: (key < ALL ('{4,10}'::integer[]))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,10]);
  key | payload 
@@ -1009,9 +987,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,5, NULL]);
                    QUERY PLAN                    
 -------------------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: (key < ALL ('{4,5,NULL}'::integer[]))
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key < ALL (ARRAY[4,5, NULL]);
  key | payload 
@@ -1023,9 +1000,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key = 1.0;
             QUERY PLAN            
 ----------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key)::numeric = 1.0)
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key = 1.0;
  key | payload 
@@ -1037,9 +1013,8 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk1 WHERE key <= 10.0;
              QUERY PLAN             
 ------------------------------------
  Seq Scan on o_pk1
-   Disabled: true
    Filter: ((key)::numeric <= 10.0)
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_pk1 WHERE key <= 10.0;
  key | payload 
@@ -2118,9 +2093,8 @@ EXPLAIN (COSTS off) SELECT id, value FROM o_pk2 WHERE id <= 71 OR id > 91;
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
  Seq Scan on o_pk2
-   Disabled: true
    Filter: ((id <= '71'::double precision) OR (id > '91'::double precision))
-(3 rows)
+(2 rows)
 
 SELECT id, value FROM o_pk2 WHERE id <= 71 OR id > 91;
  id  |   value   
@@ -2397,9 +2371,8 @@ EXPLAIN (COSTS off) SELECT id, value FROM o_pk2 WHERE id >= 71 OR id < 19;
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
  Seq Scan on o_pk2
-   Disabled: true
    Filter: ((id >= '71'::double precision) OR (id < '19'::double precision))
-(3 rows)
+(2 rows)
 
 SELECT id, value FROM o_pk2 WHERE id >= 71 OR id < 19;
  id  |   value   
@@ -2899,73 +2872,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3;
+SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
  id1 |   id2    
 -----+----------
-   1 | xyyyy
-   1 | xyyy
-   1 | xyy
-   1 | xy
-   1 | xxyyyy
-   1 | xxyyy
-   1 | xxyy
-   1 | xxy
-   1 | xxxyyyy
-   1 | xxxyyy
-   1 | xxxyy
-   1 | xxxy
-   1 | xxxxyyyy
-   1 | xxxxyyy
-   1 | xxxxyy
    1 | xxxxy
-   2 | xyyyy
-   2 | xyyy
-   2 | xyy
-   2 | xy
-   2 | xxyyyy
-   2 | xxyyy
-   2 | xxyy
-   2 | xxy
-   2 | xxxyyyy
-   2 | xxxyyy
-   2 | xxxyy
-   2 | xxxy
-   2 | xxxxyyyy
-   2 | xxxxyyy
-   2 | xxxxyy
+   1 | xxxxyy
+   1 | xxxxyyy
+   1 | xxxxyyyy
+   1 | xxxy
+   1 | xxxyy
+   1 | xxxyyy
+   1 | xxxyyyy
+   1 | xxy
+   1 | xxyy
+   1 | xxyyy
+   1 | xxyyyy
+   1 | xy
+   1 | xyy
+   1 | xyyy
+   1 | xyyyy
    2 | xxxxy
-   3 | xyyyy
-   3 | xyyy
-   3 | xyy
-   3 | xy
-   3 | xxyyyy
-   3 | xxyyy
-   3 | xxyy
-   3 | xxy
-   3 | xxxyyyy
-   3 | xxxyyy
-   3 | xxxyy
-   3 | xxxy
-   3 | xxxxyyyy
-   3 | xxxxyyy
-   3 | xxxxyy
+   2 | xxxxyy
+   2 | xxxxyyy
+   2 | xxxxyyyy
+   2 | xxxy
+   2 | xxxyy
+   2 | xxxyyy
+   2 | xxxyyyy
+   2 | xxy
+   2 | xxyy
+   2 | xxyyy
+   2 | xxyyyy
+   2 | xy
+   2 | xyy
+   2 | xyyy
+   2 | xyyyy
    3 | xxxxy
-   4 | xyyyy
-   4 | xyyy
-   4 | xyy
-   4 | xy
-   4 | xxyyyy
-   4 | xxyyy
-   4 | xxyy
-   4 | xxy
-   4 | xxxyyyy
-   4 | xxxyyy
-   4 | xxxyy
-   4 | xxxy
-   4 | xxxxyyyy
-   4 | xxxxyyy
-   4 | xxxxyy
+   3 | xxxxyy
+   3 | xxxxyyy
+   3 | xxxxyyyy
+   3 | xxxy
+   3 | xxxyy
+   3 | xxxyyy
+   3 | xxxyyyy
+   3 | xxy
+   3 | xxyy
+   3 | xxyyy
+   3 | xxyyyy
+   3 | xy
+   3 | xyy
+   3 | xyyy
+   3 | xyyyy
    4 | xxxxy
+   4 | xxxxyy
+   4 | xxxxyyy
+   4 | xxxxyyyy
+   4 | xxxy
+   4 | xxxyy
+   4 | xxxyyy
+   4 | xxxyyyy
+   4 | xxy
+   4 | xxyy
+   4 | xxyyy
+   4 | xxyyyy
+   4 | xy
+   4 | xyy
+   4 | xyyy
+   4 | xyyyy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3051,73 +3024,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3;
+SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
  id1 |   id2    
 -----+----------
-   4 | xyyyy
-   4 | xyyy
-   4 | xyy
-   4 | xy
-   4 | xxyyyy
-   4 | xxyyy
-   4 | xxyy
-   4 | xxy
-   4 | xxxyyyy
-   4 | xxxyyy
-   4 | xxxyy
-   4 | xxxy
-   4 | xxxxyyyy
-   4 | xxxxyyy
-   4 | xxxxyy
-   4 | xxxxy
-   3 | xyyyy
-   3 | xyyy
-   3 | xyy
-   3 | xy
-   3 | xxyyyy
-   3 | xxyyy
-   3 | xxyy
-   3 | xxy
-   3 | xxxyyyy
-   3 | xxxyyy
-   3 | xxxyy
-   3 | xxxy
-   3 | xxxxyyyy
-   3 | xxxxyyy
-   3 | xxxxyy
-   3 | xxxxy
-   2 | xyyyy
-   2 | xyyy
-   2 | xyy
-   2 | xy
-   2 | xxyyyy
-   2 | xxyyy
-   2 | xxyy
-   2 | xxy
-   2 | xxxyyyy
-   2 | xxxyyy
-   2 | xxxyy
-   2 | xxxy
-   2 | xxxxyyyy
-   2 | xxxxyyy
-   2 | xxxxyy
-   2 | xxxxy
-   1 | xyyyy
-   1 | xyyy
-   1 | xyy
-   1 | xy
-   1 | xxyyyy
-   1 | xxyyy
-   1 | xxyy
-   1 | xxy
-   1 | xxxyyyy
-   1 | xxxyyy
-   1 | xxxyy
-   1 | xxxy
-   1 | xxxxyyyy
-   1 | xxxxyyy
-   1 | xxxxyy
    1 | xxxxy
+   1 | xxxxyy
+   1 | xxxxyyy
+   1 | xxxxyyyy
+   1 | xxxy
+   1 | xxxyy
+   1 | xxxyyy
+   1 | xxxyyyy
+   1 | xxy
+   1 | xxyy
+   1 | xxyyy
+   1 | xxyyyy
+   1 | xy
+   1 | xyy
+   1 | xyyy
+   1 | xyyyy
+   2 | xxxxy
+   2 | xxxxyy
+   2 | xxxxyyy
+   2 | xxxxyyyy
+   2 | xxxy
+   2 | xxxyy
+   2 | xxxyyy
+   2 | xxxyyyy
+   2 | xxy
+   2 | xxyy
+   2 | xxyyy
+   2 | xxyyyy
+   2 | xy
+   2 | xyy
+   2 | xyyy
+   2 | xyyyy
+   3 | xxxxy
+   3 | xxxxyy
+   3 | xxxxyyy
+   3 | xxxxyyyy
+   3 | xxxy
+   3 | xxxyy
+   3 | xxxyyy
+   3 | xxxyyyy
+   3 | xxy
+   3 | xxyy
+   3 | xxyyy
+   3 | xxyyyy
+   3 | xy
+   3 | xyy
+   3 | xyyy
+   3 | xyyyy
+   4 | xxxxy
+   4 | xxxxyy
+   4 | xxxxyyy
+   4 | xxxxyyyy
+   4 | xxxy
+   4 | xxxyy
+   4 | xxxyyy
+   4 | xxxyyyy
+   4 | xxy
+   4 | xxyy
+   4 | xxyyy
+   4 | xxyyyy
+   4 | xy
+   4 | xyy
+   4 | xyyy
+   4 | xyyyy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3263,12 +3236,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::time
    Index Cond: ((dt = 'Mon Mar 01 00:00:00 2021'::timestamp without time zone) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp ORDER BY dt;
  i |            dt            
 ---+--------------------------
- 2 | Sat May 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Mon Mar 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Sat May 01 00:00:00 2021
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date;
@@ -3278,12 +3251,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date
    Index Cond: ((dt = '03-01-2021'::date) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date ORDER BY dt;
  i |            dt            
 ---+--------------------------
- 2 | Sat May 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Mon Mar 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Sat May 01 00:00:00 2021
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/expected/primary_key_2.out
+++ b/test/expected/primary_key_2.out
@@ -2899,73 +2899,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
+SELECT id1, id2 FROM o_pk3;
  id1 |   id2    
 -----+----------
-   1 | xxxxy
-   1 | xxxxyy
-   1 | xxxxyyy
-   1 | xxxxyyyy
-   1 | xxxy
-   1 | xxxyy
-   1 | xxxyyy
-   1 | xxxyyyy
-   1 | xxy
-   1 | xxyy
-   1 | xxyyy
-   1 | xxyyyy
-   1 | xy
-   1 | xyy
-   1 | xyyy
    1 | xyyyy
-   2 | xxxxy
-   2 | xxxxyy
-   2 | xxxxyyy
-   2 | xxxxyyyy
-   2 | xxxy
-   2 | xxxyy
-   2 | xxxyyy
-   2 | xxxyyyy
-   2 | xxy
-   2 | xxyy
-   2 | xxyyy
-   2 | xxyyyy
-   2 | xy
-   2 | xyy
-   2 | xyyy
+   1 | xyyy
+   1 | xyy
+   1 | xy
+   1 | xxyyyy
+   1 | xxyyy
+   1 | xxyy
+   1 | xxy
+   1 | xxxyyyy
+   1 | xxxyyy
+   1 | xxxyy
+   1 | xxxy
+   1 | xxxxyyyy
+   1 | xxxxyyy
+   1 | xxxxyy
+   1 | xxxxy
    2 | xyyyy
-   3 | xxxxy
-   3 | xxxxyy
-   3 | xxxxyyy
-   3 | xxxxyyyy
-   3 | xxxy
-   3 | xxxyy
-   3 | xxxyyy
-   3 | xxxyyyy
-   3 | xxy
-   3 | xxyy
-   3 | xxyyy
-   3 | xxyyyy
-   3 | xy
-   3 | xyy
-   3 | xyyy
+   2 | xyyy
+   2 | xyy
+   2 | xy
+   2 | xxyyyy
+   2 | xxyyy
+   2 | xxyy
+   2 | xxy
+   2 | xxxyyyy
+   2 | xxxyyy
+   2 | xxxyy
+   2 | xxxy
+   2 | xxxxyyyy
+   2 | xxxxyyy
+   2 | xxxxyy
+   2 | xxxxy
    3 | xyyyy
-   4 | xxxxy
-   4 | xxxxyy
-   4 | xxxxyyy
-   4 | xxxxyyyy
-   4 | xxxy
-   4 | xxxyy
-   4 | xxxyyy
-   4 | xxxyyyy
-   4 | xxy
-   4 | xxyy
-   4 | xxyyy
-   4 | xxyyyy
-   4 | xy
-   4 | xyy
-   4 | xyyy
+   3 | xyyy
+   3 | xyy
+   3 | xy
+   3 | xxyyyy
+   3 | xxyyy
+   3 | xxyy
+   3 | xxy
+   3 | xxxyyyy
+   3 | xxxyyy
+   3 | xxxyy
+   3 | xxxy
+   3 | xxxxyyyy
+   3 | xxxxyyy
+   3 | xxxxyy
+   3 | xxxxy
    4 | xyyyy
+   4 | xyyy
+   4 | xyy
+   4 | xy
+   4 | xxyyyy
+   4 | xxyyy
+   4 | xxyy
+   4 | xxy
+   4 | xxxyyyy
+   4 | xxxyyy
+   4 | xxxyy
+   4 | xxxy
+   4 | xxxxyyyy
+   4 | xxxxyyy
+   4 | xxxxyy
+   4 | xxxxy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3051,73 +3051,73 @@ SELECT count(*) FROM o_pk3;
     64
 (1 row)
 
-SELECT id1, id2 FROM o_pk3 ORDER BY id1, id2;
+SELECT id1, id2 FROM o_pk3;
  id1 |   id2    
 -----+----------
-   1 | xxxxy
-   1 | xxxxyy
-   1 | xxxxyyy
-   1 | xxxxyyyy
-   1 | xxxy
-   1 | xxxyy
-   1 | xxxyyy
-   1 | xxxyyyy
-   1 | xxy
-   1 | xxyy
-   1 | xxyyy
-   1 | xxyyyy
-   1 | xy
-   1 | xyy
-   1 | xyyy
-   1 | xyyyy
-   2 | xxxxy
-   2 | xxxxyy
-   2 | xxxxyyy
-   2 | xxxxyyyy
-   2 | xxxy
-   2 | xxxyy
-   2 | xxxyyy
-   2 | xxxyyyy
-   2 | xxy
-   2 | xxyy
-   2 | xxyyy
-   2 | xxyyyy
-   2 | xy
-   2 | xyy
-   2 | xyyy
-   2 | xyyyy
-   3 | xxxxy
-   3 | xxxxyy
-   3 | xxxxyyy
-   3 | xxxxyyyy
-   3 | xxxy
-   3 | xxxyy
-   3 | xxxyyy
-   3 | xxxyyyy
-   3 | xxy
-   3 | xxyy
-   3 | xxyyy
-   3 | xxyyyy
-   3 | xy
-   3 | xyy
-   3 | xyyy
-   3 | xyyyy
-   4 | xxxxy
-   4 | xxxxyy
-   4 | xxxxyyy
-   4 | xxxxyyyy
-   4 | xxxy
-   4 | xxxyy
-   4 | xxxyyy
-   4 | xxxyyyy
-   4 | xxy
-   4 | xxyy
-   4 | xxyyy
-   4 | xxyyyy
-   4 | xy
-   4 | xyy
-   4 | xyyy
    4 | xyyyy
+   4 | xyyy
+   4 | xyy
+   4 | xy
+   4 | xxyyyy
+   4 | xxyyy
+   4 | xxyy
+   4 | xxy
+   4 | xxxyyyy
+   4 | xxxyyy
+   4 | xxxyy
+   4 | xxxy
+   4 | xxxxyyyy
+   4 | xxxxyyy
+   4 | xxxxyy
+   4 | xxxxy
+   3 | xyyyy
+   3 | xyyy
+   3 | xyy
+   3 | xy
+   3 | xxyyyy
+   3 | xxyyy
+   3 | xxyy
+   3 | xxy
+   3 | xxxyyyy
+   3 | xxxyyy
+   3 | xxxyy
+   3 | xxxy
+   3 | xxxxyyyy
+   3 | xxxxyyy
+   3 | xxxxyy
+   3 | xxxxy
+   2 | xyyyy
+   2 | xyyy
+   2 | xyy
+   2 | xy
+   2 | xxyyyy
+   2 | xxyyy
+   2 | xxyy
+   2 | xxy
+   2 | xxxyyyy
+   2 | xxxyyy
+   2 | xxxyy
+   2 | xxxy
+   2 | xxxxyyyy
+   2 | xxxxyyy
+   2 | xxxxyy
+   2 | xxxxy
+   1 | xyyyy
+   1 | xyyy
+   1 | xyy
+   1 | xy
+   1 | xxyyyy
+   1 | xxyyy
+   1 | xxyy
+   1 | xxy
+   1 | xxxyyyy
+   1 | xxxyyy
+   1 | xxxyy
+   1 | xxxy
+   1 | xxxxyyyy
+   1 | xxxxyyy
+   1 | xxxxyy
+   1 | xxxxy
 (64 rows)
 
 \i 'sql/composite_pk_quals'
@@ -3263,12 +3263,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::time
    Index Cond: ((dt = 'Mon Mar 01 00:00:00 2021'::timestamp without time zone) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp ORDER BY dt;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::timestamp;
  i |            dt            
 ---+--------------------------
- 2 | Mon Mar 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Sat May 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Mon Mar 01 00:00:00 2021
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date;
@@ -3278,12 +3278,12 @@ EXPLAIN (COSTS off) SELECT * FROM o_pk6 WHERE i <= 2 AND dt = '2021-03-01'::date
    Index Cond: ((dt = '03-01-2021'::date) AND (i <= 2))
 (2 rows)
 
-SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date ORDER BY dt;
+SELECT * FROM o_pk6 WHERE i = 2 AND dt >= '2021-03-01'::date;
  i |            dt            
 ---+--------------------------
- 2 | Mon Mar 01 00:00:00 2021
- 2 | Thu Apr 01 00:00:00 2021
  2 | Sat May 01 00:00:00 2021
+ 2 | Thu Apr 01 00:00:00 2021
+ 2 | Mon Mar 01 00:00:00 2021
 (3 rows)
 
 RESET enable_seqscan;

--- a/test/expected/tableam.out
+++ b/test/expected/tableam.out
@@ -4924,10 +4924,10 @@ CREATE INDEX o_test_1_idx ON o_test_1 (b, a);
 UPDATE o_test_1 SET b = '-0' WHERE b = '0';
 UPDATE o_test_1 SET a = '-0' WHERE a = '0';
 SET enable_seqscan = off;
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_1 ORDER BY b;
-                   QUERY PLAN                   
-------------------------------------------------
- Index Only Scan using o_test_1_idx on o_test_1
+EXPLAIN SELECT * FROM o_test_1 ORDER BY b;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Index Only Scan using o_test_1_idx on o_test_1  (cost=0.13..4.16 rows=2 width=8)
 (1 row)
 
 SELECT * FROM o_test_1 ORDER BY b;
@@ -4997,58 +4997,6 @@ SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
 ------+------
  1000 | 1000
     1 |    1
-(2 rows)
-
--- Backward IOS with 3-element IN list
-SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000) ORDER BY a DESC, b DESC;
-  a   |  b   
-------+------
- 1000 | 1000
-  500 |  500
-    1 |    1
-(3 rows)
-
--- Backward IOS with IN on both columns
-SELECT * FROM o_test_lockstep WHERE a in (1, 500) AND b in (1, 500)
-	ORDER BY a DESC, b DESC;
-  a  |  b  
------+-----
- 500 | 500
-   1 |   1
-(2 rows)
-
--- Multiple rows per array element
-INSERT INTO o_test_lockstep VALUES (1, 100), (1, 200), (1000, 100), (1000, 200);
-SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
-  a   |  b   
-------+------
- 1000 | 1000
- 1000 |  200
- 1000 |  100
-    1 |  200
-    1 |  100
-    1 |    1
-(6 rows)
-
--- Forward same query for comparison
-SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a, b;
-  a   |  b   
-------+------
-    1 |    1
-    1 |  100
-    1 |  200
- 1000 |  100
- 1000 |  200
- 1000 | 1000
-(6 rows)
-
--- Backward with LIMIT
-SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000)
-	ORDER BY a DESC, b DESC LIMIT 2;
-  a   |  b   
-------+------
- 1000 | 1000
- 1000 |  200
 (2 rows)
 
 DROP EXTENSION orioledb CASCADE;

--- a/test/expected/tableam.out
+++ b/test/expected/tableam.out
@@ -2184,9 +2184,10 @@ FROM query_to_text('EXPLAIN (ANALYZE TRUE, BUFFERS TRUE)
 -------------------------------------------------------------------------------------------------------
  Index Scan using o_tableamx_ixx on o_tableamx  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
    Index Cond: ((val > 'x'::text) AND (val < 'a'::text))
+   Index Searches: x
  Planning Time: x ms
  Execution Time: x ms
-(4 rows)
+(5 rows)
 
 DROP TABLE o_tableam5;
 CREATE TABLE o_tableam_delete1
@@ -4212,12 +4213,15 @@ FROM query_to_text('EXPLAIN (ANALYZE TRUE, BUFFERS TRUE) WITH src AS (
    ->  Hash Join  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
          Hash Cond: ((srcxid + x) = dstxid)
          ->  CTE Scan on src  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
+               Storage: Memory  Maximum Storage: xkB
          ->  Hash  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
                Buckets: x  Batches: x  Memory Usage: xkB
                ->  Seq Scan on o_tableam_explain_x dst  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
+ Planning:
+   Buffers: shared hit=x
  Planning Time: x ms
  Execution Time: x ms
-(14 rows)
+(17 rows)
 
 SELECT * FROM o_tableam_explain_1;
  id | val | val2 
@@ -4924,10 +4928,10 @@ CREATE INDEX o_test_1_idx ON o_test_1 (b, a);
 UPDATE o_test_1 SET b = '-0' WHERE b = '0';
 UPDATE o_test_1 SET a = '-0' WHERE a = '0';
 SET enable_seqscan = off;
-EXPLAIN SELECT * FROM o_test_1 ORDER BY b;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Index Only Scan using o_test_1_idx on o_test_1  (cost=0.13..4.16 rows=2 width=8)
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_1 ORDER BY b;
+                   QUERY PLAN                   
+------------------------------------------------
+ Index Only Scan using o_test_1_idx on o_test_1
 (1 row)
 
 SELECT * FROM o_test_1 ORDER BY b;
@@ -4997,6 +5001,58 @@ SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
 ------+------
  1000 | 1000
     1 |    1
+(2 rows)
+
+-- Backward IOS with 3-element IN list
+SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000) ORDER BY a DESC, b DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+  500 |  500
+    1 |    1
+(3 rows)
+
+-- Backward IOS with IN on both columns
+SELECT * FROM o_test_lockstep WHERE a in (1, 500) AND b in (1, 500)
+	ORDER BY a DESC, b DESC;
+  a  |  b  
+-----+-----
+ 500 | 500
+   1 |   1
+(2 rows)
+
+-- Multiple rows per array element
+INSERT INTO o_test_lockstep VALUES (1, 100), (1, 200), (1000, 100), (1000, 200);
+SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+ 1000 |  200
+ 1000 |  100
+    1 |  200
+    1 |  100
+    1 |    1
+(6 rows)
+
+-- Forward same query for comparison
+SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a, b;
+  a   |  b   
+------+------
+    1 |    1
+    1 |  100
+    1 |  200
+ 1000 |  100
+ 1000 |  200
+ 1000 | 1000
+(6 rows)
+
+-- Backward with LIMIT
+SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000)
+	ORDER BY a DESC, b DESC LIMIT 2;
+  a   |  b   
+------+------
+ 1000 | 1000
+ 1000 |  200
 (2 rows)
 
 DROP EXTENSION orioledb CASCADE;

--- a/test/expected/tableam_1.out
+++ b/test/expected/tableam_1.out
@@ -2184,10 +2184,9 @@ FROM query_to_text('EXPLAIN (ANALYZE TRUE, BUFFERS TRUE)
 -------------------------------------------------------------------------------------------------------
  Index Scan using o_tableamx_ixx on o_tableamx  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
    Index Cond: ((val > 'x'::text) AND (val < 'a'::text))
-   Index Searches: x
  Planning Time: x ms
  Execution Time: x ms
-(5 rows)
+(4 rows)
 
 DROP TABLE o_tableam5;
 CREATE TABLE o_tableam_delete1
@@ -4213,15 +4212,12 @@ FROM query_to_text('EXPLAIN (ANALYZE TRUE, BUFFERS TRUE) WITH src AS (
    ->  Hash Join  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
          Hash Cond: ((srcxid + x) = dstxid)
          ->  CTE Scan on src  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
-               Storage: Memory  Maximum Storage: xkB
          ->  Hash  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
                Buckets: x  Batches: x  Memory Usage: xkB
                ->  Seq Scan on o_tableam_explain_x dst  (cost=x rows=x width=x) (actual time=x rows=x loops=x)
- Planning:
-   Buffers: shared hit=x
  Planning Time: x ms
  Execution Time: x ms
-(17 rows)
+(14 rows)
 
 SELECT * FROM o_tableam_explain_1;
  id | val | val2 
@@ -4928,10 +4924,10 @@ CREATE INDEX o_test_1_idx ON o_test_1 (b, a);
 UPDATE o_test_1 SET b = '-0' WHERE b = '0';
 UPDATE o_test_1 SET a = '-0' WHERE a = '0';
 SET enable_seqscan = off;
-EXPLAIN SELECT * FROM o_test_1 ORDER BY b;
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Index Only Scan using o_test_1_idx on o_test_1  (cost=0.13..4.16 rows=2 width=8)
+EXPLAIN (COSTS OFF) SELECT * FROM o_test_1 ORDER BY b;
+                   QUERY PLAN                   
+------------------------------------------------
+ Index Only Scan using o_test_1_idx on o_test_1
 (1 row)
 
 SELECT * FROM o_test_1 ORDER BY b;
@@ -5001,6 +4997,58 @@ SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
 ------+------
  1000 | 1000
     1 |    1
+(2 rows)
+
+-- Backward IOS with 3-element IN list
+SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000) ORDER BY a DESC, b DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+  500 |  500
+    1 |    1
+(3 rows)
+
+-- Backward IOS with IN on both columns
+SELECT * FROM o_test_lockstep WHERE a in (1, 500) AND b in (1, 500)
+	ORDER BY a DESC, b DESC;
+  a  |  b  
+-----+-----
+ 500 | 500
+   1 |   1
+(2 rows)
+
+-- Multiple rows per array element
+INSERT INTO o_test_lockstep VALUES (1, 100), (1, 200), (1000, 100), (1000, 200);
+SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
+  a   |  b   
+------+------
+ 1000 | 1000
+ 1000 |  200
+ 1000 |  100
+    1 |  200
+    1 |  100
+    1 |    1
+(6 rows)
+
+-- Forward same query for comparison
+SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a, b;
+  a   |  b   
+------+------
+    1 |    1
+    1 |  100
+    1 |  200
+ 1000 |  100
+ 1000 |  200
+ 1000 | 1000
+(6 rows)
+
+-- Backward with LIMIT
+SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000)
+	ORDER BY a DESC, b DESC LIMIT 2;
+  a   |  b   
+------+------
+ 1000 | 1000
+ 1000 |  200
 (2 rows)
 
 DROP EXTENSION orioledb CASCADE;

--- a/test/expected/tableam_1.out
+++ b/test/expected/tableam_1.out
@@ -4928,10 +4928,10 @@ CREATE INDEX o_test_1_idx ON o_test_1 (b, a);
 UPDATE o_test_1 SET b = '-0' WHERE b = '0';
 UPDATE o_test_1 SET a = '-0' WHERE a = '0';
 SET enable_seqscan = off;
-EXPLAIN (COSTS OFF) SELECT * FROM o_test_1 ORDER BY b;
-                   QUERY PLAN                   
-------------------------------------------------
- Index Only Scan using o_test_1_idx on o_test_1
+EXPLAIN SELECT * FROM o_test_1 ORDER BY b;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Index Only Scan using o_test_1_idx on o_test_1  (cost=0.13..4.16 rows=2 width=8)
 (1 row)
 
 SELECT * FROM o_test_1 ORDER BY b;
@@ -5001,58 +5001,6 @@ SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
 ------+------
  1000 | 1000
     1 |    1
-(2 rows)
-
--- Backward IOS with 3-element IN list
-SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000) ORDER BY a DESC, b DESC;
-  a   |  b   
-------+------
- 1000 | 1000
-  500 |  500
-    1 |    1
-(3 rows)
-
--- Backward IOS with IN on both columns
-SELECT * FROM o_test_lockstep WHERE a in (1, 500) AND b in (1, 500)
-	ORDER BY a DESC, b DESC;
-  a  |  b  
------+-----
- 500 | 500
-   1 |   1
-(2 rows)
-
--- Multiple rows per array element
-INSERT INTO o_test_lockstep VALUES (1, 100), (1, 200), (1000, 100), (1000, 200);
-SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a DESC, b DESC;
-  a   |  b   
-------+------
- 1000 | 1000
- 1000 |  200
- 1000 |  100
-    1 |  200
-    1 |  100
-    1 |    1
-(6 rows)
-
--- Forward same query for comparison
-SELECT * FROM o_test_lockstep WHERE a in (1, 1000) ORDER BY a, b;
-  a   |  b   
-------+------
-    1 |    1
-    1 |  100
-    1 |  200
- 1000 |  100
- 1000 |  200
- 1000 | 1000
-(6 rows)
-
--- Backward with LIMIT
-SELECT * FROM o_test_lockstep WHERE a in (1, 500, 1000)
-	ORDER BY a DESC, b DESC LIMIT 2;
-  a   |  b   
-------+------
- 1000 | 1000
- 1000 |  200
 (2 rows)
 
 DROP EXTENSION orioledb CASCADE;

--- a/test/specs/parallel_idx_scan.spec
+++ b/test/specs/parallel_idx_scan.spec
@@ -1,0 +1,81 @@
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+	CREATE TABLE IF NOT EXISTS o_par_idx_scan (
+		id int4 NOT NULL,
+		val int4 NOT NULL,
+		PRIMARY KEY (id)
+	) USING orioledb;
+	CREATE INDEX IF NOT EXISTS o_par_idx_scan_val_ix ON o_par_idx_scan (val);
+	TRUNCATE o_par_idx_scan;
+	INSERT INTO o_par_idx_scan
+		SELECT i, i % 100 FROM generate_series(1, 10000) AS i;
+}
+
+teardown
+{
+	DROP TABLE o_par_idx_scan;
+}
+
+session "s1"
+step "s1_begin_rr" {
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; }
+step "s1_begin_rc" {
+	BEGIN ISOLATION LEVEL READ COMMITTED; }
+step "s1_insert" {
+	INSERT INTO o_par_idx_scan
+		SELECT i, i % 100 FROM generate_series(10001, 11000) AS i; }
+step "s1_update" {
+	UPDATE o_par_idx_scan SET val = val + 1000 WHERE id <= 500; }
+step "s1_delete" {
+	DELETE FROM o_par_idx_scan WHERE id BETWEEN 5001 AND 6000; }
+step "s1_commit" { COMMIT; }
+step "s1_rollback" { ROLLBACK; }
+
+session "s2"
+step "s2_setup" {
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 4; }
+step "s2_begin_rr" {
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; }
+step "s2_begin_rc" {
+	BEGIN ISOLATION LEVEL READ COMMITTED; }
+step "s2_count_all" {
+	SELECT count(*) FROM o_par_idx_scan; }
+step "s2_count_range" {
+	SELECT count(*) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 5000; }
+step "s2_count_val" {
+	SELECT count(*) FROM o_par_idx_scan WHERE val = 0; }
+step "s2_sum_val" {
+	SELECT sum(val) FROM o_par_idx_scan WHERE id BETWEEN 1 AND 1000; }
+step "s2_commit" { COMMIT; }
+
+# REPEATABLE READ: parallel scan sees snapshot taken at BEGIN
+permutation "s2_setup" "s2_begin_rr" "s2_count_all" "s1_insert" "s2_count_all" "s2_commit"
+permutation "s2_setup" "s2_begin_rr" "s2_count_all" "s1_delete" "s2_count_all" "s2_commit"
+permutation "s2_setup" "s2_begin_rr" "s2_count_all" "s1_update" "s2_count_all" "s2_commit"
+
+# REPEATABLE READ: parallel index range scan under concurrent DML
+permutation "s2_setup" "s2_begin_rr" "s2_count_range" "s1_insert" "s2_count_range" "s2_commit"
+permutation "s2_setup" "s2_begin_rr" "s2_count_range" "s1_delete" "s2_count_range" "s2_commit"
+permutation "s2_setup" "s2_begin_rr" "s2_count_range" "s1_update" "s2_count_range" "s2_commit"
+
+# REPEATABLE READ: parallel index scan on val column under DML
+permutation "s2_setup" "s2_begin_rr" "s2_count_val" "s1_update" "s2_count_val" "s2_commit"
+
+# READ COMMITTED: parallel scan sees committed changes mid-transaction
+permutation "s2_setup" "s2_begin_rc" "s2_count_all" "s1_begin_rc" "s1_insert" "s1_commit" "s2_count_all" "s2_commit"
+permutation "s2_setup" "s2_begin_rc" "s2_count_all" "s1_begin_rc" "s1_delete" "s1_commit" "s2_count_all" "s2_commit"
+permutation "s2_setup" "s2_begin_rc" "s2_count_all" "s1_begin_rc" "s1_update" "s1_commit" "s2_count_all" "s2_commit"
+
+# READ COMMITTED: parallel scan does NOT see rolled-back changes
+permutation "s2_setup" "s2_begin_rc" "s2_count_all" "s1_begin_rc" "s1_insert" "s1_rollback" "s2_count_all" "s2_commit"
+
+# REPEATABLE READ: parallel scan with index sum under update
+permutation "s2_setup" "s2_begin_rr" "s2_sum_val" "s1_update" "s2_sum_val" "s2_commit"
+
+# Concurrent parallel scans from two sessions
+permutation "s1_begin_rr" "s2_setup" "s2_begin_rr" "s2_count_all" "s1_insert" "s2_count_all" "s1_commit" "s2_commit"

--- a/test/specs/parallel_ordered_scan.spec
+++ b/test/specs/parallel_ordered_scan.spec
@@ -1,0 +1,107 @@
+# Parallel ordered (key-order) index scan under concurrency.
+#
+# The scanning session pauses a parallel ordered scan in the middle of reading
+# an on-disk leaf (the scan_disk_page stop event, which every backend -- leader
+# included -- hits independently while reading evicted leaves inline in key
+# order).  While it is parked, the other session mutates the very range being
+# scanned -- inserting (page splits), deleting (merges), updating, checkpoint,
+# re-eviction -- and only then releases the scan.  The resumed scan must still
+# return its snapshot-consistent result in exact key order, proving the ordered
+# walk (backward re-descent by low key, cooperative double-buffering, undo-based
+# snapshot reads) survives the tree changing shape underneath it.
+#
+# An always-true but per-row-expensive sqrt() filter makes the parallel ordered
+# path win over the naturally-ordered serial index scan, so the planner picks
+# Gather Merge deterministically.
+
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+	CREATE TABLE IF NOT EXISTS o_ord (
+		id int8 NOT NULL,
+		val int8 NOT NULL,
+		PRIMARY KEY (id)
+	) USING orioledb;
+	TRUNCATE o_ord;
+	INSERT INTO o_ord SELECT i, i % 97 FROM generate_series(1, 60000) i;
+	ANALYZE o_ord;
+	CHECKPOINT;
+	SELECT orioledb_evict_pages('o_ord'::regclass::oid, 0);
+}
+
+teardown
+{
+	DROP TABLE o_ord;
+}
+
+# --- scanning session -------------------------------------------------------
+session "s1"
+step "s1_setup" {
+	SET orioledb.enable_stopevents = true;
+	SET enable_seqscan = off;
+	SET enable_bitmapscan = off;
+	SET parallel_setup_cost = 0;
+	SET parallel_tuple_cost = 0;
+	SET min_parallel_table_scan_size = 0;
+	SET min_parallel_index_scan_size = 0;
+	SET max_parallel_workers_per_gather = 3; }
+step "s1_begin_rr" { BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; }
+step "s1_begin_rc" { BEGIN ISOLATION LEVEL READ COMMITTED; }
+# Backward ordered scan: parks on the first on-disk leaf, resumes after reset.
+step "s1_scan_desc" {
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) o) t; }
+# Forward ordered scan.
+step "s1_scan_asc" {
+	SELECT count(*), min(id), max(id),
+		(count(*) = count(*) FILTER (WHERE prev IS NULL OR id >= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_ord
+			WHERE id BETWEEN 5000 AND 25000 AND sqrt(val::float8) >= 0
+			ORDER BY id) o) t; }
+step "s1_commit" { COMMIT; }
+
+# --- controller / modifier session ------------------------------------------
+session "s2"
+step "s2_arm" {
+	SELECT pg_stopevent_set('scan_disk_page', 'true'); }
+# Insert into the scanned range -> page splits under the parked scan.
+step "s2_insert_mid" {
+	INSERT INTO o_ord SELECT i, i % 97
+		FROM generate_series(1000000, 1030000) i
+		WHERE i % 3 = 0; }
+# Delete a big chunk of the scanned range -> merges under the parked scan.
+step "s2_delete_mid" {
+	DELETE FROM o_ord WHERE id BETWEEN 8000 AND 20000; }
+# Move rows via update (val is filtered on, id is the scan key).
+step "s2_update" {
+	UPDATE o_ord SET val = val + 1 WHERE id BETWEEN 5000 AND 25000; }
+step "s2_checkpoint" { CHECKPOINT; }
+step "s2_evict" {
+	SELECT orioledb_evict_pages('o_ord'::regclass::oid, 0); }
+step "s2_reset" {
+	SELECT pg_stopevent_reset('scan_disk_page'); }
+
+# REPEATABLE READ: paused backward scan is unaffected by concurrent inserts
+# (page splits) committed while it is parked.
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan_desc" "s2_insert_mid" "s2_checkpoint" "s2_reset" "s1_commit"
+
+# REPEATABLE READ: paused backward scan unaffected by concurrent deletes (merges).
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan_desc" "s2_delete_mid" "s2_checkpoint" "s2_reset" "s1_commit"
+
+# REPEATABLE READ: paused backward scan unaffected by concurrent update + re-eviction.
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan_desc" "s2_update" "s2_evict" "s2_reset" "s1_commit"
+
+# REPEATABLE READ: forward scan, concurrent insert + delete + checkpoint.
+permutation "s2_arm" "s1_setup" "s1_begin_rr" "s1_scan_asc" "s2_insert_mid" "s2_delete_mid" "s2_checkpoint" "s2_reset" "s1_commit"
+
+# READ COMMITTED: the scan's snapshot is fixed at statement start, so a commit
+# landing while it is parked is still not visible; result stays consistent.
+permutation "s2_arm" "s1_setup" "s1_begin_rc" "s1_scan_desc" "s2_delete_mid" "s2_reset" "s1_commit"
+
+# Autocommit (no explicit BEGIN): paused backward scan + concurrent update.
+permutation "s2_arm" "s1_setup" "s1_scan_desc" "s2_update" "s2_checkpoint" "s2_reset"

--- a/test/sql/indices.sql
+++ b/test/sql/indices.sql
@@ -2493,6 +2493,26 @@ DROP TABLE o_test_skip_bounded;
 
 \endif
 
+-- A backward scan over an array (SAOP) key must cover every element, not just
+-- the one the forward scan would start at.
+CREATE TABLE o_test_array_backward (
+	a int NOT NULL,
+	b int NOT NULL
+) USING orioledb;
+CREATE INDEX o_test_array_backward_idx ON o_test_array_backward(a);
+INSERT INTO o_test_array_backward SELECT a, a FROM generate_series(1, 1000) a;
+ANALYZE o_test_array_backward;
+
+SET enable_seqscan = OFF;
+SET enable_bitmapscan = OFF;
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+SELECT a FROM o_test_array_backward WHERE a IN (1, 500, 1000) ORDER BY a DESC;
+SELECT a FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a;
+SELECT a, b FROM o_test_array_backward WHERE a IN (1, 1000) ORDER BY a DESC;
+RESET enable_bitmapscan;
+RESET enable_seqscan;
+DROP TABLE o_test_array_backward;
+
 SELECT orioledb_parallel_debug_stop();
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA indices CASCADE;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -133,6 +133,7 @@ RESET min_parallel_table_scan_size;
 RESET parallel_leader_participation;
 
 BEGIN;
+SET LOCAL enable_indexonlyscan = off;
 CREATE TABLE o_test_parallel_bitmap_scan (
 	val_1 int
 ) USING orioledb;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -616,6 +616,77 @@ DROP TABLE o_test1;
 DROP TABLE o_test2;
 COMMIT;
 
+-- Parallel ordered (key-order) index scan: forward and backward.  An ordered
+-- path reads on-disk downlinks inline so each worker emits a sorted stream that
+-- Gather Merge combines; ORDER BY / ORDER BY DESC should use Gather Merge, and
+-- the result must match the serial scan exactly.
+BEGIN;
+CREATE TABLE o_test_ordered_scan (
+	id int8 PRIMARY KEY,
+	val int8
+) USING orioledb;
+INSERT INTO o_test_ordered_scan
+	SELECT g, g % 777 FROM generate_series(1, 60000) g;
+ANALYZE o_test_ordered_scan;
+
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 0;
+SET LOCAL min_parallel_index_scan_size = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+-- An always-true but per-row-expensive filter (sqrt) makes the parallel
+-- ordered path cheaper than the naturally-ordered serial index scan, so the
+-- planner picks Gather Merge deterministically.
+
+-- Plan shape: ORDER BY ascending uses Gather Merge over a forward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id;
+
+-- Plan shape: ORDER BY DESC uses Gather Merge over a backward scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC;
+
+-- Correctness: ascending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id >= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id) s) t;
+
+-- Correctness: descending output is fully sorted and matches serial
+SELECT count(*), min(id), max(id),
+	(count(*) = count(*) FILTER (WHERE prev IS NULL OR id <= prev)) AS sorted
+	FROM (SELECT id, lag(id) OVER () AS prev FROM (
+		SELECT id FROM o_test_ordered_scan
+			WHERE id BETWEEN 10000 AND 50000 AND sqrt(val::float8) >= 0
+			ORDER BY id DESC) s) t;
+
+-- Serial vs parallel equivalence (descending), whole ordered vector
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id) AS serial_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SELECT array_agg(id) AS parallel_desc FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE id BETWEEN 990 AND 1010 AND sqrt(val::float8) >= 0
+		ORDER BY id DESC) s;
+
+-- Full ordered scan (no range), descending
+SELECT count(*), min(id), max(id) FROM (
+	SELECT id FROM o_test_ordered_scan
+		WHERE sqrt(val::float8) >= 0 ORDER BY id DESC) s;
+COMMIT;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA parallel_scan CASCADE;
 RESET search_path;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -397,35 +397,6 @@ SELECT * FROM o_test_parallel_join
 COMMIT;
 
 BEGIN;
-CREATE TABLE o_test_no_parallel_index_scan (
-  val_1 INT PRIMARY KEY,
-  val_2 text
-) USING orioledb;
-
-INSERT INTO o_test_no_parallel_index_scan VALUES (1, 'a'), (2, 'b');
-
-SET LOCAL max_parallel_workers_per_gather = 1;
-SET LOCAL parallel_setup_cost = 0;
-SET LOCAL parallel_tuple_cost = 0;
-SET LOCAL min_parallel_table_scan_size = 1;
-SET LOCAL min_parallel_index_scan_size = 1;
-SET LOCAL enable_seqscan = off;
-SET LOCAL enable_bitmapscan = off;
-
--- Parallel Index Only Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF) SELECT val_1 FROM o_test_no_parallel_index_scan;
-SELECT val_1 FROM o_test_no_parallel_index_scan;
-SET LOCAL enable_indexonlyscan = off;
--- Parallel Index Scan is not implemented yet, so it doesn't used here
-EXPLAIN (COSTS OFF)
-	SELECT array_agg(val_1), array_agg(val_2)
-		FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
-SELECT array_agg(val_1), array_agg(val_2)
-	FROM o_test_no_parallel_index_scan WHERE val_1 > 0;
-
-COMMIT;
-
-BEGIN;
 
 SET LOCAL parallel_setup_cost = 0;
 SET LOCAL min_parallel_table_scan_size = 1;
@@ -455,6 +426,169 @@ COMMIT;
 
 BEGIN;
 
+-- Parallel index range scan on primary index
+CREATE TABLE o_test_parallel_index_range (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+
+INSERT INTO o_test_parallel_index_range (val, name)
+	SELECT g, 'name_' || g FROM generate_series(1, 100000) g;
+
+CREATE INDEX o_test_parallel_index_range_val_idx
+	ON o_test_parallel_index_range (val);
+
+ANALYZE o_test_parallel_index_range;
+
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+-- Range scan on primary key
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range
+		WHERE id BETWEEN 1000 AND 5000;
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE id BETWEEN 1000 AND 5000;
+
+-- Range scan: serial vs parallel equivalence
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_count
+	FROM o_test_parallel_index_range WHERE id BETWEEN 1000 AND 5000;
+
+-- Parallel index scan with aggregation on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 50000;
+
+-- Serial vs parallel equivalence on primary index range
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE id BETWEEN 990 AND 1010;
+
+-- Plan shape: primary index range scan
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_index_range WHERE id > 50000;
+
+-- Plan shape: index-only scan on secondary index
+EXPLAIN (COSTS OFF)
+	SELECT val FROM o_test_parallel_index_range
+		WHERE val BETWEEN 100 AND 200;
+
+-- Plan shape: full index scan
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_parallel_index_range;
+
+-- Edge case: empty result set
+SELECT count(*) FROM o_test_parallel_index_range
+	WHERE val BETWEEN 999900 AND 999999;
+
+-- Edge case: single row result
+SELECT id, val FROM o_test_parallel_index_range WHERE id = 42;
+
+-- Edge case: full table scan via index
+SELECT count(*) FROM o_test_parallel_index_range WHERE val > 0;
+
+-- Filter on non-index column: serial vs parallel equivalence
+-- Tests that generic Filter conditions (not convertible to scan keys)
+-- are correctly applied in parallel index scans
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_filter_count
+	FROM o_test_parallel_index_range WHERE val > 0 AND id > 50000;
+
+-- Parallel index scan with ORDER BY
+SELECT count(*) FROM (
+	SELECT id FROM o_test_parallel_index_range
+		WHERE val BETWEEN 1000 AND 2000 ORDER BY id
+) sub;
+
+-- Secondary index parallel scan: index-only
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_val_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+
+-- Secondary index parallel scan: full row lookup
+SET LOCAL enable_indexonlyscan = off;
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_full_count
+	FROM o_test_parallel_index_range WHERE val BETWEEN 1000 AND 2000;
+
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT array_agg(id ORDER BY id) AS serial_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT array_agg(id ORDER BY id) AS parallel_ids
+	FROM o_test_parallel_index_range WHERE val BETWEEN 990 AND 1010;
+
+DROP TABLE o_test_parallel_index_range;
+
+-- Parallel index scan with SAOP (ScalarArrayOpExpr) on secondary index
+-- Uses repeating val values (low cardinality) so planner picks parallel
+CREATE TABLE o_test_parallel_saop (
+	id SERIAL PRIMARY KEY,
+	val INT,
+	name TEXT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop (val, name)
+	SELECT (g % 100) + 1, 'name_' || g FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_val_idx
+	ON o_test_parallel_saop (val);
+ANALYZE o_test_parallel_saop;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+-- SAOP literal IN-list: plan shape
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop
+		WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+-- SAOP literal IN-list: parallel result
+SELECT count(*) FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+-- SAOP literal IN-list: serial result
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+
+-- SAOP with full row lookup through secondary index
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL max_parallel_workers_per_gather = 2;
+SELECT count(*) AS parallel_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_full FROM o_test_parallel_saop
+	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+
+DROP TABLE o_test_parallel_saop;
+
+COMMIT;
+
+BEGIN;
 CREATE TABLE o_test1(i int, t text) USING orioledb;
 CREATE TABLE o_test2(i int, t text) USING orioledb;
 INSERT INTO o_test1 SELECT x, repeat('a', 500) FROM generate_series(1,10) as x;

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -575,6 +575,44 @@ SET LOCAL max_parallel_workers_per_gather = 0;
 SELECT count(*) AS serial_saop_count FROM o_test_parallel_saop
 	WHERE val IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
 
+-- Sparse SAOP list: the union range between the smallest and the largest
+-- element covers the whole index, so the scan has to reject the leaves that
+-- hold no element rather than read and filter them.
+CREATE TABLE o_test_parallel_saop_sparse (
+	id SERIAL PRIMARY KEY,
+	val INT
+) USING orioledb;
+INSERT INTO o_test_parallel_saop_sparse (val)
+	SELECT (g % 10) + 1 FROM generate_series(1, 100000) g;
+CREATE INDEX o_test_parallel_saop_sparse_idx
+	ON o_test_parallel_saop_sparse (val);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+SELECT count(*) AS parallel_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_sparse FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+
+-- The same on a DESC index: elements are ordered the other way round, so the
+-- page-level membership test has to compare in index order.
+DROP INDEX o_test_parallel_saop_sparse_idx;
+CREATE INDEX o_test_parallel_saop_sparse_desc_idx
+	ON o_test_parallel_saop_sparse (val DESC);
+ANALYZE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+EXPLAIN (COSTS OFF)
+	SELECT count(*) FROM o_test_parallel_saop_sparse WHERE val IN (1, 10);
+SELECT count(*) AS parallel_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+SET LOCAL max_parallel_workers_per_gather = 0;
+SELECT count(*) AS serial_saop_desc FROM o_test_parallel_saop_sparse
+	WHERE val IN (1, 10);
+DROP TABLE o_test_parallel_saop_sparse;
+SET LOCAL max_parallel_workers_per_gather = 2;
+
 -- SAOP with full row lookup through secondary index
 SET LOCAL enable_indexonlyscan = off;
 SET LOCAL max_parallel_workers_per_gather = 2;

--- a/test/t/parallel_ordered_scan_test.py
+++ b/test/t/parallel_ordered_scan_test.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+# Parallel ordered (key-order) index scan under concurrency, driven with stop
+# events for precise timing.
+#
+# Each scenario parks a parallel ordered scan in the middle of the tree walk
+# (reading an on-disk leaf, or descending during the backward re-descent) and,
+# while it is parked, mutates the exact range being scanned from another
+# connection -- page splits, merges, updates, checkpoints, re-eviction -- before
+# releasing it.  The resumed scan must return its snapshot's rows in the exact
+# key order, compared element-for-element against a reference vector captured
+# before the mutation.  This exercises the backward re-descent by low key, the
+# cooperative double-buffered internal-page walk and undo-based snapshot reads
+# while the physical tree changes shape underneath the scan.
+
+import unittest
+
+from .base_test import BaseTest
+from .base_test import ThreadQueryExecutor
+
+# An always-true but per-row-expensive filter makes the parallel ordered path
+# cheaper than the naturally-ordered serial index scan, so the planner picks
+# Gather Merge deterministically.
+FILTER = "sqrt(val::float8) >= 0"
+LO, HI = 2000, 8000
+NROWS = 15000
+
+
+class ParallelOrderedScanTest(BaseTest):
+
+	def setUp(self):
+		super().setUp()
+		# NB: stop events are enabled per-connection in the scanner only, so
+		# that the mutating connection never parks on the same event.
+		self.node.append_conf(
+		    'postgresql.conf', "max_worker_processes = 16\n"
+		    "max_parallel_workers = 16\n"
+		    "orioledb.main_buffers = 8MB\n")
+		self.node.start()
+		self.node.safe_psql('postgres',
+		                    "CREATE EXTENSION IF NOT EXISTS orioledb;")
+
+	def _load(self):
+		self.node.safe_psql(
+		    'postgres', f"""
+			DROP TABLE IF EXISTS o_ord;
+			CREATE TABLE o_ord (
+				id int8 NOT NULL,
+				val int8 NOT NULL,
+				PRIMARY KEY (id)
+			) USING orioledb;
+			INSERT INTO o_ord SELECT i, i % 97 FROM generate_series(1, {NROWS}) i;
+			ANALYZE o_ord;
+			CHECKPOINT;
+		""")
+
+	def _evict(self):
+		# Push all leaves to disk so the scan reads them (and hits
+		# scan_disk_page).  Must run right before the scan: reading the table
+		# for any reason (ANALYZE, the reference query) reloads pages into the
+		# in-memory pool.
+		self.node.safe_psql(
+		    'postgres',
+		    "SELECT orioledb_evict_pages('o_ord'::regclass::oid, 0);")
+
+	def _scan_setup(self, con):
+		con.execute("SET orioledb.enable_stopevents = true;")
+		con.execute("SET enable_seqscan = off;")
+		con.execute("SET enable_bitmapscan = off;")
+		con.execute("SET parallel_setup_cost = 0;")
+		con.execute("SET parallel_tuple_cost = 0;")
+		con.execute("SET min_parallel_table_scan_size = 0;")
+		con.execute("SET min_parallel_index_scan_size = 0;")
+		con.execute("SET max_parallel_workers_per_gather = 3;")
+
+	def _scan_sql(self, desc):
+		return (f"SELECT id FROM o_ord "
+		        f"WHERE id BETWEEN {LO} AND {HI} AND {FILTER} "
+		        f"ORDER BY id %s" % ("DESC" if desc else "ASC"))
+
+	def _reference(self, desc):
+		# Ordered id vector of the pre-mutation committed state.
+		rows = self.node.execute(
+		    'postgres', f"SELECT id FROM o_ord WHERE id BETWEEN {LO} AND {HI} "
+		    f"AND {FILTER} ORDER BY id %s" % ("DESC" if desc else "ASC"))
+		return [r[0] for r in rows]
+
+	def _assert_parallel_plan(self, con, desc):
+		plan = "\n".join(r[0] for r in con.execute("EXPLAIN (COSTS OFF) " +
+		                                           self._scan_sql(desc)))
+		self.assertIn("Gather Merge", plan)
+		self.assertIn("Parallel Custom Scan", plan)
+
+	def _wait_any_parked(self, ctrl_con, event, timeout=60):
+		import time
+		deadline = time.time() + timeout
+		while True:
+			r = ctrl_con.execute(
+			    "SELECT coalesce(array_length(waiter_pids, 1), 0) "
+			    "FROM pg_stopevents() WHERE stopevent = '%s';" % event)
+			if r and r[0][0] and r[0][0] > 0:
+				return
+			if time.time() > deadline:
+				raise AssertionError("no backend parked on %s" % event)
+			time.sleep(0.05)
+
+	# Core driver: park an ordered scan at `event`, run `mutate(dml_con)` while
+	# it is parked, release it, and assert the result equals the pre-mutation
+	# ordered reference vector.
+	def _run_parked(self, desc, event, condition, mutate):
+		node = self.node
+		self._load()
+		reference = self._reference(desc)
+		self.assertGreater(len(reference), 3000)
+
+		scan_con = node.connect()
+		ctrl_con = node.connect()
+		dml_con = node.connect()
+		try:
+			self._scan_setup(scan_con)
+			self._assert_parallel_plan(scan_con, desc)
+
+			# Re-evict AFTER the reference query / plan check reloaded pages,
+			# so the parked scan actually reads from disk.
+			self._evict()
+			ctrl_con.execute("SELECT pg_stopevent_set('%s', '%s');" %
+			                 (event, condition))
+
+			scan = ThreadQueryExecutor(scan_con, self._scan_sql(desc))
+			scan.start()
+			try:
+				self._wait_any_parked(ctrl_con, event)
+				# The scan must still be running (genuinely parked), otherwise
+				# the mutation would not be concurrent with it.
+				self.assertTrue(scan.is_alive())
+				mutate(dml_con)
+			finally:
+				ctrl_con.execute("SELECT pg_stopevent_reset('%s');" % event)
+
+			rows = scan.join()
+			result = [r[0] for r in rows]
+			self.assertEqual(result, reference)
+			# Persist the mutations so the post-run integrity check sees the
+			# mutated tree (testgres connections are not autocommit).
+			dml_con.commit()
+		finally:
+			scan_con.close()
+			ctrl_con.close()
+			dml_con.close()
+
+		# Independent structural check, on a fresh connection after the working
+		# transactions have released their locks.
+		self.assertEqual(
+		    node.execute('postgres',
+		                 "SELECT orioledb_tbl_check('o_ord'::regclass)")[0][0],
+		    True)
+
+	# --- scenarios ----------------------------------------------------------
+
+	# Backward scan parked on the first on-disk leaf; concurrent inserts into the
+	# scanned range split pages, then a checkpoint + re-eviction rewrites them.
+	def test_backward_survives_splits(self):
+
+		def mutate(con):
+			con.execute(
+			    "INSERT INTO o_ord SELECT i, i %% 97 FROM "
+			    "generate_series(1000000, 1020000) i WHERE i %% 2 = 0;")
+			con.execute("CHECKPOINT;")
+			con.execute(
+			    "SELECT orioledb_evict_pages('o_ord'::regclass::oid, 0);")
+
+		self._run_parked(True, 'scan_disk_page', 'true', mutate)
+
+	# Backward scan parked; concurrent deletes across the scanned range merge
+	# pages under it.
+	def test_backward_survives_merges(self):
+
+		def mutate(con):
+			con.execute("DELETE FROM o_ord WHERE id BETWEEN 3000 AND 6000;")
+			con.execute("CHECKPOINT;")
+
+		self._run_parked(True, 'scan_disk_page', 'true', mutate)
+
+	# Forward scan parked; a mix of insert (splits), delete (merges), update and
+	# checkpoint all land while it is parked.
+	def test_forward_survives_mixed(self):
+
+		def mutate(con):
+			con.execute("INSERT INTO o_ord SELECT i, i %% 97 FROM "
+			            "generate_series(1000000, 1020000) i;")
+			con.execute("DELETE FROM o_ord WHERE id BETWEEN 3000 AND 4000;")
+			con.execute("UPDATE o_ord SET val = val + 1 "
+			            "WHERE id BETWEEN 5000 AND 6000;")
+			con.execute("CHECKPOINT;")
+			con.execute(
+			    "SELECT orioledb_evict_pages('o_ord'::regclass::oid, 0);")
+
+		self._run_parked(False, 'scan_disk_page', 'true', mutate)
+
+	# Two parallel ordered scans (ascending and descending) parked at once;
+	# cross DML lands while both are parked, then both are released together.
+	def test_two_concurrent_scans(self):
+		node = self.node
+		self._load()
+		ref_desc = self._reference(True)
+		ref_asc = self._reference(False)
+
+		desc_con = node.connect()
+		asc_con = node.connect()
+		ctrl_con = node.connect()
+		dml_con = node.connect()
+		try:
+			self._scan_setup(desc_con)
+			self._scan_setup(asc_con)
+			self._evict()
+			ctrl_con.execute(
+			    "SELECT pg_stopevent_set('scan_disk_page', 'true');")
+
+			desc_scan = ThreadQueryExecutor(desc_con, self._scan_sql(True))
+			asc_scan = ThreadQueryExecutor(asc_con, self._scan_sql(False))
+			desc_scan.start()
+			asc_scan.start()
+			try:
+				# Wait until both scans have parked (>= 2 distinct waiters).
+				import time
+				deadline = time.time() + 60
+				while True:
+					n = ctrl_con.execute(
+					    "SELECT coalesce(array_length(waiter_pids, 1), 0) "
+					    "FROM pg_stopevents() "
+					    "WHERE stopevent = 'scan_disk_page';")[0][0]
+					if n and n >= 2:
+						break
+					self.assertLess(time.time(), deadline,
+					                "scans did not both park")
+					time.sleep(0.05)
+				self.assertTrue(desc_scan.is_alive() and asc_scan.is_alive())
+				dml_con.execute("INSERT INTO o_ord SELECT i, i %% 97 FROM "
+				                "generate_series(1000000, 1020000) i;")
+				dml_con.execute(
+				    "DELETE FROM o_ord WHERE id BETWEEN 3000 AND 6000;")
+				dml_con.execute("CHECKPOINT;")
+			finally:
+				ctrl_con.execute(
+				    "SELECT pg_stopevent_reset('scan_disk_page');")
+
+			got_desc = [r[0] for r in desc_scan.join()]
+			got_asc = [r[0] for r in asc_scan.join()]
+			self.assertEqual(got_desc, ref_desc)
+			self.assertEqual(got_asc, ref_asc)
+		finally:
+			desc_con.close()
+			asc_con.close()
+			ctrl_con.close()
+			dml_con.close()
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -455,6 +455,7 @@ class ReplicationTest(BaseTest):
 			    "checkpoint_timeout = 86400\n"
 			    "max_wal_size = 1GB\n"
 			    "enable_seqscan = off\n"
+			    "max_parallel_workers_per_gather = 0\n"
 			    "orioledb.recovery_pool_size = 1\n"
 			    "orioledb.debug_disable_bgwriter = true\n")
 			master.start()


### PR DESCRIPTION
Re-creation of #863 (author @fatih-akatlar). #1010 is merged, so this now sits directly on `main`.

**History reworked for review.** The original 22-commit history is preserved unchanged at `parallel-index-scan-on-rewind-orig-20260817`; the tree it produced was verified byte-identical to the reworked one before the rebase (same tree hash `f10e0015`), and the diff against `main` is the same 30 files / +4559 / -890.

Five commits now, in review order:

1. **Fix index-only scan cost estimation by setting allvisfrac to 1** — independent of everything else, but it moves plans, which is why so many expected outputs change.
2. **Fix backward array (SAOP) index scan dropping all but the smallest element** — an independent bug fix that was buried mid-branch.
3. **Add parallel index scan support** — the core, with the range-filtering and `fullyInRange` refinements folded in.
4. **Parallel ordered index scan** — forward and backward, lokey derivation at arbitrary depth, cost-based path selection.
5. **Regenerate expected outputs** — PG16/PG17 variants, no code.

Three sequences of pure churn were collapsed rather than replayed, since a reviewer should not have to read a change and then its undo:

- `_bt_preprocess_keys()` in `o_rescan_custom_scan()` was added by the parallel-scan commit and removed ten commits later; it is now simply never added, and only the comment explaining why it must not be called remains.
- `orioledb.debug_parallel_ordered_scan` was added and then removed; net zero in `include/orioledb.h`.
- The serial ordered scan engine and its debug SRF were added and then removed; net zero in `src/tableam/func.c` and `sql/orioledb--1.8--1.9_dev.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)