### PR TITLE
ci: don't fail the run when the coveralls upload does

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,6 +200,11 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           files: ./orioledb/coverage.info
+          # The action downloads its own binary at run time; when that
+          # download or its checksum fetch fails ("Failed to download
+          # coveralls binary or checksum") the whole run goes red over a
+          # coverage upload that changes nothing about the tests.
+          fail-on-error: false
 
   cleanup:
     needs: finish


### PR DESCRIPTION
`Failed to download coveralls binary or checksum (Linux).` turned the whole
check run red on `main` ([run 31612397180](https://github.com/orioledb/orioledb/actions/runs/31612397180))
after every test job had already passed. The action fetches its own binary at
run time, so its network hiccups say nothing about the code under test.

`fail-on-error: false` keeps the coverage upload best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)