### PR TITLE
Fix index-descriptor lifecycle crashes and an uninterruptible modify hang

### DIFF
--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -120,6 +120,19 @@ struct OIndexDescr
 	int			refcnt;
 	bool		valid;
 
+	/*
+	 * Set while get_index_descr() is (re)filling this cache entry.  Between
+	 * HASH_ENTER and o_index_fill_descr() the entry is not yet initialized (a
+	 * fresh dynahash slot still holds a previously-freed descriptor's stale
+	 * pointers), and o_indices_get_extended() can run
+	 * AcceptInvalidationMessages -> o_invalidate_descrs() reentrantly.
+	 * o_invalidate_descrs_internal() skips entries with this flag so it never
+	 * frees a half-built descriptor (which would FreeTupleDesc() a stale
+	 * leafTupdesc and corrupt/double-free the shared descrCxt chunk). Cleared
+	 * by reset_filling_descrs() on error.
+	 */
+	bool		fill_in_progress;
+
 	BTreeDescr	desc;
 
 	/* Name of the index */
@@ -276,6 +289,8 @@ struct OTableDescr
 	/* number of unique trees */
 	int			nUniqueIndices;
 	bool		noInvalidation;
+	/* see OIndexDescr.fill_in_progress -- same guard for the table entry */
+	bool		fill_in_progress;
 };
 
 typedef struct
@@ -369,6 +384,7 @@ extern void o_invalidate_comparator_callback(UndoLogType undoType, UndoLocation 
 											 OXid oxid, OUndoCallbackStage stage,
 											 bool changeCountsValid);
 extern void reset_saving_inval_messages(void);
+extern void reset_filling_descrs(void);
 
 extern void ResourceOwnerRememberOTableDescr(ResourceOwner owner, OTableDescr *descr);
 extern void ResourceOwnerForgetOTableDescr(ResourceOwner owner, OTableDescr *descr);

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -158,6 +158,24 @@ o_btree_modify_internal(OBTreeFindPageContext *pageFindContext,
 
 retry:
 
+	/*
+	 * Keep the modify retry loop interruptible.  A row-lock conflict against
+	 * a concurrent transaction can livelock here:
+	 * o_btree_modify_handle_conflicts() returns ConflictResolutionRetry --
+	 * e.g. a committed/aborted lock-only undo record that has not yet been
+	 * removed from the chain -- and we loop with the leaf page-content lock
+	 * held and without waiting, at 100% CPU.  Without an interrupt check that
+	 * spin is uninterruptible: a query cancel / statement_timeout can't break
+	 * it and it runs until the job/step timeout. CHECK_FOR_INTERRUPTS() is
+	 * safe here even under the page lock -- page locks don't hold off
+	 * interrupts, and orioledb_error_cleanup_hook() releases all held page
+	 * locks on the resulting error, which also breaks the page-lock vs.
+	 * apply_undo_stack() deadlock the STOPEVENT below documents.  It is a
+	 * no-op inside critical sections (the actual page mutation happens
+	 * later).
+	 */
+	CHECK_FOR_INTERRUPTS();
+
 	context.needsUndo = desc->undoType != UndoLogNone;
 	if (!(callbackInfo && callbackInfo->needsUndoForSelfCreated) &&
 		OXidIsValid(desc->createOxid) &&
@@ -1251,6 +1269,14 @@ o_btree_insert_unique(BTreeDescr *desc, OTuple tuple, BTreeKeyType tupleType,
 	Assert(findResult == OFindPageResultSuccess);
 
 retry:
+
+	/*
+	 * Interruptible for the same reason as o_btree_modify_internal()'s retry
+	 * loop: the unique-check path also retries under a row-lock conflict (the
+	 * wait_for_oxid() paths below), and must remain cancellable.  Safe under
+	 * the page lock -- see the note there.
+	 */
+	CHECK_FOR_INTERRUPTS();
 
 	fastpath = false;
 	found_but_insert = false;

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -163,8 +163,13 @@ oIndicesFetchCallback(OTuple tuple, OXid tupOxid, OSnapshot *oSnapshot,
 	OIndexChunkKey *tupleKey = (OIndexChunkKey *) tuple.data;
 	OIndexChunkBoundKey *boundKey = (OIndexChunkBoundKey *) arg;
 
-	/* Ignore reloid because it may changes */
+	/*
+	 * reloid must match: relfilenumbers are reused, so a differing reloid on
+	 * the same (datoid, relnode) means a DIFFERENT relation took over that
+	 * relnode after a drop -- exactly the collision we must not resolve to.
+	 */
 	if (tupleKey->oids.datoid == boundKey->key.oids.datoid &&
+		tupleKey->oids.reloid == boundKey->key.oids.reloid &&
 		tupleKey->oids.relnode == boundKey->key.oids.relnode &&
 		tupleKey->oids.spcoid == boundKey->key.oids.spcoid &&
 		tupleKey->type == boundKey->key.type)

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -2039,6 +2039,7 @@ orioledb_error_cleanup_hook(void)
 		s3_headers_error_cleanup();
 	in_nontransactional_truncate = false;
 	reset_saving_inval_messages();
+	reset_filling_descrs();
 }
 
 static void

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -1498,6 +1498,25 @@ get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchCon
 
 	existed = found;
 
+	if (!found)
+	{
+		/*
+		 * A fresh HASH_ENTER slot carries a previously-freed descriptor's
+		 * stale pointers (dynahash does not zero the value part).  If the
+		 * (re)fill below errors before o_index_fill_descr() memset()s the
+		 * descriptor -- e.g. o_indices_get_extended() longjmps -- the
+		 * error-cleanup hook only clears fill_in_progress and leaves this
+		 * entry in the hash.  A later o_invalidate_descrs() would then treat
+		 * those stale tupdesc pointers as live and FreeTupleDesc() them,
+		 * corrupting memory or crashing the checkpointer on a MAXALIGN
+		 * assert.  Zero the slot now (restoring the hash key) so such a
+		 * half-built entry is safe: all freeable pointers are NULL and refcnt
+		 * is 0.
+		 */
+		memset(result, 0, sizeof(*result));
+		result->oids = ixOids;
+	}
+
 	/*
 	 * The descriptor cache is keyed by (datoid, reloid, relnode) only, but
 	 * the tablespace (ORelOids.spcoid) is now part of the tree identity (file

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -105,6 +105,15 @@ typedef struct DeferredDescrInvalidation
 static bool saving_inval_messages = false;
 static List *saved_descr_invals = NIL;
 
+/*
+ * Descriptors currently being (re)filled by get_index_descr() /
+ * get_table_descr().  o_invalidate_descrs_internal() skips them so a reentrant
+ * invalidation never frees a half-built entry; reset_filling_descrs() clears
+ * the flag on transaction abort (called from the orioledb error-cleanup hook).
+ */
+static OIndexDescr *filling_index_descr = NULL;
+static OTableDescr *filling_table_descr = NULL;
+
 
 struct OComparatorKey
 {
@@ -911,6 +920,7 @@ create_table_descr(ORelOids oids, OTableFetchContext ctx)
 	bool		found;
 	OTable	   *o_table;
 	bool		old_enable_stopevents;
+	OTableDescr *prev_filling;
 
 	old_enable_stopevents = enable_stopevents;
 	enable_stopevents = false;
@@ -931,15 +941,32 @@ create_table_descr(ORelOids oids, OTableFetchContext ctx)
 
 	Assert(ctx.snapshot);
 
+	/*
+	 * Protect the half-built entry: fill_table_descr() fetches per-index
+	 * descriptors, which read catalogs and can run
+	 * AcceptInvalidationMessages() -> o_invalidate_descrs() reentrantly. Mark
+	 * the entry so that reentrant invalidation skips it instead of
+	 * freeing/recreating a descriptor whose indices[] array is not populated
+	 * yet (see OIndexDescr.fill_in_progress).
+	 */
+	prev_filling = filling_table_descr;
+	filling_table_descr = descr;
+	descr->fill_in_progress = true;
+
 	descr->refcnt = 0;
 	if (!fill_table_descr(descr, o_table, ctx.snapshot))
 	{
+		descr->fill_in_progress = false;
+		filling_table_descr = prev_filling;
 		table_descr_free(descr);
 		(void) hash_search(oTableDescrHash, &oids,
 						   HASH_REMOVE, &found);
 		enable_stopevents = old_enable_stopevents;
 		return NULL;
 	}
+
+	descr->fill_in_progress = false;
+	filling_table_descr = prev_filling;
 
 	enable_stopevents = old_enable_stopevents;
 	return descr;
@@ -1208,7 +1235,13 @@ o_invalidate_descrs_internal(Oid datoid, Oid reloid, Oid relfilenode)
 		hash_seq_init(&scan_status, oTableDescrHash);
 		while ((tableDescr = (OTableDescr *) hash_seq_search(&scan_status)) != NULL)
 		{
-			bool		delete = tableDescr->refcnt == 0;
+			bool		delete;
+
+			/* Never touch an entry that is still being (re)filled. */
+			if (tableDescr->fill_in_progress)
+				continue;
+
+			delete = tableDescr->refcnt == 0;
 
 			Assert(!tableDescr->noInvalidation);
 
@@ -1222,6 +1255,10 @@ o_invalidate_descrs_internal(Oid datoid, Oid reloid, Oid relfilenode)
 		hash_seq_init(&scan_status, oIndexDescrHash);
 		while ((indexDescr = (OIndexDescr *) hash_seq_search(&scan_status)) != NULL)
 		{
+			/* Never touch an entry that is still being (re)filled. */
+			if (indexDescr->fill_in_progress)
+				continue;
+
 			if (indexDescr->refcnt == 0)
 				index_descr_delete_from_hash(indexDescr);
 			else
@@ -1234,7 +1271,7 @@ o_invalidate_descrs_internal(Oid datoid, Oid reloid, Oid relfilenode)
 		bool		found;
 
 		tableDescr = hash_search(oTableDescrHash, &oids, HASH_FIND, &found);
-		if (found)
+		if (found && !tableDescr->fill_in_progress)
 		{
 			bool		delete = tableDescr->refcnt == 0;
 
@@ -1248,7 +1285,7 @@ o_invalidate_descrs_internal(Oid datoid, Oid reloid, Oid relfilenode)
 		}
 
 		indexDescr = hash_search(oIndexDescrHash, &oids, HASH_FIND, &found);
-		if (found)
+		if (found && !indexDescr->fill_in_progress)
 		{
 			if (indexDescr->refcnt == 0)
 				index_descr_delete_from_hash(indexDescr);
@@ -1454,6 +1491,7 @@ get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchCon
 	bool		found = false;
 	bool		existed;
 	int			refcnt = 0;
+	OIndexDescr *prev_filling;
 
 	result = hash_search(oIndexDescrHash, &ixOids, HASH_ENTER, &found);
 	Assert((found && result) || !found);
@@ -1474,10 +1512,28 @@ get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchCon
 		 result->version == ctx.version))
 		return result;
 
+	/*
+	 * Mark the entry as being (re)filled before the first call that can run
+	 * AcceptInvalidationMessages() (o_indices_get_extended() reads the
+	 * O_INDICES sys-tree).  Until o_index_fill_descr() runs, a fresh
+	 * HASH_ENTER slot still carries a previously-freed descriptor's stale
+	 * pointers, and an existing entry we are about to index_descr_free() is
+	 * half-torn-down; a reentrant o_invalidate_descrs() must skip it rather
+	 * than free it (which would double-free a shared-descrCxt tupdesc chunk
+	 * -> FreeTupleDesc MAXALIGN crash in the checkpointer).
+	 * o_index_fill_descr() memset()s the flag off, but wraps its own body in
+	 * o_start_saving_inval_messages(), so the whole (re)fill window stays
+	 * protected.
+	 */
+	prev_filling = filling_index_descr;
+	filling_index_descr = result;
+	result->fill_in_progress = true;
+
 	oIndex = o_indices_get_extended(ixOids, ixType, ctx);
 	Assert(oIndex || miss_ok);
 	if (!oIndex && miss_ok)
 	{
+		filling_index_descr = prev_filling;
 		(void) hash_search(oIndexDescrHash, &ixOids, HASH_REMOVE, &found);
 		Assert(found);
 		return NULL;
@@ -1508,6 +1564,9 @@ get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchCon
 	if (existed)
 		result->refcnt = refcnt;
 	free_o_index(oIndex);
+
+	result->fill_in_progress = false;
+	filling_index_descr = prev_filling;
 
 	return result;
 }
@@ -2521,6 +2580,27 @@ void
 reset_saving_inval_messages(void)
 {
 	saving_inval_messages = false;
+}
+
+/*
+ * Clear the "being filled" flag on any descriptor whose get_index_descr() /
+ * create_table_descr() was interrupted by an error longjmp, so it is not left
+ * permanently exempt from invalidation.  Called from the orioledb
+ * error-cleanup hook.
+ */
+void
+reset_filling_descrs(void)
+{
+	if (filling_index_descr != NULL)
+	{
+		filling_index_descr->fill_in_progress = false;
+		filling_index_descr = NULL;
+	}
+	if (filling_table_descr != NULL)
+	{
+		filling_table_descr->fill_in_progress = false;
+		filling_table_descr = NULL;
+	}
 }
 
 /*


### PR DESCRIPTION
Four independent fixes lifted from the `ci_fixes` churn-hunt branch (validated there via the aggressive-checkpoint + create/drop-database + primary/standby stress matrix). No TEMP instrumentation or CI-harness churn is included — only the fixes.

## 1. `o_btree_modify` retry loops become interruptible
A row-lock conflict in the modify path can livelock: `o_btree_modify_internal()` holds the leaf page-content lock, `o_btree_modify_handle_conflicts()` returns `ConflictResolutionRetry`, and the loop does `goto retry` with the page still locked and without waiting — spinning at 100% CPU, unbounded. The dominant trigger is a lock-only undo record of an already committed/aborted transaction that `row_lock_conflicts()` should have removed but hasn't (concurrent commit/abort).

There was no `CHECK_FOR_INTERRUPTS()` anywhere in the loop, so the spin was **uninterruptible** — query cancel, `statement_timeout`, and `SIGTERM` all bounced off it (observed as the pg_upgrade / pg_tests hangs on `ci_fixes`, spinning in `o_tbl_delete`/`o_tbl_insert` → `o_btree_modify`). Adds `CHECK_FOR_INTERRUPTS()` at both `retry:` labels. It is safe under the page lock (page locks do not hold off interrupts; the error-cleanup hook releases them) and a no-op in critical sections. This makes the hang cancellable; the underlying livelock is tracked separately.

## 2. Skip invalidating descriptors that are being filled (reentrant-free fix)
`get_index_descr()` `HASH_ENTER`s the `oIndexDescrHash` slot **before** reading the O_INDICES sys-tree and filling the descriptor. A fresh slot still carries a previously-freed descriptor's stale pointers, and the sys-tree read can run `AcceptInvalidationMessages()` → the orioledb hook → `o_invalidate_descrs()` reentrantly. Under a full-cache reset (e.g. a DROP DATABASE replay on a standby) the reentrant invalidation sees the half-built entry with `refcnt==0`, frees it, and `FreeTupleDesc()`s its stale `leafTupdesc` — double-freeing a shared `descrCxt` tupdesc chunk and tripping the checkpointer MAXALIGN assert.

Adds an `OIndexDescr`/`OTableDescr` `fill_in_progress` flag, set from `HASH_ENTER` until the descriptor is fully (re)built, and skips flagged entries in `o_invalidate_descrs_internal()`. Unlike deferring the whole invalidation, this only protects the in-flight entry; every completed descriptor still invalidates normally. `reset_filling_descrs()` clears the flag on error longjmp (wired into the error-cleanup hook). Validated: `checkpoint_concurrent` 13/13, regress ddl/indices/indices_build/alter_type/truncate/primary_key/createas/index_bridging, replication resurrect + parallel-worker-rollback + ddl_test.

## 3. Zero a fresh index-descr hash slot on entry
Follow-up to #2. `HASH_ENTER` only fills the key; the value part is uninitialized. If the pre-fill step (`o_indices_get_extended()`) longjmps before `o_index_fill_descr()` `memset`s the slot, `reset_filling_descrs` only clears `fill_in_progress` — the half-built entry stays in the hash carrying a previous descriptor's stale tupdesc pointers and a garbage refcnt. A later full `o_invalidate_descrs()` then sees `fill_in_progress == false`, a refcnt that reads as 0, and non-NULL tupdesc pointers, and `FreeTupleDesc()`s them — corrupting memory / crashing the checkpointer.

Zeroes the new slot (restoring the hash key) right after `HASH_ENTER` so a half-built entry is always safe to free: all freeable pointers NULL, refcnt 0. The existing-entry re-fill path was already safe.

## 4. Match reloid when fetching an OrioleDB index descriptor
`oIndicesFetchCallback()` ignored `reloid`, so a fetch for a dropped `(reloid, relnode)` could resolve to a **different relation that reused the same relnode**. Because the per-tree lock is keyed by `(datoid, reloid)` while the sys-tree fetch was keyed by `relnode` alone, `o_fetch_index_descr_extended()` could take a lock on one reloid and get an unlocked different tree — the root of the checkpointer `seq_buf_finalize` freed-page crash (`nextChkp`/`tmpBuf` `.shared` pointing into a reused meta page). Now compares `reloid` so such a fetch misses and returns NULL instead. (Comparators in the sys-tree stay relnode-keyed on purpose — the version model stores multiple reloids of the same relnode across ctid→PK conversion; only the fetch callback must disambiguate.)

## Testing
- Builds clean against the patched PostgreSQL (PG16/17/18 fork).
- `regresscheck` ddl / indices / indices_build / alter_type / createas / index_bridging / primary_key: 7/7.
- Fixes #4 and #2/#3 were validated under the `ci_fixes` churn matrix (100+ VM iterations + CI churn, 0 finalize-badpage / MAXALIGN recurrences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)