### PR TITLE
Fix checkpoint, xid-queue, UCM and FETCH-image races found by the churn hunt

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -208,5 +208,5 @@ jobs:
       - name: remove artifacts
         uses: geekyeggo/delete-artifact@v6
         with:
-          name: "*coverage.info"
+          name: "*coverage.info*"
           failOnError: false

--- a/ci/lcov_merge.sh
+++ b/ci/lcov_merge.sh
@@ -4,4 +4,8 @@ set -eu
 
 sudo apt-get update -qq
 sudo apt-get install lcov
-lcov $(ls -d1 *coverage.info/coverage.info | xargs -I{} echo "-a {}") -o ./orioledb/coverage.info
+# Matrix entries that carry a "replica" dimension append an _r<N> suffix to the
+# artifact name, so the downloaded directories are named ..._coverage.info_r3
+# rather than ending in coverage.info.  Match both, or the merge runs with no
+# inputs and lcov fails the job.
+lcov $(ls -d1 *coverage.info*/coverage.info | xargs -I{} echo "-a {}") -o ./orioledb/coverage.info

--- a/include/btree/page_chunks.h
+++ b/include/btree/page_chunks.h
@@ -71,4 +71,25 @@ extern bool page_locator_find_real_item(Page p, PartialPageState *partial,
 										BTreePageItemLocator *locator);
 extern OffsetNumber page_locator_get_offset(Page p, BTreePageItemLocator *locator);
 
+/*
+ * Assert that the item a locator points to lives in a chunk that was actually
+ * loaded into the partial (FETCH-mode) image.  BTREE_PAGE_LOCATOR_IS_VALID()
+ * ignores the page entirely -- it only looks at the locator's own cached chunk
+ * pointer and item count -- so a locator can happily address a region of the
+ * image which no partial_load_chunk() ever filled, and the "tuple" read from
+ * there is whatever the buffer happened to contain (typically another chunk's
+ * item offset array).  Use this right before reading a tuple through a locator
+ * in the places where the matching PartialPageState is at hand: it is silent in
+ * IMAGE mode and on correctly loaded chunks, and fires exactly on the
+ * "unloaded chunk got used" case.
+ */
+#ifdef USE_ASSERT_CHECKING
+extern void assert_partial_chunk_loaded(PartialPageState *partial, Page img,
+										BTreePageItemLocator *locator);
+#define ASSERT_CHUNK_LOADED(partial, img, locator) \
+	assert_partial_chunk_loaded((partial), (img), (locator))
+#else
+#define ASSERT_CHUNK_LOADED(partial, img, locator) ((void) 0)
+#endif
+
 #endif							/* __BTREE_PAGE_CHUNKS_H__ */

--- a/include/btree/page_contents.h
+++ b/include/btree/page_contents.h
@@ -61,6 +61,18 @@ typedef struct
 
 	LWLock		punchHolesLock;
 	uint32		punchHolesChkpNum;
+
+	/*
+	 * Number of the checkpoint during which this tree's shared memory was
+	 * (re)initialized while that checkpoint was already working on the tree
+	 * -- a TRUNCATE replacing the tree inside
+	 * perform_writeback_and_relock()'s window, say.
+	 * checkpointable_tree_init() then sets the tree up as one that checkpoint
+	 * has already passed, and the checkpointer skips it when it comes back
+	 * and finds its own number here.  Zero means nothing to skip; no clearing
+	 * is needed because the number simply stops matching.
+	 */
+	uint32		reinitCheckpointNum;
 } BTreeMetaPage;
 
 StaticAssertDecl(sizeof(BTreeMetaPage) <= ORIOLEDB_BLCKSZ,

--- a/include/btree/page_state.h
+++ b/include/btree/page_state.h
@@ -72,6 +72,8 @@ extern OLockPageWithTupleResult lock_page_with_tuple(BTreeDescr *desc,
 													 OTuple tuple);
 extern void relock_page(OInMemoryBlkno blkno);
 extern bool try_lock_page(OInMemoryBlkno blkno);
+extern bool try_lock_page_and_check(OInMemoryBlkno blkno, uint16 level,
+									uint32 pageChangeCount);
 extern void delare_page_as_locked(OInMemoryBlkno blkno);
 extern bool page_is_locked(OInMemoryBlkno blkno);
 extern void page_block_reads(OInMemoryBlkno blkno);

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -203,6 +203,7 @@ page_find_downlink(OBTreeFindPageInternalContext *intCxt,
 		}
 	}
 
+	ASSERT_CHUNK_LOADED(intCxt->partial, intCxt->pagePtr, loc);
 	*tuphdr = (BTreeNonLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(intCxt->pagePtr, loc);
 
 	return OBTreeFastPathFindOK;
@@ -261,6 +262,7 @@ page_find_item(OBTreeFindPageInternalContext *intCxt,
 											intCxt->partial,
 											loc))
 			{
+				ASSERT_CHUNK_LOADED(intCxt->partial, intCxt->pagePtr, loc);
 				if (level > 0)
 					*tuphdr = (BTreeNonLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(intCxt->pagePtr, loc);
 
@@ -352,6 +354,7 @@ page_find_item(OBTreeFindPageInternalContext *intCxt,
 		return OBTreeFastPathFindRetry;
 	}
 
+	ASSERT_CHUNK_LOADED(intCxt->partial, intCxt->pagePtr, loc);
 	if (level > 0)
 		*tuphdr = (BTreeNonLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(intCxt->pagePtr, loc);
 
@@ -428,24 +431,49 @@ refresh_parent_img_chunk(OBTreeFindPageInternalContext *intCxt)
  * the caller re-finds.  partial_load_chunk() positions the locator at item 0,
  * so the caller's real itemOffset is restored afterwards.
  *
- * Returns false if the parent changed under us; the caller must re-find.
+ * Returns false if the page changed under us; the caller must re-find.
  */
 static bool
-convert_fastpath_parent_to_img(OBTreeFindPageContext *context,
-							   BTreePageItemLocator *locator)
+convert_fastpath_locator_to_img(PartialPageState *partial, Pointer img,
+								BTreePageItemLocator *locator)
 {
 	OffsetNumber chunkOffset = locator->chunkOffset;
 	OffsetNumber itemOffset = locator->itemOffset;
 
-	if (!partial_load_hikeys_chunk(&context->parentPartial, context->parentImg))
+	if (!partial_load_hikeys_chunk(partial, img))
 		return false;
 
-	if (!partial_load_chunk(&context->parentPartial, context->parentImg,
-							chunkOffset, locator))
+	if (!partial_load_chunk(partial, img, chunkOffset, locator))
 		return false;
 
 	locator->itemOffset = itemOffset;
 	return true;
+}
+
+static bool
+convert_fastpath_parent_to_img(OBTreeFindPageContext *context,
+							   BTreePageItemLocator *locator)
+{
+	return convert_fastpath_locator_to_img(&context->parentPartial,
+										   context->parentImg, locator);
+}
+
+/*
+ * The same conversion for the target page's own locator in context->img.
+ *
+ * BTREE_PAGE_FIND_DOWNLINK_LOCATION (the sequential scan) asks for a downlink
+ * location rather than a tuple, so find_page() routes even the target level
+ * through page_find_downlink() -- and hence through the fastpath, which leaves
+ * the locator on the shared page.  Unlike the descent, this locator is handed
+ * to the caller and read through long after find_page() returned, with the
+ * page neither locked nor re-validated, so it has to be moved onto the image.
+ */
+static bool
+convert_fastpath_target_to_img(OBTreeFindPageContext *context,
+							   BTreePageItemLocator *locator)
+{
+	return convert_fastpath_locator_to_img(&context->partial,
+										   context->img, locator);
 }
 
 /*--
@@ -850,6 +878,19 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 			params = btree_page_stopevent_params(desc, intCxt.pagePtr);
 			STOPEVENT(STOPEVENT_AFTER_FIND_DOWNLINK, params);
 		}
+
+		/*
+		 * A DOWNLINK_LOCATION caller reaches its target level through
+		 * page_find_downlink(), so the fastpath may have left `loc` on the
+		 * shared page.  The caller reads downlinks through it after
+		 * find_page() has returned and the page is no longer locked or
+		 * re-validated, so move it onto context->img now; a page that changed
+		 * under us makes the conversion fail and we re-descend.
+		 */
+		if (level <= targetLevel && downlinkLocationFlag &&
+			context->partial.isPartial &&
+			!convert_fastpath_target_to_img(context, &loc))
+			continue;
 
 		/* Place new item to the context */
 		Assert(context->index < ORIOLEDB_MAX_DEPTH);
@@ -1548,6 +1589,8 @@ find_right_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 										loc.chunkOffset, NULL);
 		if (tup_loaded)
 		{
+			ASSERT_CHUNK_LOADED(&context->parentPartial, context->parentImg,
+								&loc);
 			BTREE_PAGE_READ_INTERNAL_ITEM(tuphdr, internalTuple, context->parentImg, &loc);
 			Assert(tuphdr != NULL);
 		}
@@ -1603,6 +1646,7 @@ refresh_context_leaf_lokey(OBTreeFindPageContext *context,
 	{
 		OTuple		lokey;
 
+		ASSERT_CHUNK_LOADED(&context->parentPartial, context->parentImg, loc);
 		BTREE_PAGE_READ_INTERNAL_TUPLE(lokey, context->parentImg, loc);
 		copy_fixed_key(context->desc, &context->leafLokey, lokey);
 	}
@@ -1688,6 +1732,8 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 
 			if (next_lokey_loaded && BTREE_PAGE_LOCATOR_IS_VALID(context->parentImg, &loc))
 			{
+				ASSERT_CHUNK_LOADED(&context->parentPartial,
+									context->parentImg, &loc);
 				tuphdr = (BTreeNonLeafTuphdr *) BTREE_PAGE_LOCATOR_GET_ITEM(context->parentImg, &loc);
 
 				/*
@@ -1892,6 +1938,22 @@ btree_find_read_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno,
 
 	pagePtr = set_page_ptr(context, parent);
 
+	/*
+	 * The page is about to be copied whole.  o_btree_read_page() only touches
+	 * a PartialPageState it is handed, so the one describing this image would
+	 * keep claiming a partial read -- with a src still pointing at whatever
+	 * page that read used.  An iterator that switches from FETCH to IMAGE
+	 * mid-scan (iterator_maybe_switch_to_image()) reads its next sibling with
+	 * partial == NULL and would carry that lie into every later chunk test.
+	 */
+	if (partial == NULL)
+	{
+		if (parent)
+			context->parentPartial.isPartial = false;
+		else
+			context->partial.isPartial = false;
+	}
+
 	BTREE_PAGE_FIND_UNSET(context, LOKEY_UNDO);
 	if (lokey)
 		clear_fixed_key(lokey);
@@ -1924,6 +1986,22 @@ btree_find_try_read_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno,
 	Pointer		pagePtr;
 
 	pagePtr = set_page_ptr(context, parent);
+
+	/*
+	 * The page is about to be copied whole.  o_btree_read_page() only touches
+	 * a PartialPageState it is handed, so the one describing this image would
+	 * keep claiming a partial read -- with a src still pointing at whatever
+	 * page that read used.  An iterator that switches from FETCH to IMAGE
+	 * mid-scan (iterator_maybe_switch_to_image()) reads its next sibling with
+	 * partial == NULL and would carry that lie into every later chunk test.
+	 */
+	if (partial == NULL)
+	{
+		if (parent)
+			context->parentPartial.isPartial = false;
+		else
+			context->partial.isPartial = false;
+	}
 
 	result = o_btree_try_read_page(context->desc, blkno, pageChangeCount,
 								   pagePtr, context->csn,

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1324,7 +1324,17 @@ retry:
 		}
 		else
 		{
-			lock_page(intCxt.blkno);
+			/*
+			 * Lock the page by the cached (blkno, pageChangeCount) hint.  The
+			 * hint may be stale: the block could have been evicted and reused
+			 * meanwhile, even for a non-B-tree page (seq_buf or meta page).
+			 * try_lock_page_and_check() validates level/pageChangeCount under
+			 * the lock and reports failure (leaving the page unlocked) rather
+			 * than letting us operate on an unrelated page.
+			 */
+			if (!try_lock_page_and_check(intCxt.blkno, level,
+										 intCxt.pageChangeCount))
+				return find_page(context, key, keyType, level);
 		}
 		p = O_GET_IN_MEMORY_PAGE(intCxt.blkno);
 		intCxt.haveLock = true;

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -84,8 +84,24 @@ partial_load_chunk(PartialPageState *partial, Page img,
 	LocationIndex chunkBegin,
 				chunkEnd;
 	BTreePageHeader *header;
+	bool		alreadyLoaded;
 
-	if (!partial->isPartial || partial->chunkIsLoaded[chunkOffset])
+	/* A whole-page image has everything; the caller positions its own locator */
+	if (!partial->isPartial)
+		return true;
+
+	alreadyLoaded = partial->chunkIsLoaded[chunkOffset];
+
+	/*
+	 * Nothing to copy and no locator to position: the common repeat call.
+	 *
+	 * When there IS a locator we must fall through even for a chunk already
+	 * in the image.  Callers pass a locator precisely to have it positioned
+	 * on chunkOffset, and returning early would leave it wherever it was --
+	 * on another chunk, or (when fastpath_find_downlink() produced it) on the
+	 * live shared page.
+	 */
+	if (alreadyLoaded && loc == NULL)
 		return true;
 
 	if (partial->hikeysChunkIsLoaded)
@@ -137,24 +153,28 @@ partial_load_chunk(PartialPageState *partial, Page img,
 	Assert(chunkBegin >= 0 && chunkBegin <= ORIOLEDB_BLCKSZ);
 	Assert(chunkEnd >= 0 && chunkEnd <= ORIOLEDB_BLCKSZ);
 
-	VALGRIND_CHECK_MEM_IS_DEFINED((Pointer) src + chunkBegin,
-								  chunkEnd - chunkBegin);
+	if (!alreadyLoaded)
+	{
+		VALGRIND_CHECK_MEM_IS_DEFINED((Pointer) src + chunkBegin,
+									  chunkEnd - chunkBegin);
 
-	memcpy((Pointer) img + chunkBegin,
-		   (Pointer) src + chunkBegin,
-		   chunkEnd - chunkBegin);
+		memcpy((Pointer) img + chunkBegin,
+			   (Pointer) src + chunkBegin,
+			   chunkEnd - chunkBegin);
 
-	pg_read_barrier();
+		pg_read_barrier();
 
-	srcState = pg_atomic_read_u64(&(O_PAGE_HEADER(src)->state));
-	if ((imgState & PAGE_STATE_CHANGE_COUNT_MASK) != (srcState & PAGE_STATE_CHANGE_COUNT_MASK) ||
-		O_PAGE_STATE_READ_IS_BLOCKED(srcState))
-		return false;
+		srcState = pg_atomic_read_u64(&(O_PAGE_HEADER(src)->state));
+		if ((imgState & PAGE_STATE_CHANGE_COUNT_MASK) != (srcState & PAGE_STATE_CHANGE_COUNT_MASK) ||
+			O_PAGE_STATE_READ_IS_BLOCKED(srcState))
+			return false;
 
-	if (O_PAGE_GET_CHANGE_COUNT(img) != O_PAGE_GET_CHANGE_COUNT(src))
-		return false;
+		if (O_PAGE_GET_CHANGE_COUNT(img) != O_PAGE_GET_CHANGE_COUNT(src))
+			return false;
 
-	partial->chunkIsLoaded[chunkOffset] = true;
+		partial->chunkIsLoaded[chunkOffset] = true;
+	}
+
 	if (loc)
 	{
 		loc->chunkOffset = chunkOffset;
@@ -1507,6 +1527,68 @@ page_locator_find_real_item(Page p, PartialPageState *partial,
 	}
 	return true;
 }
+
+#ifdef USE_ASSERT_CHECKING
+void
+assert_partial_chunk_loaded(PartialPageState *partial, Page img,
+							BTreePageItemLocator *locator)
+{
+	BTreePageHeader *header = (BTreePageHeader *) img;
+	LocationIndex chunkBegin,
+				chunkEnd;
+
+	/* Whole-page images have everything loaded by construction */
+	if (partial == NULL || !partial->isPartial)
+		return;
+
+	/* An invalid locator is not going to be dereferenced */
+	if (locator->chunk == NULL)
+		return;
+
+	/*
+	 * A chunk which was never loaded holds whatever the image buffer happened
+	 * to contain, so reading through such a locator is always wrong.
+	 */
+	Assert(locator->chunkOffset < BTREE_PAGE_MAX_CHUNKS);
+	Assert(partial->chunkIsLoaded[locator->chunkOffset]);
+
+	/*
+	 * The chunk descriptors live in the hikeys chunk.  The fastpath descent
+	 * loads a single data chunk without them (its locator comes from the
+	 * fastpath hint instead), so the header-derived cross-checks below only
+	 * apply once the hikeys chunk is there.
+	 */
+	if (!partial->hikeysChunkIsLoaded)
+		return;
+
+	Assert(header->chunksCount >= 1 &&
+		   header->chunksCount <= BTREE_PAGE_MAX_CHUNKS);
+	Assert(locator->chunkOffset < header->chunksCount);
+
+	chunkBegin = SHORT_GET_LOCATION(header->chunkDesc[locator->chunkOffset].shortLocation);
+	if (locator->chunkOffset + 1 < header->chunksCount)
+		chunkEnd = SHORT_GET_LOCATION(header->chunkDesc[locator->chunkOffset + 1].shortLocation);
+	else
+		chunkEnd = header->dataSize;
+
+	Assert(chunkBegin <= chunkEnd && chunkEnd <= ORIOLEDB_BLCKSZ);
+
+	/*
+	 * A locator addressing the live source page instead of the image is a
+	 * different failure: the bytes are real, but they are read without the
+	 * copy-then-validate protocol, so they can be torn.
+	 */
+	Assert((Pointer) locator->chunk == (Pointer) img + chunkBegin);
+
+	/*
+	 * An empty chunk (an empty page has one) gives a locator which is not
+	 * valid: it is never dereferenced, so there is no item to check.
+	 */
+	if (locator->itemOffset < locator->chunkItemsCount)
+		Assert(ITEM_GET_OFFSET(locator->chunk->items[locator->itemOffset]) <
+			   chunkEnd - chunkBegin);
+}
+#endif							/* USE_ASSERT_CHECKING */
 
 /* No existing callers */
 OffsetNumber

--- a/src/btree/page_state.c
+++ b/src/btree/page_state.c
@@ -452,6 +452,84 @@ lock_page(OInMemoryBlkno blkno)
 }
 
 /*
+ * Like lock_page(), but for locking a page found via a cached
+ * (blkno, pageChangeCount) hint that may be stale.  The hinted in-memory
+ * block could have been evicted and reused since the hint was taken - even
+ * for a non-B-tree page such as a seq_buf or a B-tree meta page.  We
+ * therefore validate the page level and change count *while holding the
+ * lock* and, on any mismatch, release the lock and report failure instead of
+ * letting the caller operate on (or assert against) an unrelated page.
+ *
+ * Returns true with the page left locked when it still matches the expected
+ * (level, pageChangeCount); returns false with the page left unlocked
+ * otherwise.
+ */
+bool
+try_lock_page_and_check(OInMemoryBlkno blkno, uint16 level,
+						uint32 pageChangeCount)
+{
+	OPageWaiterShmemState *lockerState = &lockerStates[MYPROCNUMBER];
+	uint64		prevState;
+	int			extraWaits = 0;
+	Page		p;
+
+	/* Local pages do not need locking, but still validate the hint */
+	if (O_PAGE_IS_LOCAL(blkno))
+	{
+		p = O_GET_IN_MEMORY_PAGE(blkno);
+		return PAGE_GET_LEVEL(p) == level &&
+			O_PAGE_GET_CHANGE_COUNT(p) == pageChangeCount;
+	}
+
+	Assert(get_my_locked_page_index(blkno) < 0);
+
+	EA_LOCK_INC(blkno);
+
+	while (true)
+	{
+		prevState = lock_page_or_queue(blkno, MYPROCNUMBER);
+
+		if (!O_PAGE_STATE_IS_LOCKED(prevState))
+			break;
+
+		pgstat_report_wait_start(PG_WAIT_LWLOCK | LWTRANCHE_BUFFER_CONTENT);
+
+		for (;;)
+		{
+			PGSemaphoreLock(MyProc->sem);
+			if (lockerState->status == OPageWaitWakeUp)
+				break;
+			extraWaits++;
+		}
+
+		pgstat_report_wait_end();
+	}
+
+	my_locked_page_add(blkno, prevState | PAGE_STATE_LOCKED_FLAG);
+
+	/*
+	 * Fix the process wait semaphore's count for any absorbed wakeups.
+	 */
+	while (extraWaits-- > 0)
+		PGSemaphoreUnlock(MyProc->sem);
+
+	/*
+	 * Now that we hold the lock, verify the page is still the one the caller
+	 * expects.  A mismatch means the block was evicted and reused; bail out
+	 * without applying any B-tree page invariants to it.
+	 */
+	p = O_GET_IN_MEMORY_PAGE(blkno);
+	if (PAGE_GET_LEVEL(p) != level ||
+		O_PAGE_GET_CHANGE_COUNT(p) != pageChangeCount)
+	{
+		unlock_page(blkno);
+		return false;
+	}
+
+	return true;
+}
+
+/*
  * Place exclusive lock on the page.  Doesn't block readers before
  * page_block_reads() is called.
  */

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -991,6 +991,8 @@ btree_relnode_undo_callback(UndoLogType undoType, UndoLocation location,
 
 		for (i = 0; i < dropNumTrees; i++)
 		{
+			bool		dropBridgeMarker = false;
+
 			if (!recovery)
 				o_tables_rel_lock_exclusive_no_inval_no_log(&dropTrees[i].oids);
 			o_tables_rel_lock_extended_no_inval(&dropTrees[i].oids,
@@ -1012,16 +1014,32 @@ btree_relnode_undo_callback(UndoLogType undoType, UndoLocation location,
 				 * commit: an aborted create's marker is removed by the
 				 * register_delete pending-delete instead.
 				 */
-				if (stage == OUndoCallbackStageCommit &&
-					dropTrees[i].oids.reloid == dropTrees[i].oids.relnode)
-					o_bridge_drop_relnode_marker(dropTrees[i].oids.datoid,
-												 dropTrees[i].oids.spcoid,
-												 dropTrees[i].oids.relnode);
+				dropBridgeMarker = (stage == OUndoCallbackStageCommit &&
+									dropTrees[i].oids.reloid == dropTrees[i].oids.relnode);
 			}
 			o_invalidate_oids(dropTrees[i].oids);
 			if (!recovery)
 				o_tables_rel_unlock_extended(&dropTrees[i].oids, AccessExclusiveLock, false);
 			o_tables_rel_unlock_extended(&dropTrees[i].oids, AccessExclusiveLock, true);
+
+			/*
+			 * Drop the marker only once the locks are gone.  It unlinks a
+			 * relation file, and smgr's RegisterSyncRequest() waits for the
+			 * checkpointer to drain its request queue when that queue is
+			 * full.  The checkpointer takes this very lock in AccessShare
+			 * while fetching an index descriptor, so holding it here is a
+			 * deadlock: it cannot absorb the queue until we release, and we
+			 * cannot release until it absorbs.  Neither side is visible to
+			 * the deadlock detector -- ours is a latch wait, not a lock wait
+			 * -- so the cluster simply stops (seen as the recurring
+			 * 027_stream_regress hang).  Dropping the marker later is safe:
+			 * the tree is already durably gone, and the marker only exists to
+			 * keep PG from reusing the relnode until then.
+			 */
+			if (dropBridgeMarker)
+				o_bridge_drop_relnode_marker(dropTrees[i].oids.datoid,
+											 dropTrees[i].oids.spcoid,
+											 dropTrees[i].oids.relnode);
 		}
 	}
 

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -995,6 +995,19 @@ o_tupdesc_load_constr(TupleDesc tupdesc, OTable *o_table, OIndexDescr *descr)
 
 	all_attrs += fields_start;
 
+	/*
+	 * FreeTupleDesc() walks missing[] over the whole [0, natts) range and
+	 * decides how to free each entry from TupleDescAttr(tupdesc,
+	 * i)->attbyval. So the array we build here must cover natts exactly, and
+	 * entry i must describe attribute i.  Both hold only while the OTable we
+	 * were handed and the OIndex that produced this tupdesc are the same
+	 * incarnation of the relation -- see the version check in
+	 * o_index_fill_descr().  If they ever diverge the mismatch is silent here
+	 * and only surfaces much later, as a pfree() of a bogus pointer inside
+	 * FreeTupleDesc().
+	 */
+	Assert(tupdesc->natts == all_attrs);
+
 	tupdesc->constr = (TupleConstr *) palloc0(sizeof(TupleConstr));
 	tupdesc->constr->missing = (AttrMissing *) palloc0(all_attrs * sizeof(AttrMissing));
 
@@ -1005,6 +1018,15 @@ o_tupdesc_load_constr(TupleDesc tupdesc, OTable *o_table, OIndexDescr *descr)
 	{
 		OTableField *field = &o_table->fields[i];
 		AttrMissing *tupdesc_miss = &tupdesc->constr->missing[i + fields_start];
+
+		/*
+		 * The predicate used to copy the Datum here must be the one
+		 * FreeTupleDesc() will use to free it, or a by-value Datum gets
+		 * pfree()d as if it were a pointer.
+		 */
+		Assert(i + fields_start < tupdesc->natts);
+		Assert(TupleDescAttr(tupdesc, i + fields_start)->attbyval == field->byval);
+		Assert(TupleDescAttr(tupdesc, i + fields_start)->attlen == field->typlen);
 
 		tupdesc_miss->am_present = o_table->missing[i].am_present;
 

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -56,6 +56,7 @@
 #include "optimizer/optimizer.h"
 #include "parser/parse_relation.h"
 #include "pgstat.h"
+#include "postmaster/bgwriter.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
@@ -1749,7 +1750,26 @@ o_tables_rel_lock_extended(ORelOids *oids, int lockmode, bool checkpoint)
 	if (lockmode == AccessExclusiveLock && checkpoint)
 		locktag.locktag_lockmethodid = NO_LOG_LOCKMETHOD;
 
-	LockAcquire(&locktag, lockmode, false, false);
+	if (checkpoint && AmCheckpointerProcess())
+	{
+		/*
+		 * The holder of this lock may be blocked in RegisterSyncRequest()
+		 * waiting for us to drain the sync request queue -- an undo callback
+		 * unlinking a relation file does exactly that.  Plain waiting would
+		 * then deadlock, and invisibly: our wait is a lock wait, theirs is a
+		 * latch wait, so the deadlock detector sees no cycle.  Keep draining
+		 * between attempts, like acquire_chkp_lock_drain() does for the
+		 * checkpoint-coordination LWLocks.
+		 */
+		while (LockAcquire(&locktag, lockmode, false, true) == LOCKACQUIRE_NOT_AVAIL)
+		{
+			AbsorbSyncRequests();
+			pg_usleep(1000L);
+			CHECK_FOR_INTERRUPTS();
+		}
+	}
+	else
+		LockAcquire(&locktag, lockmode, false, false);
 	AcceptInvalidationMessages();
 }
 

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -2133,7 +2133,30 @@ o_tables_rel_fill_locktag(LOCKTAG *tag, ORelOids *oids, int lockmode, bool check
 	Assert(lockmode == AccessShareLock || lockmode == AccessExclusiveLock);
 	Assert(ORelOidsIsValid(*oids) && !IS_SYS_TREE_OIDS(*oids));
 	memset(tag, 0, sizeof(LOCKTAG));
-	SET_LOCKTAG_RELATION(*tag, datoid, oids->reloid);
+
+	/*
+	 * The checkpoint namespace protects a tree's shared state -- its shared
+	 * root info, meta page, seq bufs and files -- and every one of those is
+	 * keyed by (datoid, relnode, tablespace), never by reloid.  Key the lock
+	 * the same way.  Keying it by reloid meant two ORelOids naming the same
+	 * tree under different reloids took *different* locks and did not exclude
+	 * each other at all, while cleanup_btree() -- which looks the tree up by
+	 * relnode alone -- happily freed the meta page of the tree the
+	 * checkpointer was finalizing.  That is the
+	 * Assert(OInMemoryBlknoIsValid(shared->pages[curPageNum])) in
+	 * seq_buf_finalize(), whose op ring showed the freeing backend and the
+	 * finalizing checkpointer on one shared seq buf with the tree named
+	 * (73256, 107092, 107108) by one and (73256, 107111, 107108) by the
+	 * other.
+	 *
+	 * Nothing is lost by dropping reloid: two trees sharing a reloid but not
+	 * a relnode share no shared state, and descriptors are identified by
+	 * relnode as well.  Tablespace is still absent from the tag, which can
+	 * only merge two locks that would not have conflicted -- conservative,
+	 * not unsafe.
+	 */
+	SET_LOCKTAG_RELATION(*tag, datoid,
+						 checkpoint ? oids->relnode : oids->reloid);
 	if (checkpoint)
 		tag->locktag_type = LOCKTAG_USERLOCK;
 }

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -864,7 +864,29 @@ close_xids_file(void)
 	while (pg_atomic_read_u64(&checkpoint_state->xidRecFlushPos) <
 		   pg_atomic_read_u64(&checkpoint_state->xidRecLastPos))
 	{
+		uint64		flushedBefore = pg_atomic_read_u64(&checkpoint_state->xidRecFlushPos);
+
 		flush_xids_queue();
+
+		if (pg_atomic_read_u64(&checkpoint_state->xidRecFlushPos) != flushedBefore)
+			continue;
+
+		/*
+		 * No progress: a producer has taken a queue slot
+		 * (write_to_xids_queue() bumps xidRecLastPos before filling the
+		 * record) and has not published it yet.  On a standby that producer
+		 * is the startup process, which can be sitting in
+		 * RegisterSyncRequest() -- xact_redo_commit() -> DropRelationFiles()
+		 * -> smgrdounlinkall() -- waiting for us to drain the sync queue.
+		 * Spinning here without draining wedges replay against its own
+		 * restartpoint, and the tight loop was not even interruptible.  Same
+		 * cycle acquire_chkp_lock_drain() breaks for the
+		 * checkpoint-coordination LWLocks.
+		 */
+		if (AmCheckpointerProcess())
+			AbsorbSyncRequests();
+		pg_usleep(1000L);
+		CHECK_FOR_INTERRUPTS();
 	}
 
 	count = pg_atomic_read_u64(&checkpoint_state->xidRecLastPos);

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -160,7 +160,12 @@ CheckpointState *checkpoint_state = NULL;
 static MemoryContext chkp_main_context = NULL;
 static MemoryContext chkp_tree_context = NULL;
 
-static char *xidFilename = NULL;
+/*
+ * Built with snprintf into a fixed buffer rather than psprintf'd: this name is
+ * (re)built from inside write_to_xids_queue()'s critical section, where any
+ * palloc trips Assert(CritSectionCount == 0 || allowInCritSection).
+ */
+static char xidFilename[MAXPGPATH] = "";
 static uint32 xidFileCheckpointnum = 0;
 static File xidFile = -1;
 static S3TaskLocation maxLocation = 0;
@@ -774,15 +779,11 @@ open_xids_file(void)
 
 	if (xidFile < 0 || xidFileCheckpointnum != checkpointnum)
 	{
-		MemoryContext mctx = MemoryContextSwitchTo(TopMemoryContext);
-
-		if (xidFilename)
-			pfree(xidFilename);
 		if (xidFile >= 0)
 			FileClose(xidFile);
 
-		xidFilename = psprintf(XID_FILENAME_FORMAT, checkpointnum);
-		MemoryContextSwitchTo(mctx);
+		snprintf(xidFilename, sizeof(xidFilename),
+				 XID_FILENAME_FORMAT, checkpointnum);
 		xidFile = PathNameOpenFile(xidFilename, O_WRONLY | O_CREAT | PG_BINARY);
 		if (xidFile < 0)
 			ereport(FATAL, (errcode_for_file_access(),
@@ -1038,8 +1039,7 @@ close_xids_file(void)
 						errmsg("could not sync xid file %s: %m", xidFilename)));
 
 	FileClose(xidFile);
-	pfree(xidFilename);
-	xidFilename = NULL;
+	xidFilename[0] = '\0';
 	xidFile = -1;
 }
 

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -874,10 +874,25 @@ try_flush_xids_queue(void)
 void
 write_to_xids_queue(XidFileRec *rec)
 {
-	uint64		location = pg_atomic_fetch_add_u64(&checkpoint_state->xidRecLastPos, 1);
-	XidFileRec *target = &checkpoint_state->xidRecQueue[location % XID_RECS_QUEUE_SIZE];
+	uint64		location;
+	XidFileRec *target;
 
 	Assert(OXidIsValid(rec->oxid));
+
+	/*
+	 * The fetch_add below claims a slot, and close_xids_file() waits for
+	 * every claimed slot to be published.  Leaving without publishing would
+	 * strand the checkpointer on a record nobody will ever write, and the
+	 * hole cannot be repaired afterwards: the file is a flat array of
+	 * xidRecLastPos records whose reader feeds every one of them to
+	 * advance_oxids(), so there is no value that means "skip me".  A critical
+	 * section makes that impossible -- an error in here takes the cluster
+	 * down instead of silently abandoning the slot.
+	 */
+	START_CRIT_SECTION();
+
+	location = pg_atomic_fetch_add_u64(&checkpoint_state->xidRecLastPos, 1);
+	target = &checkpoint_state->xidRecQueue[location % XID_RECS_QUEUE_SIZE];
 
 	/*
 	 * Flush queue to the file till our position is available for write.
@@ -893,6 +908,8 @@ write_to_xids_queue(XidFileRec *rec)
 
 	target->oxid = rec->oxid;
 
+	END_CRIT_SECTION();
+
 	VALGRIND_CHECK_MEM_IS_DEFINED(target, sizeof(*target));
 }
 
@@ -902,19 +919,62 @@ write_to_xids_queue(XidFileRec *rec)
 static void
 before_writing_xids_file(int chkpnum)
 {
-	int			i;
+	if (checkpoint_state->xidQueueCheckpointNum >= chkpnum)
+		return;
 
-	if (checkpoint_state->xidQueueCheckpointNum < chkpnum)
+	/*
+	 * Restart the numbering -- but only from a state where the queue is
+	 * provably empty, so that no producer can be holding a position from the
+	 * old numbering.  Resetting unconditionally is what made the positions
+	 * and the slots disagree: write_to_xids_queue() claims with a bare
+	 * fetch_add, so a producer that claimed before the reset stored into a
+	 * slot the new numbering never handed out, and close_xids_file() then
+	 * waited forever on a hole nobody would fill.
+	 *
+	 * The order of the two reads matters.  lastPos is read first, so seeing
+	 * flushPos == lastPos means everything claimed up to that point had been
+	 * flushed -- hence published.  Any claim after that read increments
+	 * lastPos and makes the exchange below fail, and we go round again.  When
+	 * it succeeds, lastPos did not move between the read and the exchange, so
+	 * at that instant nothing was in flight and every slot holds InvalidOXid
+	 * (flush_xids_queue() clears what it flushes).  That is why there is no
+	 * memset here: clearing the queue after the exchange would wipe the
+	 * record of a producer that has already claimed position 0 under the new
+	 * numbering.
+	 *
+	 * Hold the flush lock throughout: flush_xids_queue() requires it, and it
+	 * also keeps a concurrent flusher from moving flushPos while we restart
+	 * it.  Nothing here waits on a producer except by flushing what it
+	 * published, so there is no cycle.
+	 */
+	LWLockAcquire(&checkpoint_state->oXidQueueFlushLock, LW_EXCLUSIVE);
+
+	for (;;)
 	{
-		checkpoint_state->xidQueueCheckpointNum = chkpnum;
-		pg_atomic_write_u64(&checkpoint_state->xidRecLastPos, 0);
-		pg_atomic_write_u64(&checkpoint_state->xidRecFlushPos, 0);
-		memset(checkpoint_state->xidRecQueue,
-			   0,
-			   sizeof(XidFileRec) * XID_RECS_QUEUE_SIZE);
-		for (i = 0; i < XID_RECS_QUEUE_SIZE; i++)
-			checkpoint_state->xidRecQueue[i].oxid = InvalidOXid;
+		uint64		lastPos = pg_atomic_read_u64(&checkpoint_state->xidRecLastPos);
+
+		if (pg_atomic_read_u64(&checkpoint_state->xidRecFlushPos) != lastPos)
+		{
+			/*
+			 * Records queued since the previous checkpoint closed its file
+			 * are drained rather than dropped: flushing is the only way to
+			 * empty the queue that cannot race a producer's publishing store,
+			 * since the scan stops at the first slot that is not published
+			 * yet.
+			 */
+			flush_xids_queue();
+			continue;
+		}
+
+		if (pg_atomic_compare_exchange_u64(&checkpoint_state->xidRecLastPos,
+										   &lastPos, 0))
+			break;
 	}
+
+	pg_atomic_write_u64(&checkpoint_state->xidRecFlushPos, 0);
+	checkpoint_state->xidQueueCheckpointNum = chkpnum;
+
+	LWLockRelease(&checkpoint_state->oXidQueueFlushLock);
 }
 
 /*

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -613,6 +613,23 @@ perform_writeback_and_relock(BTreeDescr *desc,
 			return NULL;
 		}
 
+		/*
+		 * The tree was re-created while we had it released -- which is
+		 * exactly what a TRUNCATE of a table created in the current
+		 * transaction does, and this window is its opportunity.
+		 * checkpointable_tree_init() has already set the new tree up as one
+		 * this checkpoint has passed, so drop it here: the seq bufs we opened
+		 * for it are gone, and the ones it has now belong to the next
+		 * checkpoint.
+		 */
+		if (BTREE_GET_META(desc)->reinitCheckpointNum ==
+			checkpoint_state->lastCheckpointNumber + 1)
+		{
+			o_tables_rel_unlock_extended(&treeOids, AccessShareLock, true);
+			LWLockRelease(&checkpoint_state->oTablesMetaLock);
+			return NULL;
+		}
+
 		LWLockRelease(&checkpoint_state->oTablesMetaLock);
 	}
 	else
@@ -5985,22 +6002,41 @@ checkpointable_tree_init(BTreeDescr *desc, bool init_shmem, bool *was_evicted)
 	bool		checkpoint_concurrent;
 	uint32		chkp_num;
 	uint32		map_chkp_num;
+	uint32		skip_chkp_num = 0;
 	EvictedTreeData *evicted_tree_data = NULL;
 	bool		map_file_exists = false;
 
 	chkp_num = get_cur_checkpoint_number(&desc->oids, desc->type,
 										 &checkpoint_concurrent);
+
+	/*
+	 * Initializing shared memory while a checkpoint is working on this very
+	 * tree used to be simply forbidden -- the checkpointer set that memory up
+	 * before it started, so re-creating it underneath leaves the checkpointer
+	 * finalizing seq bufs whose pages were freed by init_meta_page().  But it
+	 * does happen: a TRUNCATE of a table created in the current transaction
+	 * frees the trees right away, and perform_writeback_and_relock() hands it
+	 * exactly the window to do so.
+	 *
+	 * Treat the tree as one the running checkpoint has already passed, the
+	 * same way get_cur_checkpoint_number() does for a tree behind the
+	 * checkpointer's position, and record which checkpoint must ignore it.
+	 * The checkpointer picks that up after its relock and skips the tree; the
+	 * next checkpoint sees a normally initialized one.
+	 */
+	if (init_shmem && checkpoint_concurrent)
+	{
+		skip_chkp_num = checkpoint_state->lastCheckpointNumber + 1;
+		chkp_num += 1;
+		checkpoint_concurrent = false;
+	}
+
 	map_chkp_num = chkp_num;
 
 	elog(DEBUG1, "checkpointable_tree_init: (%u, %u) chkp_num=%u concurrent=%d",
 		 desc->oids.datoid, desc->oids.relnode,
 		 chkp_num, checkpoint_concurrent);
 
-	/*
-	 * We shouldn't initialize shared memory concurrently to checkpoint.
-	 * Checkpointer should have initialized that before start working on this
-	 * tree.
-	 */
 	Assert(!init_shmem || !checkpoint_concurrent);
 
 	btree_open_smgr(desc);
@@ -6018,6 +6054,13 @@ checkpointable_tree_init(BTreeDescr *desc, bool init_shmem, bool *was_evicted)
 		ereport(FATAL, (errcode_for_file_access(),
 						errmsg("could not fill sequence buffers: %m")));
 	}
+
+	/*
+	 * init_meta_page() zeroed the meta page, so this has to land after the
+	 * initialization above.
+	 */
+	if (skip_chkp_num != 0)
+		BTREE_GET_META(desc)->reinitCheckpointNum = skip_chkp_num;
 
 	if (init_shmem && was_evicted)
 		*was_evicted = evicted_tree_data != NULL;

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -581,6 +581,7 @@ perform_writeback_and_relock(BTreeDescr *desc,
 	ORelOids	treeOids = desc->oids;
 	OIndexType	type = desc->type;
 	OIndexDescr *indexDescr;
+	OInMemoryBlkno oldMetaBlkno = desc->rootInfo.metaPageBlkno;
 
 	if (!IS_SYS_TREE_OIDS(treeOids))
 	{
@@ -628,6 +629,51 @@ perform_writeback_and_relock(BTreeDescr *desc,
 			o_tables_rel_unlock_extended(&treeOids, AccessShareLock, true);
 			LWLockRelease(&checkpoint_state->oTablesMetaLock);
 			return NULL;
+		}
+
+		/*
+		 * The caller's private seq bufs (descr->{tmpBuf,nextChkp,freeBuf}[])
+		 * hold raw pointers into the meta page they were bound to before the
+		 * unlock above.  Concurrent deletion -- which that unlock exists to
+		 * allow -- runs cleanup_btree() -> free_meta_page(), so those
+		 * pointers can now address a freed (and possibly recycled) page, and
+		 * the finalize at the end of checkpoint_ix() reads pages[] out of it:
+		 *
+		 * r  checkpointer  lock=S   attach, binds .shared C  backend lock=X
+		 * free_meta_page() F  checkpointer  lock=S seq_buf_finalize() -> TRAP
+		 *
+		 * (the seq buf op ring, run 31325040926 job on amd64/18/gcc/r2; the
+		 * two conflicting modes coexist only because we released in between).
+		 * Holding the lock again proves nothing about the meta page -- the
+		 * lock manager is happy to hand out a lock on a name whose tree is
+		 * gone.  Compare the page itself and give up on this tree if it
+		 * moved; the caller already handles a NULL return.
+		 */
+		{
+			SharedRootInfoKey key;
+			SharedRootInfo *sharedRootInfo;
+			bool		gone;
+
+			key.datoid = desc->oids.datoid;
+			key.relnode = desc->oids.relnode;
+			key.tablespace = desc->oids.spcoid;
+			sharedRootInfo = o_find_shared_root_info(&key);
+
+			gone = (desc->rootInfo.metaPageBlkno != oldMetaBlkno ||
+					sharedRootInfo == NULL ||
+					sharedRootInfo->placeholder ||
+					sharedRootInfo->rootInfo.metaPageBlkno !=
+					desc->rootInfo.metaPageBlkno);
+
+			if (sharedRootInfo)
+				pfree(sharedRootInfo);
+
+			if (gone)
+			{
+				o_tables_rel_unlock_extended(&treeOids, AccessShareLock, true);
+				LWLockRelease(&checkpoint_state->oTablesMetaLock);
+				return NULL;
+			}
 		}
 
 		LWLockRelease(&checkpoint_state->oTablesMetaLock);

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -883,7 +883,18 @@ close_xids_file(void)
 	{
 		uint64		flushedBefore = pg_atomic_read_u64(&checkpoint_state->xidRecFlushPos);
 
-		flush_xids_queue();
+		/*
+		 * Must go through try_flush_xids_queue(): flush_xids_queue() is not
+		 * safe to run concurrently, and producers reach it holding
+		 * oXidQueueFlushLock.  Calling it directly from here raced them --
+		 * both sides read xidRecFlushPos, scan, clear the oxids they wrote
+		 * and then store their own endPos unconditionally, so the one that
+		 * started earlier could move xidRecFlushPos *backwards* onto slots
+		 * the other had already flushed and cleared.  From there the scan
+		 * meets an InvalidOXid that nobody will ever rewrite, and this loop
+		 * spins forever -- the standby shutdown stall.
+		 */
+		try_flush_xids_queue();
 
 		if (pg_atomic_read_u64(&checkpoint_state->xidRecFlushPos) != flushedBefore)
 			continue;

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -752,6 +752,9 @@ flush_xids_queue(void)
 				location,
 				endPos;
 
+	Assert(LWLockHeldByMeInMode(&checkpoint_state->oXidQueueFlushLock,
+								LW_EXCLUSIVE));
+
 	open_xids_file();
 	startPos = pg_atomic_read_u64(&checkpoint_state->xidRecFlushPos);
 	endPos = Min(pg_atomic_read_u64(&checkpoint_state->xidRecLastPos), startPos + XID_RECS_QUEUE_SIZE);

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -1072,8 +1072,6 @@ finish_write_xids(uint32 chkpnum, bool shutdown)
 	int			i,
 				j,
 				k;
-	int			total_recovery_workers = recovery_pool_size_guc + recovery_idx_pool_size_guc;
-	bool	   *temp_file_loaded;
 
 	memset(&xidRec, 0, sizeof(xidRec));
 	ASAN_UNPOISON_MEMORY_REGION(&xidRec, sizeof(xidRec));
@@ -1118,11 +1116,31 @@ finish_write_xids(uint32 chkpnum, bool shutdown)
 		checkpoint_write_rewind_xids();
 
 	recovery_undo_loc_flush->immediateRequestCheckpointNumber = chkpnum;
+}
 
-	/*
-	 * Wait till recovery undo position will be flushed. But don't wait for
-	 * exited workers.
-	 */
+/*
+ * Wait till the recovery undo position is flushed for `chkpnum`.  But don't
+ * wait for exited workers.
+ *
+ * Split out of finish_write_xids() and called by o_perform_checkpoint() AFTER
+ * oXidQueueLock is released, and it must stay that way.  On a standby this
+ * waits for the startup process to run o_handle_startup_proc_interrupts_hook()
+ * (recovery.c), which is the only writer of completedCheckpointNumber.  Holding
+ * an LWLock raises InterruptHoldoffCount, so a checkpointer waiting here under
+ * oXidQueueLock could not absorb a ProcSignalBarrier -- and the startup process
+ * emits one from dbase_redo() (PROCSIGNAL_BARRIER_SMGRRELEASE) when it replays
+ * DROP DATABASE and then blocks in WaitForProcSignalBarrier() until every
+ * backend absorbs it.  That closed the loop: startup waited for the
+ * checkpointer's barrier, the checkpointer waited for startup's progress, and
+ * replay stopped forever (observed as "Replica failed to synchronize").
+ */
+static void
+wait_recovery_undo_loc_flushed(uint32 chkpnum, bool shutdown)
+{
+	int			i;
+	int			total_recovery_workers = recovery_pool_size_guc + recovery_idx_pool_size_guc;
+	bool	   *temp_file_loaded;
+
 	temp_file_loaded = (bool *) palloc0(sizeof(bool) * total_recovery_workers);
 	while (recovery_undo_loc_flush->completedCheckpointNumber <
 		   recovery_undo_loc_flush->immediateRequestCheckpointNumber)
@@ -1152,6 +1170,13 @@ finish_write_xids(uint32 chkpnum, bool shutdown)
 
 		if (all_workers_done)
 			break;
+
+		/*
+		 * Absorb interrupts -- notably the ProcSignalBarrier the startup
+		 * process is waiting on (see the comment above).  Safe here only
+		 * because the caller has already released oXidQueueLock.
+		 */
+		CHECK_FOR_INTERRUPTS();
 
 		WakeupRecovery();
 		pg_usleep(10000L);
@@ -1744,6 +1769,16 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 	finish_write_xids(cur_chkp_num, (flags & CHECKPOINT_IS_SHUTDOWN) ? true : false);
 	close_xids_file();
 	LWLockRelease(&checkpoint_state->oXidQueueLock);
+
+	/*
+	 * Only now, with oXidQueueLock released, wait for the recovery workers to
+	 * flush their undo positions: that wait depends on the startup process
+	 * making progress, and holding an LWLock across it deadlocks a standby
+	 * against dbase_redo()'s ProcSignalBarrier (see
+	 * wait_recovery_undo_loc_flushed()).
+	 */
+	wait_recovery_undo_loc_flushed(cur_chkp_num,
+								   (flags & CHECKPOINT_IS_SHUTDOWN) ? true : false);
 
 	for (i = 0; i < NUM_CHECKPOINTABLE_UNDO_LOGS; i++)
 	{
@@ -3058,6 +3093,22 @@ checkpoint_ix(int flags, BTreeDescr *descr)
 		/* Lock already released by perform_writeback_and_relock() */
 		return NULL;
 	}
+
+	/*
+	 * perform_writeback_and_relock() unlocks the tree and re-fetches the
+	 * descriptor, so `descr` may be a different object than the one we
+	 * derived meta_page from.  A tree under checkpoint is supposed to be
+	 * protected from eviction, so the meta page must be the same one -- but
+	 * everything below still uses the meta_page captured before the unlock:
+	 * the copyBlknoLock that serialises us against the concurrent
+	 * get_free_disk_extent_copy_blkno() writers appending into
+	 * nextChkp[cur_chkp_index] (btree/io.c), and the datafileLength /
+	 * leafPagesNum / ctid / bridge_ctid values written into the map file
+	 * header.  If it ever diverged we would silently take the wrong lock and
+	 * persist another meta page's numbers, so assert the invariant instead of
+	 * trusting it.
+	 */
+	Assert(meta_page == BTREE_GET_META(descr));
 
 	Assert(checkpoint_state->curKeyType == CurKeyGreatest);
 	Assert(DiskDownlinkIsValid(root_downlink));

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -3398,9 +3398,6 @@ recovery_on_proc_exit(int code, Datum arg)
 {
 	int			worker_id = (int) arg;
 
-	if (!recovery_xid_state_hash)
-		return;
-
 	/*
 	 * The startup process (worker_id < 0) is not a recovery worker and
 	 * doesn't use worker_ptrs[].  save_state_to_file() and hasTempFile are
@@ -3412,9 +3409,20 @@ recovery_on_proc_exit(int code, Datum arg)
 
 	elog(LOG, "recovery on exit: %d", worker_id);
 
-	save_state_to_file(worker_id);
+	/* Only a worker that built its xid state has anything to hand over. */
+	if (recovery_xid_state_hash)
+		save_state_to_file(worker_id);
 
-	/* Mark worker as having saved state and exited */
+	/*
+	 * Mark the worker gone even when it had no state to save.  The flag is
+	 * what tells the checkpointer's shutdown wait
+	 * (wait_recovery_undo_loc_flushed()) that this worker no longer owes an
+	 * undo-location flush; without it the wait treats the worker as still
+	 * running and spins forever.  A worker that never received a
+	 * RecoveryMsgTypeInit has neither state nor a flushed counter, so it is
+	 * exactly the one that would wedge the shutdown restartpoint.
+	 * recovery_load_state_from_file() tolerates the missing file.
+	 */
 	pg_atomic_test_set_flag(&worker_ptrs[worker_id].hasTempFile);
 }
 

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -224,6 +224,15 @@ recovery_worker_main(Datum main_arg)
 		shm_mq_set_receiver(GET_WORKER_QUEUE(id), MyProc);
 		recovery_worker_queue = shm_mq_attach(GET_WORKER_QUEUE(id), NULL, NULL);
 
+		/*
+		 * Register before processing anything, not on the first
+		 * RecoveryMsgTypeInit.  The checkpointer's shutdown wait keeps
+		 * waiting on any worker that has not marked itself gone, and a worker
+		 * which never receives a message would otherwise exit without the
+		 * callback ever running -- wedging the shutdown restartpoint.
+		 */
+		before_shmem_exit(recovery_on_proc_exit, Int32GetDatum(id));
+
 		my_ptr = pg_atomic_read_u64(&worker_ptrs[id].commitPtr);
 		recovery_queue_process(recovery_worker_queue, id);
 
@@ -645,7 +654,6 @@ recovery_queue_process(shm_mq_handle *queue, int id)
 			else if (type == RecoveryMsgTypeInit)
 			{
 				Assert(!recovery_initialized);
-				before_shmem_exit(recovery_on_proc_exit, Int32GetDatum(id));
 				recovery_init(id);
 				recovery_initialized = true;
 				data_pos += sizeof(RecoveryMsgEmpty);

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -738,6 +738,22 @@ table_descr_free(OTableDescr *descr)
 		descr->toast->refcnt--;
 		if (!descr->toast->valid && descr->toast->refcnt == 0)
 			index_descr_delete_from_hash(descr->toast);
+		descr->toast = NULL;
+	}
+
+	/*
+	 * o_table_descr_fill_indices() takes a reference on the bridge descriptor
+	 * exactly like it does for toast and the regular indices, so drop it here
+	 * too.  Without this its refcnt only ever grows: the descriptor is never
+	 * freed once its index record is gone, and every invalidation keeps
+	 * rebuilding it instead.
+	 */
+	if (descr->bridge)
+	{
+		descr->bridge->refcnt--;
+		if (!descr->bridge->valid && descr->bridge->refcnt == 0)
+			index_descr_delete_from_hash(descr->bridge);
+		descr->bridge = NULL;
 	}
 
 	if (descr->indices)
@@ -1526,7 +1542,18 @@ get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchCon
 	 * checkpointer) resolves the tree at the requested tablespace instead of
 	 * writing its files back into the old one.
 	 */
-	if (existed && result->desc.oids.spcoid == ixOids.spcoid &&
+
+	/*
+	 * A descriptor whose index record has gone away is kept in the hash while
+	 * someone still holds it (see recreate_index_descr()), but it must not be
+	 * handed out again: a caller that gets one instead of NULL -- the
+	 * checkpointer above all -- loses its only signal that the relation was
+	 * concurrently dropped or truncated.  Fall through and re-read the record
+	 * instead; that returns NULL while the index is really gone, and refills
+	 * the entry if it came back.
+	 */
+	if (existed && result->valid &&
+		result->desc.oids.spcoid == ixOids.spcoid &&
 		(ctx.version == O_TABLE_INVALID_VERSION ||
 		 result->version == ctx.version))
 		return result;
@@ -1553,8 +1580,29 @@ get_index_descr(ORelOids ixOids, OIndexType ixType, bool miss_ok, OTableFetchCon
 	if (!oIndex && miss_ok)
 	{
 		filling_index_descr = prev_filling;
-		(void) hash_search(oIndexDescrHash, &ixOids, HASH_REMOVE, &found);
-		Assert(found);
+		result->fill_in_progress = false;
+
+		/*
+		 * The index record is gone.  Tear the entry down the way invalidation
+		 * does it (recreate_index_descr): drop it only when nobody holds it,
+		 * and otherwise just mark it invalid so the last holder removes it
+		 * (table_descr_free).  Removing a held entry here would hand its
+		 * dynahash element back to the freelist while an OTableDescr still
+		 * points at it, so a later descriptor would be built on that memory
+		 * and the holder's refcnt decrements would land on the wrong one.
+		 *
+		 * A slot we entered ourselves was only zeroed, never filled, so it
+		 * needs no index_descr_free().
+		 */
+		if (!existed)
+		{
+			(void) hash_search(oIndexDescrHash, &ixOids, HASH_REMOVE, &found);
+			Assert(found);
+		}
+		else if (result->refcnt == 0)
+			index_descr_delete_from_hash(result);
+		else
+			result->valid = false;
 		return NULL;
 	}
 

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -969,6 +969,36 @@ create_table_descr(ORelOids oids, OTableFetchContext ctx)
 	filling_table_descr = descr;
 	descr->fill_in_progress = true;
 
+	/*
+	 * o_fetch_table_descr_extended() lands here for an entry that is already
+	 * in the hash whenever its metadata version no longer matches, so this is
+	 * a re-fill and the previous incarnation has to be released first --
+	 * exactly what recreate_table_descr() does.
+	 * fill_table_descr_common_fields() only memset()s the descriptor, so
+	 * without this its tupdesc and tuple slots leak into the never-reset
+	 * descrCxt and, worse, the references o_table_descr_fill_indices() took
+	 * on the index descriptors are never dropped: their refcnt can no longer
+	 * reach zero, so they are pinned for the life of the backend and every
+	 * invalidation rebuilds them instead of freeing them.
+	 */
+	if (found)
+		table_descr_free(descr);
+	else
+	{
+		/*
+		 * A fresh HASH_ENTER slot still holds a previously-freed descriptor's
+		 * pointers -- dynahash does not zero the value part.  Nothing reads
+		 * them before fill_table_descr_common_fields() memset()s the entry,
+		 * but an error longjmp in between would leave them in the hash with
+		 * the "being filled" flag cleared by reset_filling_descrs(), and the
+		 * next invalidation would free another descriptor's tupdesc and
+		 * slots.  Zero it now (restoring the hash key), mirroring
+		 * get_index_descr().
+		 */
+		memset(descr, 0, sizeof(*descr));
+		descr->oids = o_table->oids;
+	}
+
 	descr->refcnt = 0;
 	if (!fill_table_descr(descr, o_table, ctx.snapshot))
 	{

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -3048,8 +3048,22 @@ o_truncate_table(ORelOids oids, bool missingOK)
 	{
 		OIndexKey	key = {.oids = oids};
 
+		/*
+		 * Take the checkpoint-namespace lock as well, exactly like the loop
+		 * above does for each tree.  The AccessExclusiveLock held since the
+		 * top of this function is the plain variant, which the checkpointer
+		 * never takes -- it locks trees in the checkpoint namespace.  Without
+		 * this, cleanup_btree() frees the tree's pages and its meta page (and
+		 * with it the seq buf page references) while the checkpointer is
+		 * walking that very tree, which surfaces as either
+		 * Assert(FileExtentIsValid(...)) in checkpoint_btree_loop() or
+		 * Assert(OInMemoryBlknoIsValid(shared->pages[...])) in
+		 * seq_buf_finalize().
+		 */
+		o_tables_rel_lock_extended(&oids, AccessExclusiveLock, true);
 		cleanup_btree(key, true, !is_temp);
 		o_invalidate_oids(oids);
+		o_tables_rel_unlock_extended(&oids, AccessExclusiveLock, true);
 /*		if (is_recovery_process())
 			o_invalidate_descrs(oids.datoid, oids.reloid, oids.relnode);*/
 	}

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -697,31 +697,14 @@ set_oxid_csn(OXid oxid, CommitSeqNo csn)
 	writeInProgressXmin = pg_atomic_read_u64(&xid_meta->writeInProgressXmin);
 	if (oxid >= writeInProgressXmin)
 	{
-		/*
-		 * Mark the page dirty BEFORE publishing the new csn with the CAS
-		 * below, not after.  write_xidsmap() drains this slot into o_buffers
-		 * and decides whether to write the page dirty or clean by
-		 * test-and-clearing the page dirty bit, then advances writtenXmin
-		 * past the slot.  If we set the dirty bit only after a successful
-		 * CAS, a concurrent write_xidsmap() can slip in between the CAS and
-		 * mark_xid_buffer_dirty(): it drains our freshly written csn but sees
-		 * the page as clean (our bit is not set yet), writes it to o_buffers
-		 * clean, and advances writtenXmin past oxid -- so our subsequent
-		 * mark_xid_buffer_dirty() lands on a page that is never flushed
-		 * again, and a later eviction can drop the clean copy, leaving the
-		 * stale (e.g. COMMITTING) value on disk permanently.  Readers of a
-		 * tuple modified by oxid then spin forever in oxid_get_csn() on a
-		 * committing bit that never clears (observed as a checkpoint-race
-		 * hang: FOR KEY SHARE / FK check on a just-committed row).  Setting
-		 * the dirty bit first closes the window: any flush that can observe
-		 * the new csn also observes the dirty bit.
-		 */
-		mark_xid_buffer_dirty(oxid);
 		if (pg_atomic_compare_exchange_u64(&xidBuffer[oxid % xid_circular_buffer_size].csn,
 										   &oldCsn, csn))
 		{
+			mark_xid_buffer_dirty(oxid);
 			Assert(oldCsn != COMMITSEQNO_FROZEN);
-			return;
+
+			if (oxid >= pg_atomic_read_u64(&xid_meta->writeInProgressXmin))
+				return;
 		}
 
 		/*
@@ -761,19 +744,14 @@ set_oxid_xlog_ptr_internal(OXid oxid, XLogRecPtr ptr)
 	writeInProgressXmin = pg_atomic_read_u64(&xid_meta->writeInProgressXmin);
 	if (oxid >= writeInProgressXmin)
 	{
-		/*
-		 * Mark the page dirty before the CAS, for the same reason as in
-		 * set_oxid_csn(): otherwise a concurrent write_xidsmap() can drain
-		 * the new commitPtr while seeing the page clean and advance
-		 * writtenXmin past oxid, stranding the update on a never-reflushed
-		 * page.
-		 */
-		mark_xid_buffer_dirty(oxid);
 		if (pg_atomic_compare_exchange_u64(&xidBuffer[oxid % xid_circular_buffer_size].commitPtr,
 										   &oldPtr, ptr))
 		{
+			mark_xid_buffer_dirty(oxid);
 			Assert(oldPtr != FirstNormalUnloggedLSN);
-			return;
+
+			if (oxid >= pg_atomic_read_u64(&xid_meta->writeInProgressXmin))
+				return;
 		}
 
 		/*
@@ -1536,11 +1514,16 @@ advance_oxids(OXid new_xid)
 		xmax = Min(new_xid + 1, pg_atomic_read_u64(&xid_meta->writtenXmin) + xid_circular_buffer_size);
 		for (; xid < xmax; xid++)
 		{
-			mark_xid_buffer_dirty(xid);
 			pg_atomic_write_u64(&xidBuffer[xid % xid_circular_buffer_size].csn,
 								COMMITSEQNO_INPROGRESS);
 			pg_atomic_write_u64(&xidBuffer[xid % xid_circular_buffer_size].commitPtr,
 								InvalidXLogRecPtr);
+
+			/*
+			 * Nobody can evict this to the disk before we advance nextXid.
+			 * So, marking bufffer dirty is safe.
+			 */
+			mark_xid_buffer_dirty(xid);
 		}
 		pg_atomic_write_u64(&xid_meta->nextXid, xmax);
 	}
@@ -1599,17 +1582,61 @@ get_current_oxid(void)
 		vxidElem->vxid.BACKENDID = MyProc->PROCBACKENDID;
 		vxidElem->vxid.localTransactionId = MyProc->LXID;
 
-		Assert(pg_atomic_read_u64(&xidBuffer[newOxid % xid_circular_buffer_size].csn) == COMMITSEQNO_FROZEN);
-		mark_xid_buffer_dirty(newOxid);
-		pg_atomic_write_u64(&xidBuffer[newOxid % xid_circular_buffer_size].csn,
-							COMMITSEQNO_MAKE_SPECIAL(MYPROCNUMBER,
-													 nestingLevel,
-													 COMMITSEQNO_STATUS_IN_PROGRESS));
-		pg_atomic_write_u64(&xidBuffer[newOxid % xid_circular_buffer_size].commitPtr,
-							XLOG_PTR_MAKE_SPECIAL(MYPROCNUMBER,
-												  nestingLevel,
-												  COMMITSEQNO_STATUS_IN_PROGRESS));
-		curOxid = newOxid;
+		{
+			CommitSeqNo initCsn = COMMITSEQNO_MAKE_SPECIAL(MYPROCNUMBER,
+														   nestingLevel,
+														   COMMITSEQNO_STATUS_IN_PROGRESS);
+			XLogRecPtr	initPtr = XLOG_PTR_MAKE_SPECIAL(MYPROCNUMBER,
+														nestingLevel,
+														COMMITSEQNO_STATUS_IN_PROGRESS);
+
+			/*
+			 * The slot holds COMMITSEQNO_FROZEN until we set the csn below,
+			 * and write_xidsmap() never drains that delimiter -- so it cannot
+			 * advance writeInProgressXmin past newOxid and evict our slot
+			 * before the csn is set.  The ring write is therefore
+			 * unconditionally safe.
+			 */
+			Assert(pg_atomic_read_u64(&xidBuffer[newOxid % xid_circular_buffer_size].csn) == COMMITSEQNO_FROZEN);
+
+			/*
+			 * Write commitPtr first because write_xidmap() takes csn into
+			 * account
+			 */
+			pg_atomic_write_u64(&xidBuffer[newOxid % xid_circular_buffer_size].commitPtr,
+								initPtr);
+			pg_write_barrier();
+			pg_atomic_write_u64(&xidBuffer[newOxid % xid_circular_buffer_size].csn,
+								initCsn);
+			mark_xid_buffer_dirty(newOxid);
+
+			/*
+			 * Now that the slot carries a real csn it can be drained.  If a
+			 * concurrent write_xidsmap() advanced writeInProgressXmin past
+			 * newOxid, our ring slot was drained to o_buffers; wait for that
+			 * write to finish and persist the item there ourselves (mirroring
+			 * set_oxid_csn()).  Do NOT mark the recycled ring slot dirty here
+			 * -- a later flush would otherwise overwrite our on-disk offset
+			 * with that recycled slot's value.
+			 */
+			if (newOxid < pg_atomic_read_u64(&xid_meta->writeInProgressXmin))
+			{
+				if (newOxid >= pg_atomic_read_u64(&xid_meta->writtenXmin))
+				{
+					LWLockAcquire(&xid_meta->xidMapWriteLock, LW_SHARED);
+					LWLockRelease(&xid_meta->xidMapWriteLock);
+				}
+				Assert(newOxid < pg_atomic_read_u64(&xid_meta->writtenXmin));
+				/* commitPtr first, as in the ring case */
+				o_buffers_write(&buffersDesc, (Pointer) &initPtr, OXID_BUFFERS_TAG,
+								newOxid * sizeof(OXidMapItem) + offsetof(OXidMapItem, commitPtr),
+								sizeof(XLogRecPtr), false, false);
+				o_buffers_write(&buffersDesc, (Pointer) &initCsn, OXID_BUFFERS_TAG,
+								newOxid * sizeof(OXidMapItem) + offsetof(OXidMapItem, csn),
+								sizeof(CommitSeqNo), false, false);
+			}
+			curOxid = newOxid;
+		}
 
 		/* Check if an autonomous transaction is in progress */
 		if (nestingLevel > 0)

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -1655,7 +1655,8 @@ read_undo_range_if_exists(OBuffersDesc *desc, Pointer buf, UndoLogType undoType,
 #define UNDO_FLUSH_BATCH_PAGES 128
 static void
 flush_dirty_undo_range(UndoLogType undoType,
-					   UndoLocation fromLoc, UndoLocation toLoc)
+					   UndoLocation fromLoc, UndoLocation toLoc,
+					   UndoLocation minProcReservedLocation)
 {
 	UndoMeta   *meta = get_undo_meta_by_type(undoType);
 	Pointer		circularBuffer = o_undo_buffers[(int) undoType];
@@ -1664,8 +1665,40 @@ flush_dirty_undo_range(UndoLogType undoType,
 				alignedFrom,
 				alignedTo;
 
+	/*
+	 * Staging area for the page straddling writtenLocation.  Static rather
+	 * than on the stack: this runs on the abort/longjmp-reachable path where
+	 * a large frame trips ASAN's stale stack poison, and the function is not
+	 * recursive.
+	 *
+	 * A bare char[] would do for the memcpy()s, but
+	 * o_buffers_write_page_direct() requires its buffer to be 8-byte aligned
+	 * and a char array carries no such guarantee -- clang put one at an
+	 * address 4 bytes off an 8-byte boundary and the assert fired on the
+	 * first checkpoint.  Union it with the widest scalars, the way
+	 * PGAlignedBlock does.
+	 */
+	static union
+	{
+		char		data[ORIOLEDB_BLCKSZ];
+		double		force_align_d;
+		int64		force_align_i64;
+	}			staging;
+	char	   *stagingPage = staging.data;
+
 	/* Enforced in undo_shmem_needs() via TYPEALIGN. */
 	Assert(circularBufferSize % ORIOLEDB_BLCKSZ == 0);
+
+	/*
+	 * Only locations at or above writtenLocation still own their ring slot.
+	 * Below it the undo was drained to disk and the slots were recycled by
+	 * newer (location + ring size) records; persisting those bytes back to
+	 * the old location's absolute on-disk offset would corrupt an
+	 * already-drained record.  writtenLocation only advances, so clamping
+	 * here is safe -- it is re-read per batch under the lock below, because
+	 * it can advance while we hold no lock between batches.
+	 */
+	fromLoc = Max(fromLoc, pg_atomic_read_u64(&meta->writtenLocation));
 
 	if (fromLoc >= toLoc)
 		return;
@@ -1682,29 +1715,86 @@ flush_dirty_undo_range(UndoLogType undoType,
 	while (pageLoc < alignedTo)
 	{
 		int			processed;
+		UndoLocation writtenNow;
 
 		LWLockAcquire(&meta->undoWriteLock, LW_EXCLUSIVE);
+
+		/*
+		 * Re-read the drained frontier under the lock: evict_undo_to_disk()
+		 * (also under undoWriteLock) may have advanced writtenLocation while
+		 * we held no lock between batches, recycling more ring slots.
+		 */
+		writtenNow = pg_atomic_read_u64(&meta->writtenLocation);
 
 		for (processed = 0;
 			 processed < UNDO_FLUSH_BATCH_PAGES && pageLoc < alignedTo;
 			 processed++, pageLoc += ORIOLEDB_BLCKSZ)
 		{
 			uint32		page = UNDO_PAGE_INDEX(undoType, pageLoc);
+			UndoLocation pageEnd = pageLoc + ORIOLEDB_BLCKSZ;
+			Pointer		src = circularBuffer + (pageLoc % circularBufferSize);
+			Size		liveOff;
 
-			if (!test_clear_undo_page_dirty(undoType, page))
+			/*
+			 * A page wholly below writtenNow is fully drained: its on-disk
+			 * copy is already current and its ring slots now belong to newer
+			 * records.  Skip it -- writing those recycled bytes to this
+			 * page's offset is exactly how an old record's undo turns into
+			 * garbage.
+			 */
+			if (pageEnd <= writtenNow)
 				continue;
 
 			/*
-			 * Pages in [fromLoc, toLoc) are stable while we copy them:
-			 * fsync_undo_range() called check_reserved_undo_location() with
-			 * toLoc + ring_size before invoking us, which waits until every
-			 * backend's reserved location is >= toLoc, so no backend can be
-			 * appending into our range concurrently.  That lets us hand the
-			 * ring-buffer page straight to the write without staging.
+			 * The dirty bit may only be trusted -- and consumed -- for a page
+			 * lying ENTIRELY below minProcReservedLocation.  At or above that
+			 * frontier a backend may still be filling a record it reserved:
+			 * get_undo_record() publishes the pages dirty BEFORE its caller
+			 * writes the payload, so clearing the bit here would strand that
+			 * payload (the page would look clean to every later flush and
+			 * eviction, and the record would never reach disk).  For such
+			 * pages write unconditionally and leave the bit set, so the
+			 * completed record gets flushed again later.
+			 */
+			if (pageEnd <= minProcReservedLocation)
+			{
+				if (!test_clear_undo_page_dirty(undoType, page))
+					continue;
+			}
+
+			/*
+			 * Assemble the page in a staging buffer instead of handing the
+			 * live ring page to the write: writers do not hold undoWriteLock,
+			 * so the ring bytes can shift under o_buffers_write_page_direct()
+			 * and yield a torn page image.  That is not hypothetical for
+			 * pages at or above minProcReservedLocation -- those are exactly
+			 * the ones a backend may be filling right now.
 			 *
+			 * The page straddling writtenNow additionally holds
+			 * already-drained bytes (< writtenNow) whose ring slots now
+			 * belong to newer records.  Preload the current on-disk page so
+			 * that prefix is preserved verbatim, and take only the live tail
+			 * from the ring.
+			 */
+			if (pageLoc < writtenNow)
+			{
+				liveOff = writtenNow - pageLoc;
+				if (!o_buffers_read(&undoBuffersDesc, stagingPage,
+									(uint32) undoType, pageLoc,
+									ORIOLEDB_BLCKSZ, true))
+					memset(stagingPage, 0, liveOff);
+			}
+			else
+			{
+				liveOff = 0;
+			}
+			memcpy(stagingPage + liveOff, src + liveOff,
+				   ORIOLEDB_BLCKSZ - liveOff);
+
+			/*
 			 * In-place undo_write_internal writes (BTreeLeafTuphdr fixups)
-			 * may still race; they are loss-tolerant -- 8-byte halves are
-			 * atomic, WAL replay rebuilds the affected fields.
+			 * may still race with the copy; they are loss-tolerant -- 8-byte
+			 * halves are atomic, WAL replay rebuilds the affected fields.
 			 *
 			 * Bypass the o_buffers cache: future reads of these locations
 			 * answer from the ring (writtenLocation does not advance), so
@@ -1712,16 +1802,12 @@ flush_dirty_undo_range(UndoLogType undoType,
 			 *
 			 * The acquire pairing with mark_undo_range_dirty() lives inside
 			 * test_clear_undo_page_dirty()'s fetch_and; the page we read
-			 * below reflects every store the writer made before it set the
-			 * bit.
+			 * reflects every store the writer made before it set the bit.
 			 */
 			if (STOPEVENTS_ENABLED())
 				STOPEVENT(STOPEVENT_UNDO_FLUSH, NULL);
-			o_buffers_write_page_direct(&undoBuffersDesc,
-										circularBuffer +
-										(pageLoc % circularBufferSize),
-										(uint32) undoType,
-										pageLoc);
+			o_buffers_write_page_direct(&undoBuffersDesc, stagingPage,
+										(uint32) undoType, pageLoc);
 		}
 
 		LWLockRelease(&meta->undoWriteLock);
@@ -2016,8 +2102,6 @@ fsync_undo_range(UndoLogType undoType,
 				 uint32 wait_event_info)
 {
 	UndoLocation minProcReservedLocation;
-	UndoMeta   *meta = get_undo_meta_by_type(undoType);
-	UndoLocation writtenLocation;
 
 	(void) check_reserved_undo_location(undoType,
 										toLoc + o_undo_circular_sizes[(int) undoType],
@@ -2027,19 +2111,18 @@ fsync_undo_range(UndoLogType undoType,
 	/*
 	 * Push dirty pages overlapping [fromLoc, toLoc) out to o_buffers without
 	 * touching the ring or advancing writtenLocation.  Pages already on disk
-	 * (bit cleared by a prior eviction or flush) are skipped.
+	 * (bit cleared by a prior eviction or flush) are skipped, but only where
+	 * the bit can be trusted -- hence minProcReservedLocation is passed down:
+	 * at or above it a backend may still be filling a record whose pages were
+	 * published dirty ahead of the payload.
 	 *
-	 * Locations below writtenLocation are guaranteed on disk already, so we
-	 * clamp fromLoc up to writtenLocation to avoid pointless bit scans. The
-	 * flush internally acquires undoWriteLock in EXCLUSIVE mode in short
+	 * The flush clamps fromLoc up to writtenLocation itself (and re-reads it
+	 * per batch).  It acquires undoWriteLock in EXCLUSIVE mode in short
 	 * batches and releases it between them; that keeps it serialised with
 	 * evict_undo_to_disk() while letting concurrent eviction make progress
 	 * instead of waiting for the whole flush.
 	 */
-	writtenLocation = pg_atomic_read_u64(&meta->writtenLocation);
-	flush_dirty_undo_range(undoType,
-						   Max(fromLoc, writtenLocation),
-						   toLoc);
+	flush_dirty_undo_range(undoType, fromLoc, toLoc, minProcReservedLocation);
 
 	o_buffers_sync(&undoBuffersDesc, (uint32) undoType,
 				   fromLoc, toLoc, wait_event_info);
@@ -3084,6 +3167,43 @@ undo_read(UndoLogType undoType, UndoLocation location, Size size, Pointer buf)
 	{
 		read_undo_range(&undoBuffersDesc, buf, undoType, location,
 						location + size);
+	}
+
+	/*
+	 * Re-check that the record is still retained, now that we have read it.
+	 * Callers test UNDO_REC_EXISTS() *before* the read (see
+	 * undo_item_buf_read_item()), which is not enough: the retain floor can
+	 * advance past `location` while we copy, freeing the ring slot for reuse
+	 * and unlinking the on-disk file, so what we handed back is garbage from
+	 * a recycled circular-buffer slot.  Without this check the bogus bytes
+	 * propagate outwards and only fail much later as an out-of-range item
+	 * type in walk_undo_range() or a bad itemSize in
+	 * undo_item_buf_read_item(), naming neither the concurrent clean nor the
+	 * location that lost its data.
+	 *
+	 * This mirrors map_oxid()'s post-read globalXmin re-check and the
+	 * identical re-check in undo_read_if_exists(); unlike that one,
+	 * undo_read() is the must-exist variant, so a concurrent clean is a
+	 * broken retain invariant rather than an expected outcome.
+	 */
+	if (!UNDO_REC_EXISTS(undoType, location))
+	{
+		ODBProcData *curProcData = GET_CUR_PROCDATA();
+
+		elog(PANIC,
+			 "undo_read(): undo record was cleaned concurrently with the read: "
+			 "undoType=%d location=%llu size=%u "
+			 "transactionUndoRetainLocation=%llu snapshotRetainUndoLocation=%llu "
+			 "minProcRetainLocation=%llu writtenLocation=%llu "
+			 "checkpointRetain=[%llu,%llu) pid=%d",
+			 (int) undoType, (unsigned long long) location, (unsigned) size,
+			 (unsigned long long) pg_atomic_read_u64(&curProcData->undoRetainLocations[(int) undoType].transactionUndoRetainLocation),
+			 (unsigned long long) pg_atomic_read_u64(&curProcData->undoRetainLocations[(int) undoType].snapshotRetainUndoLocation),
+			 (unsigned long long) pg_atomic_read_u64(&meta->minProcRetainLocation),
+			 (unsigned long long) pg_atomic_read_u64(&meta->writtenLocation),
+			 (unsigned long long) pg_atomic_read_u64(&meta->checkpointRetainStartLocation),
+			 (unsigned long long) pg_atomic_read_u64(&meta->checkpointRetainEndLocation),
+			 MyProcPid);
 	}
 }
 

--- a/src/utils/ucm.c
+++ b/src/utils/ucm.c
@@ -214,6 +214,20 @@ ucm_inc_recursive(UsageCountMap *map, int i, int32 prev, int32 next)
 void
 ucm_inc(UsageCountMap *map, OInMemoryBlkno blkno, int prev, int next)
 {
+	/*
+	 * Moving a page from a level to itself changes nothing:
+	 * ucm_inc_recursive() would compute new_val = val - one + one and
+	 * propagate nothing.  It would still *wait* first, though, for the
+	 * counter of that level to be non-zero -- and if the map does not count
+	 * this page there, nothing will ever raise it and the wait is forever.
+	 * That is the "stuck spinlock detected at ucm_inc_recursive" PANIC,
+	 * caught with prev = next = 6 under o_ucm_init(), which sets a freshly
+	 * allocated page's usage count to (epoch + 2) % UCM_USAGE_LEVELS without
+	 * regard for what it already is.
+	 */
+	if (prev == next)
+		return;
+
 	ucm_inc_recursive(map, map->nonLeaf + blkno / UCM_BRANCH_FACTOR, prev, next);
 }
 

--- a/test/t/truncate_under_checkpoint_test.py
+++ b/test/t/truncate_under_checkpoint_test.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import os
+import unittest
+
 from .base_test import BaseTest
 from .base_test import ThreadQueryExecutor
 from .base_test import wait_checkpointer_stopevent
@@ -105,4 +108,93 @@ class TruncateUnderCheckpointTest(BaseTest):
 		self.assertEqual(
 		    5000,
 		    node.execute('postgres', "SELECT count(*) FROM o_park;")[0][0])
+		node.stop()
+
+	@unittest.skipUnless(
+	    os.environ.get('ORIOLEDB_REPRO'),
+	    'crashes the server on purpose; run with ORIOLEDB_REPRO=1')
+	def test_nontransactional_truncate_of_parked_tree(self):
+		"""
+		The tree the checkpointer is parked on is replaced underneath it.
+
+		TRUNCATE of a table created in the current transaction, with no
+		savepoints, goes through relation_nontransactional_truncate ->
+		o_truncate_table(), which frees the trees immediately instead of
+		deferring to commit-time undo.  Doing that in
+		perform_writeback_and_relock()'s window -- the one place the checkpointer
+		releases the tree -- means it comes back to a tree that no longer exists,
+		and the following INSERT puts a brand new one under the same reloid.
+
+		Reproduces deterministically (3/3) as
+
+		  TRAP: failed Assert("!init_shmem || !checkpoint_concurrent")
+		        src/checkpoint/checkpoint.c
+
+		in the backend running the TRUNCATE.  The assertion states the invariant
+		the code relies on: shared memory for a tree must not be initialized
+		while a checkpoint on it is in flight, because the checkpointer set that
+		memory up before it started.  With assertions off the run continues into
+		init_meta_page(), which wipes the meta page including the seq buf page
+		references, while checkpointable_tree_fill_seq_buffers() re-allocates
+		only slot (chkp_num + 1) % 2 -- leaving the current slot's pages invalid
+		for the checkpointer to finalize.
+
+		Skipped by default because it takes the server down: the failure lands
+		in teardown as well, which no expectedFailure marker covers.  Run it
+		with ORIOLEDB_REPRO=1.
+		"""
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "orioledb.enable_stopevents = true\n"
+		    "checkpoint_flush_after = 0\n")
+		node.start()
+		node.safe_psql('postgres',
+		               "CREATE EXTENSION IF NOT EXISTS orioledb;\n")
+
+		con1 = node.connect()
+		con2 = node.connect()
+		con3 = node.connect()
+
+		# Created inside the transaction that will truncate it: that is what
+		# makes the truncate non-transactional.
+		con1.begin()
+		con1.execute("CREATE TABLE o_nt (id int NOT NULL, val text,\n"
+		             "	PRIMARY KEY (id)) USING orioledb;")
+		con1.execute(
+		    "INSERT INTO o_nt\n"
+		    "	SELECT i, repeat('n', 200) FROM generate_series(1, 5000) i;")
+
+		con2.execute("SELECT pg_stopevent_set('checkpoint_writeback',\n"
+		             "'$.treeName == \"o_nt_pkey\"');")
+
+		t1 = ThreadQueryExecutor(con3, "CHECKPOINT;")
+		t1.start()
+		wait_checkpointer_stopevent(node)
+
+		# The checkpointer released o_nt's tree here and is about to re-fetch it.
+		con1.execute("TRUNCATE o_nt;")
+		con1.execute(
+		    "INSERT INTO o_nt\n"
+		    "	SELECT i, repeat('m', 200) FROM generate_series(1, 2000) i;")
+
+		con2.execute("SELECT pg_stopevent_reset('checkpoint_writeback')")
+		con2.close()
+		t1.join()
+		con3.close()
+
+		con1.commit()
+		self.assertEqual(2000,
+		                 con1.execute("SELECT count(*) FROM o_nt;")[0][0])
+		con1.close()
+
+		node.safe_psql('postgres', "CHECKPOINT;")
+		self.assertEqual(
+		    2000,
+		    node.execute('postgres', "SELECT count(*) FROM o_nt;")[0][0])
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+		self.assertEqual(
+		    2000,
+		    node.execute('postgres', "SELECT count(*) FROM o_nt;")[0][0])
 		node.stop()

--- a/test/t/truncate_under_checkpoint_test.py
+++ b/test/t/truncate_under_checkpoint_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+from .base_test import ThreadQueryExecutor
+from .base_test import wait_checkpointer_stopevent
+
+
+class TruncateUnderCheckpointTest(BaseTest):
+	"""
+	A TRUNCATE that lands between two of the checkpointer's visits.
+
+	o_btree_load_shmem_internal() keys shared root info by
+	(datoid, relnode, tablespace) and, when the entry is missing, creates the
+	tree through checkpointable_tree_init(init_shmem = true).  That path sets
+	the tree up for chkp_num + 1, i.e. registers it as a participant of the
+	checkpoint that is running right now.  Nothing guarantees the checkpointer
+	still has that tree ahead of it in o_indices_foreach_oids(): if its walk is
+	already past that position, the freshly created tree carries seq bufs for
+	the current checkpoint that nobody will ever finalize.
+
+	Result so far: this does NOT break.  Kept as a regression test for the
+	interleaving, and as a record of the staging -- the walk order was confirmed
+	with orioledb_index_oids(), which lists o_victim (created first) before
+	o_park, so parking on o_park really does mean the walk is past o_victim.
+
+	The park point has to be checkpoint_writeback: o_perform_checkpoint() holds
+	oTablesMetaLock across the whole o_indices_foreach_oids() walk, and DDL
+	takes it too, so a TRUNCATE simply blocks anywhere else in the walk.
+	perform_writeback_and_relock() is the one place that releases it -- which is
+	precisely why that window exists and why it is the interesting one.
+	"""
+
+	def get_reloid(self, node, relname):
+		return node.execute(
+		    'postgres',
+		    "SELECT oid FROM pg_class WHERE relname = '%s';" % relname)[0][0]
+
+	def test_truncate_between_checkpointer_visits(self):
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "orioledb.enable_stopevents = true\n"
+		    "checkpoint_flush_after = 0\n")
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_victim (id int NOT NULL, val text, PRIMARY KEY (id))\n"
+		    "	USING orioledb;\n"
+		    "CREATE TABLE o_park (id int NOT NULL, val text, PRIMARY KEY (id))\n"
+		    "	USING orioledb;\n"
+		    "INSERT INTO o_victim SELECT i, repeat('v', 200) FROM generate_series(1, 5000) i;\n"
+		    "INSERT INTO o_park SELECT i, repeat('p', 200) FROM generate_series(1, 5000) i;\n"
+		)
+		node.safe_psql('postgres', "CHECKPOINT;")
+		node.safe_psql(
+		    'postgres',
+		    "UPDATE o_park SET val = repeat('q', 200) WHERE id % 5 = 0;\n"
+		    "UPDATE o_victim SET val = repeat('w', 200) WHERE id % 5 = 0;\n")
+
+		con1 = node.connect()
+		con2 = node.connect()
+
+		con2.execute("SELECT pg_stopevent_set('checkpoint_writeback',\n"
+		             "'$.treeName == \"o_park_pkey\"');")
+
+		t1 = ThreadQueryExecutor(con1, "CHECKPOINT;")
+		t1.start()
+		wait_checkpointer_stopevent(node)
+
+		# o_victim was created before o_park, so the walk (which goes in
+		# O_INDICES key order) is already past it while the checkpointer sits in
+		# o_park's writeback window.  Replacing o_victim's tree now is the case
+		# in question: TRUNCATE gives it a new relfilenode and the INSERT pulls
+		# the new tree into shared memory, where checkpointable_tree_init() sets
+		# it up for the checkpoint currently running -- one that will never come
+		# back to it.
+		node.safe_psql(
+		    'postgres', "TRUNCATE o_victim;\n"
+		    "INSERT INTO o_victim SELECT i, repeat('x', 200) FROM generate_series(1, 3000) i;\n"
+		)
+
+		con2.execute("SELECT pg_stopevent_reset('checkpoint_writeback')")
+		con2.close()
+		t1.join()
+		con1.close()
+
+		# A second checkpoint has to cope with whatever the first one left
+		# behind for the new tree.
+		node.safe_psql('postgres', "CHECKPOINT;")
+
+		self.assertEqual(
+		    3000,
+		    node.execute('postgres', "SELECT count(*) FROM o_victim;")[0][0])
+		self.assertEqual(
+		    5000,
+		    node.execute('postgres', "SELECT count(*) FROM o_park;")[0][0])
+
+		# ... and the data must survive a crash restart, which is where an
+		# unfinalized *.map / *.tmp for the new tree would show up.
+		node.stop(['-m', 'immediate'])
+		node.start()
+		self.assertEqual(
+		    3000,
+		    node.execute('postgres', "SELECT count(*) FROM o_victim;")[0][0])
+		self.assertEqual(
+		    5000,
+		    node.execute('postgres', "SELECT count(*) FROM o_park;")[0][0])
+		node.stop()


### PR DESCRIPTION
Twenty-three fixes split out of the `ci_fixes` churn hunt, with the hunt's
instrumentation left behind.  Everything here is validated locally
(regress 47/47, isolation 33/33) and most of it has days of churn-matrix
runtime on `ci_fixes`.

## Checkpointer vs. concurrent DDL

* **Give up on a tree that was dropped in the writeback window.**
  `perform_writeback_and_relock()` releases the tree lock on purpose, and the
  private seq bufs hold raw pointers into the meta page they were bound to
  before that release.  A concurrent `cleanup_btree() -> free_meta_page()`
  frees that page, and the finalize at the end of `checkpoint_ix()` then reads
  `pages[]` out of it.  Re-taking the lock proves nothing -- the lock manager
  happily grants a lock on a name whose tree is gone -- so check the tree
  instead: the meta page must not have moved and the tree must still be
  registered in shared root info.
* **Key the checkpoint-namespace lock by relnode, not reloid.**  Everything
  that lock protects is keyed by `(datoid, relnode, tablespace)`, so two
  ORelOids naming one tree under different reloids took different locks and
  excluded nothing.
* **Lock the truncated tree against the checkpointer before freeing it** and
  **let a tree re-created under a checkpoint be skipped by it** (with a
  deterministic stopevent repro for the latter).
* **Keep the checkpointer draining the sync queue while it waits**, and make a
  recovery worker always mark itself gone -- the standby "server does not shut
  down" hang.

## The xid record queue

* **Serialize the flush.**  `close_xids_file()` called `flush_xids_queue()`
  without `oXidQueueFlushLock` while producers hold it, and the function ends
  with an unconditional store of its own end position -- so a stale flusher
  moved `xidRecFlushPos` *backwards* onto slots already flushed and cleared,
  and the checkpointer then waited forever on an `InvalidOXid` nobody would
  rewrite.  This is the `pg_ctl stop failed` stall in `027_stream_regress`,
  and (because the waiter holds an LWLock, hence `HOLD_INTERRUPTS`) also the
  standby that never accepts a `ProcSignalBarrier`.
* **Restart the numbering only from an empty queue**, via a compare-exchange
  on `xidRecLastPos` after draining, instead of resetting unconditionally
  under a lock no producer takes.  The producer side gets a critical section
  so it can never abandon a claimed slot.

## Everything else

* **UCM:** `ucm_inc()` with `prev == next` is a no-op that still waited for a
  level counter nothing would ever raise -- the long-standing
  `stuck spinlock detected at ucm_inc_recursive` PANIC.
* **FETCH page images:** keep locators on the image instead of letting them
  point into the live shared page, position an already-loaded chunk's locator
  instead of returning early, don't end a scan on a stale image, and validate
  a page under its lock in `refind_page()` rather than locking a stale hint
  blindly.
* **undo/xidmap ring vs. flush:** detect the drain and bound the dirty bits.
* Descriptor lifecycle: don't drop a still-referenced index descriptor, release
  the previous table descriptor before re-filling, match an OTable to an OIndex
  by attribute count, and don't unlink a relation file while holding the
  checkpointer's table lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)