### PR TITLE
Start a split's historical page walk at the reading page's own low bound

### DIFF
--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1346,9 +1346,17 @@ reconstruct_split_diff(BTreeDescr *desc, UndoLocation undoLocation,
 	splitKey.tuple.data = splitKey.fixedData;
 
 	/*
-	 * Determine which half `dest` is from its own hikey: the left half's
-	 * hikey is exactly the split key; the right half's hikey is the original
-	 * page's (larger) hikey, or it is rightmost.
+	 * Determine which side of the split `dest` is on from its own hikey.  Its
+	 * key range lies wholly within one half -- a page is a descendant of
+	 * exactly one of them -- so everything left of the split ends at or
+	 * before the split key and everything right of it ends after.  Being
+	 * rightmost means an unbounded hikey, hence the right side.
+	 *
+	 * Testing for a hikey merely *different* from the split key would only
+	 * tell the two halves of this very split apart: once the left half is
+	 * itself split, its left part ends before the split key and would read as
+	 * the right half, taking the split key as a low boundary that lies past
+	 * its whole range.
 	 */
 	if (O_PAGE_IS(dest, RIGHTMOST))
 		rightHalf = true;
@@ -1358,7 +1366,7 @@ reconstruct_split_diff(BTreeDescr *desc, UndoLocation undoLocation,
 
 		BTREE_PAGE_GET_HIKEY(destHikey, dest);
 		rightHalf = (o_btree_cmp(desc, &destHikey, BTreeKeyNonLeafKey,
-								 &splitKey.tuple, BTreeKeyNonLeafKey) != 0);
+								 &splitKey.tuple, BTreeKeyNonLeafKey) > 0);
 	}
 
 	if (is_left != NULL)
@@ -1444,30 +1452,34 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 		undo_read(undoType, left_loc, ORIOLEDB_BLCKSZ, dest);
 		if (page_lokey && header.type == UndoPageImageSplit)
 		{
-			bool		set_page_lokey = false;
+			OFixedKey	splitKey;
 
-			if (!page_hikey || O_TUPLE_IS_NULL(*page_hikey))
-			{
-				set_page_lokey = true;
-			}
-			else if (!O_PAGE_IS(dest, RIGHTMOST))
-			{
-				BTREE_PAGE_GET_HIKEY(hikey, dest);
-				cmp = o_btree_cmp(desc, page_hikey, BTreeKeyNonLeafKey, &hikey, BTreeKeyNonLeafKey);
-				Assert(cmp <= 0);
-				if (cmp == 0)
-					set_page_lokey = true;
-			}
+			undo_read(undoType,
+					  left_loc + ORIOLEDB_BLCKSZ,
+					  header.splitKeyLen,
+					  splitKey.fixedData);
+			splitKey.tuple.formatFlags = header.splitKeyFlags;
+			splitKey.tuple.data = (Pointer) &splitKey.fixedData;
 
-			if (set_page_lokey)
-			{
-				undo_read(undoType,
-						  left_loc + ORIOLEDB_BLCKSZ,
-						  header.splitKeyLen,
-						  page_lokey->fixedData);
-				page_lokey->tuple.formatFlags = header.splitKeyFlags;
-				page_lokey->tuple.data = (Pointer) &page_lokey->fixedData;
-			}
+			/*
+			 * Which side of the split does the caller's page sit on?  Its key
+			 * range lies wholly within one half -- a page is a descendant of
+			 * exactly one of them -- so its hikey answers it: everything left
+			 * of the split ends at or before the split key, everything right
+			 * of it ends after.  Being rightmost means an unbounded hikey,
+			 * hence the right side.
+			 *
+			 * Comparing against the pre-split page's hikey instead only tells
+			 * the two halves of *this* split apart.  After the right half is
+			 * itself split, its left part ends before the pre-split hikey and
+			 * so read as the left half, and the reconstructed page was walked
+			 * from its very first item -- re-emitting every key that belongs
+			 * to a sibling the caller visits separately.
+			 */
+			if (!page_hikey || O_TUPLE_IS_NULL(*page_hikey) ||
+				o_btree_cmp(desc, page_hikey, BTreeKeyNonLeafKey,
+							&splitKey.tuple, BTreeKeyNonLeafKey) > 0)
+				copy_fixed_key(desc, page_lokey, splitKey.tuple);
 		}
 		return;
 	}

--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -4,6 +4,9 @@
 import unittest
 import testgres
 import string
+import time
+
+from threading import Event, Thread
 
 from testgres.enums import NodeStatus
 from testgres.connection import NodeConnection
@@ -288,6 +291,90 @@ class MergeTest(BaseTest):
 
 		self.assertTrue(
 		    node.execute("SELECT orioledb_tbl_check('o_split_diff'::regclass)")
+		    [0][0])
+
+	def test_split_diff_scan_during_split(self):
+		"""
+		A sequential scan on an old snapshot must not return a row twice while
+		the leaves under it are splitting.
+
+		Scanning keeps a page-level undo image alive for every split, so each
+		live leaf reconstructs the page it came from.  A leaf produced by two
+		splits sits strictly inside the older image, and the walk has to start
+		at that leaf's own low boundary -- otherwise it re-emits the keys that
+		went to a sibling the scan visits on its own.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_split_conc ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb;"
+		    "TRUNCATE o_split_conc;")
+		node.execute("INSERT INTO o_split_conc "
+		             "(SELECT id * 2, repeat('x', 100) "
+		             "FROM generate_series(1, 5000) id);")
+
+		# The scan has to be in flight when the pages split -- that is what
+		# makes the split keep a page-level undo image at all -- so it runs
+		# from its own thread, started before the interleaving insert and
+		# stopped after it.
+		stop = Event()
+		outcome = {}
+
+		def scanner():
+			con = node.connect()
+			try:
+				con.begin()
+				con.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+				con.execute("SET enable_indexscan = off;")
+				con.execute("SET enable_bitmapscan = off;")
+				outcome['first'] = con.execute(
+				    "SELECT count(*) FROM o_split_conc;")[0][0]
+				while not stop.is_set():
+					# Any key the scan hands out twice shows up here.
+					dups = con.execute("SELECT id, count(*) FROM o_split_conc "
+					                   "GROUP BY id HAVING count(*) > 1 "
+					                   "ORDER BY id;")
+					if dups:
+						outcome['bad'] = dups[:5]
+						return
+				outcome['last'] = con.execute(
+				    "SELECT count(*), min(id), max(id), sum(id::bigint) "
+				    "FROM o_split_conc;")[0]
+			except Exception as e:
+				outcome['error'] = repr(e)
+			finally:
+				con.rollback()
+				con.close()
+
+		t = Thread(target=scanner)
+		t.start()
+		try:
+			deadline = time.time() + 30
+			while ('first' not in outcome and t.is_alive()
+			       and time.time() < deadline):
+				time.sleep(0.01)
+			time.sleep(0.3)
+
+			node.execute("INSERT INTO o_split_conc "
+			             "(SELECT id * 2 - 1, repeat('y', 100) "
+			             "FROM generate_series(1, 5000) id);")
+			time.sleep(0.2)
+		finally:
+			stop.set()
+			t.join(timeout=60)
+
+		self.assertNotIn('error', outcome)
+		self.assertEqual(outcome.get('first'), 5000)
+		self.assertNotIn('bad', outcome)
+		self.assertEqual(outcome.get('last'), (5000, 2, 10000, 25005000))
+
+		self.assertEqual(
+		    node.execute("SELECT count(*) FROM o_split_conc;")[0][0], 10000)
+		self.assertTrue(
+		    node.execute("SELECT orioledb_tbl_check('o_split_conc'::regclass)")
 		    [0][0])
 
 	def test_split_diff_update_grow(self):


### PR DESCRIPTION
`merge_test.test_split_diff_old_snapshot_read` failed **`5023 != 5000`** on
`valgrind_1` (amd64/18/gcc, [run 31606843432](https://github.com/orioledb/orioledb/actions/runs/31606843432)):
an old REPEATABLE READ snapshot counted 23 rows too many. `count(DISTINCT id)`
was 5000, so nothing invisible leaked in — **a sequential scan handed out 23
keys twice**.

### What goes wrong

A scan in flight keeps a split from taking the differential shortcut, so every
split under it leaves a *full* page image in undo, and both halves point at it.
Reading a half under an older snapshot reconstructs that whole pre-split page,
so the walk has to start at the half's own low boundary — the rest belongs to a
sibling the scan visits separately. `get_page_from_undo()` reports that
boundary through `page_lokey`, deciding which side the caller is on by
comparing the caller's hikey with the **pre-split page's hikey** — a test that
only tells the two halves of that one split apart.

One INSERT splits a page repeatedly. A leaf that came from splitting the right
half *again* ends before the pre-split hikey, so it read as the left half, took
no low boundary, and walked the reconstructed page from its very first item —
re-emitting every key that had gone to its left sibling, which the scan had
already returned from that sibling's own downlink.

Instrumenting the scan showed it directly — three leaves rebuilding the same
image with hikey 1770, and the middle one starting at 1666:

```
SDPAGE blkno=2074 low=1666 high=1712 livehi=1712 hist=1 histhi=1770 histfirst=1666
SDPAGE blkno=2187 low=1712 high=1741 livehi=1741 hist=1 histhi=1770 histfirst=1666  <-- 
SDPAGE blkno=2188 low=1741 high=1770 livehi=1770 hist=1 histhi=1770 histfirst=1742
```

### The fix

A page descends from exactly one half of any split in its history, so its hikey
tells the two apart on its own: at or before the split key is the left side,
after it the right (rightmost meaning unbounded, hence right). Use that in both
the full-image path and in `reconstruct_split_diff()`, which tested for a hikey
merely *different* from the split key — the same mistake mirrored, for a left
half that was split again.

The differential path already reported the boundary, which is why the failure
needed a full image and so only showed up with a scan running.

### Test

`test_split_diff_scan_during_split` loops a scan on an old snapshot while 5000
interleaved keys split the leaves under it, and checks no key comes back twice.
It fails 3 runs out of 3 before the fix; after it, 120 iterations of the same
scenario are clean. regress (48), isolation (34) and merge_test (12) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)