### PR TITLE
Don't read a row lock's oxid as the writer of the tuple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \
 						test/t/recovery_item_rollback_test.py \
+						test/t/recovery_row_lock_test.py \
 						test/t/reindex_test.py \
 						test/t/s3_test.py \
 						test/t/schema_test.py \

--- a/include/btree/btree.h
+++ b/include/btree/btree.h
@@ -466,6 +466,19 @@ typedef enum RowLockMode
 	((xactInfo) & XACT_INFO_LOCK_OXID_MASK)
 #define XACT_INFO_OXID_EQ(xactInfo, oxid) \
 	(XACT_INFO_GET_OXID((xactInfo)) == (oxid))
+/*
+ * True when the tuple version described by 'xactInfo' was *written* by 'oxid'.
+ *
+ * XACT_INFO_OXID_EQ() alone cannot answer that: a lock-only header carries the
+ * oxid of whoever took the row lock, not of whoever wrote the tuple.  Headers
+ * handed to a modify callback are routinely lock-only -- row_lock_conflicts()
+ * reports a conflicting locker as the conflict header, and its "no conflict"
+ * fallback returns the final version, which is a row lock whenever the chain
+ * walk stops on one (during recovery it stops immediately, since a recovery
+ * process retains no snapshot).
+ */
+#define XACT_INFO_WRITTEN_BY(xactInfo, oxid) \
+	(!XACT_INFO_IS_LOCK_ONLY((xactInfo)) && XACT_INFO_OXID_EQ((xactInfo), (oxid)))
 #define XACT_INFO_OXID_IS_CURRENT(xactInfo) \
 	(XACT_INFO_GET_OXID((xactInfo)) == get_current_oxid_if_any())
 #define	XACT_INFO_IS_FINISHED(xactInfo) \

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -2391,7 +2391,7 @@ recovery_insert_primary_callback(BTreeDescr *descr,
 								 UndoLocation location, RowLockMode *lock_mode,
 								 BTreeLocationHint *hint, void *arg)
 {
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid) &&
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid) &&
 		o_tuple_get_version(tup) >= o_tuple_get_version(*newtup))
 		return OBTreeCallbackActionUndo;
 	return OBTreeCallbackActionUpdate;
@@ -2407,7 +2407,7 @@ recovery_delete_primary_callback(BTreeDescr *descr,
 {
 	OTuple	   *key = (OTuple *) arg;
 
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid) &&
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid) &&
 		o_tuple_get_version(tup) > o_tuple_get_version(*key))
 		return OBTreeCallbackActionUndo;
 
@@ -2422,7 +2422,7 @@ recovery_insert_overwrite_callback(BTreeDescr *descr,
 								   RowLockMode *lock_mode,
 								   BTreeLocationHint *hint, void *arg)
 {
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid))
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid))
 		return OBTreeCallbackActionUndo;
 
 	return OBTreeCallbackActionUpdate;
@@ -2436,7 +2436,7 @@ recovery_delete_overwrite_callback(BTreeDescr *descr,
 								   RowLockMode *lock_mode,
 								   BTreeLocationHint *hint, void *arg)
 {
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid))
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid))
 		return OBTreeCallbackActionUndo;
 
 	return OBTreeCallbackActionDelete;
@@ -2460,7 +2460,7 @@ recovery_insert_deleted_primary_callback(BTreeDescr *descr,
 										 UndoLocation location, RowLockMode *lock_mode,
 										 BTreeLocationHint *hint, void *arg)
 {
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid) &&
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid) &&
 		o_tuple_get_version(tup) >= o_tuple_get_version(*newtup))
 		return OBTreeCallbackActionUndo;
 	return OBTreeCallbackActionUpdate;
@@ -2477,7 +2477,7 @@ recovery_delete_deleted_primary_callback(BTreeDescr *descr,
 {
 	OTuple	   *key = (OTuple *) arg;
 
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid) &&
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid) &&
 		o_tuple_get_version(tup) > o_tuple_get_version(*key))
 		return OBTreeCallbackActionUndo;
 
@@ -2493,7 +2493,7 @@ recovery_insert_deleted_overwrite_callback(BTreeDescr *descr,
 										   RowLockMode *lock_mode,
 										   BTreeLocationHint *hint, void *arg)
 {
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid))
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid))
 		return OBTreeCallbackActionUndo;
 
 	return OBTreeCallbackActionUpdate;
@@ -2508,7 +2508,7 @@ recovery_delete_deleted_overwrite_callback(BTreeDescr *descr,
 										   RowLockMode *lock_mode,
 										   BTreeLocationHint *hint, void *arg)
 {
-	if (XACT_INFO_OXID_EQ(xactInfo, oxid))
+	if (XACT_INFO_WRITTEN_BY(xactInfo, oxid))
 		return OBTreeCallbackActionUndo;
 
 	return OBTreeCallbackActionDelete;

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -105,7 +105,7 @@ o_delete_copy_callback(BTreeDescr *descr,
 
 	if (descr->type == oIndexPrimary || descr->type == oIndexToast)
 	{
-		if (XACT_INFO_OXID_EQ(xactInfo, oxid) &&
+		if (XACT_INFO_WRITTEN_BY(xactInfo, oxid) &&
 			o_tuple_get_version(tup) > o_tuple_get_version(copyArg->key))
 			return OBTreeCallbackActionUndo;
 	}
@@ -136,7 +136,7 @@ o_update_copy_callback(BTreeDescr *descr,
 
 	if (descr->type == oIndexPrimary || descr->type == oIndexToast)
 	{
-		if (XACT_INFO_OXID_EQ(xactInfo, oxid) &&
+		if (XACT_INFO_WRITTEN_BY(xactInfo, oxid) &&
 			o_tuple_get_version(tup) >= o_tuple_get_version(*newtup))
 			return OBTreeCallbackActionUndo;
 	}

--- a/test/t/recovery_row_lock_test.py
+++ b/test/t/recovery_row_lock_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+
+
+class RecoveryRowLockTest(BaseTest):
+
+	def test_row_lock_in_checkpoint_image(self):
+		"""
+		A row lock taken by an in-progress transaction reaches the checkpoint
+		image, and the same transaction then updates the locked row.  On
+		restart the leaf page comes back from disk still carrying the
+		lock-only header, and WAL replay re-applies the UPDATE under the very
+		same oxid.  Recovery must not mistake that header for its own written
+		version: doing so rolls back the committed version underneath it and
+		then reads a row-lock undo record as a modify one.
+		"""
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql("""
+			CREATE TABLE o_test_row_lock (
+				id int PRIMARY KEY,
+				v text
+			) USING orioledb;
+		""")
+		node.safe_psql("""
+			INSERT INTO o_test_row_lock
+				SELECT i, 'initial' FROM generate_series(1, 50) i;
+		""")
+		node.safe_psql("CHECKPOINT;")
+
+		with node.connect() as con:
+			with node.connect() as con2:
+				con.execute("""
+					SELECT v FROM o_test_row_lock WHERE id = 7 FOR UPDATE;
+				""")
+				# push the lock-only tuple header into the checkpoint image
+				con2.execute("CHECKPOINT;")
+				con2.commit()
+				con.execute("""
+					UPDATE o_test_row_lock SET v = 'by-locker' WHERE id = 7;
+				""")
+				con.commit()
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+
+		self.assertEqual([(7, 'by-locker')],
+		                 node.execute("""
+							SELECT id, v FROM o_test_row_lock WHERE id = 7;
+						 """))
+		self.assertEqual([(50, )],
+		                 node.execute("SELECT count(*) FROM o_test_row_lock;"))
+		node.stop()


### PR DESCRIPTION
Fixes the crash-recovery failure reported as ORI-225: `Assert("item.header.type == ModifyUndoItemType")` in `src/btree/undo.c`, after which the cluster never comes up again.

## Root cause

`row_lock_conflicts()` can hand back a conflict header that is **lock-only** — both the branch that records a conflicting locker and the "no conflict" fallback (`*conflictTuphdr = finalTuphdr`). The fallback is the common one in recovery: the chain walk is bounded by `get_snapshot_retained_undo_location()`, which is `InvalidUndoLocation` in a recovery process, so the walk stops on its first step and leaves `finalTuphdr` pointing at the page header — a row lock.

All ten recovery modify callbacks then asked "did *I* write this version?" with `XACT_INFO_OXID_EQ(xactInfo, oxid)`. A lock-only header carries the **locker's** oxid, not the writer's, so a match returned `OBTreeCallbackActionUndo` and recovery rolled back a version written by a different, already committed transaction. `page_item_rollback()` then read that header's undo record as a `BTreeModifyUndoStackItem` when it was really a `RowLockUndoStackItem`. The assert is the lucky outcome — where the undo had already been discarded the symptom was "undo record does not exist", and where it still existed the old code silently reverted committed data.

## The change

`XACT_INFO_WRITTEN_BY()` (`!XACT_INFO_IS_LOCK_ONLY && XACT_INFO_OXID_EQ`), used by all ten callbacks in `recovery.c` (8) and `worker.c` (2).

## Test

`test/t/recovery_row_lock_test.py` reproduces it deterministically in ~2 s, no churn needed. The missing piece was where the lock-only header comes from: recovery never takes row locks itself, so it arrives **from the checkpoint image** — a transaction holds `SELECT ... FOR UPDATE` when a CHECKPOINT writes the leaf page, then updates the locked row under the same oxid. After an immediate stop the page comes back with that header and replay re-applies the UPDATE with the very same oxid. Without the fix the recovery worker dies on the assert and the cluster never starts.

Also validated on four dead clusters from the soak, each of which failed on every start and now recovers with `orioledb_tbl_check` clean.

## Removed from this PR

An earlier revision also dropped `Assert(!cur_state->wal_xid)` in `recovery_finish()` as a false invariant. That was wrong: narrowing the assertion to "replay applied no changes for this transaction" makes it fire on the original artifact, i.e. recovery really does replay changes for a transaction that no finish record will ever resolve. That needs its own investigation and is no longer part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)