### PR TITLE
Take the heap transaction's verdict for an oxid that has none of its own

### DIFF
--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -176,6 +176,15 @@ typedef struct
 	bool		checkpoint_xid;
 	/* is started from wal stream */
 	bool		wal_xid;
+
+	/*
+	 * Replay applied an INSERT/UPDATE/DELETE/REINSERT on behalf of this
+	 * transaction.  These are exactly the records that set
+	 * local_wal.has_material_changes on the primary, and therefore exactly
+	 * the ones that guarantee it wrote a finish record -- see the floor
+	 * branch of recovery_finish().
+	 */
+	bool		wal_modify;
 	/* usage map */
 	bool	   *used_by;
 } RecoveryXidState;
@@ -987,6 +996,7 @@ read_xids(int checkpointnum, bool recovery_single, int worker_id)
 			state->o_tables_meta_locked = false;
 			state->checkpoint_xid = true;
 			state->wal_xid = false;
+			state->wal_modify = false;
 			if (!recovery_single && worker_id < 0)
 				state->used_by = palloc0((recovery_pool_size_guc + recovery_idx_pool_size_guc) * sizeof(bool));
 			else
@@ -1975,7 +1985,30 @@ recovery_finish(int worker_id)
 				}
 				else
 				{
-					Assert(!cur_state->wal_xid);
+					/*
+					 * Below the floor there is nothing to announce: every
+					 * observer's xmin is already past this oxid, so no
+					 * WAL_REC_ROLLBACK is needed -- and emitting one would
+					 * drag a settled horizon backwards
+					 * (orioledb/orioledb#889).
+					 *
+					 * Such an entry can carry wal_xid, contrary to what this
+					 * used to assert.  The primary emits WAL_REC_XID lazily,
+					 * before the transaction's first record, and can then
+					 * finish with no finish record at all: wal_rollback()
+					 * discards a local buffer that holds no material
+					 * changes.  The floor moves past the oxid as soon as the
+					 * next transaction's finish record reports the primary's
+					 * advanced runXmin.
+					 *
+					 * What must still hold is the reason that fast path was
+					 * taken: only a modify record sets
+					 * has_material_changes, so a transaction whose changes
+					 * we replayed cannot have skipped its finish record.
+					 * Getting here with wal_modify would mean we replayed
+					 * changes for a transaction nobody will ever resolve.
+					 */
+					Assert(!cur_state->wal_modify);
 				}
 			}
 		}
@@ -2165,6 +2198,7 @@ recovery_switch_to_oxid(OXid oxid, int worker_id)
 			cur_state->invalidate_typcache = false;
 			cur_state->o_tables_meta_locked = false;
 			cur_state->checkpoint_xid = false;
+			cur_state->wal_modify = false;
 			if (worker_id < 0 && !*recovery_single_process)
 				cur_state->used_by = palloc0((recovery_pool_size_guc + recovery_idx_pool_size_guc) *
 											 sizeof(bool));
@@ -4667,6 +4701,18 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 				uint16		type = recovery_msg_from_wal_record(rec->type);
 
 				Assert(rec->oxid != InvalidOXid);
+
+				/*
+				 * Record that this transaction actually changed something on
+				 * the wire.  recovery_finish() asserts on it below the xmin
+				 * floor: no such record means the primary took the no-WAL
+				 * fast path out of wal_rollback(), which is the only way an
+				 * entry can get there having streamed a WAL_REC_XID.
+				 */
+				Assert(cur_recovery_xid_state == NULL ||
+					   cur_recovery_xid_state->oxid == rec->oxid);
+				if (cur_recovery_xid_state != NULL)
+					cur_recovery_xid_state->wal_modify = true;
 
 				build_fixed_tuples(rec, &tuple1, &tuple2);
 

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1938,77 +1938,121 @@ recovery_finish(int worker_id)
 
 		if (COMMITSEQNO_IS_INPROGRESS(cur_state->csn))
 		{
+			bool		heap_committed = false;
+
 			oxid_needs_wal_flush = cur_state->needs_wal_flush;
 			recovery_oxid = cur_state->oxid;
 			for (i = 0; i < (int) UndoLogsCount; i++)
 				set_cur_undo_locations((UndoLogType) i, cur_state->undo_stacks[i]);
 			if (flush_undo_pos)
 				flush_current_undo_stack();
-			for (i = 0; i < (int) UndoLogsCount; i++)
-				apply_undo_stack((UndoLogType) i, recovery_oxid, NULL, true);
-			walk_checkpoint_stacks(cur_state, COMMITSEQNO_ABORTED,
-								   InvalidSubTransactionId,
-								   flush_undo_pos);
 
 			/*
-			 * Remember this oxid so the after-checkpoint hook can emit a
-			 * WAL_REC_ROLLBACK for it once XLog inserts are allowed. Workers
-			 * don't write WAL: only the main recovery process does. See issue
-			 * #876.
+			 * No finish record ever arrived for this oxid, but it may still
+			 * have committed: an oxid born after XACT_EVENT_PRE_COMMIT gets
+			 * no finish record of its own, and its verdict is the verdict of
+			 * the heap transaction it rode on.  Replay of the clog is
+			 * complete by now, so ask it.  Rolling such a transaction back
+			 * would undo changes PostgreSQL considers committed.
+			 *
+			 * Done here rather than from o_xact_redo_hook() on the heap
+			 * commit record: several oxids can share one heap xid, most of
+			 * them resolve themselves (possibly through the deferred
+			 * finished_list), and settling an already settled oxid again
+			 * spins set_oxid_xlog_ptr() forever.  At this point every oxid
+			 * still INPROGRESS is one nobody resolved.
 			 */
-			if (worker_id < 0)
+			if (TransactionIdIsValid(cur_state->xid) &&
+				TransactionIdDidCommit(cur_state->xid))
 			{
-				if (cur_state->oxid >= recovery_xmin)
-				{
-					MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
+				CommitSeqNo csn;
 
-					if (recovery_finish_aborted_count == recovery_finish_aborted_capacity)
+				for (i = 0; i < (int) UndoLogsCount; i++)
+					precommit_undo_stack((UndoLogType) i, recovery_oxid, true);
+				for (i = 0; i < (int) UndoLogsCount; i++)
+					on_commit_undo_stack((UndoLogType) i, recovery_oxid, true);
+				set_oxid_csn(recovery_oxid, COMMITSEQNO_COMMITTING);
+				csn = pg_atomic_fetch_add_u64(&TRANSAM_VARIABLES->nextCommitSeqNo, 1);
+				set_oxid_csn(recovery_oxid, csn);
+				walk_checkpoint_stacks(cur_state, csn,
+									   InvalidSubTransactionId,
+									   flush_undo_pos);
+				cur_state->csn = csn;
+				heap_committed = true;
+				elog(DEBUG1, "OrioleDB recovery committed oxid " UINT64_FORMAT
+					 " from the verdict of heap xid %u",
+					 recovery_oxid, cur_state->xid);
+			}
+
+			if (!heap_committed)
+			{
+				for (i = 0; i < (int) UndoLogsCount; i++)
+					apply_undo_stack((UndoLogType) i, recovery_oxid, NULL, true);
+				walk_checkpoint_stacks(cur_state, COMMITSEQNO_ABORTED,
+									   InvalidSubTransactionId,
+									   flush_undo_pos);
+
+				/*
+				 * Remember this oxid so the after-checkpoint hook can emit a
+				 * WAL_REC_ROLLBACK for it once XLog inserts are allowed.
+				 * Workers don't write WAL: only the main recovery process
+				 * does. See issue #876.
+				 */
+				if (worker_id < 0)
+				{
+					if (cur_state->oxid >= recovery_xmin)
 					{
-						int			new_cap = recovery_finish_aborted_capacity == 0
-							? 16 : recovery_finish_aborted_capacity * 2;
+						MemoryContext oldcxt = MemoryContextSwitchTo(TopMemoryContext);
 
-						if (recovery_finish_aborted_oxids == NULL)
-							recovery_finish_aborted_oxids =
-								palloc(new_cap * sizeof(RecoveryFinishAbortedOxid));
-						else
-							recovery_finish_aborted_oxids =
-								repalloc(recovery_finish_aborted_oxids,
-										 new_cap * sizeof(RecoveryFinishAbortedOxid));
-						recovery_finish_aborted_capacity = new_cap;
+						if (recovery_finish_aborted_count == recovery_finish_aborted_capacity)
+						{
+							int			new_cap = recovery_finish_aborted_capacity == 0
+								? 16 : recovery_finish_aborted_capacity * 2;
+
+							if (recovery_finish_aborted_oxids == NULL)
+								recovery_finish_aborted_oxids =
+									palloc(new_cap * sizeof(RecoveryFinishAbortedOxid));
+							else
+								recovery_finish_aborted_oxids =
+									repalloc(recovery_finish_aborted_oxids,
+											 new_cap * sizeof(RecoveryFinishAbortedOxid));
+							recovery_finish_aborted_capacity = new_cap;
+						}
+						recovery_finish_aborted_oxids[recovery_finish_aborted_count].oxid =
+							cur_state->oxid;
+						recovery_finish_aborted_oxids[recovery_finish_aborted_count].xid =
+							cur_state->xid;
+						recovery_finish_aborted_count++;
+						MemoryContextSwitchTo(oldcxt);
 					}
-					recovery_finish_aborted_oxids[recovery_finish_aborted_count].oxid =
-						cur_state->oxid;
-					recovery_finish_aborted_oxids[recovery_finish_aborted_count].xid =
-						cur_state->xid;
-					recovery_finish_aborted_count++;
-					MemoryContextSwitchTo(oldcxt);
-				}
-				else
-				{
-					/*
-					 * Below the floor there is nothing to announce: every
-					 * observer's xmin is already past this oxid, so no
-					 * WAL_REC_ROLLBACK is needed -- and emitting one would
-					 * drag a settled horizon backwards
-					 * (orioledb/orioledb#889).
-					 *
-					 * Such an entry can carry wal_xid, contrary to what this
-					 * used to assert.  The primary emits WAL_REC_XID lazily,
-					 * before the transaction's first record, and can then
-					 * finish with no finish record at all: wal_rollback()
-					 * discards a local buffer that holds no material
-					 * changes.  The floor moves past the oxid as soon as the
-					 * next transaction's finish record reports the primary's
-					 * advanced runXmin.
-					 *
-					 * What must still hold is the reason that fast path was
-					 * taken: only a modify record sets
-					 * has_material_changes, so a transaction whose changes
-					 * we replayed cannot have skipped its finish record.
-					 * Getting here with wal_modify would mean we replayed
-					 * changes for a transaction nobody will ever resolve.
-					 */
-					Assert(!cur_state->wal_modify);
+					else
+					{
+						/*
+						 * Below the floor there is nothing to announce: every
+						 * observer's xmin is already past this oxid, so no
+						 * WAL_REC_ROLLBACK is needed -- and emitting one
+						 * would drag a settled horizon backwards
+						 * (orioledb/orioledb#889).
+						 *
+						 * Such an entry can carry wal_xid, contrary to what
+						 * this used to assert.  The primary emits WAL_REC_XID
+						 * lazily, before the transaction's first record, and
+						 * can then finish with no finish record at all:
+						 * wal_rollback() discards a local buffer that holds
+						 * no material changes.  The floor moves past the oxid
+						 * as soon as the next transaction's finish record
+						 * reports the primary's advanced runXmin.
+						 *
+						 * What must still hold is the reason that fast path
+						 * was taken: only a modify record sets
+						 * has_material_changes, so a transaction whose
+						 * changes we replayed cannot have skipped its finish
+						 * record. Getting here with wal_modify would mean we
+						 * replayed changes for a transaction nobody will ever
+						 * resolve.
+						 */
+						Assert(!cur_state->wal_modify);
+					}
 				}
 			}
 		}
@@ -4432,6 +4476,20 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 		case WAL_REC_XID:
 			advance_oxids(rec->oxid);
 			recovery_switch_to_oxid(rec->oxid, -1);
+
+			/*
+			 * Remember the heap xid this transaction rides on.  A transaction
+			 * that reaches its commit without an oxid -- a read-only
+			 * statement, say -- and only acquires one afterwards, inside
+			 * PreCommit_on_commit_actions(), can never get a finish record of
+			 * its own: wal_joint_commit() is emitted from
+			 * XACT_EVENT_PRE_COMMIT, already past, and XACT_EVENT_COMMIT runs
+			 * after RecordTransactionCommit().  Its verdict lives in the heap
+			 * xid alone, and recovery_finish() reads it from there.
+			 */
+			if (TransactionIdIsValid(rec->heapXid) &&
+				!TransactionIdIsValid(cur_recovery_xid_state->xid))
+				cur_recovery_xid_state->xid = rec->heapXid;
 			break;
 
 		case WAL_REC_SWITCH_LOGICAL_XID:


### PR DESCRIPTION
Fixes a crash-recovery data loss: changes of a transaction PostgreSQL considers **committed** were rolled back during replay.

> Stacked on #1021 — the base is that branch, since these callbacks depend on `XACT_INFO_WRITTEN_BY()`. Review/merge #1021 first and this retargets to main.

## What goes wrong

An oxid born **after** `XACT_EVENT_PRE_COMMIT` can never get a finish record of its own:

- `PreCommit_on_commit_actions()` runs after that event. A transaction that reaches its commit without an oxid — a read-only statement on a temp table with `ON COMMIT DELETE ROWS` — acquires one there, and `o_truncate_table()` / `drop_indices_for_rel()` put `WAL_REC_XID` plus records on the wire under it.
- `wal_joint_commit()` is emitted only from `XACT_EVENT_PRE_COMMIT`, already past. `XACT_EVENT_COMMIT`'s heap-xid branch merely does `set_oxid_xlog_ptr()`, and it runs after `RecordTransactionCommit()` anyway, too late for `o_xact_redo_hook()` to match.
- `current_oxid_commit()` then settles the oxid and `advance_run_xmin()` moves the horizon past it.

Replay is left with an oxid carrying changes and no verdict. `o_xact_redo_hook()` resolves only what `WAL_REC_JOINT_COMMIT` put on `joint_commit_list`, and `recovery.c` never looked at the `heapXid` that `WALRecXid` has carried since WAL version 17 (only `logical.c` did). So `recovery_finish()` aborted the transaction, undoing committed changes — and because the oxid is below `recovery_xmin` it emitted no rollback marker either, leaving a standby to hold it INPROGRESS forever (#876).

## How it was found

The first commit narrows the assertion that used to guard this spot. `Assert(!cur_state->wal_xid)` was a false invariant, but deleting it threw away a real signal; the honest invariant is *"a transaction whose changes we replayed cannot be one nobody will resolve"*. Tracked with a `wal_modify` flag set on INSERT/UPDATE/DELETE/REINSERT — exactly the records that set `has_material_changes` on the primary, hence exactly the ones that force a finish record.

The narrowed assertion fires on the crash-churn artifact where the old one did. A hypothesis-free detector on the primary (last oxid whose records reached the wire vs. last one given a finish record) then pinned the producer, and it fires in the **plain regress suite**, `test/sql/temp.sql`:

```
ORPHAN-COMMIT oxid 126 material 1 nesting 0 heapXid 795 logicalXid 64
              precommit_oxid <InvalidOXid>
```

## The fix

Remember the heap xid from `WAL_REC_XID`, and at end of redo ask the clog what became of it: an oxid still INPROGRESS whose heap transaction committed is committed too.

At end of redo rather than from the heap commit record, deliberately — I tried the latter first and it deadlocked. Several oxids share one heap xid, most resolve themselves (possibly through the deferred `finished_list`), and settling an already settled oxid spins `set_oxid_xlog_ptr()` forever. By end of redo every oxid still INPROGRESS is one nobody resolved.

No WAL format change: `heapXid` is already there. Pre-v17 WAL has it invalid, so behaviour is unchanged for old streams.

## Verification

On the artifact that used to fail on **every** start:

```
committed oxid 6094 from the verdict of heap xid 957
```

after which the cluster comes up clean.

Suites, all green: regress 47/47, isolation 34/34, `recovery_test.py` 57, `replication_test.py` + `recovery_worker_test.py` 44, `logical_test.py` 49, `logical_xid_subxacts_test.py` 8.

Logical decoding was checked on this exact case: with a `test_decoding` slot open, the late-oxid scenario interleaved with ordinary changes yields every committed change in order and the slot advances, no errors. Note the late oxid there touches only system trees, which decoding filters — so that check shows *no disturbance*, not correct streaming of late-oxid user data. Should some other producer of late oxids write to a user table, decoding would still have no commit for it; that is physical recovery only, and out of scope here.

## Not included

Two independent defects found on the way, deliberately left out of this PR: `start_autonomous_transaction()` capturing `has_material_changes` before the flush that sets it, and the fast paths in `wal_commit()` / `wal_rollback()` resetting three of the five fields `reset_local_wal_buffer()` resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)