### PR TITLE
Test: keep a timed checkpoint out of the heap-verdict window

### DIFF
--- a/test/t/recovery_heap_verdict_test.py
+++ b/test/t/recovery_heap_verdict_test.py
@@ -25,6 +25,10 @@ class RecoveryHeapVerdictTest(BaseTest):
 		used to handle by aborting.
 		"""
 		node = self.node
+		# A timed checkpoint anywhere after the temp work would move the redo
+		# point past those records and replay would never face the oxid.  The
+		# run is far slower than checkpoint_timeout under valgrind.
+		node.append_conf('postgresql.conf', "checkpoint_timeout = 1d\n")
 		node.start()
 		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
 		node.safe_psql("""
@@ -53,11 +57,16 @@ class RecoveryHeapVerdictTest(BaseTest):
 			con.commit()
 
 		# no checkpoint here: the records above must stay in the replayed
-		# range while the horizon moves past their oxid
-		for i in range(1, 201):
-			node.safe_psql(
-			    "UPDATE o_test_keep SET val = 'r%d' WHERE id = %d;" %
-			    (i, i % 50 + 1))
+		# range while the horizon moves past their oxid.  One connection, one
+		# transaction per statement -- what matters is the number of oxids
+		# consumed, and spawning 200 psql processes costs minutes under
+		# valgrind.
+		with node.connect() as con:
+			for i in range(1, 201):
+				con.execute(
+				    "UPDATE o_test_keep SET val = 'r%d' WHERE id = %d;" %
+				    (i, i % 50 + 1))
+				con.commit()
 
 		node.stop(['-m', 'immediate'])
 		node.start()


### PR DESCRIPTION
Fixes the `recovery_heap_verdict_test.py` failure on the `valgrind_2` jobs
(seen on PG16, 17 and 18 -- e.g. https://github.com/orioledb/orioledb/actions/runs/31645683701).
The test lives in `main`, so it fails on every PR's valgrind run, not just the
one it was noticed on.

## What went wrong

The test needs the temp-table records to stay inside the replayed range: it
takes a checkpoint before them and then runs 200 transactions to push runXmin
past the orphan oxid, deliberately without a checkpoint in between.

Nothing enforced that.  On the valgrind jobs each of those 200 updates was a
separate psql process taking about 1.5 seconds, so the loop ran for over five
minutes and `checkpoint_timeout` fired in the middle of it:

```
22:40:02  ... temp table work (the orphan oxid)
22:44:59  checkpoint starting: time
22:45:08  checkpoint complete: ... redo lsn=0/18B6820
22:45:41  received immediate shutdown request
22:45:48  redo starts at 0/18B6820        <-- past the orphan
```

Replay never faced the oxid, so the `committed oxid` log line was never
emitted and the assertion failed.

## Fix

- Pin `checkpoint_timeout = 1d`.
- Run the 200 transactions over a single connection instead of spawning a psql
  process per statement.  What the test needs is the number of oxids consumed,
  not a backend per oxid; this takes the loop from minutes to seconds under
  valgrind, which keeps the window small on its own.

## Testing

Passes locally (2.1 s).  Verified it still has teeth: with the
`recovery_finish()` heap-verdict branch disabled it fails exactly as before,
on the same assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)