### PR TITLE
Support CREATE DATABASE ... TEMPLATE for orioledb tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,8 @@ REGRESSCHECKS = btree_sys_check \
 				toast_column_compress \
 				trigger \
 				truncate \
-				types
+				types \
+				database_template
 ISOLATIONCHECKS = bitmap_hist_scan \
 				  bitmap_for_update_epq \
 				  bridge_index \
@@ -206,7 +207,8 @@ TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
 						test/t/rewind_xid_test.py \
 						test/t/rewind_xid_evict_large_test.py \
 						test/t/page_fit_items_test.py \
-						test/t/move_database_test.py
+						test/t/move_database_test.py \
+						test/t/database_template_test.py
 TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/checkpoint_eviction_test.py \
 						test/t/checkpoint_same_trx_test.py \

--- a/include/catalog/o_sys_cache.h
+++ b/include/catalog/o_sys_cache.h
@@ -279,6 +279,7 @@ extern Oid	o_get_hash_proc_by_btree_opclass(Oid btreeOpclass);
 
 extern void o_sys_caches_delete_by_lsn(XLogRecPtr checkPointRedo);
 
+extern void o_sys_caches_copy_datoid(Oid src_datoid, Oid dst_datoid);
 
 extern int	o_sys_cache_key_length(BTreeDescr *desc, OTuple tuple);
 extern int	o_sys_cache_tup_length(BTreeDescr *desc, OTuple tuple);

--- a/include/catalog/o_tables.h
+++ b/include/catalog/o_tables.h
@@ -197,6 +197,15 @@ extern OTable *o_tables_drop_by_oids(ORelOids oids, OXid oxid, CommitSeqNo csn);
 /* Drops all tables from o_tables list */
 extern void o_tables_drop_all(OXid oxid, CommitSeqNo csn, Oid database_id);
 
+/* Copy all tables from template database to a new database */
+extern void o_tables_copy_all(OXid oxid, CommitSeqNo csn, Oid src_datoid, Oid dst_datoid);
+
+/* Copy data files when creating a database from a template*/
+extern void o_tables_copy_database_files(Oid src_datoid, Oid dst_datoid);
+
+/* Remove any orioledb_data/ files already copied to dst_datoid by a failed */
+extern void o_tables_cleanup_database_files(Oid src_datoid, Oid dst_datoid);
+
 /* Move all tables from o_tables list */
 extern void o_tables_move_all(OXid oxid, CommitSeqNo csn, Oid database_id, Oid old_tspcoid, Oid new_tspcoid);
 

--- a/include/checkpoint/checkpoint.h
+++ b/include/checkpoint/checkpoint.h
@@ -269,6 +269,7 @@ extern void o_move_latest_chkp_num(Oid datoid, Oid relnode, Oid old_tablespace,
 								   Oid new_tablespace);
 
 extern void o_perform_checkpoint(XLogRecPtr redo_pos, int flags);
+extern void o_checkpoint_before_database_copy(void);
 extern void o_after_checkpoint_cleanup_hook(XLogRecPtr checkPointRedo,
 											int flags);
 

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -230,6 +230,8 @@ extern void add_savepoint_wal_record(SubTransactionId parentSubid,
 									 TransactionId prentLogicalXid);
 extern void add_rollback_to_savepoint_wal_record(SubTransactionId parentSubid);
 extern void add_database_copy_wal_record(Oid dboid, Oid src_tblspc, Oid dst_tblspc);
+extern void add_database_create_copy_wal_record(Oid src_datoid, Oid dst_datoid);
+extern void add_database_template_checkpoint_wal_record(Oid src_datoid);
 extern bool local_wal_is_empty(void);
 extern XLogRecPtr flush_local_wal(bool isCommit, bool withXactTime);
 extern XLogRecPtr wal_commit(OXid oxid, TransactionId logicalXid,

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -207,6 +207,13 @@ typedef struct
 	uint8		dst_tblspc[sizeof(Oid)];
 } WALRecDbCopy;
 
+typedef struct
+{
+	uint8		recType;
+	uint8		src_datoid[sizeof(Oid)];
+	uint8		dst_datoid[sizeof(Oid)];
+} WALRecDbCreateCopy;
+
 #define LOCAL_WAL_BUFFER_SIZE	(8192)
 #define ORIOLEDB_WAL_PREFIX	"o_wal"
 #define ORIOLEDB_WAL_PREFIX_SIZE (5)

--- a/include/recovery/wal_reader.h
+++ b/include/recovery/wal_reader.h
@@ -107,6 +107,12 @@ typedef struct WalRecord
 			Oid			dst_tblspc;
 		}			dbcopy;
 
+		struct
+		{
+			Oid			src_datoid;
+			Oid			dst_datoid;
+		}			dbcreate_copy;
+
 	}			u;
 
 } WalRecord;

--- a/include/recovery/wal_record.h
+++ b/include/recovery/wal_record.h
@@ -58,7 +58,9 @@
 	X(WAL_REC_REPLAY_FEEDBACK,      16, "REPLAY_FEEDBACK",    wal_parse_empty) \
 	X(WAL_REC_SWITCH_LOGICAL_XID,   17, "SWITCH_LOGICAL_XID", wal_parse_rec_switch_logical_xid) \
 	X(WAL_REC_RELREPLIDENT,         18, "RELREPLIDENT",       wal_parse_rec_relreplident) \
-	X(WAL_REC_DATABASE_COPY,        19, "DATABASE_COPY",      wal_parse_rec_dbcopy)
+	X(WAL_REC_DATABASE_COPY,        19, "DATABASE_COPY",      wal_parse_rec_dbcopy) \
+	X(WAL_REC_DATABASE_CREATE_COPY, 20, "DATABASE_CREATE_COPY", wal_parse_rec_dbcreate_copy) \
+	X(WAL_REC_DATABASE_TEMPLATE_CHECKPOINT, 21, "DATABASE_TEMPLATE_CHECKPOINT", wal_parse_rec_dbcreate_copy)
 
 typedef enum
 {

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -32,6 +32,7 @@
 #include "transam/undo.h"
 #include "tuple/slot.h"
 #include "utils/compress.h"
+#include "utils/stopevent.h"
 #include "recovery/wal.h"
 
 #include "access/genam.h"
@@ -122,6 +123,12 @@ typedef struct
 	Oid			dest_tsoid;		/* tablespace we are trying to move to */
 } movedb_params;
 
+typedef struct 
+{
+	Oid			src_datoid;
+	Oid			dst_datoid;
+} createdb_params;
+
 static ProcessUtility_hook_type next_ProcessUtility_hook = NULL;
 static object_access_hook_type old_objectaccess_hook = NULL;
 
@@ -169,10 +176,12 @@ static void redefine_indices(Relation rel, OTable *new_o_table, bool primary,
 
 static bool get_db_info(const char *name, LOCKMODE lockmode, Oid *dbIdP);
 static Oid	o_createdb(ParseState *pstate, const CreatedbStmt *stmt);
+static void o_copy_orioledb_template(Oid src_dboid, Oid dst_dboid);
 static void o_validate_replica_identity(Relation rel, ReplicaIdentityStmt *stmt);
 static void o_process_added_column(AlterTableCmd *cmd);
 static void o_check_movedb(const AlterDatabaseStmt *stmt, movedb_params *movedb);
 static void o_movedb_failure_callback(int code, Datum arg);
+static void o_createdb_failure_callback(int code, Datum arg);
 
 void
 orioledb_setup_ddl_hooks(void)
@@ -4969,10 +4978,10 @@ o_createdb(ParseState *pstate, const CreatedbStmt *stmt)
 						dbtemplate)));
 
 	if (o_tables_num(src_dboid) > 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("template database \"%s\" has OrioleDB tables",
-						dbtemplate)));
+	{
+		o_checkpoint_before_database_copy();
+		add_database_template_checkpoint_wal_record(src_dboid);
+	}
 
 	/*
 	 * Call standard PostgreSQL createdb().  It will create and copy
@@ -4983,11 +4992,50 @@ o_createdb(ParseState *pstate, const CreatedbStmt *stmt)
 	 */
 	result = createdb(pstate, stmt);
 
-	/*
-	 * Now we need to copy OrioleDB objects.
-	 */
+	o_copy_orioledb_template(src_dboid, result);
 
 	return result;
+}
+
+static void
+o_copy_orioledb_template(Oid src_dboid, Oid dst_dboid)
+{
+	if (o_tables_num(src_dboid) > 0)
+	{
+		OSnapshot		oSnapshot;
+		OXid			oxid = InvalidOXid;
+		createdb_params fparms;
+
+		fill_current_oxid_osnapshot(&oxid, &oSnapshot);
+
+		fparms.src_datoid = src_dboid;
+		fparms.dst_datoid = dst_dboid;
+
+		PG_ENSURE_ERROR_CLEANUP(o_createdb_failure_callback,
+								PointerGetDatum(&fparms));
+		{
+			o_tables_table_meta_lock(NULL);
+			o_tables_copy_database_files(src_dboid, dst_dboid);
+
+			if (STOPEVENT_CONDITION(STOPEVENT_CREATEDB_COPY_FAIL, NULL))
+				elog(ERROR, "Debug condition: createdb copy failed.");
+
+			add_database_create_copy_wal_record(src_dboid, dst_dboid);
+			o_tables_copy_all(oxid, oSnapshot.csn, src_dboid, dst_dboid);
+			o_sys_caches_copy_datoid(src_dboid, dst_dboid);
+			o_tables_table_meta_unlock(NULL, InvalidOid);
+		}
+		PG_END_ENSURE_ERROR_CLEANUP(o_createdb_failure_callback,
+									PointerGetDatum(&fparms));
+	}
+}
+
+static void
+o_createdb_failure_callback(int code, Datum arg)
+{
+	createdb_params *fparms = (createdb_params *) DatumGetPointer(arg);
+
+	o_tables_cleanup_database_files(fparms->src_datoid, fparms->dst_datoid);
 }
 
 static void

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -123,7 +123,7 @@ typedef struct
 	Oid			dest_tsoid;		/* tablespace we are trying to move to */
 } movedb_params;
 
-typedef struct 
+typedef struct
 {
 	Oid			src_datoid;
 	Oid			dst_datoid;
@@ -4979,6 +4979,12 @@ o_createdb(ParseState *pstate, const CreatedbStmt *stmt)
 
 	if (o_tables_num(src_dboid) > 0)
 	{
+		/*
+		 * Flush OrioleDB dirty data to disk before the file copy below.  The
+		 * companion WAL record makes standbys run the same checkpoint before
+		 * replaying DATABASE_CREATE_COPY, since PG's dbase_redo only flushes
+		 * its own shared buffers and leaves orioledb_data/ untouched.
+		 */
 		o_checkpoint_before_database_copy();
 		add_database_template_checkpoint_wal_record(src_dboid);
 	}
@@ -5002,8 +5008,8 @@ o_copy_orioledb_template(Oid src_dboid, Oid dst_dboid)
 {
 	if (o_tables_num(src_dboid) > 0)
 	{
-		OSnapshot		oSnapshot;
-		OXid			oxid = InvalidOXid;
+		OSnapshot	oSnapshot;
+		OXid		oxid = InvalidOXid;
 		createdb_params fparms;
 
 		fill_current_oxid_osnapshot(&oxid, &oSnapshot);

--- a/src/catalog/o_sys_cache.c
+++ b/src/catalog/o_sys_cache.c
@@ -17,6 +17,7 @@
 #include "orioledb.h"
 
 #include "btree/btree.h"
+#include "btree/iterator.h"
 #include "btree/modify.h"
 #include "catalog/o_sys_cache.h"
 #include "catalog/sys_trees.h"
@@ -2762,4 +2763,93 @@ o_reset_syscache_hooks(void)
 {
 	o_sys_cache_hooks_depth = 1;
 	o_unset_syscache_hooks();
+}
+
+static void
+o_sys_cache_copy_tree(OSysCache *sys_cache, Oid src_datoid, Oid dst_datoid)
+{
+	BTreeIterator	*it;
+	BTreeDescr		*td = get_sys_tree(sys_cache->sys_tree_num);
+	XLogRecPtr		cur_lsn;
+
+	o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
+
+	it = o_btree_iterator_create(td, NULL, BTreeKeyNone, &o_non_deleted_snapshot, ForwardScanDirection);
+
+	do
+	{
+		bool	end;
+		OTuple	tup = btree_iterate_raw(it, NULL, BTreeKeyNone, false, &end, NULL);
+
+		if (O_TUPLE_IS_NULL(tup))
+		{
+			if (end)
+				break;
+			else
+				continue;
+		}
+
+		if (sys_cache->is_toast)
+		{
+			OSysCacheToastChunkKey	*toast_key = (OSysCacheToastChunkKey *) tup.data;
+
+			if (toast_key->common.chunknum == 0)
+			{
+				OSysCacheKey *key = &toast_key->sys_cache_key;
+
+				if (key->common.datoid == src_datoid && !key->common.deleted)
+				{
+					int key_len = offsetof(OSysCacheKey, keys) + sizeof(Datum) * sys_cache->nkeys + key->common.dataLength;
+					OSysCacheKey *dst_key = palloc(key_len);
+					Pointer entry;
+
+					memcpy(dst_key, key, key_len);
+					dst_key->common.datoid = dst_datoid;
+					dst_key->common.lsn  = cur_lsn;
+					dst_key->common.deleted = false;
+
+					entry = o_sys_cache_get_from_toast_tree(sys_cache, key);
+					if (entry != NULL)
+					{
+						(void) o_sys_cache_add(sys_cache, dst_key, entry);
+						sys_cache->funcs->free_entry(entry);
+					}
+					pfree(dst_key);
+				}
+			}
+		}
+		else
+		{
+			OSysCacheKey *key = (OSysCacheKey *) tup.data;
+
+			if (key->common.datoid == src_datoid && !key->common.deleted)
+			{
+				int tup_len = o_btree_len(td, tup, OTupleLength);
+				Pointer copy = palloc(tup_len);
+
+				memcpy(copy, tup.data, tup_len);
+				((OSysCacheKey *) copy)->common.datoid = dst_datoid;
+				((OSysCacheKey *) copy)->common.lsn = cur_lsn;
+				((OSysCacheKey *) copy)->common.deleted = false;
+				(void) o_sys_cache_add(sys_cache, (OSysCacheKey *) copy, copy);
+				pfree(copy);
+			}
+		}
+	} while (true);
+	btree_iterator_free(it);
+}
+
+void
+o_sys_caches_copy_datoid(Oid src_datoid, Oid dst_datoid)
+{
+	HASH_SEQ_STATUS hash_seq;
+	OCacheIdMapEntry *entry;
+	XLogRecPtr cur_lsn;
+
+	o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
+	o_database_cache_add_if_needed(dst_datoid, dst_datoid, cur_lsn, NULL);
+
+	hash_seq_init(&hash_seq, sys_caches);
+	while ((entry = (OCacheIdMapEntry *) hash_seq_search(&hash_seq)) != NULL)
+		o_sys_cache_copy_tree(entry->sys_cache, src_datoid, dst_datoid);
 }

--- a/src/catalog/o_sys_cache.c
+++ b/src/catalog/o_sys_cache.c
@@ -2768,9 +2768,9 @@ o_reset_syscache_hooks(void)
 static void
 o_sys_cache_copy_tree(OSysCache *sys_cache, Oid src_datoid, Oid dst_datoid)
 {
-	BTreeIterator	*it;
-	BTreeDescr		*td = get_sys_tree(sys_cache->sys_tree_num);
-	XLogRecPtr		cur_lsn;
+	BTreeIterator *it;
+	BTreeDescr *td = get_sys_tree(sys_cache->sys_tree_num);
+	XLogRecPtr	cur_lsn;
 
 	o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
 
@@ -2778,8 +2778,8 @@ o_sys_cache_copy_tree(OSysCache *sys_cache, Oid src_datoid, Oid dst_datoid)
 
 	do
 	{
-		bool	end;
-		OTuple	tup = btree_iterate_raw(it, NULL, BTreeKeyNone, false, &end, NULL);
+		bool		end;
+		OTuple		tup = btree_iterate_raw(it, NULL, BTreeKeyNone, false, &end, NULL);
 
 		if (O_TUPLE_IS_NULL(tup))
 		{
@@ -2791,7 +2791,7 @@ o_sys_cache_copy_tree(OSysCache *sys_cache, Oid src_datoid, Oid dst_datoid)
 
 		if (sys_cache->is_toast)
 		{
-			OSysCacheToastChunkKey	*toast_key = (OSysCacheToastChunkKey *) tup.data;
+			OSysCacheToastChunkKey *toast_key = (OSysCacheToastChunkKey *) tup.data;
 
 			if (toast_key->common.chunknum == 0)
 			{
@@ -2799,13 +2799,13 @@ o_sys_cache_copy_tree(OSysCache *sys_cache, Oid src_datoid, Oid dst_datoid)
 
 				if (key->common.datoid == src_datoid && !key->common.deleted)
 				{
-					int key_len = offsetof(OSysCacheKey, keys) + sizeof(Datum) * sys_cache->nkeys + key->common.dataLength;
+					int			key_len = offsetof(OSysCacheKey, keys) + sizeof(Datum) * sys_cache->nkeys + key->common.dataLength;
 					OSysCacheKey *dst_key = palloc(key_len);
-					Pointer entry;
+					Pointer		entry;
 
 					memcpy(dst_key, key, key_len);
 					dst_key->common.datoid = dst_datoid;
-					dst_key->common.lsn  = cur_lsn;
+					dst_key->common.lsn = cur_lsn;
 					dst_key->common.deleted = false;
 
 					entry = o_sys_cache_get_from_toast_tree(sys_cache, key);
@@ -2824,8 +2824,8 @@ o_sys_cache_copy_tree(OSysCache *sys_cache, Oid src_datoid, Oid dst_datoid)
 
 			if (key->common.datoid == src_datoid && !key->common.deleted)
 			{
-				int tup_len = o_btree_len(td, tup, OTupleLength);
-				Pointer copy = palloc(tup_len);
+				int			tup_len = o_btree_len(td, tup, OTupleLength);
+				Pointer		copy = palloc(tup_len);
 
 				memcpy(copy, tup.data, tup_len);
 				((OSysCacheKey *) copy)->common.datoid = dst_datoid;
@@ -2844,7 +2844,7 @@ o_sys_caches_copy_datoid(Oid src_datoid, Oid dst_datoid)
 {
 	HASH_SEQ_STATUS hash_seq;
 	OCacheIdMapEntry *entry;
-	XLogRecPtr cur_lsn;
+	XLogRecPtr	cur_lsn;
 
 	o_sys_cache_set_datoid_lsn(&cur_lsn, NULL);
 	o_database_cache_add_if_needed(dst_datoid, dst_datoid, cur_lsn, NULL);

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -48,6 +48,7 @@
 #include "catalog/storage.h"
 #include "storage/smgr.h"
 #include "commands/defrem.h"
+#include "commands/tablespace.h"
 #include "executor/execExpr.h"
 #include "executor/functions.h"
 #include "funcapi.h"
@@ -57,6 +58,7 @@
 #include "parser/parse_relation.h"
 #include "pgstat.h"
 #include "postmaster/bgwriter.h"
+#include "storage/copydir.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
@@ -67,6 +69,7 @@
 #include "utils/rel.h"
 #include "utils/ruleutils.h"
 #include "utils/syscache.h"
+#include "sys/stat.h"
 
 /*
  * Relation locks from recovery workers may conflict with PostgreSQL WAL locks
@@ -2784,4 +2787,226 @@ o_tables_meta_unlock_no_wal(void)
 		if (--recovery_num_o_tables_meta_locks == 0)
 			LWLockRelease(&checkpoint_state->oTablesMetaLock);
 	}
+}
+
+typedef struct
+{
+	OXid		oxid;
+	CommitSeqNo csn;
+	Oid			src_datoid;
+	Oid			dst_datoid;
+} OTablesCopyAllArg;
+
+typedef struct
+{
+	Oid		src_datoid;
+	List	*tablespace;
+} OTablesCopyDatabaseFilesArg;
+
+static void
+o_tables_copy_database_files_collect_tablespace(ORelOids oids, void *arg)
+{
+	OTablesCopyDatabaseFilesArg *copy_arg = (OTablesCopyDatabaseFilesArg *) arg;
+	OTable	*o_table;
+	Oid		tablespace;
+	int		i;
+
+	if (oids.datoid != copy_arg->src_datoid)
+		return;
+	
+	o_table = o_tables_get(oids);
+	if (o_table == NULL)
+		return;
+
+	tablespace = OidIsValid(o_table->oids.spcoid) ? o_table->oids.spcoid : DEFAULTTABLESPACE_OID;
+	if (!list_member_oid(copy_arg->tablespace, tablespace))
+		copy_arg->tablespace = lappend_oid(copy_arg->tablespace, tablespace);
+
+	for (i = 0; i < o_table->nindices; i++)
+	{
+		tablespace = OidIsValid(o_table->indices[i].oids.spcoid) ? o_table->indices[i].oids.spcoid : DEFAULTTABLESPACE_OID;
+		if (!list_member_oid(copy_arg->tablespace, tablespace))
+			copy_arg->tablespace = lappend_oid(copy_arg->tablespace, tablespace);
+	}
+
+	o_table_free(o_table);
+}
+
+static void
+o_tables_copy_database_tablespace_files(Oid src_datoid, Oid dst_datoid, Oid tablespace)
+{
+	char	*src_path = NULL;
+	char	*dst_path = NULL;
+	char	*dst_prefix = NULL;
+	struct stat st;
+
+	o_get_prefixes_for_tablespace(src_datoid, tablespace, NULL, &src_path);
+	o_get_prefixes_for_tablespace(dst_datoid, tablespace, &dst_prefix, &dst_path);
+
+	if (stat(src_path, &st) < 0 || !S_ISDIR(st.st_mode) || directory_is_empty(src_path))
+	{
+		pfree(src_path);
+		pfree(dst_path);
+		return;
+	}
+
+	if (stat(dst_path, &st) == 0)
+	{
+		if (!rmtree(dst_path, true))
+			elog(ERROR, "could not remove directory \"%s\": %m",
+				 dst_path);
+	}
+
+	o_verify_dir_exists_or_create(dst_prefix, NULL, NULL);
+	copydir(src_path, dst_path, false);
+
+	pfree(src_path);
+	pfree(dst_path);
+}
+
+typedef struct
+{
+	Oid		src_datoid;
+	Oid		dst_datoid;
+} OTablesCopyDatabaseChkpNumArg;
+
+static void
+o_tables_copy_database_chkp_num_callback(ORelOids oids, void *arg)
+{
+	OTablesCopyDatabaseChkpNumArg *chkp_arg = (OTablesCopyDatabaseChkpNumArg *) arg;
+	OTable		*o_table;
+	OIndexKey	*trees;
+	int 		 numTrees;
+	int 		 i;
+
+	if (oids.datoid != chkp_arg->src_datoid)
+		return;
+
+	o_table = o_tables_get(oids);
+	if (o_table == NULL)
+		return;
+
+	trees = o_table_make_index_keys(o_table, &numTrees);
+	for (i = 0; i < numTrees; i++)
+	{
+		bool 	found;
+		uint32 	chkp_num;
+
+		chkp_num = o_get_latest_chkp_num(chkp_arg->src_datoid,
+										 trees[i].oids.relnode,
+										 trees[i].oids.spcoid,
+										 checkpoint_state->lastCheckpointNumber,
+										 &found);
+		if (found)
+		{
+			o_update_latest_chkp_num(chkp_arg->dst_datoid,
+									 trees[i].oids.relnode, 
+									 trees[i].oids.spcoid,
+									 chkp_num);
+		}
+	}
+
+	pfree(trees);
+	o_table_free(o_table);
+}
+
+void
+o_tables_copy_database_files(Oid src_datoid, Oid dst_datoid)
+{
+	OTablesCopyDatabaseFilesArg arg;
+	OTablesCopyDatabaseChkpNumArg chkp_arg;
+	ListCell	*lc;
+
+	arg.src_datoid = src_datoid;
+	arg.tablespace = NIL;
+
+	o_tables_foreach_oids(o_tables_copy_database_files_collect_tablespace,
+						  &o_non_deleted_snapshot, &arg);
+
+	foreach(lc, arg.tablespace)
+		o_tables_copy_database_tablespace_files(src_datoid, dst_datoid, lfirst_oid(lc));
+
+	list_free(arg.tablespace);
+
+	chkp_arg.src_datoid = src_datoid;
+	chkp_arg.dst_datoid = dst_datoid;
+	o_tables_foreach_oids(o_tables_copy_database_chkp_num_callback,
+						  &o_non_deleted_snapshot, &chkp_arg);
+}
+
+void
+o_tables_cleanup_database_files(Oid src_datoid, Oid dst_datoid)
+{
+	OTablesCopyDatabaseFilesArg arg;
+	ListCell	*lc;
+
+	arg.src_datoid = src_datoid;
+	arg.tablespace = NIL;
+
+	o_tables_foreach_oids(o_tables_copy_database_files_collect_tablespace,
+						  &o_non_deleted_snapshot, &arg);
+
+	foreach(lc, arg.tablespace)
+	{
+		Oid	tablespaces = lfirst_oid(lc);
+		char *dst_path = NULL;
+
+		o_get_prefixes_for_tablespace(dst_datoid, tablespaces, NULL, &dst_path);
+		(void) rmtree(dst_path, true);
+		pfree(dst_path);
+	}
+
+	list_free(arg.tablespace);
+}
+
+static void
+o_tables_copy_all_callback(ORelOids oids, void *arg)
+{
+	OTablesCopyAllArg *copy_arg = (OTablesCopyAllArg *) arg;
+
+	if (copy_arg->src_datoid != oids.datoid)
+		return;
+
+	OTable		*o_table;
+	o_table = o_tables_get(oids);
+	if (o_table)
+	{
+		OIndexKey	*trees;
+		int			 numTrees;
+		int			 i;
+		bool		 is_temp;
+
+		o_table->oids.datoid = copy_arg->dst_datoid;
+		for (i = 0; i < o_table->nindices; i++)
+		{
+			o_table->indices[i].oids.datoid = copy_arg->dst_datoid;
+		}
+		if (ORelOidsIsValid(o_table->bridge_oids))
+			o_table->bridge_oids.datoid = copy_arg->dst_datoid;
+		if (ORelOidsIsValid(o_table->toast_oids))
+			o_table->toast_oids.datoid = copy_arg->dst_datoid;
+
+		trees = o_table_make_index_keys(o_table, &numTrees);
+		
+		is_temp = o_table->persistence == RELPERSISTENCE_TEMP;
+		add_undo_create_relnode(o_table->oids, trees, numTrees, !is_temp);
+		o_tables_add(o_table, copy_arg->oxid, copy_arg->csn);
+		
+		pfree(trees);
+		o_table_free(o_table);
+	}
+}
+
+void
+o_tables_copy_all(OXid oxid, CommitSeqNo csn, Oid src_datoid, Oid dst_datoid)
+{
+	OTablesCopyAllArg arg;
+
+	arg.oxid = oxid;
+	arg.csn = csn;
+	arg.src_datoid = src_datoid;
+	arg.dst_datoid = dst_datoid;
+
+	o_tables_foreach_oids(o_tables_copy_all_callback,
+						  &o_non_deleted_snapshot, &arg);
 }

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -2799,21 +2799,21 @@ typedef struct
 
 typedef struct
 {
-	Oid		src_datoid;
-	List	*tablespace;
+	Oid			src_datoid;
+	List	   *tablespace;
 } OTablesCopyDatabaseFilesArg;
 
 static void
 o_tables_copy_database_files_collect_tablespace(ORelOids oids, void *arg)
 {
 	OTablesCopyDatabaseFilesArg *copy_arg = (OTablesCopyDatabaseFilesArg *) arg;
-	OTable	*o_table;
-	Oid		tablespace;
-	int		i;
+	OTable	   *o_table;
+	Oid			tablespace;
+	int			i;
 
 	if (oids.datoid != copy_arg->src_datoid)
 		return;
-	
+
 	o_table = o_tables_get(oids);
 	if (o_table == NULL)
 		return;
@@ -2835,9 +2835,9 @@ o_tables_copy_database_files_collect_tablespace(ORelOids oids, void *arg)
 static void
 o_tables_copy_database_tablespace_files(Oid src_datoid, Oid dst_datoid, Oid tablespace)
 {
-	char	*src_path = NULL;
-	char	*dst_path = NULL;
-	char	*dst_prefix = NULL;
+	char	   *src_path = NULL;
+	char	   *dst_path = NULL;
+	char	   *dst_prefix = NULL;
 	struct stat st;
 
 	o_get_prefixes_for_tablespace(src_datoid, tablespace, NULL, &src_path);
@@ -2866,18 +2866,18 @@ o_tables_copy_database_tablespace_files(Oid src_datoid, Oid dst_datoid, Oid tabl
 
 typedef struct
 {
-	Oid		src_datoid;
-	Oid		dst_datoid;
+	Oid			src_datoid;
+	Oid			dst_datoid;
 } OTablesCopyDatabaseChkpNumArg;
 
 static void
 o_tables_copy_database_chkp_num_callback(ORelOids oids, void *arg)
 {
 	OTablesCopyDatabaseChkpNumArg *chkp_arg = (OTablesCopyDatabaseChkpNumArg *) arg;
-	OTable		*o_table;
-	OIndexKey	*trees;
-	int 		 numTrees;
-	int 		 i;
+	OTable	   *o_table;
+	OIndexKey  *trees;
+	int			numTrees;
+	int			i;
 
 	if (oids.datoid != chkp_arg->src_datoid)
 		return;
@@ -2889,8 +2889,8 @@ o_tables_copy_database_chkp_num_callback(ORelOids oids, void *arg)
 	trees = o_table_make_index_keys(o_table, &numTrees);
 	for (i = 0; i < numTrees; i++)
 	{
-		bool 	found;
-		uint32 	chkp_num;
+		bool		found;
+		uint32		chkp_num;
 
 		chkp_num = o_get_latest_chkp_num(chkp_arg->src_datoid,
 										 trees[i].oids.relnode,
@@ -2900,7 +2900,7 @@ o_tables_copy_database_chkp_num_callback(ORelOids oids, void *arg)
 		if (found)
 		{
 			o_update_latest_chkp_num(chkp_arg->dst_datoid,
-									 trees[i].oids.relnode, 
+									 trees[i].oids.relnode,
 									 trees[i].oids.spcoid,
 									 chkp_num);
 		}
@@ -2915,7 +2915,7 @@ o_tables_copy_database_files(Oid src_datoid, Oid dst_datoid)
 {
 	OTablesCopyDatabaseFilesArg arg;
 	OTablesCopyDatabaseChkpNumArg chkp_arg;
-	ListCell	*lc;
+	ListCell   *lc;
 
 	arg.src_datoid = src_datoid;
 	arg.tablespace = NIL;
@@ -2938,7 +2938,7 @@ void
 o_tables_cleanup_database_files(Oid src_datoid, Oid dst_datoid)
 {
 	OTablesCopyDatabaseFilesArg arg;
-	ListCell	*lc;
+	ListCell   *lc;
 
 	arg.src_datoid = src_datoid;
 	arg.tablespace = NIL;
@@ -2948,8 +2948,8 @@ o_tables_cleanup_database_files(Oid src_datoid, Oid dst_datoid)
 
 	foreach(lc, arg.tablespace)
 	{
-		Oid	tablespaces = lfirst_oid(lc);
-		char *dst_path = NULL;
+		Oid			tablespaces = lfirst_oid(lc);
+		char	   *dst_path = NULL;
 
 		o_get_prefixes_for_tablespace(dst_datoid, tablespaces, NULL, &dst_path);
 		(void) rmtree(dst_path, true);
@@ -2962,19 +2962,19 @@ o_tables_cleanup_database_files(Oid src_datoid, Oid dst_datoid)
 static void
 o_tables_copy_all_callback(ORelOids oids, void *arg)
 {
+	OTable	   *o_table;
 	OTablesCopyAllArg *copy_arg = (OTablesCopyAllArg *) arg;
 
 	if (copy_arg->src_datoid != oids.datoid)
 		return;
 
-	OTable		*o_table;
 	o_table = o_tables_get(oids);
 	if (o_table)
 	{
-		OIndexKey	*trees;
-		int			 numTrees;
-		int			 i;
-		bool		 is_temp;
+		OIndexKey  *trees;
+		int			numTrees;
+		int			i;
+		bool		is_temp;
 
 		o_table->oids.datoid = copy_arg->dst_datoid;
 		for (i = 0; i < o_table->nindices; i++)
@@ -2987,11 +2987,11 @@ o_tables_copy_all_callback(ORelOids oids, void *arg)
 			o_table->toast_oids.datoid = copy_arg->dst_datoid;
 
 		trees = o_table_make_index_keys(o_table, &numTrees);
-		
+
 		is_temp = o_table->persistence == RELPERSISTENCE_TEMP;
 		add_undo_create_relnode(o_table->oids, trees, numTrees, !is_temp);
 		o_tables_add(o_table, copy_arg->oxid, copy_arg->csn);
-		
+
 		pfree(trees);
 		o_table_free(o_table);
 	}

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -2035,6 +2035,12 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 		next_CheckPoint_hook(redo_pos, flags);
 }
 
+void
+o_checkpoint_before_database_copy(void)
+{
+	RequestCheckpoint(CHECKPOINT_IMMEDIATE | CHECKPOINT_FORCE | CHECKPOINT_WAIT);
+}
+
 static void
 checkpoint_init_new_seq_bufs(BTreeDescr *descr, int chkpNum)
 {

--- a/src/recovery/logical.c
+++ b/src/recovery/logical.c
@@ -1097,6 +1097,8 @@ decode_on_record(WalReaderState *r, WalRecord *rec)
 		case WAL_REC_O_TABLES_META_UNLOCK:
 		case WAL_REC_TRUNCATE:
 		case WAL_REC_BRIDGE_ERASE:
+		case WAL_REC_DATABASE_CREATE_COPY:
+		case WAL_REC_DATABASE_TEMPLATE_CHECKPOINT:
 			/* Skip */
 			break;
 

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -24,6 +24,7 @@
 #include "catalog/indices.h"
 #include "catalog/o_indices.h"
 #include "catalog/o_sys_cache.h"
+#include "catalog/o_tables.h"
 #include "checkpoint/checkpoint.h"
 #include "recovery/recovery.h"
 #include "recovery/internal.h"
@@ -4654,6 +4655,36 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 		case WAL_REC_DATABASE_COPY:
 			handle_movedb(rec->u.dbcopy.datOid, rec->u.dbcopy.src_tblspc, rec->u.dbcopy.dst_tblspc);
 			break;
+
+		case WAL_REC_DATABASE_TEMPLATE_CHECKPOINT:
+			{
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->offset;
+
+				if (!ctx->single)
+					workers_synchronize(xlogPtr, true);
+
+				o_checkpoint_before_database_copy();
+
+				if (!ctx->single)
+					workers_synchronize(xlogPtr + 1, true);
+
+				break;
+			}
+
+		case WAL_REC_DATABASE_CREATE_COPY:
+			{
+				XLogRecPtr	xlogPtr = ctx->xlogRecPtr + rec->offset;
+
+				if (!ctx->single)
+					workers_synchronize(xlogPtr, true);
+
+				o_tables_copy_database_files(rec->u.dbcreate_copy.src_datoid, rec->u.dbcreate_copy.dst_datoid);
+
+				if (!ctx->single)
+					workers_synchronize(xlogPtr + 1, true);
+
+				break;
+			}
 
 		case WAL_REC_O_TABLES_META_UNLOCK:
 			{

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -585,6 +585,49 @@ add_database_copy_wal_record(Oid dboid, Oid src_tblspc, Oid dst_tblspc)
 }
 
 void
+add_database_create_copy_wal_record(Oid src_datoid, Oid dst_datoid)
+{
+	WALRecDbCreateCopy *rec;
+
+	Assert(!is_recovery_process());
+	flush_local_wal_if_needed(sizeof(*rec));
+	Assert(local_wal.buffer_offset + sizeof(*rec) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE);
+
+	add_xid_wal_record_if_needed();
+
+	rec = (WALRecDbCreateCopy *) (&local_wal.buffer[local_wal.buffer_offset]);
+
+	rec->recType = WAL_REC_DATABASE_CREATE_COPY;
+	memcpy(rec->src_datoid, &src_datoid, sizeof(Oid));
+	memcpy(rec->dst_datoid, &dst_datoid, sizeof(Oid));
+
+	local_wal.buffer_offset += sizeof(*rec);
+}
+
+void
+add_database_template_checkpoint_wal_record(Oid src_datoid)
+{
+	WALRecDbCreateCopy *rec;
+	Oid					invalid_datoid = InvalidOid;
+
+	Assert(!is_recovery_process());
+	flush_local_wal_if_needed(sizeof(*rec));
+	Assert(local_wal.buffer_offset + sizeof(*rec) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE);
+
+	(void) get_current_oxid();
+	add_xid_wal_record_if_needed();
+
+	rec = (WALRecDbCreateCopy *) (&local_wal.buffer[local_wal.buffer_offset]);
+
+	rec->recType = WAL_REC_DATABASE_TEMPLATE_CHECKPOINT;
+	memcpy(rec->src_datoid, &src_datoid, sizeof(Oid));
+	memcpy(rec->dst_datoid, &invalid_datoid, sizeof(Oid));
+
+	local_wal.buffer_offset += sizeof(*rec);
+}
+
+
+void
 add_switch_logical_xid_wal_record(TransactionId logicalXid_top, TransactionId logicalXid_sub)
 {
 	WALRecSwitchLogicalXid *rec;

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -608,7 +608,7 @@ void
 add_database_template_checkpoint_wal_record(Oid src_datoid)
 {
 	WALRecDbCreateCopy *rec;
-	Oid					invalid_datoid = InvalidOid;
+	Oid			invalid_datoid = InvalidOid;
 
 	Assert(!is_recovery_process());
 	flush_local_wal_if_needed(sizeof(*rec));

--- a/src/recovery/wal_reader.c
+++ b/src/recovery/wal_reader.c
@@ -44,6 +44,7 @@ static WalParseResult wal_parse_rec_switch_logical_xid(WalReaderState *r, WalRec
 static WalParseResult wal_parse_rec_relreplident(WalReaderState *r, WalRecord *rec);
 static WalParseResult wal_parse_rec_modify(WalReaderState *r, WalRecord *rec);
 static WalParseResult wal_parse_rec_dbcopy(WalReaderState *r, WalRecord *rec);
+static WalParseResult wal_parse_rec_dbcreate_copy(WalReaderState *r, WalRecord *rec);
 
 const char *
 wal_type_name(WalRecordType type)
@@ -325,6 +326,19 @@ wal_parse_rec_dbcopy(WalReaderState *r, WalRecord *rec)
 	WR_PARSE(r, &rec->u.dbcopy.datOid);
 	WR_PARSE(r, &rec->u.dbcopy.src_tblspc);
 	WR_PARSE(r, &rec->u.dbcopy.dst_tblspc);
+
+	return WALPARSE_OK;
+}
+
+/* Parser for WAL_REC_DATABASE_CREATE_COPY */
+static WalParseResult
+wal_parse_rec_dbcreate_copy(WalReaderState *r, WalRecord *rec)
+{
+	Assert(r);
+	Assert(rec);
+
+	WR_PARSE(r, &rec->u.dbcreate_copy.src_datoid);
+	WR_PARSE(r, &rec->u.dbcreate_copy.dst_datoid);
 
 	return WALPARSE_OK;
 }

--- a/src/utils/stopevent.c
+++ b/src/utils/stopevent.c
@@ -427,6 +427,9 @@ check_stopevent(int event_id, Jsonb *params)
 
 	Assert(event_id >= 0 && event_id < STOPEVENTS_COUNT);
 
+	if (!params)
+		params = make_empty_params();
+
 	if (event->enabled && check_stopevent_condition(event, params))
 		return true;
 

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -37,3 +37,4 @@ undo_flush
 before_o_tables_meta_unlock
 merge_before_free_extent
 iterator_next
+createdb_copy_fail

--- a/test/expected/database.out
+++ b/test/expected/database.out
@@ -9,10 +9,9 @@ CREATE DATABASE orioledb_template;
 CREATE EXTENSION orioledb;
 CREATE TABLE oriole_table (i int) USING orioledb;
 \c postgres
--- This CREATE DATABASE should fail
 CREATE DATABASE orioledb TEMPLATE orioledb_template;
-ERROR:  template database "orioledb_template" has OrioleDB tables
 DROP DATABASE orioledb_template;
+DROP DATABASE orioledb;
 DROP DATABASE heapdb;
 DROP DATABASE heapdb_template;
 -- Check pg_database_size()

--- a/test/expected/database_1.out
+++ b/test/expected/database_1.out
@@ -9,10 +9,9 @@ CREATE DATABASE orioledb_template;
 CREATE EXTENSION orioledb;
 CREATE TABLE oriole_table (i int) USING orioledb;
 \c postgres
--- This CREATE DATABASE should fail
 CREATE DATABASE orioledb TEMPLATE orioledb_template;
-ERROR:  template database "orioledb_template" has OrioleDB tables
 DROP DATABASE orioledb_template;
+DROP DATABASE orioledb;
 DROP DATABASE heapdb;
 DROP DATABASE heapdb_template;
 -- Check pg_database_size()

--- a/test/expected/database_template.out
+++ b/test/expected/database_template.out
@@ -1,0 +1,446 @@
+CREATE DATABASE orioledb_template;
+\c orioledb_template
+CREATE EXTENSION orioledb;
+-- Oriole_table without PK
+CREATE TABLE o_tb_no_pk (
+    k int NOT NULL,
+    val text NOT NULL
+) USING orioledb;
+CREATE INDEX o_tb_no_pk_idx ON o_tb_no_pk (k);
+INSERT INTO o_tb_no_pk VALUES (10, 'A'), (20, 'B');
+-- PRIMARY KEY
+CREATE TABLE o_tb (
+    id int PRIMARY KEY,
+    val text NOT NULL
+) USING orioledb;
+INSERT INTO o_tb VALUES (1, 'one'), (2, 'two');
+-- SECONDARY INDEX
+CREATE TABLE o_tb_secondary_k (
+    id int PRIMARY KEY,
+    k int NOT NULL,
+    val text
+) USING orioledb;
+CREATE INDEX o_tb_secondary_k_idx ON o_tb_secondary_k (k);
+INSERT INTO o_tb_secondary_k VALUES (10, 100, 'Val1'), (50, 500, 'Val2');
+-- BRIDGE INDEX
+CREATE TABLE o_tb_bridge (
+    id int PRIMARY KEY,
+    tag int
+) USING orioledb;
+CREATE INDEX o_tb_bridge_idx ON o_tb_bridge USING btree (tag)
+    WITH (orioledb_index = off, deduplicate_items = off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_tb_bridge'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+INSERT INTO o_tb_bridge VALUES (1, 11), (2, 22);
+-- TOAST INDEX
+CREATE TABLE o_tb_toast (
+    id int PRIMARY KEY,
+    t_key text NOT NULL,
+    t_big text NOT NULL
+) USING orioledb;
+CREATE INDEX o_tb_toast_idx ON o_tb_toast (t_key);
+INSERT INTO o_tb_toast VALUES
+    (1, 'k1', repeat('x', 3000)),
+    (2, 'k2', repeat('y', 3500));
+-- HEAP TABLE
+CREATE TABLE heap_table (
+    id int PRIMARY KEY,
+    k int NOT NULL
+) USING heap;
+CREATE INDEX heap_table_idx ON heap_table (k);
+INSERT INTO heap_table VALUES (1, 10), (2, 20);
+-- USER TABLESPACE
+SET allow_in_place_tablespaces = true;
+CREATE TABLESPACE db_template_tblspc LOCATION '';
+CREATE TABLE o_tb_tblspc (
+    id int PRIMARY KEY,
+    n int NOT NULL
+) USING orioledb TABLESPACE db_template_tblspc;
+CREATE INDEX o_tb_tblspc_idx ON o_tb_tblspc (n) TABLESPACE db_template_tblspc;
+INSERT INTO o_tb_tblspc VALUES (1, 111), (2, 222);
+------------------CHECK IN TEMPLATE -------------------------------------------------
+SELECT extname FROM pg_extension WHERE extname = 'orioledb';
+ extname  
+----------
+ orioledb
+(1 row)
+
+-- Oriole_table without PK
+SELECT * FROM o_tb_no_pk;
+ k  | val 
+----+-----
+ 10 | A
+ 20 | B
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT val FROM o_tb_no_pk WHERE k = 20;
+                QUERY PLAN                 
+-------------------------------------------
+ Custom Scan (o_scan) on o_tb_no_pk
+   Bitmap heap scan
+   Recheck Cond: (k = 20)
+   ->  Bitmap Index Scan on o_tb_no_pk_idx
+         Index Cond: (k = 20)
+(5 rows)
+
+SELECT val FROM o_tb_no_pk WHERE k = 20;
+ val 
+-----
+ B
+(1 row)
+
+COMMIT;
+-- PRIMARY KEY
+SELECT id, val FROM o_tb ORDER BY id;
+ id | val 
+----+-----
+  1 | one
+  2 | two
+(2 rows)
+
+-- SECONDARY INDEX
+SELECT * FROM o_tb_secondary_k;
+ id |  k  | val  
+----+-----+------
+ 10 | 100 | Val1
+ 50 | 500 | Val2
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_secondary_k WHERE k = 500;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Index Only Scan using o_tb_secondary_k_idx on o_tb_secondary_k
+   Index Cond: (k = 500)
+(2 rows)
+
+SELECT id FROM o_tb_secondary_k WHERE k = 500;
+ id 
+----
+ 50
+(1 row)
+
+COMMIT;
+-- BRIDGE INDEX
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_bridge WHERE tag = 11;
+                 QUERY PLAN                 
+--------------------------------------------
+ Custom Scan (o_scan) on o_tb_bridge
+   Bitmap heap scan
+   Recheck Cond: (tag = 11)
+   ->  Bitmap Index Scan on o_tb_bridge_idx
+         Index Cond: (tag = 11)
+(5 rows)
+
+SELECT id FROM o_tb_bridge WHERE tag = 11;
+ id 
+----
+  1
+(1 row)
+
+COMMIT;
+-- TOAST INDEX
+SELECT id, t_key, length(t_big) AS t_big_len
+FROM o_tb_toast
+ORDER BY id;
+ id | t_key | t_big_len 
+----+-------+-----------
+  1 | k1    |      3000
+  2 | k2    |      3500
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+                     QUERY PLAN                     
+----------------------------------------------------
+ Index Only Scan using o_tb_toast_idx on o_tb_toast
+   Index Cond: (t_key = 'k2'::text)
+(2 rows)
+
+SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+ id 
+----
+  2
+(1 row)
+
+COMMIT;
+-- HEAP TABLE
+SELECT id, k FROM heap_table ORDER BY id;
+ id | k  
+----+----
+  1 | 10
+  2 | 20
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM heap_table WHERE k = 20;
+                QUERY PLAN                 
+-------------------------------------------
+ Bitmap Heap Scan on heap_table
+   Recheck Cond: (k = 20)
+   ->  Bitmap Index Scan on heap_table_idx
+         Index Cond: (k = 20)
+(4 rows)
+
+SELECT id FROM heap_table WHERE k = 20;
+ id 
+----
+  2
+(1 row)
+
+COMMIT;
+-- USER TABLESPACE
+SELECT id, n FROM o_tb_tblspc ORDER BY id;
+ id |  n  
+----+-----
+  1 | 111
+  2 | 222
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_tblspc WHERE n = 222;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Index Only Scan using o_tb_tblspc_idx on o_tb_tblspc
+   Index Cond: (n = 222)
+(2 rows)
+
+SELECT id FROM o_tb_tblspc WHERE n = 222;
+ id 
+----
+  2
+(1 row)
+
+COMMIT;
+---------------------------------------------------------------------------------------
+\c postgres
+CREATE DATABASE orioledb_from_template TEMPLATE orioledb_template;
+\c orioledb_from_template
+SELECT extname FROM pg_extension WHERE extname = 'orioledb';
+ extname  
+----------
+ orioledb
+(1 row)
+
+-- Oriole_table without PK
+SELECT * FROM o_tb_no_pk;
+ k  | val 
+----+-----
+ 10 | A
+ 20 | B
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT val FROM o_tb_no_pk WHERE k = 20;
+                QUERY PLAN                 
+-------------------------------------------
+ Custom Scan (o_scan) on o_tb_no_pk
+   Bitmap heap scan
+   Recheck Cond: (k = 20)
+   ->  Bitmap Index Scan on o_tb_no_pk_idx
+         Index Cond: (k = 20)
+(5 rows)
+
+SELECT val FROM o_tb_no_pk WHERE k = 20;
+ val 
+-----
+ B
+(1 row)
+
+COMMIT;
+-- PRIMARY KEY
+SELECT id, val FROM o_tb ORDER BY id;
+ id | val 
+----+-----
+  1 | one
+  2 | two
+(2 rows)
+
+-- SECONDARY INDEX
+SELECT * FROM o_tb_secondary_k;
+ id |  k  | val  
+----+-----+------
+ 10 | 100 | Val1
+ 50 | 500 | Val2
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_secondary_k WHERE k = 500;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Index Only Scan using o_tb_secondary_k_idx on o_tb_secondary_k
+   Index Cond: (k = 500)
+(2 rows)
+
+SELECT id FROM o_tb_secondary_k WHERE k = 500;
+ id 
+----
+ 50
+(1 row)
+
+COMMIT;
+-- BRIDGE INDEX
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_bridge WHERE tag = 11;
+                 QUERY PLAN                 
+--------------------------------------------
+ Custom Scan (o_scan) on o_tb_bridge
+   Bitmap heap scan
+   Recheck Cond: (tag = 11)
+   ->  Bitmap Index Scan on o_tb_bridge_idx
+         Index Cond: (tag = 11)
+(5 rows)
+
+SELECT id FROM o_tb_bridge WHERE tag = 11;
+ id 
+----
+  1
+(1 row)
+
+COMMIT;
+-- TOAST INDEX
+SELECT id, t_key, length(t_big) AS t_big_len
+FROM o_tb_toast
+ORDER BY id;
+ id | t_key | t_big_len 
+----+-------+-----------
+  1 | k1    |      3000
+  2 | k2    |      3500
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+                     QUERY PLAN                     
+----------------------------------------------------
+ Index Only Scan using o_tb_toast_idx on o_tb_toast
+   Index Cond: (t_key = 'k2'::text)
+(2 rows)
+
+SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+ id 
+----
+  2
+(1 row)
+
+COMMIT;
+-- HEAP TABLE
+SELECT id, k FROM heap_table ORDER BY id;
+ id | k  
+----+----
+  1 | 10
+  2 | 20
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM heap_table WHERE k = 20;
+                QUERY PLAN                 
+-------------------------------------------
+ Bitmap Heap Scan on heap_table
+   Recheck Cond: (k = 20)
+   ->  Bitmap Index Scan on heap_table_idx
+         Index Cond: (k = 20)
+(4 rows)
+
+SELECT id FROM heap_table WHERE k = 20;
+ id 
+----
+  2
+(1 row)
+
+COMMIT;
+-- USER TABLESPACE
+SELECT id, n FROM o_tb_tblspc ORDER BY id;
+ id |  n  
+----+-----
+  1 | 111
+  2 | 222
+(2 rows)
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_tblspc WHERE n = 222;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Index Only Scan using o_tb_tblspc_idx on o_tb_tblspc
+   Index Cond: (n = 222)
+(2 rows)
+
+SELECT id FROM o_tb_tblspc WHERE n = 222;
+ id 
+----
+  2
+(1 row)
+
+COMMIT;
+-- DML AFTER CLONE
+INSERT INTO o_tb VALUES (3, 'three');
+INSERT INTO o_tb_toast VALUES (3, 'k3', repeat('w', 3200));
+SELECT * FROM o_tb;
+ id |  val  
+----+-------
+  1 | one
+  2 | two
+  3 | three
+(3 rows)
+
+SELECT id, t_key, length(t_big) AS t_big_len FROM o_tb_toast;
+ id | t_key | t_big_len 
+----+-------+-----------
+  1 | k1    |      3000
+  2 | k2    |      3500
+  3 | k3    |      3200
+(3 rows)
+
+\c postgres
+DROP DATABASE orioledb_from_template;
+\c orioledb_template
+SELECT * FROM o_tb;
+ id | val 
+----+-----
+  1 | one
+  2 | two
+(2 rows)
+
+SELECT id, t_key FROM o_tb_toast;
+ id | t_key 
+----+-------
+  1 | k1
+  2 | k2
+(2 rows)
+
+DROP TABLE o_tb_toast;
+DROP TABLE o_tb_bridge;
+DROP TABLE o_tb_secondary_k;
+DROP TABLE o_tb;
+DROP TABLE o_tb_no_pk;
+DROP TABLE o_tb_tblspc;
+DROP EXTENSION orioledb CASCADE;
+\c postgres
+DROP DATABASE orioledb_template;

--- a/test/sql/database.sql
+++ b/test/sql/database.sql
@@ -17,10 +17,10 @@ CREATE TABLE oriole_table (i int) USING orioledb;
 
 \c postgres
 
--- This CREATE DATABASE should fail
 CREATE DATABASE orioledb TEMPLATE orioledb_template;
 
 DROP DATABASE orioledb_template;
+DROP DATABASE orioledb;
 DROP DATABASE heapdb;
 DROP DATABASE heapdb_template;
 

--- a/test/sql/database_template.sql
+++ b/test/sql/database_template.sql
@@ -1,0 +1,229 @@
+CREATE DATABASE orioledb_template;
+\c orioledb_template
+
+CREATE EXTENSION orioledb;
+
+-- Oriole_table without PK
+CREATE TABLE o_tb_no_pk (
+    k int NOT NULL,
+    val text NOT NULL
+) USING orioledb;
+CREATE INDEX o_tb_no_pk_idx ON o_tb_no_pk (k);
+INSERT INTO o_tb_no_pk VALUES (10, 'A'), (20, 'B');
+
+-- PRIMARY KEY
+CREATE TABLE o_tb (
+    id int PRIMARY KEY,
+    val text NOT NULL
+) USING orioledb;
+INSERT INTO o_tb VALUES (1, 'one'), (2, 'two');
+
+-- SECONDARY INDEX
+CREATE TABLE o_tb_secondary_k (
+    id int PRIMARY KEY,
+    k int NOT NULL,
+    val text
+) USING orioledb;
+CREATE INDEX o_tb_secondary_k_idx ON o_tb_secondary_k (k);
+INSERT INTO o_tb_secondary_k VALUES (10, 100, 'Val1'), (50, 500, 'Val2');
+
+-- BRIDGE INDEX
+CREATE TABLE o_tb_bridge (
+    id int PRIMARY KEY,
+    tag int
+) USING orioledb;
+CREATE INDEX o_tb_bridge_idx ON o_tb_bridge USING btree (tag)
+    WITH (orioledb_index = off, deduplicate_items = off);
+INSERT INTO o_tb_bridge VALUES (1, 11), (2, 22);
+
+-- TOAST INDEX
+CREATE TABLE o_tb_toast (
+    id int PRIMARY KEY,
+    t_key text NOT NULL,
+    t_big text NOT NULL
+) USING orioledb;
+CREATE INDEX o_tb_toast_idx ON o_tb_toast (t_key);
+INSERT INTO o_tb_toast VALUES
+    (1, 'k1', repeat('x', 3000)),
+    (2, 'k2', repeat('y', 3500));
+
+-- HEAP TABLE
+CREATE TABLE heap_table (
+    id int PRIMARY KEY,
+    k int NOT NULL
+) USING heap;
+CREATE INDEX heap_table_idx ON heap_table (k);
+INSERT INTO heap_table VALUES (1, 10), (2, 20);
+
+-- USER TABLESPACE
+SET allow_in_place_tablespaces = true;
+CREATE TABLESPACE db_template_tblspc LOCATION '';
+
+CREATE TABLE o_tb_tblspc (
+    id int PRIMARY KEY,
+    n int NOT NULL
+) USING orioledb TABLESPACE db_template_tblspc;
+CREATE INDEX o_tb_tblspc_idx ON o_tb_tblspc (n) TABLESPACE db_template_tblspc;
+INSERT INTO o_tb_tblspc VALUES (1, 111), (2, 222);
+
+------------------CHECK IN TEMPLATE -------------------------------------------------
+SELECT extname FROM pg_extension WHERE extname = 'orioledb';
+
+-- Oriole_table without PK
+SELECT * FROM o_tb_no_pk;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT val FROM o_tb_no_pk WHERE k = 20;
+SELECT val FROM o_tb_no_pk WHERE k = 20;
+COMMIT;
+
+
+-- PRIMARY KEY
+SELECT id, val FROM o_tb ORDER BY id;
+
+-- SECONDARY INDEX
+SELECT * FROM o_tb_secondary_k;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_secondary_k WHERE k = 500;
+SELECT id FROM o_tb_secondary_k WHERE k = 500;
+COMMIT;
+
+-- BRIDGE INDEX
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_bridge WHERE tag = 11;
+SELECT id FROM o_tb_bridge WHERE tag = 11;
+COMMIT;
+
+-- TOAST INDEX
+SELECT id, t_key, length(t_big) AS t_big_len
+FROM o_tb_toast
+ORDER BY id;
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+COMMIT;
+
+-- HEAP TABLE
+SELECT id, k FROM heap_table ORDER BY id;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM heap_table WHERE k = 20;
+SELECT id FROM heap_table WHERE k = 20;
+COMMIT;
+
+-- USER TABLESPACE
+SELECT id, n FROM o_tb_tblspc ORDER BY id;
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_tblspc WHERE n = 222;
+SELECT id FROM o_tb_tblspc WHERE n = 222;
+COMMIT;
+
+---------------------------------------------------------------------------------------
+
+\c postgres
+CREATE DATABASE orioledb_from_template TEMPLATE orioledb_template;
+
+\c orioledb_from_template
+
+SELECT extname FROM pg_extension WHERE extname = 'orioledb';
+
+-- Oriole_table without PK
+SELECT * FROM o_tb_no_pk;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT val FROM o_tb_no_pk WHERE k = 20;
+SELECT val FROM o_tb_no_pk WHERE k = 20;
+COMMIT;
+
+
+-- PRIMARY KEY
+SELECT id, val FROM o_tb ORDER BY id;
+
+-- SECONDARY INDEX
+SELECT * FROM o_tb_secondary_k;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_secondary_k WHERE k = 500;
+SELECT id FROM o_tb_secondary_k WHERE k = 500;
+COMMIT;
+
+-- BRIDGE INDEX
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_bridge WHERE tag = 11;
+SELECT id FROM o_tb_bridge WHERE tag = 11;
+COMMIT;
+
+-- TOAST INDEX
+SELECT id, t_key, length(t_big) AS t_big_len
+FROM o_tb_toast
+ORDER BY id;
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+SELECT id FROM o_tb_toast WHERE t_key = 'k2';
+COMMIT;
+
+-- HEAP TABLE
+SELECT id, k FROM heap_table ORDER BY id;
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM heap_table WHERE k = 20;
+SELECT id FROM heap_table WHERE k = 20;
+COMMIT;
+
+-- USER TABLESPACE
+SELECT id, n FROM o_tb_tblspc ORDER BY id;
+
+BEGIN;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+    SELECT id FROM o_tb_tblspc WHERE n = 222;
+SELECT id FROM o_tb_tblspc WHERE n = 222;
+COMMIT;
+
+-- DML AFTER CLONE
+INSERT INTO o_tb VALUES (3, 'three');
+INSERT INTO o_tb_toast VALUES (3, 'k3', repeat('w', 3200));
+
+SELECT * FROM o_tb;
+SELECT id, t_key, length(t_big) AS t_big_len FROM o_tb_toast;
+
+
+
+\c postgres
+DROP DATABASE orioledb_from_template;
+
+\c orioledb_template
+SELECT * FROM o_tb;
+SELECT id, t_key FROM o_tb_toast;
+
+DROP TABLE o_tb_toast;
+DROP TABLE o_tb_bridge;
+DROP TABLE o_tb_secondary_k;
+DROP TABLE o_tb;
+DROP TABLE o_tb_no_pk;
+DROP TABLE o_tb_tblspc;
+
+DROP EXTENSION orioledb CASCADE;
+
+\c postgres
+DROP DATABASE orioledb_template;

--- a/test/t/database_template_test.py
+++ b/test/t/database_template_test.py
@@ -6,9 +6,10 @@ import os
 from .base_test import BaseTest
 from testgres.exceptions import QueryException
 
+
 class DatabaseTemplateTest(BaseTest):
 
-    TEMPLATE_DDL = """
+	TEMPLATE_DDL = """
         CREATE EXTENSION orioledb;
 
         CREATE TABLE o_tb_no_pk (
@@ -58,7 +59,7 @@ class DatabaseTemplateTest(BaseTest):
         INSERT INTO heap_table VALUES (1, 10), (2, 20);
     """
 
-    TEMPLATE_TABLESPACE_DDL = """
+	TEMPLATE_TABLESPACE_DDL = """
         CREATE TABLE o_tb_tblspc (
             id int PRIMARY KEY,
             n int NOT NULL
@@ -67,125 +68,135 @@ class DatabaseTemplateTest(BaseTest):
         INSERT INTO o_tb_tblspc VALUES (1, 111), (2, 222);
     """
 
-    def setup_template_database(self, master):
-        master.safe_psql("CREATE DATABASE orioledb_template;")
-        master.safe_psql("orioledb_template", self.TEMPLATE_DDL)
-        master.safe_psql("orioledb_template", "CREATE TABLESPACE db_template_tblspc LOCATION '';")
-        master.safe_psql("orioledb_template", self.TEMPLATE_TABLESPACE_DDL)
+	def setup_template_database(self, master):
+		master.safe_psql("CREATE DATABASE orioledb_template;")
+		master.safe_psql("orioledb_template", self.TEMPLATE_DDL)
+		master.safe_psql("orioledb_template",
+		                 "CREATE TABLESPACE db_template_tblspc LOCATION '';")
+		master.safe_psql("orioledb_template", self.TEMPLATE_TABLESPACE_DDL)
 
-    def createdb_from_template(self, master):
-        master.safe_psql(
-            "CREATE DATABASE orioledb TEMPLATE orioledb_template;")
+	def createdb_from_template(self, master):
+		master.safe_psql(
+		    "CREATE DATABASE orioledb TEMPLATE orioledb_template;")
 
-    def check_orioledb_data(self, node, dbname):
-        self.assertEqual(
-            [(10, 'A'), (20, 'B')],
-            node.execute(dbname, "SELECT k, val FROM o_tb_no_pk;"))
-        self.assertEqual(
-            [(1, 'one'), (2, 'two')],
-            node.execute(dbname, "SELECT id, val FROM o_tb ORDER BY id;"))
-        self.assertEqual(
-            [(10, 100, 'Val1'), (50, 500, 'Val2')],
-            node.execute(dbname, "SELECT * FROM o_tb_secondary_k;"))
-        self.assertEqual(
-            [(1, 11), (2, 22)],
-            node.execute(dbname, "SELECT * FROM o_tb_bridge ORDER BY id;"))
-        self.assertEqual(
-            [(1, 'k1', 3000), (2, 'k2', 3500)],
-            node.execute(dbname, "SELECT id, t_key, length(t_big) FROM o_tb_toast ORDER BY id;"))
-        self.assertEqual(
-            [(1, 10), (2, 20)],
-            node.execute(dbname, "SELECT id, k FROM heap_table ORDER BY id;"))
-        self.assertEqual(
-            [(1, 111), (2, 222)],
-            node.execute(dbname, "SELECT id, n FROM o_tb_tblspc ORDER BY id;"))
+	def check_orioledb_data(self, node, dbname):
+		self.assertEqual([(10, 'A'), (20, 'B')],
+		                 node.execute(dbname,
+		                              "SELECT k, val FROM o_tb_no_pk;"))
+		self.assertEqual([(1, 'one'), (2, 'two')],
+		                 node.execute(dbname,
+		                              "SELECT id, val FROM o_tb ORDER BY id;"))
+		self.assertEqual([(10, 100, 'Val1'), (50, 500, 'Val2')],
+		                 node.execute(dbname,
+		                              "SELECT * FROM o_tb_secondary_k;"))
+		self.assertEqual([(1, 11), (2, 22)],
+		                 node.execute(
+		                     dbname, "SELECT * FROM o_tb_bridge ORDER BY id;"))
+		self.assertEqual(
+		    [(1, 'k1', 3000), (2, 'k2', 3500)],
+		    node.execute(
+		        dbname,
+		        "SELECT id, t_key, length(t_big) FROM o_tb_toast ORDER BY id;")
+		)
+		self.assertEqual([(1, 10), (2, 20)],
+		                 node.execute(
+		                     dbname,
+		                     "SELECT id, k FROM heap_table ORDER BY id;"))
+		self.assertEqual([(1, 111), (2, 222)],
+		                 node.execute(
+		                     dbname,
+		                     "SELECT id, n FROM o_tb_tblspc ORDER BY id;"))
 
-        with node.connect(dbname) as con:
-            con.execute("SET enable_seqscan = off;")
-            self.assertEqual(
-                [(20, 'B')],
-                con.execute("SELECT k, val FROM o_tb_no_pk WHERE k = 20;"))
-            self.assertEqual(
-                [(50, 'Val2')],
-                con.execute("SELECT id, val FROM o_tb_secondary_k WHERE k = 500;"))
-            self.assertEqual(
-                [(1, 11)],
-                con.execute("SELECT id, tag FROM o_tb_bridge WHERE tag = 11;"))
-            self.assertEqual(
-                [(2, 'k2', 3500)],
-                con.execute("SELECT id, t_key, length(t_big) FROM o_tb_toast WHERE t_key = 'k2';"))
-            self.assertEqual(
-                [(2, 20)],
-                con.execute("SELECT id, k FROM heap_table WHERE k = 20;"))
-            self.assertEqual(
-                [(2, 222)],
-                con.execute("SELECT id, n FROM o_tb_tblspc WHERE n = 222;"))
+		with node.connect(dbname) as con:
+			con.execute("SET enable_seqscan = off;")
+			self.assertEqual(
+			    [(20, 'B')],
+			    con.execute("SELECT k, val FROM o_tb_no_pk WHERE k = 20;"))
+			self.assertEqual(
+			    [(50, 'Val2')],
+			    con.execute(
+			        "SELECT id, val FROM o_tb_secondary_k WHERE k = 500;"))
+			self.assertEqual(
+			    [(1, 11)],
+			    con.execute("SELECT id, tag FROM o_tb_bridge WHERE tag = 11;"))
+			self.assertEqual(
+			    [(2, 'k2', 3500)],
+			    con.execute(
+			        "SELECT id, t_key, length(t_big) FROM o_tb_toast WHERE t_key = 'k2';"
+			    ))
+			self.assertEqual(
+			    [(2, 20)],
+			    con.execute("SELECT id, k FROM heap_table WHERE k = 20;"))
+			self.assertEqual(
+			    [(2, 222)],
+			    con.execute("SELECT id, n FROM o_tb_tblspc WHERE n = 222;"))
 
-    def orioledb_data_datoids(self, node):
-        data_root = os.path.join(node.data_dir, "orioledb_data")
-        if not os.path.isdir(data_root):
-            return []
-        return sorted(
-            name for name in os.listdir(data_root)
-            if os.path.isdir(os.path.join(data_root, name)))
+	def orioledb_data_datoids(self, node):
+		data_root = os.path.join(node.data_dir, "orioledb_data")
+		if not os.path.isdir(data_root):
+			return []
+		return sorted(name for name in os.listdir(data_root)
+		              if os.path.isdir(os.path.join(data_root, name)))
 
-    def test_create_database_template_failure_cleans_orioledb_data(self):
-        with self.node as master:
-            master.append_conf("orioledb.enable_stopevents = true\n")
-            master.start()
-            master.safe_psql("CREATE EXTENSION orioledb;")
-            master.safe_psql("CREATE DATABASE orioledb_template;")
-            master.safe_psql("orioledb_template", """
+	def test_create_database_template_failure_cleans_orioledb_data(self):
+		with self.node as master:
+			master.append_conf("orioledb.enable_stopevents = true\n")
+			master.start()
+			master.safe_psql("CREATE EXTENSION orioledb;")
+			master.safe_psql("CREATE DATABASE orioledb_template;")
+			master.safe_psql(
+			    "orioledb_template", """
                 CREATE EXTENSION orioledb;
                 CREATE TABLE oriole_table (id int PRIMARY KEY) USING orioledb;
                 INSERT INTO oriole_table VALUES (1);
             """)
 
-            before_datoids = self.orioledb_data_datoids(master)
-            master.safe_psql(
-                "SELECT pg_stopevent_set('createdb_copy_fail', 'true');")
-            with self.assertRaises(QueryException) as cm:
-                master.safe_psql(
-                    "CREATE DATABASE orioledb TEMPLATE orioledb_template;")
-            self.assertIn("createdb copy failed", str(cm.exception))
+			before_datoids = self.orioledb_data_datoids(master)
+			master.safe_psql(
+			    "SELECT pg_stopevent_set('createdb_copy_fail', 'true');")
+			with self.assertRaises(QueryException) as cm:
+				master.safe_psql(
+				    "CREATE DATABASE orioledb TEMPLATE orioledb_template;")
+			self.assertIn("createdb copy failed", str(cm.exception))
 
-            self.assertEqual([], master.execute(
-                "SELECT 1 from pg_database WHERE datname = 'orioledb';"))
-            self.assertEqual(before_datoids, self.orioledb_data_datoids(master))
-        
+			self.assertEqual(
+			    [],
+			    master.execute(
+			        "SELECT 1 from pg_database WHERE datname = 'orioledb';"))
+			self.assertEqual(before_datoids,
+			                 self.orioledb_data_datoids(master))
 
-    def test_create_database_template_on_master(self):
-        with self.node as master:
-            master.append_conf("allow_in_place_tablespaces = true\n")
-            master.start()
-            self.setup_template_database(master)
-            self.createdb_from_template(master)
-            self.check_orioledb_data(master, "orioledb_template")
-            self.check_orioledb_data(master, "orioledb")
+	def test_create_database_template_on_master(self):
+		with self.node as master:
+			master.append_conf("allow_in_place_tablespaces = true\n")
+			master.start()
+			self.setup_template_database(master)
+			self.createdb_from_template(master)
+			self.check_orioledb_data(master, "orioledb_template")
+			self.check_orioledb_data(master, "orioledb")
 
-    def test_create_database_template_replication(self):
-        with self.node as master:
-            master.append_conf("allow_in_place_tablespaces = true\n")
-            master.start()
+	def test_create_database_template_replication(self):
+		with self.node as master:
+			master.append_conf("allow_in_place_tablespaces = true\n")
+			master.start()
 
-            replica = self.getReplica()
-            replica.append_conf("allow_in_place_tablespaces = true\n")
-            with replica.start() as replica:
-                master.safe_psql(
-                    "CREATE EXTENSION IF NOT EXISTS orioledb;")
+			replica = self.getReplica()
+			replica.append_conf("allow_in_place_tablespaces = true\n")
+			with replica.start() as replica:
+				master.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
 
-                self.setup_template_database(master)
+				self.setup_template_database(master)
 
-                self.catchup_orioledb(replica)
+				self.catchup_orioledb(replica)
 
-                self.createdb_from_template(master)
+				self.createdb_from_template(master)
 
-                self.catchup_orioledb(replica)
+				self.catchup_orioledb(replica)
 
-                replica.poll_query_until(
-                    "SELECT orioledb_has_retained_undo();", expected=False)
+				replica.poll_query_until(
+				    "SELECT orioledb_has_retained_undo();", expected=False)
 
-                self.check_orioledb_data(master, "orioledb_template")
-                self.check_orioledb_data(replica, "orioledb_template")
-                self.check_orioledb_data(master, "orioledb")
-                self.check_orioledb_data(replica, "orioledb")
+				self.check_orioledb_data(master, "orioledb_template")
+				self.check_orioledb_data(replica, "orioledb_template")
+				self.check_orioledb_data(master, "orioledb")
+				self.check_orioledb_data(replica, "orioledb")

--- a/test/t/database_template_test.py
+++ b/test/t/database_template_test.py
@@ -1,0 +1,191 @@
+#!usr/bin/env python3
+# coding: utf-8
+
+import os
+
+from .base_test import BaseTest
+from testgres.exceptions import QueryException
+
+class DatabaseTemplateTest(BaseTest):
+
+    TEMPLATE_DDL = """
+        CREATE EXTENSION orioledb;
+
+        CREATE TABLE o_tb_no_pk (
+            k int NOT NULL,
+            val text NOT NULL
+        ) USING orioledb;
+        CREATE INDEX o_tb_no_pk_idx ON o_tb_no_pk (k);
+        INSERT INTO o_tb_no_pk VALUES (10, 'A'), (20, 'B');
+
+        CREATE TABLE o_tb (
+            id int PRIMARY KEY,
+            val text NOT NULL
+        ) USING orioledb;
+        INSERT INTO o_tb VALUES (1, 'one'), (2, 'two');
+
+        CREATE TABLE o_tb_secondary_k (
+            id int PRIMARY KEY,
+            k int NOT NULL,
+            val text
+        ) USING orioledb;
+        CREATE INDEX o_tb_secondary_k_idx ON o_tb_secondary_k (k);
+        INSERT INTO o_tb_secondary_k VALUES (10, 100, 'Val1'), (50, 500, 'Val2');
+
+        CREATE TABLE o_tb_bridge (
+            id int PRIMARY KEY,
+            tag int
+        ) USING orioledb;
+        CREATE INDEX o_tb_bridge_idx ON o_tb_bridge USING btree (tag)
+            WITH (orioledb_index = off, deduplicate_items = off);
+        INSERT INTO o_tb_bridge VALUES (1, 11), (2, 22);
+
+        CREATE TABLE o_tb_toast (
+            id int PRIMARY KEY,
+            t_key text NOT NULL,
+            t_big text NOT NULL
+        ) USING orioledb;
+        CREATE INDEX o_tb_toast_idx ON o_tb_toast (t_key);
+        INSERT INTO o_tb_toast VALUES
+            (1, 'k1', repeat('x', 3000)),
+            (2, 'k2', repeat('y', 3500));
+
+        CREATE TABLE heap_table (
+            id int PRIMARY KEY,
+            k int NOT NULL
+        ) USING heap;
+        CREATE INDEX heap_table_idx ON heap_table (k);
+        INSERT INTO heap_table VALUES (1, 10), (2, 20);
+    """
+
+    TEMPLATE_TABLESPACE_DDL = """
+        CREATE TABLE o_tb_tblspc (
+            id int PRIMARY KEY,
+            n int NOT NULL
+        ) USING orioledb TABLESPACE db_template_tblspc;
+        CREATE INDEX o_tb_tblspc_idx ON o_tb_tblspc (n) TABLESPACE db_template_tblspc;
+        INSERT INTO o_tb_tblspc VALUES (1, 111), (2, 222);
+    """
+
+    def setup_template_database(self, master):
+        master.safe_psql("CREATE DATABASE orioledb_template;")
+        master.safe_psql("orioledb_template", self.TEMPLATE_DDL)
+        master.safe_psql("orioledb_template", "CREATE TABLESPACE db_template_tblspc LOCATION '';")
+        master.safe_psql("orioledb_template", self.TEMPLATE_TABLESPACE_DDL)
+
+    def createdb_from_template(self, master):
+        master.safe_psql(
+            "CREATE DATABASE orioledb TEMPLATE orioledb_template;")
+
+    def check_orioledb_data(self, node, dbname):
+        self.assertEqual(
+            [(10, 'A'), (20, 'B')],
+            node.execute(dbname, "SELECT k, val FROM o_tb_no_pk;"))
+        self.assertEqual(
+            [(1, 'one'), (2, 'two')],
+            node.execute(dbname, "SELECT id, val FROM o_tb ORDER BY id;"))
+        self.assertEqual(
+            [(10, 100, 'Val1'), (50, 500, 'Val2')],
+            node.execute(dbname, "SELECT * FROM o_tb_secondary_k;"))
+        self.assertEqual(
+            [(1, 11), (2, 22)],
+            node.execute(dbname, "SELECT * FROM o_tb_bridge ORDER BY id;"))
+        self.assertEqual(
+            [(1, 'k1', 3000), (2, 'k2', 3500)],
+            node.execute(dbname, "SELECT id, t_key, length(t_big) FROM o_tb_toast ORDER BY id;"))
+        self.assertEqual(
+            [(1, 10), (2, 20)],
+            node.execute(dbname, "SELECT id, k FROM heap_table ORDER BY id;"))
+        self.assertEqual(
+            [(1, 111), (2, 222)],
+            node.execute(dbname, "SELECT id, n FROM o_tb_tblspc ORDER BY id;"))
+
+        with node.connect(dbname) as con:
+            con.execute("SET enable_seqscan = off;")
+            self.assertEqual(
+                [(20, 'B')],
+                con.execute("SELECT k, val FROM o_tb_no_pk WHERE k = 20;"))
+            self.assertEqual(
+                [(50, 'Val2')],
+                con.execute("SELECT id, val FROM o_tb_secondary_k WHERE k = 500;"))
+            self.assertEqual(
+                [(1, 11)],
+                con.execute("SELECT id, tag FROM o_tb_bridge WHERE tag = 11;"))
+            self.assertEqual(
+                [(2, 'k2', 3500)],
+                con.execute("SELECT id, t_key, length(t_big) FROM o_tb_toast WHERE t_key = 'k2';"))
+            self.assertEqual(
+                [(2, 20)],
+                con.execute("SELECT id, k FROM heap_table WHERE k = 20;"))
+            self.assertEqual(
+                [(2, 222)],
+                con.execute("SELECT id, n FROM o_tb_tblspc WHERE n = 222;"))
+
+    def orioledb_data_datoids(self, node):
+        data_root = os.path.join(node.data_dir, "orioledb_data")
+        if not os.path.isdir(data_root):
+            return []
+        return sorted(
+            name for name in os.listdir(data_root)
+            if os.path.isdir(os.path.join(data_root, name)))
+
+    def test_create_database_template_failure_cleans_orioledb_data(self):
+        with self.node as master:
+            master.append_conf("orioledb.enable_stopevents = true\n")
+            master.start()
+            master.safe_psql("CREATE EXTENSION orioledb;")
+            master.safe_psql("CREATE DATABASE orioledb_template;")
+            master.safe_psql("orioledb_template", """
+                CREATE EXTENSION orioledb;
+                CREATE TABLE oriole_table (id int PRIMARY KEY) USING orioledb;
+                INSERT INTO oriole_table VALUES (1);
+            """)
+
+            before_datoids = self.orioledb_data_datoids(master)
+            master.safe_psql(
+                "SELECT pg_stopevent_set('createdb_copy_fail', 'true');")
+            with self.assertRaises(QueryException) as cm:
+                master.safe_psql(
+                    "CREATE DATABASE orioledb TEMPLATE orioledb_template;")
+            self.assertIn("createdb copy failed", str(cm.exception))
+
+            self.assertEqual([], master.execute(
+                "SELECT 1 from pg_database WHERE datname = 'orioledb';"))
+            self.assertEqual(before_datoids, self.orioledb_data_datoids(master))
+        
+
+    def test_create_database_template_on_master(self):
+        with self.node as master:
+            master.append_conf("allow_in_place_tablespaces = true\n")
+            master.start()
+            self.setup_template_database(master)
+            self.createdb_from_template(master)
+            self.check_orioledb_data(master, "orioledb_template")
+            self.check_orioledb_data(master, "orioledb")
+
+    def test_create_database_template_replication(self):
+        with self.node as master:
+            master.append_conf("allow_in_place_tablespaces = true\n")
+            master.start()
+
+            replica = self.getReplica()
+            replica.append_conf("allow_in_place_tablespaces = true\n")
+            with replica.start() as replica:
+                master.safe_psql(
+                    "CREATE EXTENSION IF NOT EXISTS orioledb;")
+
+                self.setup_template_database(master)
+
+                self.catchup_orioledb(replica)
+
+                self.createdb_from_template(master)
+
+                self.catchup_orioledb(replica)
+
+                replica.poll_query_until(
+                    "SELECT orioledb_has_retained_undo();", expected=False)
+
+                self.check_orioledb_data(master, "orioledb_template")
+                self.check_orioledb_data(replica, "orioledb_template")
+                self.check_orioledb_data(master, "orioledb")
+                self.check_orioledb_data(replica, "orioledb")


### PR DESCRIPTION
Implement o_createdb() to copy orioledb_data/, o_tables metadata and sys cache when cloning a template database that contains OrioleDB objects. Add WAL records DATABASE_CREATE_COPY and DATABASE_TEMPLATE_CHECKPOINT for physical replication replay on standbys. On failure after file copy starts, remove partially copied orioledb_data/ via error callback. Add SQL and testgres tests for template clone on primary and replica. Fixes #1026