### PR TITLE
Don't leave a stale page locator behind after an item rollback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/not_supported_yet_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \
+						test/t/recovery_item_rollback_test.py \
 						test/t/reindex_test.py \
 						test/t/s3_test.py \
 						test/t/schema_test.py \

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -710,11 +710,20 @@ o_btree_modify_item_rollback(BTreeModifyInternalContext *context)
 	END_CRIT_SECTION();
 
 	if (!applyResult)
-	{
 		btree_page_search(desc, page, context->key,
 						  context->keyType, NULL, &loc);
-		pageFindContext->items[pageFindContext->index].locator = loc;
-	}
+
+	/*
+	 * Store the locator back unconditionally.  page_item_rollback() reverts
+	 * an update by shrinking the item, and page_locator_resize_item() then
+	 * adjusts both the page header and the locator it was given -- but that
+	 * was our local copy.  Leaving the stale copy in the find context makes
+	 * the caller's next page_locator_resize_item() compute a chunk end past
+	 * header->dataSize, so the memmove() length turns negative and, as a
+	 * size_t, shifts the whole shared memory segment instead of the page
+	 * tail.
+	 */
+	pageFindContext->items[pageFindContext->index].locator = loc;
 
 	return applyResult;
 }

--- a/src/btree/page_chunks.c
+++ b/src/btree/page_chunks.c
@@ -619,6 +619,19 @@ page_locator_resize_item(Page p, BTreePageItemLocator *locator,
 
 	Assert(endPtr + dataShift <= (Pointer) p + ORIOLEDB_BLCKSZ);
 
+	/*
+	 * The locator must agree with the page header: if the chunk it describes
+	 * ends past dataSize, the length below goes negative and memmove() reads
+	 * it as a huge size_t -- which does not corrupt this page, it walks the
+	 * whole shared memory segment.  Fail loudly instead.
+	 */
+	if (nextItemPtr > endPtr || endPtr + dataShift > (Pointer) p + ORIOLEDB_BLCKSZ)
+		elog(PANIC, "locator does not fit the page: chunk %u ends at %u, "
+			 "data size %u, shift %d",
+			 (unsigned) locator->chunkOffset,
+			 (unsigned) (nextItemPtr - (Pointer) p),
+			 (unsigned) header->dataSize, dataShift);
+
 	/* Shift the data after the item */
 	memmove(nextItemPtr + dataShift, nextItemPtr, endPtr - nextItemPtr);
 

--- a/test/t/recovery_item_rollback_test.py
+++ b/test/t/recovery_item_rollback_test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+
+
+class RecoveryItemRollbackTest(BaseTest):
+
+	def test_item_rollback_locator_reuse(self):
+		"""
+		Replay re-applies records the page already carries, which is the only
+		path that reaches the item rollback: a CHECKPOINT taken while the
+		transaction is still open writes its in-progress versions into the
+		image, and after an immediate stop those same UPDATE records are
+		replayed on top of them.  The callback then sees a version at least as
+		new as the incoming one, rolls the item back -- which resizes it --
+		and retries.  The retry must not reuse the locator the rollback made
+		stale, or the next resize shifts the wrong range of the page.
+
+		The updates change the item's size in both directions on purpose: a
+		rollback that does not change the size cannot expose the stale
+		locator.
+		"""
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql("""
+			CREATE TABLE o_test_item_rollback (
+				id int PRIMARY KEY,
+				v text
+			) USING orioledb;
+		""")
+		node.safe_psql("""
+			INSERT INTO o_test_item_rollback
+				SELECT i, repeat('x', 40) FROM generate_series(1, 60) i;
+		""")
+		node.safe_psql("CHECKPOINT;")
+
+		with node.connect() as con:
+			with node.connect() as con2:
+				con.execute("""
+					UPDATE o_test_item_rollback SET v = repeat('L', 900)
+						WHERE id = 7;
+				""")
+				con.execute("""
+					UPDATE o_test_item_rollback SET v = 'short' WHERE id = 7;
+				""")
+				con.execute("""
+					UPDATE o_test_item_rollback SET v = repeat('M', 300)
+						WHERE id = 7;
+				""")
+				# the image now holds the in-progress versions, while replay
+				# still starts before the records that made them
+				con2.execute("CHECKPOINT;")
+				con2.commit()
+				con.commit()
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+
+		self.assertEqual(
+		    [(60, )],
+		    node.execute("SELECT count(*) FROM o_test_item_rollback;"))
+		self.assertEqual([(7, 300)],
+		                 node.execute("""
+							SELECT id, length(v) FROM o_test_item_rollback
+								WHERE length(v) <> 40 ORDER BY id;
+						 """))
+		self.assertEqual([],
+		                 node.execute("""
+			SELECT g.id FROM generate_series(1, 60) g(id)
+				WHERE NOT EXISTS (SELECT 1 FROM o_test_item_rollback t
+									WHERE t.id = g.id);
+		"""))
+		node.stop()


### PR DESCRIPTION
## What happens

`o_btree_modify_item_rollback()` takes a **copy** of the find context's locator and hands it to `page_item_rollback()`. That call reverts an update by shrinking the item through `page_locator_resize_item()`, which adjusts both the page header and the locator it was given — our copy. The copy is stored back into the context only when the rollback reports the item is gone, so on the normal path the context keeps a locator whose chunk ends past `header->dataSize`.

`o_btree_modify_insert_update()` then reuses that locator, and the next `page_locator_resize_item()` runs

```c
memmove(nextItemPtr + dataShift, nextItemPtr, endPtr - nextItemPtr);
```

with `nextItemPtr > endPtr`. The length is negative, `memmove()` reads it as a `size_t`, and the copy walks off the page and **shifts the whole shared memory segment** by `dataShift` bytes until it reaches the end of the mapping.

Observed on a real page: chunk 13 at +5976 with `chunkSize` 368 (so it ends at 6344) against `dataSize` 6336 — length −8, i.e. `memmove` of 18446744073709551608 bytes.

## Why it looks like several unrelated bugs

The damage lands wherever the segment happens to be laid out, in whatever process reads it next, so it surfaces as assertions that have nothing to do with B-trees:

- `Assert(reservedUndoLocation == InvalidUndoLocation)` in `free_retained_undo_location()`, in every recovery worker
- `latch->owner_pid == MyProcPid` / `latch->maybe_sleeping == false`
- `slot->in_use` in the postmaster's `ForgetBackgroundWorker()`
- `mq->mq_receiver == MyProc` in `shm_mq`

A cluster hit by this **cannot be restarted**: every recovery worker dies again on replay, and single-process recovery then segfaults.

## The change

- store the locator back into the find context unconditionally;
- make `page_locator_resize_item()` `PANIC` instead of issuing a `memmove()` whose length went negative — a locator that disagrees with the page header is a bug worth reporting, not worth turning into segment-wide corruption.

I checked the other places that copy `items[index].locator` out of a find context; this is the only one that then mutates the page through the copy.

## Testing

- Six crash-churn clusters that were permanently unstartable (each one reproduced the recovery-worker assertion on every start) now recover and serve queries.
- `make installcheck` with `IS_DEV=1`: regress 47/47, isolation 33/33.
- Crash-churn loops re-run on top of the fix without reproducing this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)