### PR TITLE
Drop a sequential scan's index-descriptor pin exactly once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ REGRESSCHECKS = btree_sys_check \
 				row_level_locks \
 				row_security \
 				sanitizers \
+				seq_scan_descr_pin \
 				serializable \
 				stats \
 				subquery \

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -144,6 +144,15 @@ struct BTreeSeqScan
 
 	bool		initialized;
 	bool		checkpointNumberSet;
+
+	/*
+	 * Whether this scan still holds the OIndexDescr pin taken below.  Like
+	 * every other resource here, the pin has to be released exactly once:
+	 * free_btree_seq_scan_internal() runs twice for a scan released from a
+	 * ResourceOwner, because that path deliberately leaves the scan on
+	 * listOfScans for seq_scans_cleanup() to finish off.
+	 */
+	bool		descrPinned;
 	OSnapshot	oSnapshot;
 	OBTreeFindPageContext context;
 	OFixedKey	prevHikey;
@@ -1848,7 +1857,8 @@ make_btree_seq_scan_internal(BTreeDescr *desc, OSnapshot *oSnapshot,
 
 	scan->poscan = poscan;
 	scan->desc = desc;
-	if (!IS_SYS_TREE_OIDS(desc->oids))
+	scan->descrPinned = !IS_SYS_TREE_OIDS(desc->oids);
+	if (scan->descrPinned)
 		((OIndexDescr *) desc->arg)->refcnt++;
 	scan->oSnapshot = *oSnapshot;
 	scan->status = BTreeSeqScanInMemory;
@@ -2522,7 +2532,7 @@ free_btree_seq_scan_internal(BTreeSeqScan *scan, bool fromResowner)
 		scan->diskDownlinks = NULL;
 	}
 
-	if (!IS_SYS_TREE_OIDS(desc->oids))
+	if (scan->descrPinned)
 	{
 		OIndexDescr *indexDescr = (OIndexDescr *) desc->arg;
 
@@ -2534,6 +2544,7 @@ free_btree_seq_scan_internal(BTreeSeqScan *scan, bool fromResowner)
 						  "OIndexDescr refcnt is positive when a sequential scan drops its reference",
 						  NULL);
 		indexDescr->refcnt--;
+		scan->descrPinned = false;
 	}
 	scan->status = BTreeSeqScanFinished;
 

--- a/test/expected/seq_scan_descr_pin.out
+++ b/test/expected/seq_scan_descr_pin.out
@@ -1,0 +1,82 @@
+-- A sequential scan pins the OIndexDescr it reads and has to drop that pin
+-- exactly once.  A cursor closed by ROLLBACK TO is released from its
+-- ResourceOwner, which frees the scan but deliberately leaves it on the list
+-- for seq_scans_cleanup() to finish off at COMMIT -- so the free path runs
+-- twice for the same scan.  Every other resource it holds is cleared on the
+-- first pass; the pin used to be dropped on both, taking the counter below
+-- the pins actually held and, one round later, past zero.
+CREATE SCHEMA seq_scan_descr_pin;
+SET SESSION search_path = 'seq_scan_descr_pin';
+CREATE EXTENSION orioledb;
+CREATE TABLE o_test_pin (
+	id int PRIMARY KEY,
+	val text
+) USING orioledb;
+INSERT INTO o_test_pin SELECT g, 'val' || g FROM generate_series(1, 20) g;
+-- warm the descriptor cache, so the count below is the cache's own pin
+SELECT count(*) FROM o_test_pin;
+ count 
+-------
+    20
+(1 row)
+
+SELECT c.relname, d.refcnt
+	FROM orioledb_index_descr d JOIN pg_class c ON c.oid = d.reloid
+	WHERE c.relname = 'o_test_pin_pkey';
+     relname     | refcnt 
+-----------------+--------
+ o_test_pin_pkey |      1
+(1 row)
+
+BEGIN;
+SAVEPOINT x;
+DECLARE c1 CURSOR FOR SELECT * FROM o_test_pin;
+FETCH FROM c1;
+ id | val  
+----+------
+  1 | val1
+(1 row)
+
+ROLLBACK TO x;
+COMMIT;
+SELECT c.relname, d.refcnt
+	FROM orioledb_index_descr d JOIN pg_class c ON c.oid = d.reloid
+	WHERE c.relname = 'o_test_pin_pkey';
+     relname     | refcnt 
+-----------------+--------
+ o_test_pin_pkey |      1
+(1 row)
+
+-- a second round: this is where the counter used to wrap past zero
+BEGIN;
+SAVEPOINT x;
+DECLARE c1 CURSOR FOR SELECT * FROM o_test_pin;
+FETCH FROM c1;
+ id | val  
+----+------
+  1 | val1
+(1 row)
+
+ROLLBACK TO x;
+COMMIT;
+SELECT c.relname, d.refcnt
+	FROM orioledb_index_descr d JOIN pg_class c ON c.oid = d.reloid
+	WHERE c.relname = 'o_test_pin_pkey';
+     relname     | refcnt 
+-----------------+--------
+ o_test_pin_pkey |      1
+(1 row)
+
+-- at refcnt 0 an invalidation deletes the descriptor instead of recreating it
+-- in place, while the table descriptor still points at it
+ALTER TABLE o_test_pin SET (fillfactor = 90);
+SELECT count(*) FROM o_test_pin;
+ count 
+-------
+    20
+(1 row)
+
+DROP SCHEMA seq_scan_descr_pin CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to extension orioledb
+drop cascades to table o_test_pin

--- a/test/sql/seq_scan_descr_pin.sql
+++ b/test/sql/seq_scan_descr_pin.sql
@@ -1,0 +1,52 @@
+-- A sequential scan pins the OIndexDescr it reads and has to drop that pin
+-- exactly once.  A cursor closed by ROLLBACK TO is released from its
+-- ResourceOwner, which frees the scan but deliberately leaves it on the list
+-- for seq_scans_cleanup() to finish off at COMMIT -- so the free path runs
+-- twice for the same scan.  Every other resource it holds is cleared on the
+-- first pass; the pin used to be dropped on both, taking the counter below
+-- the pins actually held and, one round later, past zero.
+CREATE SCHEMA seq_scan_descr_pin;
+SET SESSION search_path = 'seq_scan_descr_pin';
+CREATE EXTENSION orioledb;
+
+CREATE TABLE o_test_pin (
+	id int PRIMARY KEY,
+	val text
+) USING orioledb;
+INSERT INTO o_test_pin SELECT g, 'val' || g FROM generate_series(1, 20) g;
+
+-- warm the descriptor cache, so the count below is the cache's own pin
+SELECT count(*) FROM o_test_pin;
+SELECT c.relname, d.refcnt
+	FROM orioledb_index_descr d JOIN pg_class c ON c.oid = d.reloid
+	WHERE c.relname = 'o_test_pin_pkey';
+
+BEGIN;
+SAVEPOINT x;
+DECLARE c1 CURSOR FOR SELECT * FROM o_test_pin;
+FETCH FROM c1;
+ROLLBACK TO x;
+COMMIT;
+
+SELECT c.relname, d.refcnt
+	FROM orioledb_index_descr d JOIN pg_class c ON c.oid = d.reloid
+	WHERE c.relname = 'o_test_pin_pkey';
+
+-- a second round: this is where the counter used to wrap past zero
+BEGIN;
+SAVEPOINT x;
+DECLARE c1 CURSOR FOR SELECT * FROM o_test_pin;
+FETCH FROM c1;
+ROLLBACK TO x;
+COMMIT;
+
+SELECT c.relname, d.refcnt
+	FROM orioledb_index_descr d JOIN pg_class c ON c.oid = d.reloid
+	WHERE c.relname = 'o_test_pin_pkey';
+
+-- at refcnt 0 an invalidation deletes the descriptor instead of recreating it
+-- in place, while the table descriptor still points at it
+ALTER TABLE o_test_pin SET (fillfactor = 90);
+SELECT count(*) FROM o_test_pin;
+
+DROP SCHEMA seq_scan_descr_pin CASCADE;


### PR DESCRIPTION
Fixes the intermittent property failure reported as ORI-248, *OIndexDescr refcnt is positive when a sequential scan drops its reference*.

## What happens

`free_btree_seq_scan_internal()` runs **twice** for a scan that a `ResourceOwner` releases:

1. the ResourceOwner callback calls it with `fromResowner = true`, which deliberately skips the tail of the function — the scan stays allocated and on `listOfScans`;
2. `seq_scans_cleanup()` later walks `listOfScans` and calls it again with `fromResowner = false` to unlink and `pfree` the scan.

Every other resource the function releases is guarded against that second call: `resowner`, `dsmSeg`, `iter` and `diskDownlinks` are cleared as they go, `checkpointNumberSet` is reset. The `OIndexDescr` pin was not — it was keyed off `IS_SYS_TREE_OIDS(desc->oids)`, which says nothing about whether *this scan* still holds the pin. So the second call decremented `refcnt` for a pin that had already been dropped.

## Why it matters beyond the assertion

The property is not flaky — it is catching the real thing. With assertions compiled out there is no report, the refcnt simply underflows, and the index descriptor is freed while a scan still refers to it. That is exactly the failure the property was added for in #1006 (ORI-215, `OIndexDescr ... is not owned by resource owner`).

## The change

Track the pin in the scan (`descrPinned`) and release it only while it is held — the same shape as every other resource in that function.

I did not establish why antithesis sees this only under Read Committed; the mechanism does not depend on the isolation level, and RC simply produces more rollbacks, so more scans are released through a ResourceOwner rather than normally.

## Testing

`make installcheck` with `IS_DEV=1`: regress 47/47, isolation 34/34, testgres running clean at the time of opening (will confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demonstrated, not just argued

The double free is reachable from plain SQL and the counter is visible through `orioledb_index_descr.refcnt`, so the added regress test needs nothing but a cursor and a savepoint:

```sql
BEGIN; SAVEPOINT x;
DECLARE c1 CURSOR FOR SELECT * FROM o_test_pin;
FETCH FROM c1;
ROLLBACK TO x;   -- ResourceOwner release: free with fromResowner = true
COMMIT;          -- seq_scans_cleanup(): free again with fromResowner = false
```

On the parent commit `refcnt` reads **1 → 0 → 4294967295** over two rounds; with the fix it stays at the descriptor cache's own single pin. The `ALTER TABLE` at the end of the test is the consequence in the open: at `refcnt == 0` an invalidation takes the `index_descr_delete_from_hash()` branch instead of recreating the descriptor in place, while the table descriptor still points at it.

The same double free also shows up in the existing `tableam` regress case (cursor declared inside a savepoint, `ROLLBACK TO`, `COMMIT`) — confirmed with a temporary probe: first call `fromResowner=1`, second `fromResowner=0`, `refcnt=1` going into the second drop.
