### PR TITLE
Add orioledb.debug_recovery_crash_lsn to crash replay at a chosen LSN

### DIFF
--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -503,6 +503,9 @@ extern int	rewind_max_transactions;
 extern int	logical_xid_buffers_guc;
 extern bool orioledb_strict_mode;
 extern XLogRecPtr replay_until_lsn;
+#ifdef IS_DEV
+extern XLogRecPtr debug_recovery_crash_lsn;
+#endif
 
 /* For page eviction/read checkpoint test only */
 extern uint32 min_read_page_checkpoint;

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -169,6 +169,10 @@ int			logical_xid_buffers_guc = 64;
 bool		orioledb_strict_mode = false;
 XLogRecPtr	replay_until_lsn = InvalidXLogRecPtr;
 static char *replay_until_lsn_string;
+#ifdef IS_DEV
+XLogRecPtr	debug_recovery_crash_lsn = InvalidXLogRecPtr;
+static char *debug_recovery_crash_lsn_string;
+#endif
 
 /* For page eviction/read checkpoint test only */
 uint32		min_read_page_checkpoint = UINT32_MAX;
@@ -464,6 +468,39 @@ orioledb_replay_until_lsn_assign_hook(const char *newval, void *extra)
 	if (newval && strcmp(newval, "") != 0)
 		replay_until_lsn = *((XLogRecPtr *) extra);
 }
+
+#ifdef IS_DEV
+/*
+ * GUC check_hook for orioledb.debug_recovery_crash_lsn
+ */
+static bool
+orioledb_debug_recovery_crash_lsn_check_hook(char **newval, void **extra,
+											 GucSource source)
+{
+	if (strcmp(*newval, "") != 0)
+	{
+		XLogRecPtr	lsn;
+		XLogRecPtr *myextra;
+		bool		have_error = false;
+
+		lsn = pg_lsn_in_internal(*newval, &have_error);
+		if (have_error)
+			return false;
+
+		myextra = (XLogRecPtr *) guc_malloc(ERROR, sizeof(XLogRecPtr));
+		*myextra = lsn;
+		*extra = (void *) myextra;
+	}
+	return true;
+}
+
+static void
+orioledb_debug_recovery_crash_lsn_assign_hook(const char *newval, void *extra)
+{
+	if (newval && strcmp(newval, "") != 0)
+		debug_recovery_crash_lsn = *((XLogRecPtr *) extra);
+}
+#endif							/* IS_DEV */
 
 void
 _PG_init(void)
@@ -1140,6 +1177,23 @@ _PG_init(void)
 							   orioledb_replay_until_lsn_check_hook,
 							   orioledb_replay_until_lsn_assign_hook,
 							   NULL);
+
+#ifdef IS_DEV
+	DefineCustomStringVariable("orioledb.debug_recovery_crash_lsn",
+							   "Makes recovery PANIC once replay reaches this"
+							   " write-ahead log location.",
+							   "For tests that need a crash in the middle of"
+							   " replay, so that the next start replays the"
+							   " same range again.  Never set this on a real"
+							   " cluster.",
+							   &debug_recovery_crash_lsn_string,
+							   "",
+							   PGC_POSTMASTER,
+							   0,
+							   orioledb_debug_recovery_crash_lsn_check_hook,
+							   orioledb_debug_recovery_crash_lsn_assign_hook,
+							   NULL);
+#endif							/* IS_DEV */
 
 	if (orioledb_s3_mode)
 	{

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1216,6 +1216,20 @@ orioledb_redo(XLogReaderState *record)
 	Assert((XLogRecGetInfo(record) & ~XLR_INFO_MASK) == ORIOLEDB_XLOG_CONTAINER);
 	recovery_single = *recovery_single_process;
 
+	/*
+	 * Simulate a crash in the middle of replay.  PANIC leaves the control
+	 * file pointing at the same checkpoint, so the next start replays this
+	 * range again -- which is the window several recovery bugs need and that
+	 * no amount of load can be made to hit on purpose.  Test-only; the GUC
+	 * defaults to unset.
+	 */
+#ifdef IS_DEV
+	if (unlikely(XLogRecPtrIsValid(debug_recovery_crash_lsn)) &&
+		record->ReadRecPtr >= debug_recovery_crash_lsn)
+		elog(PANIC, "orioledb.debug_recovery_crash_lsn reached at %X/%X",
+			 LSN_FORMAT_ARGS(record->ReadRecPtr));
+#endif
+
 	if (unlikely(XLogRecPtrIsValid(replay_until_lsn)))
 	{
 		/* Scoped to the lifetime of the Startup process. */


### PR DESCRIPTION
Several recovery bugs only appear when the same WAL range is replayed twice: the first replay has to stop part way through, so that the second one meets a page the first one already changed. Load alone cannot be aimed at that window, which is why those bugs have only ever been caught by crash churn and never by a test.

This adds a debug-only GUC, modelled on the existing `orioledb.replay_until_lsn`: when replay reaches the given location, the startup process PANICs. The control file still points at the older checkpoint, so the next start replays the same range again.

- name says `debug_`, so it reads as a debugging knob at the call site;
- compiled only into `IS_DEV` builds, so a production build has no such setting at all;
- `PGC_POSTMASTER`, default unset.

Verified end to end on an `IS_DEV` build: starting with the GUC set stops replay exactly at the requested LSN, starting again without it replays the range a second time and the cluster comes up with its data intact. A build without `IS_DEV` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)