### PR TITLE
Fix flake in insert_fails isolation test

### DIFF
--- a/test/specs/insert_fails.spec
+++ b/test/specs/insert_fails.spec
@@ -44,4 +44,4 @@ step "s4_reset" {
 		pg_stopevent_reset('page_split') a,
 		pg_stopevent_reset('relock_page') b; }
 
-permutation "s1_setup" "s2_setup" "s3_setup" "s1_split_prepare" "s4_bp" "s1_split" "s2_insert" "s3_insert" "s4_reset"
+permutation "s1_setup" "s2_setup" "s3_setup" "s1_split_prepare" "s4_bp" "s1_split" "s2_insert"(s1_split) "s3_insert" "s4_reset"


### PR DESCRIPTION
Found in CI https://github.com/orioledb/orioledb/actions/runs/31185058520/job/92887497785#step:10:27

```
========= Contents of ./orioledb/test/output_iso/regression.diffs (first 500 lines)
diff -U3 /home/runner/_work/orioledb/orioledb/orioledb/test/expected/insert_fails.out /home/runner/_work/orioledb/orioledb/orioledb/test/output_iso/results/insert_fails.out
--- /home/runner/_work/orioledb/orioledb/orioledb/test/expected/insert_fails.out	2026-08-07 13:56:52.876201983 +0000
+++ /home/runner/_work/orioledb/orioledb/orioledb/test/output_iso/results/insert_fails.out	2026-08-07 14:00:12.932672967 +0000
@@ -31,5 +31,5 @@
 t|f
 (1 row)
 
-step s1_split: <... completed>
 step s2_insert: <... completed>
+step s1_split: <... completed>
```