### PR TITLE
Don't read a leaf item that the rollback just deleted

### DIFF
--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -613,8 +613,19 @@ o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 				return ConflictResolutionRetry;
 			}
 
-			/* Update tuple and header pointer after page_item_rollback() */
-			BTREE_PAGE_READ_LEAF_ITEM(tuphdr, curTuple, page, loc);
+			/*
+			 * Update tuple and header pointer after page_item_rollback().
+			 *
+			 * Only when the item is still there.  A rollback that reverts an
+			 * insertion deletes the item and reports cmp == -1; the locator
+			 * then points at the following item, which is one past the end
+			 * whenever the deleted item was the last of its chunk.  Reading
+			 * through it picks up chunk->items[chunkItemsCount], now
+			 * overlapping item data, so tuphdr would land at an arbitrary
+			 * offset within the page.
+			 */
+			if (context->cmp == 0)
+				BTREE_PAGE_READ_LEAF_ITEM(tuphdr, curTuple, page, loc);
 		}
 	}
 	else if (IsolationUsesXactSnapshot() && IsRelationTree(desc))
@@ -655,7 +666,13 @@ o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 								   context->savepointUndoLocation);
 	}
 
-	if (!context->needsUndo)
+	/*
+	 * Inheriting the chain only makes sense while there is an item to inherit
+	 * it from.  After a rollback deleted the item (cmp == -1) the caller goes
+	 * on to insert a fresh one, which starts its own chain -- leafTuphdr
+	 * keeps the InvalidUndoLocation it was initialized with.
+	 */
+	if (!context->needsUndo && context->cmp == 0)
 		context->leafTuphdr.undoLocation = tuphdr->undoLocation;
 	return ConflictResolutionOK;
 }


### PR DESCRIPTION
`o_btree_modify_handle_conflicts()` rolls back an aborted transaction's changes
itself instead of waiting for its owner.  When that rollback reverts an
insertion, `page_item_rollback()` calls `page_locator_delete_item()` and returns
false, and we record the disappearance as `cmp == -1`.

The re-read right after it did not honour that:

```c
/* Update tuple and header pointer after page_item_rollback() */
BTREE_PAGE_READ_LEAF_ITEM(tuphdr, curTuple, page, loc);
```

`page_locator_delete_item()` keeps the locator coherent, but it leaves
`itemOffset` pointing at the following item -- which is one past the end
whenever the deleted item was the last of its chunk.  `BTREE_PAGE_READ_LEAF_ITEM()`
does not check the locator, so it reads `chunk->items[chunkItemsCount]`, an entry
that the shrunk items array now shares with item data, and `tuphdr` lands at an
arbitrary offset inside the page.

The bogus header mostly goes nowhere, because the caller sees `cmp != 0` and
takes the tuple-not-found path.  It does escape in one case: the `!needsUndo`
branch copies `tuphdr->undoLocation` into the header of the tuple about to be
inserted.  For a tree whose `undoType` is `UndoLogRegular`,
`o_btree_modify_insert_update()` overwrites that field again, but for any other
undo type the garbage location survives onto the page.

Reachable from an ordinary workload: A inserts key K and aborts, B inserts K and
performs A's rollback on its behalf.

The fix skips both the re-read and the inheritance when the item is gone.  A
freshly inserted tuple starts its own chain anyway, so `leafTuphdr` keeps the
`InvalidUndoLocation` it was initialized with.

The sibling caller `o_btree_modify_item_rollback()` already guards the same
situation, by re-searching the page when `page_item_rollback()` reports the item
gone.

## Testing

`regresscheck` (48) and `isolationcheck` (34) pass.  No new test: the read is
out of bounds only within the page, so it produces neither a crash nor an
observable wrong answer on the `UndoLogRegular` trees the test suite exercises.

Found while auditing the row-level lock and conflict-detection paths for a
dirty-write route; this is not that route, but it is a real defect on the same
paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)