### PR TITLE
Tell apart the two halves of a differential split image

### DIFF
--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -200,7 +200,8 @@ extern void make_waiter_undo_record(BTreeDescr *desc, OInMemoryBlkno blkno,
 extern void get_page_from_undo(BTreeDescr *desc, UndoLocation undo_loc, Pointer key,
 							   BTreeKeyType kind, Pointer dest,
 							   bool *is_left, bool *is_right, OFixedKey *lokey,
-							   OFixedKey *page_lokey, OTuple *page_hikey);
+							   OFixedKey *page_lokey, OTuple *page_hikey,
+							   bool *is_differential);
 extern UndoLocation page_add_image_to_undo(BTreeDescr *desc, Pointer p,
 										   CommitSeqNo imageCsn,
 										   OTuple *splitKey, LocationIndex splitKeyLen);

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -2403,10 +2403,10 @@ undo_it_find_internal(UndoIterator *undoIt, void *key, BTreeKeyType kind)
 		/* Load the next page item from page-level undo item */
 		if (undoIt->it->scanDir == ForwardScanDirection)
 			get_page_from_undo(desc, undoLocation, key, kind,
-							   undoIt->image, &left, &right, NULL, NULL, NULL);
+							   undoIt->image, &left, &right, NULL, NULL, NULL, NULL);
 		else
 			get_page_from_undo(desc, undoLocation, key, kind,
-							   undoIt->image, &left, &right, &undoIt->lokey, NULL, NULL);
+							   undoIt->image, &left, &right, &undoIt->lokey, NULL, NULL, NULL);
 
 		undoIt->rightmost = (undoIt->rightmost && right) || O_PAGE_IS(undoIt->image, RIGHTMOST);
 		undoIt->leftmost = (undoIt->leftmost && left) || O_PAGE_IS(undoIt->image, LEFTMOST);

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -38,6 +38,27 @@ static void clear_fixed_tuple(OFixedTuple *dst);
 /*
  * Navigates and reads the page image from undo log according to `key` of
  * `keyType` and `csn`.  Saves lokey of the page to lokey if *lokey != NULL.
+ *
+ * *lokey accumulates the tightest lower bound any record in the chain reported,
+ * never the last one.  A record reports where the half it carried forward
+ * begins *at that record's generation*, and the walk runs newest to oldest, so
+ * the bounds only get looser as it goes: a page split twice yields two
+ * UndoPageImageSplitDiff records that both see the same (narrow) right half
+ * and each name their own split key, the older one lower than the newer.
+ * Overwriting would hand the caller a bound from before the newer split while
+ * the image stays clipped to the newer half -- and a backward scan takes that
+ * bound as the page's own, stepping left past every leaf in between and
+ * silently dropping their rows.
+ *
+ * The returned image location identifies the image the caller ends up with, so
+ * that a caller stepping sideways can tell when several current leaves resolve
+ * to one historical page (find_left_page(), find_right_page()).  For a chain
+ * that goes through a differential record that identity is the first such
+ * record and the side it took, not the record the walk stopped at: the halves
+ * of a differential split keep their own narrow contents, but their chains
+ * converge on the same older history, so the stopping record cannot tell them
+ * apart.  Reporting it would make a caller treat one half as already covered
+ * by the other and skip it whole.
  */
 UndoLocation
 read_page_from_undo(BTreeDescr *desc, Page img, UndoLocation undo_loc,
@@ -48,15 +69,41 @@ read_page_from_undo(BTreeDescr *desc, Page img, UndoLocation undo_loc,
 	CommitSeqNo page_csn;
 	UndoLocation rec_undo_location;
 	bool		is_left = true;
+	bool		is_differential;
+	bool		imageIdentityLatched = false;
+	UndoLocation imageIdentityLoc = InvalidUndoLocation;
+	bool		imageIdentityIsLeft = true;
+	OFixedKey	stepLokey;
 	UndoLogType undoType PG_USED_FOR_ASSERTS_ONLY = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 
 	Assert(UndoLocationIsValid(undo_loc));
 
+	if (lokey)
+		clear_fixed_key(lokey);
+
 	while (true)
 	{
 		/* Read page image from page-level undo item */
+		clear_fixed_key(&stepLokey);
+		is_differential = false;
 		get_page_from_undo(desc, undo_loc, key, keyType, img,
-						   &is_left, NULL, lokey, NULL, NULL);
+						   &is_left, NULL, lokey ? &stepLokey : NULL,
+						   NULL, NULL, &is_differential);
+
+		/* Latch the image identity at the first differential record */
+		if (is_differential && !imageIdentityLatched)
+		{
+			imageIdentityLatched = true;
+			imageIdentityLoc = undo_loc;
+			imageIdentityIsLeft = is_left;
+		}
+
+		/* Keep the tightest bound reported so far -- see above */
+		if (lokey && !O_TUPLE_IS_NULL(stepLokey.tuple) &&
+			(O_TUPLE_IS_NULL(lokey->tuple) ||
+			 o_btree_cmp(desc, &stepLokey.tuple, BTreeKeyNonLeafKey,
+						 &lokey->tuple, BTreeKeyNonLeafKey) > 0))
+			copy_fixed_key(desc, lokey, stepLokey.tuple);
 
 		header = (BTreePageHeader *) img;
 		page_csn = header->csn;
@@ -79,6 +126,9 @@ read_page_from_undo(BTreeDescr *desc, Page img, UndoLocation undo_loc,
 
 	/* Page-level undo item should be retained */
 	Assert(UNDO_REC_EXISTS(undoType, undo_loc));
+
+	if (imageIdentityLatched)
+		return O_UNDO_GET_IMAGE_LOCATION(imageIdentityLoc, imageIdentityIsLeft);
 
 	return O_UNDO_GET_IMAGE_LOCATION(undo_loc, is_left);
 }

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -393,7 +393,7 @@ load_first_historical_page(BTreeSeqScan *scan)
 
 		(void) get_page_from_undo(scan->desc, header->undoLocation, key, kind,
 								  scan->histImg, NULL, NULL, NULL,
-								  lokeyPtr, &hikey.tuple);
+								  lokeyPtr, &hikey.tuple, NULL);
 
 		if (!O_PAGE_IS(scan->histImg, RIGHTMOST))
 			copy_fixed_hikey(scan->desc, &hikey, scan->histImg);
@@ -458,7 +458,7 @@ load_next_historical_page(BTreeSeqScan *scan)
 		(void) get_page_from_undo(scan->desc, header->undoLocation,
 								  (Pointer) &prevHikey.tuple, BTreeKeyNonLeafKey,
 								  scan->histImg, NULL, NULL, NULL,
-								  NULL, NULL);
+								  NULL, NULL, NULL);
 		header = (BTreePageHeader *) scan->histImg;
 	}
 	BTREE_PAGE_LOCATOR_FIRST(scan->histImg, &scan->histLoc);

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1401,7 +1401,8 @@ void
 get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 				   BTreeKeyType kind, Pointer dest,
 				   bool *is_left, bool *is_right, OFixedKey *lokey,
-				   OFixedKey *page_lokey, OTuple *page_hikey)
+				   OFixedKey *page_lokey, OTuple *page_hikey,
+				   bool *is_differential)
 {
 	/*
 	 * Read enough bytes to cover the peek header and (if this is a full
@@ -1420,6 +1421,10 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 
 	undo_read(undoType, undoLocation, sizeof(header), (Pointer) &header);
 	left_loc = undoLocation + MAXALIGN(sizeof(header));
+
+	if (is_differential != NULL)
+		*is_differential = (header.type == UndoPageImageMergeDiff ||
+							header.type == UndoPageImageSplitDiff);
 
 	if (header.type == UndoPageImageMergeDiff)
 	{

--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -377,6 +377,57 @@ class MergeTest(BaseTest):
 		    node.execute("SELECT orioledb_tbl_check('o_split_conc'::regclass)")
 		    [0][0])
 
+	def test_split_diff_backward_scan_across_split(self):
+		"""
+		A backward ordered scan must not lose rows to a split under it.
+
+		A cursor holds the scan in flight between two FETCHes, so the split
+		lands at an exactly reproducible point rather than by timing.  While
+		the scan is parked, interleaved keys split every leaf under it, twice
+		over: the leaf the scan is standing on ends up as the right half of one
+		split whose own history is another split.
+
+		Both halves of a differential split image (UndoPageImageSplitDiff) keep
+		their own narrow contents but their undo chains converge on the same
+		older history.  A backward step that identified a historical image by
+		where its chain stopped therefore could not tell the two halves apart,
+		took the left one for already covered, and stepped past it -- dropping
+		every row on it.  Issue #1036.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_backscan ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb;"
+		    "TRUNCATE o_backscan;")
+		node.execute("INSERT INTO o_backscan "
+		             "(SELECT id * 2, repeat('x', 100) "
+		             "FROM generate_series(1, 2000) id);")
+
+		con = node.connect()
+		try:
+			con.begin()
+			con.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+			con.execute("SET enable_seqscan = off;")
+			con.execute("SET enable_bitmapscan = off;")
+			con.execute("DECLARE c NO SCROLL CURSOR FOR "
+			            "SELECT id FROM o_backscan ORDER BY id DESC;")
+			# Park the scan a few leaves in, still far from the low keys.
+			got = [r[0] for r in con.execute("FETCH 100 FROM c;")]
+
+			# Split every leaf under the parked scan.
+			node.execute("INSERT INTO o_backscan "
+			             "(SELECT id * 2 - 1, repeat('y', 100) "
+			             "FROM generate_series(1, 2000) id);")
+
+			got += [r[0] for r in con.execute("FETCH ALL FROM c;")]
+			self.assertEqual(got, [i * 2 for i in range(2000, 0, -1)])
+		finally:
+			con.rollback()
+			con.close()
+
 	def test_split_diff_update_grow(self):
 		"""
 		A single UPDATE that grows every row, forcing in-statement page splits


### PR DESCRIPTION
Fixes #1036.

A `REPEATABLE READ` backward ordered index scan silently loses a contiguous
range of rows while another transaction splits the leaves under it — a whole
leaf at a time, 3-11% of the result in the reports on the issue. Forward index
scans and sequential scans on the same snapshot at the same instant are
complete.

### What the scan actually does

Traced with the deterministic reproducer below (probe output, keys are the
table's `id`):

```
VISIT 181                                     <- last item of the leaf [181, 210)
FLP lokey 181  img-hikey 210  img-first 181  undoloc 312784
FLP lokey 152  img-hikey 181  img-first 152  undoloc 312784   <- same undoloc
BACKSTEP boundary 152
```

The leaf `[152, 181)` is **read and then not reported**. Its snapshot-visible
keys 152..180 are exactly the first missing run.

### Why

`find_left_page()` steps to the left sibling and, when the image it reads
carries the same undo image location as the page being left, takes the sibling
for a part of the historical page it has already walked and steps on without
reporting it. That shortcut is what lets one wide pre-split image serve several
current leaves in a single pass.

`read_page_from_undo()` reported that location from the record the chain walk
**stopped at**. For a page reached through `UndoPageImageSplitDiff` that is the
wrong record. A differential split stores no page bytes: each half keeps the
narrow contents it already had and only rewires its header into the original
page's history. The halves are therefore distinct images — but their chains
converge on the same older record, and both walks stop there on the same side.
The shortcut reads the left half, recognizes "the image I just had", and steps
past it with every row on it.

### The fix

Report the image identity from the **first differential record** in the chain,
together with the side it took. That record is what made this half distinct
from its sibling, and it is unique to it: two pages can share it only by being
the two halves of that very split, where the sides differ. Chains with no
differential record are unchanged, so several leaves resolving to one full
image still dedup exactly as before.

### A second defect in the same walk, also fixed

`*lokey` is handed to every record of the chain in turn, so an older record can
widen a bound a newer one already narrowed: a page split twice yields two
`UndoPageImageSplitDiff` records that both see the same narrow right half and
each name their own split key, the older and lower one overwriting the newer.
A backward step then takes that bound as the page's own and jumps left past the
leaves in between. The walk now keeps the tightest bound reported.

This one was found and fixed first, and on its own it does **not** stop the row
loss — both defects had to go.

### Deterministic reproducer, no stop events

A cursor holds the scan in flight between two `FETCH`es, so the split lands at
a fixed point of the scan instead of by timing:

```
FETCH 100 FROM c  ->  INSERT 2000 interleaved keys  ->  FETCH ALL FROM c
```

Before: `got=1475 expected=2000 missing=525`, in perfectly periodic runs —
`(152,180), (256,284), (360,388), (464,492), …`. After: all 2000 rows in order.

Added as `test_split_diff_backward_scan_across_split` in
`test/t/merge_test.py`, next to `test_split_diff_old_snapshot_read` which sets
up the same table. Verified it fails on every run without the fix and passes
with it.

### Testing

regress 48/48, isolation 35/35, `merge_test` 12/12. The race-based reproducer
from the issue, which failed about one run in ten to twenty-five, is clean over
30 iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
