### PR TITLE
CI: dump stuck processes when a pg_upgrade job hangs too

### DIFF
--- a/.github/workflows/pg_upgrade.yml
+++ b/.github/workflows/pg_upgrade.yml
@@ -93,3 +93,7 @@ jobs:
             ./postgresql${{ matrix.version.new }}/src/test/regress/regression.diffs
           retention-days: 2
           if-no-files-found: ignore
+
+      - name: Show stuck processes
+        run: bash ./orioledb/ci/list_stuck.sh
+        if: ${{ always() }}


### PR DESCRIPTION
`check.yml` already ends with a `Show stuck processes` step running
`ci/list_stuck.sh` on `always()`. That gives, for a hung Check step, a full
`thread apply all bt full` per postgres process plus `held_lwlocks`,
`myLockedPages`, `dump_stuck_pages.py`, and the same through `vgdb` under
valgrind.

`pg_upgrade.yml` never had it.

That is why `pg_upgrade (arm64, clang, 17->18)`
([run 31727267090](https://github.com/orioledb/orioledb/actions/runs/31727267090))
produced no backtrace at all when it hung: the step was killed by its
30-minute timeout with the log stopping mid-regression, and the only clue
anywhere was the uploaded server log, whose last line was `orioledb
checkpoint 20 started` with no completion. Pinning that on
`wait_finish_active_commits()` (fixed in #1041) took extracting the running
binary out of `/proc/<pid>/map_files` on an unrelated machine that happened to
be holding three specimens of the same wedge.

A step killed by its timeout does not take the cluster down with it — `pg_ctl`
daemonized it — so whatever is stuck is still there when the next step runs.

**Note on the earlier revision of this PR:** it added a second, weaker dumper
of its own. @akorotkov pointed out that `list_stuck.sh` already exists; it does
strictly more (the lwlock/locked-page state and the valgrind path in
particular), so the new script is gone and this is now one step reusing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)