### PR TITLE
Don't let two waiters with the same key into one leaf page

### DIFF
--- a/src/btree/insert.c
+++ b/src/btree/insert.c
@@ -519,7 +519,8 @@ merge_waited_tuples(BTreeDescr *desc, Page p, BTreeSplitItems *outputItems,
 {
 	int			inputIndex = 0,
 				outputIndex = 0,
-				waitersIndex = 0;
+				waitersIndex = 0,
+				lastAcceptedWaiter = -1;
 	int			totalSize = 0,
 				totalCount = 0;
 	int			rightSpace,
@@ -620,6 +621,45 @@ merge_waited_tuples(BTreeDescr *desc, Page p, BTreeSplitItems *outputItems,
 						newLeftSpace,
 						candidateTotalSize;
 
+			/*
+			 * Waiters are only ever compared against the *input* items above,
+			 * never against each other -- and when the inputs run out that
+			 * comparison is skipped entirely (cmp is forced to 1).  Two
+			 * waiters carrying the same key would therefore both be accepted
+			 * and both written out by the split, leaving two live items with
+			 * one key in the leaf.
+			 *
+			 * The non-split branch of o_btree_insert_item_with_waiters() does
+			 * not have the problem: it probes each waiter against the page
+			 * after the earlier ones have already been written into it, so
+			 * btree_leaf_probe_insert_slot() reports the duplicate.
+			 *
+			 * waiter_info_cmp() sorts by key, so equal keys are adjacent and
+			 * comparing against the last accepted waiter is enough.  Drop the
+			 * duplicate exactly like an input conflict: leaving `inserted`
+			 * false makes that backend re-take the page lock and resolve the
+			 * conflict itself against the key it now finds there.
+			 */
+			if (lastAcceptedWaiter >= 0)
+			{
+				OTuple		prevTup;
+				OTuple		curTup;
+
+				prevTup.formatFlags = tupleWaiterInfos[lastAcceptedWaiter].item.flags;
+				prevTup.data = tupleWaiterInfos[lastAcceptedWaiter].item.data +
+					BTreeLeafTuphdrSize;
+				curTup.formatFlags = tupleWaiterInfos[waitersIndex].item.flags;
+				curTup.data = tupleWaiterInfos[waitersIndex].item.data +
+					BTreeLeafTuphdrSize;
+
+				if (o_btree_cmp(desc, &prevTup, BTreeKeyLeafTuple,
+								&curTup, BTreeKeyLeafTuple) == 0)
+				{
+					waitersIndex++;
+					continue;
+				}
+			}
+
 			item = tupleWaiterInfos[waitersIndex].item;
 			tup.formatFlags = item.flags;
 			tup.data = item.data + BTreeLeafTuphdrSize;
@@ -647,6 +687,7 @@ merge_waited_tuples(BTreeDescr *desc, Page p, BTreeSplitItems *outputItems,
 			}
 
 			tupleWaiterInfos[waitersIndex].inserted = true;
+			lastAcceptedWaiter = waitersIndex;
 			accepted[acceptedTop].outputPos = outputIndex;
 			accepted[acceptedTop].waiterIdx = waitersIndex;
 			accepted[acceptedTop].keyLen = newKeyLen;

--- a/test/t/page_fit_items_test.py
+++ b/test/t/page_fit_items_test.py
@@ -948,3 +948,115 @@ class MergeWaitedTuplesTest(BaseTest):
 			    [0])
 		finally:
 			node.stop()
+
+	def test_merge_waited_tuples_drops_duplicate_waiter(self):
+		"""
+		Two waiters carrying the SAME key must not both be inserted.
+
+		merge_waited_tuples() compares each waiter against the *input* items
+		of the page only, never against the other waiters -- and once the
+		inputs run out it forces cmp = 1 and accepts every remaining waiter
+		with no comparison at all.  So two waiters with one key both got
+		accepted and both were written out by the split, leaving two live
+		items with the same primary key in the leaf.
+
+		The non-split path does not have the problem: it probes each waiter
+		against the page after the earlier ones have already been written
+		into it, so btree_leaf_probe_insert_slot() reports the duplicate.
+
+		This is ORI-233, where the duplicate surfaced far from its origin --
+		as an out-of-order tuple tripping the ordering assertion in
+		o_btree_iterator_fetch() under the jepsen "append" workload.
+		"""
+
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "orioledb.enable_stopevents = true\n")
+		node.start()
+		node.safe_psql(
+		    'postgres', """
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE t (
+				k text NOT NULL,
+				v text NOT NULL,
+				PRIMARY KEY (k)
+			) USING orioledb;
+
+			-- Values wide enough that the splitter plus the two waiters
+			-- cannot share a page with these three, so the merge has to
+			-- split.
+			INSERT INTO t (k, v)
+			SELECT 'k' || to_char(g * 10, 'fm0000'), repeat('a', 2000)
+			FROM generate_series(1, 3) g;
+		""")
+
+		splitter = node.connect(autocommit=True)
+		waiters = [node.connect(autocommit=True) for _ in range(2)]
+		ctl = node.connect()
+
+		try:
+			ctl.execute(
+			    "SELECT pg_stopevent_set('before_get_waiters_with_tuples',\n"
+			    "                        'true');")
+
+			splitter_pid = splitter.pid
+			t_split = ThreadQueryExecutor(
+			    splitter, "INSERT INTO t (k, v) VALUES "
+			    "('k0035', repeat('h', 2000));")
+			t_split.start()
+			wait_stopevent(node, splitter_pid)
+
+			# Both waiters insert one and the same key, and it sorts after
+			# every item on the page -- that is the branch where the merge
+			# stopped comparing altogether.
+			waiter_threads = []
+			pids = []
+			for i, conn in enumerate(waiters):
+				pids.append(conn.pid)
+				thr = ThreadQueryExecutor(
+				    conn, "INSERT INTO t (k, v) VALUES "
+				    "('k0045', repeat('%s', 2000));" % (chr(ord('b') + i), ))
+				thr.start()
+				waiter_threads.append(thr)
+
+				# One at a time: the order they enter the queue in is what
+				# decides which one the merge sees first.
+				deadline = time.time() + 300.0
+				while time.time() < deadline:
+					blocked = node.execute(
+					    "SELECT count(*) FROM pg_stat_activity "
+					    "WHERE pid IN (%s) AND wait_event IS NOT NULL;" %
+					    (','.join([str(pid) for pid in pids])))[0][0]
+					if blocked >= len(pids):
+						break
+					time.sleep(0.1)
+
+			ctl.execute("SELECT pg_stopevent_reset("
+			            "'before_get_waiters_with_tuples');")
+
+			t_split.join()
+
+			errors = 0
+			for thr in waiter_threads:
+				try:
+					thr.join()
+				except DatabaseError:
+					errors += 1
+
+			# A point lookup by the primary key stops at the first match, so
+			# it reports one row either way: the duplicate is only visible to
+			# something that walks the leaf.
+			self.assertEqual([('k0010', ), ('k0020', ), ('k0030', ),
+			                  ('k0035', ), ('k0045', )],
+			                 node.execute("SELECT k FROM t;"))
+
+			# The dropped waiter re-takes the page lock, finds the key it
+			# wanted already there and fails on the unique constraint.
+			# Exactly one of the two has to get that far.
+			self.assertEqual(1, errors)
+
+			self.assertTrue(
+			    node.execute("SELECT orioledb_tbl_check('t'::regclass);")[0]
+			    [0])
+		finally:
+			node.stop()


### PR DESCRIPTION
Fixes ORI-233 (duplicate primary key in an OrioleDB leaf page).

## The bug

A backend that finds a leaf page locked doesn't wait for the lock: it queues itself together with its serialized tuple, and the lock holder inserts it on the backend's behalf. The holder resolves that queue in two places, and only one of them looked for duplicates.

- `o_btree_insert_item_with_waiters()`'s **non-split** path probes each waiter against the page with `btree_leaf_probe_insert_slot()` *after* the earlier waiters have already been written into it, so a second waiter carrying a key an earlier one just inserted comes back as `BTreeLeafProbeDuplicate` and is dropped.
- `merge_waited_tuples()` has no such protection. It walks the page's input items and the waiter array together, comparing each waiter against the **input** items only — never against the other waiters — and once the inputs are exhausted it forces `cmp = 1` and accepts every remaining waiter with no comparison at all.

So two waiters with one key both got accepted and the split wrote both out: two live items with the same primary key in one leaf, differing only in their non-key columns and written by two different transactions.

That matches the ORI-233 evidence exactly — adjacent offsets, two different oxids, undo records 64 bytes apart from back-to-back `make_waiter_undo_record()` calls, both live. The duplicate surfaced far from where it was created, as an out-of-order tuple tripping the ordering assertion in `o_btree_iterator_fetch()` under the jepsen `append` workload.

## The fix

`waiter_info_cmp()` sorts the queue by key, so equal keys are adjacent and comparing against the last accepted waiter is enough. The duplicate is dropped the same way an input conflict is dropped — leaving `inserted` false makes that backend re-take the page lock and resolve the conflict itself against the key it now finds there.

## Test

`MergeWaitedTuplesTest.test_merge_waited_tuples_drops_duplicate_waiter` drives the interleaving deterministically: it parks the holder on the `before_get_waiters_with_tuples` stop event with a page too full to absorb three more rows, queues two inserts of one key behind it, and checks that the tree comes back with a single copy and that exactly one of the two inserts failed.

Verified in both directions on this branch: passes with the fix, and without it a scan of the leaf returns `k0045` twice.

Two things worth knowing about how this corruption hides: a primary-key point lookup and an ordered index scan both return a single row even when the leaf holds the duplicate — only a seq scan exposes it — and `orioledb_tbl_check()` does not catch it either.

## Checks

regresscheck 47/47, isolationcheck 33/33, `page_fit_items` 16/16 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)