### PR TITLE
Fix checkpoint crash on concurrent root page modification

### DIFF
--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -3764,11 +3764,14 @@ checkpoint_btree_loop(BTreeDescr **descrPtr,
 
 			/*
 			 * Check if it not the page we expected, because it might
-			 * disappear due to concurrent eviction.
+			 * disappear due to concurrent eviction.  Root pages are never
+			 * evicted, so a change-count mismatch there is just a concurrent
+			 * modification; proceed with current content.
 			 */
 			if (O_PAGE_GET_CHANGE_COUNT(page) != message.content.downwards.pageChangeCount
-				&& blkno == message.content.downwards.blkno)	/* rootPageBlkno level
-																 * does not change */
+				&& blkno == message.content.downwards.blkno /* rootPageBlkno level
+															 * does not change */
+				&& blkno != descr->rootInfo.rootPageBlkno)
 			{
 				unlock_page(blkno);
 				message.action = WalkUpwards;


### PR DESCRIPTION
The fuzzy sys-tree checkpoint (4e0aa762) removed the exclusive oTablesMetaLock/oSysTreesLock around sys-tree capture.  Concurrent DDL can now modify a sys-tree root page between the initial change-count capture and the re-lock via checkpoint_fix_split_and_lock_page. When the change count differs, checkpoint_btree_loop treats it as eviction and sends WalkUpwards with InvalidDiskDownlink.  Since there is no parent level above the root, Assert(valid_doff) fires.

Root pages cannot be evicted, so a change-count mismatch there is always a concurrent modification, not eviction.  Skip the bail-out for the root page and checkpoint it as-is.

This PR fixes CI fail https://github.com/orioledb/orioledb/actions/runs/31185962809/job/92890523246#step:11:168 :

```
Thread 1 (Thread 0xff24c5169ca0 (LWP 33176)):
#0  __pthread_kill_implementation (threadid=280533390498976, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
        tid = 33176
        ret = 0
        pd = 0xff24c5169ca0
        old_mask = {__val = {280533338034773}}
        ret = <optimized out>
#1  0x0000ff24c4957540 in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
No locals.
#2  0x0000ff24c490cb3c in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
        ret = <optimized out>
#3  0x0000ff24c48f7e00 in __GI_abort () at ./stdlib/abort.c:79
        save_stage = 1
        act = {__sigaction_handler = {sa_handler = 0x20, sa_sigaction = 0x20}, sa_mask = {__val = {48, 2, 280533382943648, 0, 1, 280533390576464, 0, 8461419775034225779, 7887038117715735660, 280375465082880, 0, 15728640, 0, 0, 0, 0}}, sa_flags = 0, sa_restorer = 0x0}
#4  0x0000aadf76d359e0 in ExceptionalCondition (conditionName=0xff24c1f61255 "valid_doff", fileName=0xff24c1f60974 "src/checkpoint/checkpoint.c", lineNumber=lineNumber@entry=4044) at assert.c:66
No locals.
#5  0x0000ff24c1e8c4b0 in checkpoint_btree_loop (descrPtr=descrPtr@entry=0xfffff23a9208, state=state@entry=0xff24ba63c380, writeback=writeback@entry=0xfffff23a9198, tmp_context=tmp_context@entry=0xaadfb2441430) at src/checkpoint/checkpoint.c:4044
        tuphdr = <optimized out>
        img = <optimized out>
        output_config_variable = <optimized out>
        listen_addr_saved = <optimized out>
        userDoption = <optimized out>
        opt = <optimized out>
        status = <optimized out>
#17 0x0000aadf76a40330 in main (argc=3, argv=0xaadfb1b31fc0) at main.c:227
        dispatch_option = <optimized out>
        do_check_root = <optimized out>
$1 = {{lock = 0xff24ba6bccd0, mode = LW_EXCLUSIVE}}
$2 = 0xff24c1fcc1a8 <myLockedPages>
#17 0x0000aadf76a40330 in main 
```