### PR TITLE
Order the min-undo-location scan against its own change-count bump

### DIFF
--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -597,7 +597,24 @@ update_min_undo_locations(UndoLogType undoType,
 
 	meta->minUndoLocationsChangeCount++;
 
-	pg_write_barrier();
+	/*
+	 * A full barrier, not pg_write_barrier(): what needs ordering here is a
+	 * store followed by loads, and a write barrier only orders stores against
+	 * stores.  On x86-64 pg_write_barrier() is a compiler barrier that emits
+	 * no instruction at all, because the one ordering x86 does not give for
+	 * free is exactly StoreLoad.
+	 *
+	 * set_my_reserved_location() publishes its location, fences, waits for
+	 * this counter to be even, and then refuses to proceed if the published
+	 * minimums already run above it.  For that handshake to hold, our loads
+	 * of everyone's locations below must not run until this increment is
+	 * visible to them. Otherwise we read a proc's location from before it
+	 * reserved while that proc reads the counter from before we bumped it,
+	 * and both sides conclude they agreed: the minimum we publish is then too
+	 * high, and undo somebody still needs can be written out or recycled
+	 * underneath them.
+	 */
+	pg_memory_barrier();
 
 	lastUsedLocation = pg_atomic_read_u64(&meta->lastUsedLocation);
 	minTransactionRetainLocation = minRetainLocation = minReservedLocation = lastUsedLocation;


### PR DESCRIPTION
`update_min_undo_locations()` announces itself by making `minUndoLocationsChangeCount` odd, then reads every backend's reserved and retained undo locations to compute the new minimums. The announcement was followed by `pg_write_barrier()`.

That is the wrong barrier. A write barrier orders **stores against stores**; what needs ordering here is a **store followed by loads**. On x86-64 `pg_write_barrier()` is `pg_compiler_barrier_impl()` and emits no instruction at all — exactly because StoreLoad is the one ordering x86 does not give for free:

```c
/* port/atomics/arch-x86.h */
#define pg_memory_barrier_impl()  __asm__ __volatile__ ("lock; addl $0,0(%%rsp)" : : : "memory", "cc")
#define pg_read_barrier_impl()    pg_compiler_barrier_impl()
#define pg_write_barrier_impl()   pg_compiler_barrier_impl()
```

## How the handshake breaks

`set_my_reserved_location()` is written correctly: it publishes its location, issues a full `pg_memory_barrier()`, waits for the counter to be even, and then re-checks the published minimums and retries if they already run above it.

Without StoreLoad ordering on our side, both halves fail at once:

- we read a backend's location from **before** it reserved, because our loads ran ahead of our own increment;
- that backend reads the counter from **before** we bumped it, finds it even, re-checks the minimums, sees the *old* ones still below its location, and proceeds.

Each side concludes the other agreed. The minimum published is then above a location a backend is still using, and undo below it can be written out or recycled underneath it.

## Why it is being looked at now

A retain location that runs too high also truncates the undo chain walk in `row_lock_conflicts()`, which stops at `undoLocation < retainedUndoLocation`. A conflicting in-progress writer one step below the bound is then never seen, `row_lock_conflicts()` reports no conflict, and the caller overwrites an uncommitted version — two transactions modify one row without either waiting.

That is the shape the Antithesis jepsen runs report as **G0 write cycles under Read Committed** (47 in a single recent run): two committed transactions write the same two rows in the same order, yet come out inverted between the rows. Those runs are on `x86_64-pc-linux-gnu`, where this barrier is a no-op.

This PR does not claim to close that report — the window is not demonstrable by a local test, and confirming it needs a run. It fixes a real memory-ordering defect that is one plausible route to it.

## Testing

regress 48/48, isolation 34/34. No test can be expected to exercise a StoreLoad window; the change is justified by the protocol, not by a reproducer.

Credit: found by @akorotkov while reading the protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)