### PR TITLE
Drop redundant row locks only once the callback has settled the action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  rll \
 				  rll_deadlock \
 				  rll_mix \
+				  rll_mode_raise \
 				  rll_subtrans \
 				  skipundo \
 				  table_lock_test \

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -55,6 +55,7 @@ typedef struct
 	int			pageReserveKind;
 	int			cmp;
 	BTreeModifyLockStatus lockStatus;
+	bool		haveRedundantRowLocks;
 	bool		pagesAreReserved;
 	bool		undoIsReserved;
 	BTreeOperationType action;
@@ -157,6 +158,15 @@ o_btree_modify_internal(OBTreeFindPageContext *pageFindContext,
 	Assert(OXidIsValid(opOxid) == context.undoIsReserved);
 
 retry:
+
+	/*
+	 * Both describe the undo chain as it is right now, and the chain changes
+	 * while we wait, so they must not survive a retry.  row_lock_conflicts()
+	 * only ever raises lockStatus (Max()), so a stale value would claim we
+	 * still hold a row lock that a previous iteration has since removed.
+	 */
+	context.lockStatus = BTreeModifyNoLock;
+	context.haveRedundantRowLocks = false;
 
 	/*
 	 * Keep the modify retry loop interruptible.  A row-lock conflict against
@@ -299,6 +309,27 @@ retry:
 		}
 
 		Assert((action == BTreeOperationLock) || (context.lockMode >= RowLockNoKeyUpdate));
+
+		/*
+		 * Now that the callback has spoken, the action is final, so it is
+		 * safe to drop our own redundant row-level locks: every remaining
+		 * path from here writes a version that carries our lock mode.  The
+		 * one exception is a lock we are about to rely on instead of writing
+		 * anything.
+		 */
+		if (context.haveRedundantRowLocks &&
+			!(action == BTreeOperationLock &&
+			  context.lockStatus == BTreeModifySameOrStrongerLock))
+		{
+			BTREE_PAGE_READ_LEAF_ITEM(tuphdr, curTuple, page, &loc);
+			remove_redundant_row_locks(tuphdr, &context.conflictTupHdr,
+									   desc->undoType,
+									   &context.conflictUndoLocation,
+									   context.lockMode,
+									   opOxid, blkno,
+									   context.savepointUndoLocation);
+			context.haveRedundantRowLocks = false;
+		}
 
 		if (action == BTreeOperationDelete)
 			return o_btree_modify_delete(&context);
@@ -447,7 +478,6 @@ wait_for_tuple(BTreeDescr *desc, OTuple tuple, OXid oxid,
 static ConflictResolution
 o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 {
-	bool		haveRedundantRowLocks = false;
 	OBTreeFindPageContext *pageFindContext = context->pageFindContext;
 	BTreeDescr *desc = pageFindContext->desc;
 	OInMemoryBlkno blkno;
@@ -468,7 +498,7 @@ o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 						   &context->conflictUndoLocation,
 						   context->lockMode, context->opOxid, context->opCsn,
 						   blkno, context->savepointUndoLocation,
-						   &haveRedundantRowLocks, &context->lockStatus))
+						   &context->haveRedundantRowLocks, &context->lockStatus))
 	{
 		OTupleXactInfo xactInfo = context->conflictTupHdr.xactInfo;
 		OXid		oxid = XACT_INFO_GET_OXID(xactInfo);
@@ -641,19 +671,12 @@ o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 	}
 
 	/*
-	 * Remove redundant row-level locks if any.
+	 * Redundant row-level locks are dropped by the caller, once the callback
+	 * has settled what this operation actually does.  Doing it here would use
+	 * the action we started with: a modify whose callback then answers
+	 * OBTreeCallbackActionLock would have had its own lock record removed on
+	 * the promise of writing a version that never gets written.
 	 */
-	if (haveRedundantRowLocks &&
-		!(context->action == BTreeOperationLock &&
-		  context->lockStatus == BTreeModifySameOrStrongerLock))
-	{
-		remove_redundant_row_locks(tuphdr, &context->conflictTupHdr,
-								   desc->undoType,
-								   &context->conflictUndoLocation,
-								   context->lockMode,
-								   context->opOxid, blkno,
-								   context->savepointUndoLocation);
-	}
 
 	if (!context->needsUndo)
 		context->leafTuphdr.undoLocation = tuphdr->undoLocation;

--- a/test/expected/rll_mode_raise.out
+++ b/test/expected/rll_mode_raise.out
@@ -1,0 +1,17 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_begin s1_nku s1_raise s2_begin s2_upd s1_commit s2_commit
+step s1_begin: BEGIN;
+step s1_nku: SELECT * FROM o_rll_mode_raise WHERE id = 1 FOR NO KEY UPDATE;
+id| v
+--+--
+ 1|10
+(1 row)
+
+step s1_raise: UPDATE o_rll_mode_raise SET id = 2 WHERE id = 1;
+step s2_begin: BEGIN;
+step s2_upd: UPDATE o_rll_mode_raise SET v = 99 WHERE id = 1; <waiting ...>
+step s1_commit: COMMIT;
+step s2_upd: <... completed>
+ERROR:  tuple to be locked has its primary key changed due to concurrent update
+step s2_commit: COMMIT;

--- a/test/specs/rll_mode_raise.spec
+++ b/test/specs/rll_mode_raise.spec
@@ -1,0 +1,34 @@
+# The callback can raise the row lock mode mid-modify: an UPDATE that turns
+# out to touch key attributes asks for RowLockUpdate where the operation
+# started with RowLockNoKeyUpdate, and o_btree_normal_modify() retries.  Our
+# own FOR NO KEY UPDATE record is redundant for the first mode and gets
+# removed on the way, so the retry must still leave the row locked -- if it
+# does not, s2 stops blocking here.
+
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+	CREATE TABLE o_rll_mode_raise (
+		id int PRIMARY KEY,
+		v int
+	) USING orioledb;
+	INSERT INTO o_rll_mode_raise VALUES (1, 10);
+}
+
+teardown
+{
+	DROP TABLE o_rll_mode_raise;
+}
+
+session s1
+step s1_begin	{ BEGIN; }
+step s1_nku		{ SELECT * FROM o_rll_mode_raise WHERE id = 1 FOR NO KEY UPDATE; }
+step s1_raise	{ UPDATE o_rll_mode_raise SET id = 2 WHERE id = 1; }
+step s1_commit	{ COMMIT; }
+
+session s2
+step s2_begin	{ BEGIN; }
+step s2_upd		{ UPDATE o_rll_mode_raise SET v = 99 WHERE id = 1; }
+step s2_commit	{ COMMIT; }
+
+permutation s1_begin s1_nku s1_raise s2_begin s2_upd s1_commit s2_commit


### PR DESCRIPTION
From an audit of the row-level lock code.

## What is wrong

`o_btree_modify_handle_conflicts()` removes our own redundant row-level lock records, and it does so **before** the modify callback runs. The guard that protects a lock we are about to rely on is:

```c
if (haveRedundantRowLocks &&
    !(context->action == BTreeOperationLock &&
      context->lockStatus == BTreeModifySameOrStrongerLock))
    remove_redundant_row_locks(...);
```

`context->action` is still the action we started with. A callback that afterwards answers `OBTreeCallbackActionLock` — which the callbacks in `operations.c` do under `TABLE_MODIFY_LOCK_UPDATED` — turns the modify into a plain lock, so the record was removed on the promise of a version that never gets written, and `o_btree_modify_lock()` then takes its `lockStatus` fast path and reports the row locked without putting anything back.

The guard exists precisely against this hazard; it just cannot see an action that changes after it runs.

## The change

Move the removal to the caller, where the action is final. Every remaining path from there writes a version carrying our lock mode, so the removal keeps its purpose, and the guard now sees what the operation actually became. This also avoids a second walk of the undo chain, which a re-check inside the fast path would have cost.

Second, reset `lockStatus` and `haveRedundantRowLocks` at the `retry:` label. Both describe the undo chain as it is now, and the chain changes while we wait. `row_lock_conflicts()` only ever raises `lockStatus` (`Max()`), so a stale value claims we still hold a record a previous iteration removed. That part is reachable today: a callback that raises the lock mode — an UPDATE that turns out to touch key attributes — forces exactly such a retry, and a stale status additionally suppresses the heavyweight tuple lock in `wait_for_tuple()`.

## What the evidence does and does not show

I could not build a case where the old order does observable damage. The damaging combination needs a callback answering `Lock`, which needs the row to have been concurrently modified, while we already hold an **equal-mode** lock on it — and such a lock blocks the concurrent writer, so the two conditions exclude each other from SQL.

So this is not a reproduced bug. What the old order relied on is that something else always writes a version; the change makes the code locally correct rather than accidentally correct, and removes a trap for the next person to touch it.

`test/specs/rll_mode_raise.spec` covers the reachable half — the mode-raise retry with a concurrent writer — and pins that the row stays locked across it. **It passes before this change too**: a regression guard, not a reproducer.

## Also checked, and found correct

- `ROW_LOCKS_CONFLICT(l1, l2) = (l1 + l2 >= 3)` with `KeyShare=0 … Update=3` matches PostgreSQL's row-lock conflict matrix cell for cell.
- The heavyweight tuple lock is acquired once in `wait_for_tuple()` and released in `unlock_release()`; the error path leaves it to `LockReleaseAll` at abort.
- The lock tag is built from a hash of the key, so collisions cost extra serialization, never a missed conflict.
- `deleted = BTreeLeafTupleNonDeleted` in `o_btree_modify_lock()` cannot resurrect a deleted tuple: only non-deleted tuples reach it.

One cosmetic asymmetry left alone: `remove_redundant_row_locks()` does not propagate `chainHasLocks` when it unlinks the top record, where `row_lock_conflicts()` does. It errs conservative (the flag stays set, costing an extra step of walking), so it is not fixed here.

## Testing

regress 48/48, isolation 35/35 (including `row_level_locks`, `rll`, `rll_mix`, `rll_subtrans`, `rll_deadlock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)