### PR TITLE
Don't build an index descriptor from a torn OIndex/OTable pair

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/recovery_item_rollback_test.py \
 						test/t/recovery_row_lock_test.py \
 						test/t/reindex_test.py \
+						test/t/restartpoint_ddl_window_test.py \
 						test/t/s3_test.py \
 						test/t/schema_test.py \
 						test/t/seq_scan_resowner_test.py \

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -1379,9 +1379,53 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, void *o_table_source, OTa
 
 		if (oTable)
 		{
-			o_tupdesc_load_constr(descr->leafTupdesc, oTable, descr);
-			primary_init_nfields = palloc(sizeof(*primary_init_nfields));
-			*primary_init_nfields = oTable->primary_init_nfields;
+			/*
+			 * The leaf tuple descriptor above came from the OIndex record;
+			 * the constraints and primary_init_nfields come from the OTable
+			 * record.  Those are two separate sys-tree rows, and a DDL
+			 * updates them one after the other -- o_indices_update() first,
+			 * o_tables_update() second.
+			 *
+			 * A caller that handed us the OTable it already holds always sees
+			 * the pair whole.  A caller that named the table by OIDs alone
+			 * re-reads it here under o_non_deleted_snapshot, which shows
+			 * uncommitted rows, so it can catch a DDL between those two
+			 * writes and pair the new OIndex with the old OTable.  On the
+			 * primary oTablesMetaLock keeps the checkpointer out of that
+			 * window; recovery applies the enclosed modifies without taking
+			 * it, so on a standby a restartpoint walks right into it.
+			 *
+			 * A torn pair is not merely inaccurate.  o_tupdesc_load_constr()
+			 * would size missing[] from the OTable while FreeTupleDesc()
+			 * frees it by the descriptor, and fillFixedFormatSpec() would
+			 * read primary_init_nfields attributes out of a shorter
+			 * descriptor.  Everything those callers actually need comes from
+			 * the OIndex alone, so build that much and mark the descriptor
+			 * invalid: nobody gets handed it again, and the next fetch
+			 * re-reads a settled pair.
+			 *
+			 * The index incarnation version says whether the pair is whole.
+			 * make_primary_o_index()/make_ctid_o_index() stamp the new OIndex
+			 * and the OTable's primary_ixversion with the same value, and
+			 * every o_indices_update() call site writes the OTable right
+			 * after, so the two rows carry equal versions once both writes
+			 * have landed and unequal ones for exactly the window in between.
+			 * A caller that supplies the OTable it holds fetched the OIndex
+			 * by that same version (see o_table_descr_fill_indices()) and
+			 * oIndicesFetchCallback() returns only an exact version match, so
+			 * the equality holds there by construction.
+			 */
+			if (descr->version == oTable->primary_ixversion)
+			{
+				o_tupdesc_load_constr(descr->leafTupdesc, oTable, descr);
+				primary_init_nfields = palloc(sizeof(*primary_init_nfields));
+				*primary_init_nfields = oTable->primary_init_nfields;
+			}
+			else
+			{
+				Assert(source == oTableSourceContext);
+				descr->valid = false;
+			}
 			if (free_oTable)
 				o_table_free(oTable);
 		}

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -1696,6 +1696,7 @@ o_indices_get_extended(ORelOids oids, OIndexType type,
 	{
 		OIndexChunkBoundKey boundKey;
 		OIndexChunkBoundKey *found_key = NULL;
+		OIndexChunkKey deserKey;
 		Size		dataLength;
 		Pointer		result;
 		OIndex	   *oIndex;
@@ -1713,7 +1714,29 @@ o_indices_get_extended(ORelOids oids, OIndexType type,
 		if (result == NULL)
 			return NULL;
 
-		oIndex = deserialize_o_index(&key, result, dataLength);
+		/*
+		 * Take the incarnation version from the chunk we actually read, and
+		 * everything else from the key we asked with.
+		 *
+		 * A caller that names no particular incarnation asks with
+		 * O_TABLE_INVALID_VERSION; deserializing against that would stamp the
+		 * OIndex -- and every OIndexDescr built from it -- as
+		 * version-unknown, which is no basis for deciding whether an OIndex
+		 * and an OTable are the same incarnation.  *found_key is the key of
+		 * the first chunk returned, so it carries the row's real version.
+		 *
+		 * Its OIDs, though, are not necessarily the ones we asked for.  The
+		 * O_INDICES key comparator does not separate two rows that share
+		 * (datoid, relnode) but differ in reloid, so a lookup for an index
+		 * whose reloid a DDL has just changed lands on the row still keyed by
+		 * the old reloid, and oIndicesFetchCallback() hands that tuple back
+		 * rather than rejecting it.  Callers identify the descriptor by the
+		 * OIDs they asked for, so keep those.  o_tables_get_extended() takes
+		 * the same narrow slice for OTable.
+		 */
+		deserKey = key;
+		deserKey.version = found_key->key.version;
+		oIndex = deserialize_o_index(&deserKey, result, dataLength);
 		pfree(result);
 
 		if (oIndex != NULL)

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -977,6 +977,56 @@ o_table_fields_make_tupdesc(OTableField *fields, int nfields)
 	return tupdesc;
 }
 
+/*
+ * Where in a leaf tuple descriptor the OTable's own fields begin: after the
+ * synthetic ctid field of a table without a primary key, and after the bridge
+ * ctid field of a table with a bridged index.
+ */
+static inline int
+o_tupdesc_fields_start(OTable *o_table)
+{
+	int			fields_start = o_table->has_primary ? 0 : 1;
+
+	if (o_table->index_bridging)
+		fields_start++;
+
+	return fields_start;
+}
+
+#ifdef USE_ASSERT_CHECKING
+/*
+ * Does this leaf tuple descriptor describe exactly the fields of *o_table?
+ *
+ * The descriptor is built from an OIndex record and the constraints from an
+ * OTable record.  o_tupdesc_load_constr() reads the two together -- it sizes
+ * missing[] from the OTable and copies each Datum by the OTable's
+ * byval/typlen, while FreeTupleDesc() later frees it by the descriptor's --
+ * so they have to be the same incarnation of the relation.  Callers establish
+ * that from the index incarnation version (see o_index_fill_descr()); this is
+ * what it buys them, and what the assertion below spells out.
+ */
+static bool
+o_tupdesc_matches_o_table(TupleDesc tupdesc, OTable *o_table)
+{
+	int			fields_start = o_tupdesc_fields_start(o_table);
+	int			i;
+
+	if (tupdesc->natts != o_table->nfields + fields_start)
+		return false;
+
+	for (i = 0; i < o_table->nfields; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i + fields_start);
+		OTableField *field = &o_table->fields[i];
+
+		if (att->attbyval != field->byval || att->attlen != field->typlen)
+			return false;
+	}
+
+	return true;
+}
+#endif							/* USE_ASSERT_CHECKING */
+
 void
 o_tupdesc_load_constr(TupleDesc tupdesc, OTable *o_table, OIndexDescr *descr)
 {
@@ -988,10 +1038,7 @@ o_tupdesc_load_constr(TupleDesc tupdesc, OTable *o_table, OIndexDescr *descr)
 
 	idx_cxt = OGetIndexContext(descr);
 	oldcxt = MemoryContextSwitchTo(idx_cxt);
-	fields_start = o_table->has_primary ? 0 : 1;
-
-	if (o_table->index_bridging)
-		fields_start++;
+	fields_start = o_tupdesc_fields_start(o_table);
 
 	all_attrs += fields_start;
 
@@ -1001,11 +1048,14 @@ o_tupdesc_load_constr(TupleDesc tupdesc, OTable *o_table, OIndexDescr *descr)
 	 * i)->attbyval. So the array we build here must cover natts exactly, and
 	 * entry i must describe attribute i.  Both hold only while the OTable we
 	 * were handed and the OIndex that produced this tupdesc are the same
-	 * incarnation of the relation -- see the version check in
-	 * o_index_fill_descr().  If they ever diverge the mismatch is silent here
-	 * and only surfaces much later, as a pfree() of a bogus pointer inside
+	 * incarnation of the relation -- which o_index_fill_descr() establishes
+	 * from the index incarnation version before it calls us, and which
+	 * o_tupdesc_matches_o_table() states in terms of the two records
+	 * themselves.  If they ever diverge the mismatch is silent here and only
+	 * surfaces much later, as a pfree() of a bogus pointer inside
 	 * FreeTupleDesc().
 	 */
+	Assert(o_tupdesc_matches_o_table(tupdesc, o_table));
 	Assert(tupdesc->natts == all_attrs);
 
 	tupdesc->constr = (TupleConstr *) palloc0(sizeof(TupleConstr));

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -4446,6 +4446,31 @@ typedef struct
 
 } ReplayWalDescCtx;
 
+/*
+ * Params of the replay_on_record stop event: the record about to be replayed,
+ * and the sys tree it names when it is a WAL_REC_RELATION for one (-1
+ * otherwise, including for user relations).
+ */
+static Jsonb *
+replay_record_stopevent_params(WalRecord *rec)
+{
+	JsonbParseState *state = NULL;
+	Jsonb	   *res;
+	int			sysTreeNum = -1;
+	MemoryContext mctx = MemoryContextSwitchTo(stopevents_cxt);
+
+	if (rec->type == WAL_REC_RELATION && IS_SYS_TREE_OIDS(rec->oids))
+		sysTreeNum = rec->oids.relnode;
+
+	pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	jsonb_push_string_key(&state, "type", wal_type_name(rec->type));
+	jsonb_push_int8_key(&state, "systree", sysTreeNum);
+	res = JsonbValueToJsonb(pushJsonbValue(&state, WJB_END_OBJECT, NULL));
+	MemoryContextSwitchTo(mctx);
+
+	return res;
+}
+
 static WalParseResult
 replay_on_record(WalReaderState *r, WalRecord *rec)
 {
@@ -4464,12 +4489,23 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 	 * (dispatch is cheap) far ahead of the workers (apply is not), so
 	 * get_workers_commit_ptr() stays low and the finished_list drain cannot
 	 * remove a resurrected in-flight oxid before the deferred
-	 * WAL_REC_ROLLBACK re-finds it (found=1) on the leader.  The test only
-	 * needs to park on the next record after arming, so no params are pushed;
-	 * arm match-all with pg_stopevent_set('replay_on_record', 'true').
-	 * Runtime-gated by orioledb.enable_stopevents (off in production).
+	 * WAL_REC_ROLLBACK re-finds it (found=1) on the leader.  That test parks
+	 * on the next record after arming, so it arms match-all with
+	 * pg_stopevent_set('replay_on_record', 'true').
+	 *
+	 * The record's type and, for a sys tree, the tree it is about to switch
+	 * to are pushed as params, which is what lets a test park at a chosen
+	 * point inside a DDL's replay -- '$.type == "RELATION" && $.systree == 2'
+	 * stops just before the O_TABLES modifies, with the O_INDICES ones for
+	 * the same statement already applied.  Runtime-gated by
+	 * orioledb.enable_stopevents (off in production).
 	 */
-	STOPEVENT(STOPEVENT_REPLAY_ON_RECORD, NULL);
+	if (STOPEVENTS_ENABLED())
+	{
+		Jsonb	   *params = replay_record_stopevent_params(rec);
+
+		STOPEVENT(STOPEVENT_REPLAY_ON_RECORD, params);
+	}
 
 	switch (rec->type)
 	{

--- a/test/t/restartpoint_ddl_window_test.py
+++ b/test/t/restartpoint_ddl_window_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import time
+
+from testgres.enums import NodeStatus
+
+from .base_test import BaseTest, ThreadQueryExecutor
+
+
+class RestartpointDdlWindowTest(BaseTest):
+
+	def wait_replay_parked(self, replica):
+		"""Wait until the recovery leader sits on the replay_on_record event."""
+		deadline = time.time() + 60
+		while time.time() < deadline:
+			parked = replica.execute("""
+				SELECT EXISTS(
+					SELECT 1 FROM pg_stopevents() se
+					WHERE se.stopevent = 'replay_on_record'
+					  AND array_length(se.waiter_pids, 1) > 0);
+			""")[0][0]
+			if parked:
+				return
+			time.sleep(0.1)
+		raise AssertionError("replay did not stop at replay_on_record")
+
+	def test_restartpoint_inside_replayed_ddl_window(self):
+		"""
+		A restartpoint must not build an index descriptor out of a half-applied
+		DDL.
+
+		A primary index descriptor pairs two sys-tree rows: the leaf tuple
+		descriptor from the OIndex record, the constraints from the OTable
+		record.  A DDL writes them one after the other, and the checkpointer
+		reads both under o_non_deleted_snapshot, which shows uncommitted rows.
+		On the primary oTablesMetaLock keeps the two apart; recovery does not
+		take it, so a standby's restartpoint can land between the writes.
+
+		Park replay right before the O_TABLES modifies of an ALTER TABLE whose
+		O_INDICES modifies are already in, then make the standby take a
+		restartpoint.  It used to fail
+		Assert("tupdesc->natts == all_attrs") in o_tupdesc_load_constr().
+		"""
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "orioledb.enable_stopevents = true\n"
+		    "checkpoint_timeout = 1d\n")
+		node.start()
+
+		with self.getReplica().start() as replica:
+			node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+			# The standby can only take a restartpoint once it has replayed a
+			# checkpoint record, so get that out of the way before the table
+			# exists -- the restartpoint it triggers must not warm the
+			# checkpointer's descriptor cache for the table under test, or the
+			# restartpoint below would reuse the cached descriptor instead of
+			# reading the two sys-tree rows again.
+			node.safe_psql("CHECKPOINT;")
+			self.catchup_orioledb(replica)
+
+			node.safe_psql("""
+				CREATE TABLE o_test (
+					id int NOT NULL,
+					val text NOT NULL,
+					PRIMARY KEY (id)
+				) USING orioledb;
+			""")
+			node.safe_psql(
+			    "INSERT INTO o_test "
+			    "(SELECT id, 'x' FROM generate_series(1, 2000) id);")
+			self.catchup_orioledb(replica)
+
+			# Stop the recovery leader on the record that switches to the
+			# O_TABLES sys tree: everything the ALTER wrote to O_INDICES is
+			# applied, nothing it wrote to O_TABLES is.
+			replica.safe_psql("SELECT pg_stopevent_set('replay_on_record', "
+			                  "'$.type == \"RELATION\" && $.systree == 2');")
+
+			node.safe_psql("ALTER TABLE o_test ADD COLUMN val2 int;")
+			self.wait_replay_parked(replica)
+
+			# CHECKPOINT on a standby is a restartpoint.  It runs in its own
+			# thread: past the tree walk it waits for the recovery workers,
+			# which cannot answer while replay is parked.
+			con = replica.connect()
+			t = ThreadQueryExecutor(con, "CHECKPOINT;")
+			t.start()
+			time.sleep(3)
+
+			self.assertEqual(replica.status(), NodeStatus.Running,
+			                 "the standby died during the restartpoint")
+
+			replica.safe_psql("SELECT pg_stopevent_reset('replay_on_record');")
+			t.join()
+			con.close()
+
+			self.catchup_orioledb(replica)
+			self.assertEqual(
+			    replica.execute("SELECT count(*) FROM o_test;")[0][0], 2000)
+			self.assertEqual(
+			    replica.execute("SELECT count(*) FROM o_test "
+			                    "WHERE val2 IS NULL;")[0][0], 2000)
+			node.safe_psql("INSERT INTO o_test VALUES (2001, 'y', 7);")
+			self.catchup_orioledb(replica)
+			self.assertEqual(
+			    replica.execute("SELECT val2 FROM o_test WHERE id = 2001;")[0]
+			    [0], 7)


### PR DESCRIPTION
`Assert("tupdesc->natts == all_attrs")`, `o_tables.c:1009`, in the **standby checkpointer**:

```
CreateRestartPoint -> o_perform_checkpoint -> o_indices_foreach_oids
  -> checkpoint_tables_callback -> o_fetch_index_descr
  -> o_index_fill_descr -> o_tupdesc_load_constr
```

Twice on `arm64 / PG18 / pg_tests` in three days — runs
[31498780558](https://github.com/orioledb/orioledb/actions/runs/31498780558) (`all_attrs=2`, `fields_start=1`) and
[31616384031](https://github.com/orioledb/orioledb/actions/runs/31616384031) (`all_attrs=3`, `fields_start=0`) — both
`postgres: standby_1: checkpointer`. This is the assert fabd3eac added on the
suspicion that the two records could diverge. They do.

### What is torn

A primary index descriptor is assembled from two sys-tree rows:

* the leaf tuple descriptor from the **OIndex** record, and
* `missing[]` plus `primary_init_nfields` from the **OTable** record.

A DDL writes them one after the other — `o_indices_update()` first,
`o_tables_update()` second — and a caller that names the table by OIDs alone
re-reads both here under `o_non_deleted_snapshot`, which shows uncommitted
rows. The read can therefore land between the two writes and pair a new OIndex
with the old OTable.

### Why only the standby

On the primary the window is closed by `oTablesMetaLock`: the DDL holds it
SHARED across both writes, and `o_perform_checkpoint()` takes it EXCLUSIVE
around the whole `o_indices_foreach_oids()` walk. Recovery does not
participate — since 4e0aa762 `WAL_REC_O_TABLES_META_LOCK` deliberately does not
take the lock, because the enclosed modifies are applied in place against the
fuzzy sys-tree image — so on a standby a restartpoint walks straight into the
window.

### Why it matters beyond the assert

A torn pair is not merely inaccurate:

* `o_tupdesc_load_constr()` sizes `missing[]` from the OTable while
  `FreeTupleDesc()` frees it entry by entry according to the descriptor — the
  `pfree()` of a bogus pointer the assert's comment predicted, and a very
  plausible root for the rare checkpointer `FreeTupleDesc` MAXALIGN crash;
* `fillFixedFormatSpec()` reads `primary_init_nfields` attributes out of a
  descriptor that may be shorter — a plain out-of-bounds read.

---

## The fix

The pair carries its own answer. `make_primary_o_index()` and
`make_ctid_o_index()` stamp the new OIndex and the OTable's
`primary_ixversion` with the same value, and every `o_indices_update()` call
site writes the OTable immediately after. Equal versions mean one incarnation;
unequal ones mean exactly the window above. So the check is a single
comparison of `OIndexDescr.version` against `OTable.primary_ixversion`.

That needs the version to actually reach the descriptor, which it did not:

### 1. The incarnation version never reached the descriptor (f116eb09)

`deserialize_o_index()` took the version from the key the caller *asked* with.
OID-only callers ask with `O_TABLE_INVALID_VERSION`, so `OIndexDescr.version`
was version-unknown on every such path — nothing to compare. `*found_key` is
the key of the chunk actually read and carries the real version, exactly as
`o_tables_get_extended()` already uses for OTable. Only the version is taken
from it: its OIDs are not necessarily the requested ones (see the note below),
and callers identify a descriptor by the OIDs they asked for.

This also sharpens `get_index_descr()`'s cache check: until now a descriptor
built by an OID-only fetch stored version-unknown, so a later fetch naming a
version never matched it and rebuilt the descriptor every time.

### 2. The version check itself (ea5b5fe2)

Replaces the structural comparison (`natts`, per-field `byval`/`typlen`) the
first commit used. Structural equality is enough for memory safety but is not
what "the same incarnation" means — an `ALTER COLUMN TYPE` between two
by-value 4-byte types produces a torn pair it accepts. The structural
predicate stays as the assertion inside `o_tupdesc_load_constr()`, now static
and assert-only, since equal versions imply it.

**Over the regression suite the version check refuses five pairs the structural
one passed — every one an OIndex exactly one incarnation ahead of its OTable.**

---

## Dropped from this PR: making reloid part of the OIndex key

An earlier revision of this branch also made `o_index_chunk_cmp()` compare
`reloid`, because `(datoid, spcoid, relnode)` is not a relation identity —
relfilenumbers are reused, and a lookup for an index with no record of its own
silently resolves to a neighbour's record on the same relnode, relabelled with
the requested OIDs. `o_tables_oids_indexes()` leans on exactly that when ALTER
TABLE reuses an index tree under a new `pg_class` entry (its `reuse_relnode`
branch skips both the delete and the add), so the change came with an
`o_indices_rekey()` to move the record to the new reloid.

**That does not work, and the reason is worth recording.** A churn run of this
branch ([31720227564](https://github.com/orioledb/orioledb/actions/runs/31720227564))
came back 32/32 `pg_tests` and 4/4 `dm_log_writes` green and **8/8
`check_page` red** — deterministic, not a flake:
`test_alter_column_type` (`indices_build_test.py:552`) reads the table empty
after `ALTER COLUMN TYPE` + `stop -m immediate` + restart.

Reduced to a two-statement repro, the tell is decisive: with a `CHECKPOINT`
between the ALTER and the crash the rows survive; without one they are gone.
So the loss is in **WAL replay**. Records written before the ALTER name the
tree by its old reloid, and once the OIndex record moves and the comparator
starts separating reloids, recovery can no longer resolve them and drops their
data silently. Recovery *depends* on the reloid-blind lookup.

Making reloid part of the tree identity therefore needs recovery to resolve a
tree without it (or an old→new mapping), which is well outside this PR. Filed
separately; the commit is dropped here.

### Testing

regress 48/48, isolation 35/35, `indices_build_test` 10/10, and the
deterministic `restartpoint_ddl_window_test` added here, which parks the
recovery leader inside the DDL's sys-tree window and drives a restartpoint over
it: it kills the standby without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
