### PR TITLE
Let a sequential scan see its own transaction's writes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  skipundo \
 				  table_lock_test \
 				  concurrent_truncate \
+				  seqscan_own_writes \
 				  uniq
 TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
 						test/t/tablespace_test.py \

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1807,7 +1807,19 @@ init_btree_seq_scan(BTreeSeqScan *scan)
 
 	O_TUPLE_SET_NULL(scan->nextKey.tuple);
 
-	init_page_find_context(&scan->context, desc, scan->oSnapshot.csn,
+	/*
+	 * Descend with COMMITSEQNO_INPROGRESS so leaf pages come back live rather
+	 * than rolled back to the snapshot csn through page-level undo.  A
+	 * sequential scan produces the snapshot view itself: it reconstructs the
+	 * historical page in load_first_historical_page() and merges it with the
+	 * live one, and that merge is the only thing that keeps this
+	 * transaction's own uncommitted versions in the result.  Handing it an
+	 * already rolled-back image leaves nothing to merge them back from --
+	 * which is exactly what happened when the whole tree is a single leaf
+	 * page and the descent's image *is* the scan.  Internal pages are
+	 * unaffected: o_btree_read_page() only applies page-level undo to leaves.
+	 */
+	init_page_find_context(&scan->context, desc, COMMITSEQNO_INPROGRESS,
 						   BTREE_PAGE_FIND_IMAGE |
 						   BTREE_PAGE_FIND_KEEP_LOKEY |
 						   BTREE_PAGE_FIND_READ_CSN);

--- a/test/expected/seqscan_own_writes.out
+++ b/test/expected/seqscan_own_writes.out
@@ -1,0 +1,46 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_begin s1_snapshot s2_shrink s2_compact s1_update s1_seqscan_updated s1_insert s1_seqscan_inserted s1_seqscan_count s1_commit
+step s1_begin: 
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = off;
+	SET LOCAL enable_indexonlyscan = off;
+	SET LOCAL enable_seqscan = on;
+step s1_snapshot: 
+	SELECT count(*) FROM o_seqscan_own;
+count
+-----
+   22
+(1 row)
+
+step s2_shrink: 
+	UPDATE o_seqscan_own SET val = repeat('z', 10) WHERE id <= 150;
+step s2_compact: 
+	INSERT INTO o_seqscan_own VALUES (115, repeat('w', 1200));
+step s1_update: 
+	UPDATE o_seqscan_own SET val = 'mine' WHERE id = 200;
+step s1_seqscan_updated: 
+	SELECT id, val FROM o_seqscan_own WHERE id = 200;
+ id|val 
+---+----
+200|mine
+(1 row)
+
+step s1_insert: 
+	INSERT INTO o_seqscan_own VALUES (5, 'fresh');
+step s1_seqscan_inserted: 
+	SELECT id, val FROM o_seqscan_own WHERE id = 5;
+id|val  
+--+-----
+ 5|fresh
+(1 row)
+
+step s1_seqscan_count: 
+	SELECT count(*) FROM o_seqscan_own;
+count
+-----
+   23
+(1 row)
+
+step s1_commit: COMMIT;

--- a/test/specs/seqscan_own_writes.spec
+++ b/test/specs/seqscan_own_writes.spec
@@ -1,0 +1,77 @@
+# A sequential scan must see the scanning transaction's own writes even when
+# the leaf it reads has been given a page-level undo image by somebody else.
+#
+# The descent used to read leaf pages at the scan's snapshot csn, i.e. already
+# rolled back through page-level undo.  For a tree that is a single leaf page
+# that image *is* the whole scan, and the live/historical merge in
+# btree_seq_scan_getnext_internal() -- the only thing that puts the scanning
+# transaction's own uncommitted versions back into the result -- had no live
+# page left to merge them from.  So a REPEATABLE READ transaction would read
+# the pre-update version of a row it had just written itself, or miss a row it
+# had just inserted.
+#
+# The setup fills a single leaf close to capacity.  s2 then shrinks most of the
+# rows, which turns their space into vacated bytes, and inserts a row too big
+# for the remaining contiguous free space: that forces
+# perform_page_compaction(), which stores the old page in undo and stamps the
+# live page with a fresh csn -- newer than s1's snapshot.  From then on any
+# read of that page at s1's snapshot csn goes through page-level undo.
+
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+	CREATE TABLE o_seqscan_own (
+		id int4 NOT NULL,
+		val text NOT NULL,
+		PRIMARY KEY (id)
+	) USING orioledb;
+
+	-- 22 rows of ~340 bytes: one leaf, a few hundred bytes of free space left.
+	INSERT INTO o_seqscan_own
+		SELECT i * 10, repeat('x', 300) FROM generate_series(1, 22) i;
+}
+
+teardown
+{
+	DROP TABLE o_seqscan_own;
+}
+
+session "s1"
+step "s1_begin" {
+	BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+	SET LOCAL enable_indexscan = off;
+	SET LOCAL enable_bitmapscan = off;
+	SET LOCAL enable_indexonlyscan = off;
+	SET LOCAL enable_seqscan = on; }
+
+# Pins the snapshot, and with it the undo the page image below is built from.
+step "s1_snapshot" {
+	SELECT count(*) FROM o_seqscan_own; }
+
+step "s1_update" {
+	UPDATE o_seqscan_own SET val = 'mine' WHERE id = 200; }
+step "s1_insert" {
+	INSERT INTO o_seqscan_own VALUES (5, 'fresh'); }
+
+# Sequential scans: these are what used to answer from a rolled-back image.
+step "s1_seqscan_updated" {
+	SELECT id, val FROM o_seqscan_own WHERE id = 200; }
+step "s1_seqscan_inserted" {
+	SELECT id, val FROM o_seqscan_own WHERE id = 5; }
+step "s1_seqscan_count" {
+	SELECT count(*) FROM o_seqscan_own; }
+
+step "s1_commit" { COMMIT; }
+
+session "s2"
+# Shrinking the rows leaves their space behind as vacated bytes.
+step "s2_shrink" {
+	UPDATE o_seqscan_own SET val = repeat('z', 10) WHERE id <= 150; }
+# Does not fit the contiguous free space, does fit after compaction -- so this
+# is what gives the leaf its page-level undo image and a fresh csn.
+step "s2_compact" {
+	INSERT INTO o_seqscan_own VALUES (115, repeat('w', 1200)); }
+
+permutation "s1_begin" "s1_snapshot" "s2_shrink" "s2_compact"
+	"s1_update" "s1_seqscan_updated"
+	"s1_insert" "s1_seqscan_inserted" "s1_seqscan_count" "s1_commit"


### PR DESCRIPTION
The read-own-writes half of ORI-229 / #982.

## The bug

Under REPEATABLE READ, a sequential scan of a small table could return the version of a row that preceded the scanning transaction's *own* update, or miss a row it had just inserted — while an index scan of the same row in the same transaction returned the right thing.

A sequential scan produces its snapshot view of a leaf itself: it reads the live page, reconstructs the historical page from page-level undo in `load_first_historical_page()`, and merges the two in `btree_seq_scan_getnext_internal()`. That merge is the only thing that puts the scanning transaction's own uncommitted versions back into the result — it prefers the live version whenever `XACT_INFO_OXID_IS_CURRENT()` says the row is ours, because an image reconstructed to the snapshot csn cannot contain a change made after that point.

The descent handed it the wrong input. The scan's find context carried the snapshot csn, so `o_btree_read_page()` had already rolled the leaf back through page-level undo. On the multi-level path that goes unnoticed: the leaf the scan walks is read separately, by `o_btree_try_read_page()` at `imgReadCsn`, and stays live. But **when the whole tree is a single leaf page there is no separate read** — the descent's image *is* the scan — so the scan walked an image its own writes had been undone out of, with no live page left to merge them back from.

A page-level undo image is all it takes to arm this, and `perform_page_compaction()` creates one for any leaf of a table with undo, so a concurrent insert that compacts the page is enough.

## The fix

Descend with `COMMITSEQNO_INPROGRESS` and let the scan keep doing the rollback and the merge, which is what it is written to do. One line.

Nothing else in the descent depends on that csn — it feeds the page reads, an assertion that only concerns modifying descents, and two corrections in sibling navigation that a sequential scan does not use. Internal pages are unaffected either way, since `o_btree_read_page()` only applies page-level undo to leaves.

## Two corrections to what #982 records

- **Not x86-only.** A matrix run of a workload reproducer (amd64 vs arm64, 8 replicas each) failed 7/8 on amd64 and 6/8 on arm64. The architecture correlation in the issue was an artifact of where it had been run.
- **REPEATABLE READ specific, and that is meaningful.** The same matrix under READ COMMITTED was 16/16 clean, which follows directly from the mechanism: a fresh snapshot per statement means the leaf is never newer than it, so no rollback happens.

## Test

`test/specs/seqscan_own_writes.spec` drives the whole thing deterministically, no stop events needed — the isolation harness's controlled step order is enough. Fill one leaf close to capacity, pin a REPEATABLE READ snapshot, then have the other session shrink most of the rows and insert one too big for the remaining contiguous free space: that forces the compaction that gives the leaf its page-level undo image and a csn newer than the snapshot.

Without the fix it fails with all three symptoms at once:

```
-200|mine                +200|xxxxxxxx…     the pre-update value
- 5|fresh  (1 row)       +(0 rows)          its own fresh insert missing
-   23                   +   22             one row short
```

## Checks

regresscheck 47/47, isolationcheck 34/34 (including the new test) locally. A jepsen-shaped workload harness that used to hit the anomaly within ~2600 transactions now runs clean; those runs and testgres part 1 are still going as of opening this.

## Not covered here

ORI-229 also shows a second signature — the *second* append of a transaction lost while the first survives — which is not explained by this and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)