### PR TITLE
Only declare an S3 part loaded when the transition is ours to make

### DIFF
--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -2284,9 +2284,24 @@ perform_page_io_build(BTreeDescr *desc, Page img,
 			tag.checkpointNum = chkpNum;
 			tag.segNum = offset / ORIOLEDB_SEGMENT_SIZE;
 			index = (offset % ORIOLEDB_SEGMENT_SIZE) / ORIOLEDB_S3_PART_SIZE;
-			s3_header_mark_part_loading(tag, index);
-			s3_header_mark_part_loaded(tag, index);
-			s3_headers_increase_loaded_parts(1);
+
+			/*
+			 * The allocation ran into a part the file did not have yet, so
+			 * its contents are here and nothing has to be fetched -- but only
+			 * if we are the ones who claimed it.  After a crash restart the
+			 * datafile length rewinds into a part the previous run had
+			 * already uploaded and evicted, so a reader can have a download
+			 * of exactly this part in flight; forcing it to Loaded from here
+			 * leaves the s3 worker to fail Assert(status ==
+			 * S3PartStatusLoading) when that download finishes, and hands
+			 * eviction a part somebody is still writing into.
+			 *
+			 * s3_header_mark_part_loading() counts the part in
+			 * numberOfLoadedParts on the transition it makes, so there is
+			 * nothing to add here either.
+			 */
+			if (s3_header_mark_part_loading(tag, index) == S3PartStatusNotLoaded)
+				s3_header_mark_part_loaded(tag, index);
 		}
 
 		extent->off |= (uint64) chkpNum << S3_CHKP_NUM_SHIFT;

--- a/src/s3/headers.c
+++ b/src/s3/headers.c
@@ -779,10 +779,22 @@ s3_header_mark_part_loaded(S3HeaderTag tag, int index)
 	while (true)
 	{
 		uint32		newValue;
-		S3PartStatus status PG_USED_FOR_ASSERTS_ONLY;
+		S3PartStatus status;
 
 		status = S3_PART_GET_STATUS(value);
 
+		/*
+		 * Only whoever moved the part to Loading may declare it loaded.  Say
+		 * which part and which status when that does not hold: the bare
+		 * assertion left nothing to go on, and the caller that broke it (an
+		 * s3 worker finishing a download) is not the one that changed the
+		 * status out from under it.
+		 */
+		if (status != S3PartStatusLoading)
+			elog(WARNING, "part %d of file %u/%u (checkpoint %u, segment %d) "
+				 "is in status %d, expected loading",
+				 index, tag.key.oids.datoid, tag.key.oids.relnode,
+				 tag.checkpointNum, tag.segNum, (int) status);
 		Assert(status == S3PartStatusLoading);
 		newValue = S3_PART_SET_STATUS(value, S3PartStatusLoaded);
 		newValue = S3_PART_SET_USAGE_COUNT(newValue, 1);

--- a/src/s3/worker.c
+++ b/src/s3/worker.c
@@ -371,7 +371,24 @@ s3process_task(uint64 taskLocation)
 		tag.checkpointNum = task->typeSpecific.filePart.chkpNum;
 		tag.segNum = task->typeSpecific.filePart.segNum;
 
-		s3_header_mark_part_loaded(tag, task->typeSpecific.filePart.partNum);
+		/*
+		 * A worker that errors out is restarted with bgw_restart_time 0 and
+		 * replays the task it left in workers_locations[], so this download
+		 * can be the second one of a part the first attempt already marked
+		 * loaded -- the attempt only has to have died between that mark and
+		 * clearing its slot.  Claiming the part again keeps the replay
+		 * idempotent; without it the restarted worker fails Assert(status ==
+		 * S3PartStatusLoading) the moment it starts, and dies again, on the
+		 * same task.
+		 *
+		 * s3_header_mark_part_loading() returns the status it found: Loading
+		 * means the mark is still ours to make, NotLoaded means the part was
+		 * evicted in between and it just claimed it back for us, and Loaded
+		 * means the first attempt already finished this.
+		 */
+		if (s3_header_mark_part_loading(tag, task->typeSpecific.filePart.partNum) !=
+			S3PartStatusLoaded)
+			s3_header_mark_part_loaded(tag, task->typeSpecific.filePart.partNum);
 
 		pfree(filename);
 		pfree(objectname);


### PR DESCRIPTION
`TRAP: failed Assert("status == S3PartStatusLoading")`, `src/s3/headers.c:786`,
in **`orioledb s3 worker 2`** on `valgrind_2`
([run 31606843432](https://github.com/orioledb/orioledb/actions/runs/31606843432)) —
one line after that worker logged that it had started. It killed the second
`node.start()` of `s3_test.test_s3_data_eviction`, and PG18's postmaster
followed with `pmchild freelist for backend type 6 is corrupt`.

`s3_header_mark_part_loaded()` moves a part from Loading to Loaded and asserts
it finds Loading — i.e. that its caller is the one that claimed the part. Two
callers never check.

**`s3process_task()`, for `S3TaskTypeReadFilePart`.** An s3 worker is registered
with `bgw_restart_time = 0` and records the task it is about to run in
`workers_locations[]`, so a worker that errors is restarted at once and replays
it — which is what a crash immediately after `started` looks like. The first
attempt only has to have died between marking the part loaded and clearing its
slot for the replay to find the part `Loaded`, abort, and abort again on the
same task.

**`perform_page_io_build()`**, where an allocation running into a part the file
did not have yet marks it present without a download. After a crash restart the
datafile length rewinds into a part the previous run had already uploaded and
evicted, so a reader can have a download of exactly that part in flight;
forcing it to Loaded from there leaves the s3 worker to hit the same assertion
when the download finishes, and hands eviction a part still being written into.
While here: the extra `s3_headers_increase_loaded_parts(1)` double-counted,
because `s3_header_mark_part_loading()` already counts the part on the
transition it makes.

Both callers now go through `s3_header_mark_part_loading()` and act on what it
found. The assertion also says which part and which status now, since the
process that trips it is not the one that changed the status.

**Not reproduced.** 10 local runs of the failing test are clean and the
collision never showed up under an instrumented build, so this is the two
illegal transitions the code allows, matching the crash, rather than a caught
one. The whole `s3_test` suite (17 tests) plus regress (48) and isolation (34)
pass with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)