### PR TITLE
Reject an over-long primary key instead of crashing on it

### DIFF
--- a/src/rewind/rewind.c
+++ b/src/rewind/rewind.c
@@ -202,6 +202,14 @@ orioledb_rewind_queue_age(PG_FUNCTION_ARGS)
 Datum
 orioledb_get_complete_oxid(PG_FUNCTION_ARGS)
 {
+	if (!enable_rewind)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("orioledb rewind mode is turned off")),
+				errdetail("to use rewind set orioledb.enable_rewind = on in PostgreSQL config file."));
+	}
+
 	elog(DEBUG3, "COMPLETE OXid " UINT64_FORMAT " XID %u",
 		 rewindMeta->complete_oxid, rewindMeta->complete_xid);
 	PG_RETURN_DATUM(rewindMeta->complete_oxid);
@@ -211,6 +219,14 @@ orioledb_get_complete_oxid(PG_FUNCTION_ARGS)
 Datum
 orioledb_get_complete_xid(PG_FUNCTION_ARGS)
 {
+	if (!enable_rewind)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("orioledb rewind mode is turned off")),
+				errdetail("to use rewind set orioledb.enable_rewind = on in PostgreSQL config file."));
+	}
+
 	elog(DEBUG3, "COMPLETE Oxid " UINT64_FORMAT " XID %u",
 		 rewindMeta->complete_oxid, rewindMeta->complete_xid);
 	PG_RETURN_DATUM(rewindMeta->complete_xid);

--- a/src/tuple/slot.c
+++ b/src/tuple/slot.c
@@ -656,6 +656,69 @@ tts_orioledb_materialize(TupleTableSlot *slot)
 	}
 }
 
+/*
+ * Decompress/detoast the primary key attributes in place.
+ *
+ * Key attributes have to be plain values: they are compared against keys
+ * already in the tree, and their length is what O_BTREE_MAX_TUPLE_SIZE is
+ * checked against.  A value that arrives still compressed -- which is what
+ * happens when a statement moves one column into the key, as in
+ * "UPDATE t SET k = body" -- measures as its compressed length, so the tuple
+ * sails past the size check and only expands later, when the key is actually
+ * formed.  Expanding here makes the size the caller computes the real one.
+ */
+static void
+detoast_key_attrs(TupleTableSlot *slot, OTableDescr *descr)
+{
+	OTableSlot *oslot = (OTableSlot *) slot;
+	OIndexDescr *id = GET_PRIMARY(descr);
+	TupleDesc	tupleDesc = slot->tts_tupleDescriptor;
+	int			i;
+	int			ctid_off = id->primaryIsCtid ? 1 : 0;
+
+	if (id->bridging)
+		ctid_off++;
+
+	for (i = 0; i < id->nonLeafTupdesc->natts; i++)
+	{
+		int			attnum = id->tableAttnums[i];
+		int			attindex = attnum - 1 - ctid_off;
+		Form_pg_attribute att;
+		Datum		tmp;
+		MemoryContext mctx;
+
+		/* ctid and bridge ctid are not stored among the slot's values */
+		if (attindex < 0 || attindex >= tupleDesc->natts)
+			continue;
+
+		att = TupleDescAttr(tupleDesc, attindex);
+		if (slot->tts_isnull[attindex] || att->attlen != -1)
+			continue;
+
+		/*
+		 * Only compressed and external values need expanding.  NOT
+		 * VARATT_IS_EXTENDED(): that is also true of a short-header varlena,
+		 * and rewriting those into 4-byte form would change the layout of
+		 * every short key -- which shifted tuple sizes enough to alter
+		 * row-lock and serialization outcomes in the isolation suite.
+		 */
+		if (!VARATT_IS_COMPRESSED(slot->tts_values[attindex]) &&
+			!VARATT_IS_EXTERNAL(slot->tts_values[attindex]))
+			continue;
+
+		if (!oslot->vfree)
+			alloc_to_toast_vfree_detoasted(slot);
+
+		mctx = MemoryContextSwitchTo(slot->tts_mcxt);
+		tmp = PointerGetDatum(PG_DETOAST_DATUM(slot->tts_values[attindex]));
+		MemoryContextSwitchTo(mctx);
+		if (oslot->vfree[attindex])
+			pfree(DatumGetPointer(slot->tts_values[attindex]));
+		slot->tts_values[attindex] = tmp;
+		oslot->vfree[attindex] = true;
+	}
+}
+
 void
 tts_orioledb_detoast(TupleTableSlot *slot)
 {
@@ -1235,6 +1298,9 @@ tts_orioledb_toast(TupleTableSlot *slot, OTableDescr *descr)
 		ctid_off++;
 
 	slot_getallattrs(slot);
+
+	/* the size computed below must be the one the key really occupies */
+	detoast_key_attrs(slot, descr);
 
 	/* temporary, pointers to TupleDesc attributes */
 	natts = tupdesc->natts;

--- a/test/expected/toast_column_compress.out
+++ b/test/expected/toast_column_compress.out
@@ -313,6 +313,45 @@ SELECT length(f1) FROM cmdata WHERE a = 1;
 (1 row)
 
 DROP TABLE cmdata;
+-- case 5: a value moved into the primary key.  The key has to be a plain datum
+-- -- it is compared against keys already in the tree, and its length is what
+-- the O_BTREE_MAX_TUPLE_SIZE check measures.  A value arriving still
+-- compressed measured as its compressed length, so an over-long key sailed
+-- past that check and only expanded later: with asserts it tripped
+-- Assert(!VARATT_IS_COMPRESSED(...)), and an external value reached
+-- "PANIC: not enough reserved undo".  An UPDATE must now be rejected exactly
+-- like the equivalent INSERT.
+CREATE TABLE cmpk(k text PRIMARY KEY, body text) USING orioledb;
+INSERT INTO cmpk VALUES ('a', repeat('compressible ', 500));
+-- should error: the key does not fit, same as the INSERT below
+UPDATE cmpk SET k = body;
+ERROR:  index row size 6610 exceeds orioledb maximum 2688 for table "cmpk"
+-- should error for the same reason
+INSERT INTO cmpk VALUES (repeat('compressible ', 500), 'x');
+ERROR:  index row size 6514 exceeds orioledb maximum 2688 for table "cmpk"
+-- an incompressible value is rejected too, rather than panicking on undo
+CREATE TABLE cmpk2(k text PRIMARY KEY, body text) USING orioledb;
+INSERT INTO cmpk2 VALUES ('a', (SELECT string_agg(md5(g::text), '')
+                                  FROM generate_series(1, 400) g));
+UPDATE cmpk2 SET k = body;
+ERROR:  index row size 12861 exceeds orioledb maximum 2688 for table "cmpk2"
+-- a key that does fit still works
+CREATE TABLE cmpk3(k text PRIMARY KEY, body text) USING orioledb;
+INSERT INTO cmpk3 VALUES ('a', repeat('x', 2000));
+UPDATE cmpk3 SET k = body;
+SELECT length(k), k = body AS key_matches_body FROM cmpk3;
+ length | key_matches_body 
+--------+------------------
+   2000 | t
+(1 row)
+
+SELECT orioledb_tbl_check('cmpk3'::regclass, true);
+ orioledb_tbl_check 
+--------------------
+ t
+(1 row)
+
+DROP TABLE cmpk, cmpk2, cmpk3;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table o_test_2

--- a/test/sql/toast_column_compress.sql
+++ b/test/sql/toast_column_compress.sql
@@ -156,6 +156,33 @@ INSERT INTO cmdata VALUES(1, repeat('1234567890', 266));
 SELECT length(f1) FROM cmdata WHERE a = 1;
 DROP TABLE cmdata;
 
+-- case 5: a value moved into the primary key.  The key has to be a plain datum
+-- -- it is compared against keys already in the tree, and its length is what
+-- the O_BTREE_MAX_TUPLE_SIZE check measures.  A value arriving still
+-- compressed measured as its compressed length, so an over-long key sailed
+-- past that check and only expanded later: with asserts it tripped
+-- Assert(!VARATT_IS_COMPRESSED(...)), and an external value reached
+-- "PANIC: not enough reserved undo".  An UPDATE must now be rejected exactly
+-- like the equivalent INSERT.
+CREATE TABLE cmpk(k text PRIMARY KEY, body text) USING orioledb;
+INSERT INTO cmpk VALUES ('a', repeat('compressible ', 500));
+-- should error: the key does not fit, same as the INSERT below
+UPDATE cmpk SET k = body;
+-- should error for the same reason
+INSERT INTO cmpk VALUES (repeat('compressible ', 500), 'x');
+-- an incompressible value is rejected too, rather than panicking on undo
+CREATE TABLE cmpk2(k text PRIMARY KEY, body text) USING orioledb;
+INSERT INTO cmpk2 VALUES ('a', (SELECT string_agg(md5(g::text), '')
+                                  FROM generate_series(1, 400) g));
+UPDATE cmpk2 SET k = body;
+-- a key that does fit still works
+CREATE TABLE cmpk3(k text PRIMARY KEY, body text) USING orioledb;
+INSERT INTO cmpk3 VALUES ('a', repeat('x', 2000));
+UPDATE cmpk3 SET k = body;
+SELECT length(k), k = body AS key_matches_body FROM cmpk3;
+SELECT orioledb_tbl_check('cmpk3'::regclass, true);
+DROP TABLE cmpk, cmpk2, cmpk3;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA toast_column_compress CASCADE;
 RESET search_path;


### PR DESCRIPTION
Two ways to take a backend down, both found by a SQLSmith run (the fuzzing job itself is stacked on top of this branch).

## Missing `enable_rewind` guard

`orioledb_get_complete_xid()` and `orioledb_get_complete_oxid()` dereference `rewindMeta` unconditionally, but `rewind_init_shmem()` returns before assigning it when rewind is off — the default. Every other SQL-callable function in that file already raises *"orioledb rewind mode is turned off"*; these two now do the same.

They are executable by PUBLIC (`proacl` is null), so any user could reach them. On Linux this is a SIGSEGV; on macOS the backend wedges instead.

```
SELECT orioledb_get_complete_xid();   -- before: crash / hang
                                      -- after:  ERROR: orioledb rewind mode is turned off
```

I checked the other five SQL-callable functions in the file — they were already guarded.

## An over-long key slipping past the size check

A key attribute has to be a plain value: it is compared against keys already in the tree, and its length is what `O_BTREE_MAX_TUPLE_SIZE` is measured against. When a statement moves another column into the key the executor hands over whatever the source column held, typically a compressed datum:

```sql
CREATE TABLE t (k text PRIMARY KEY, body text) USING orioledb;
INSERT INTO t VALUES ('a', repeat('compressible ', 500));
UPDATE t SET k = body;
```

`expected_tuple_len()` measured the **compressed** length, so the tuple sailed past `o_btree_check_size_of_tuple()` and only expanded later, when the key was actually formed. The equivalent `INSERT` was rejected, so the two paths disagreed on identical data.

That single under-measurement produced three different symptoms:

| Input | Before | After |
|---|---|---|
| compressed value into the key | `Assert(!VARATT_IS_COMPRESSED(...))`, `slot.c:145` | `ERROR: index row size 6610 exceeds orioledb maximum 2688` |
| external value into the key | `PANIC: get_undo_record(): not enough reserved undo` | `ERROR: index row size 12861 exceeds ...` |
| same size via `INSERT` | `ERROR: index row size 6514 exceeds ...` | unchanged — now consistent |
| key that fits (2000 bytes) | works | works, `orioledb_tbl_check` passes |

In a production build the assert is compiled out, so that first row meant writing a key too long for the tree.

The fix expands the key attributes at the start of `tts_orioledb_toast()`, before any length is computed, so the existing check measures the real key.

### One trap worth flagging for review

Only compressed and external values are expanded. `VARATT_IS_EXTENDED()` is the obvious test and is **wrong** here — it is also true of a short-header varlena, and rewriting those into four-byte form changes the layout of every short key. My first attempt did exactly that and the isolation suite caught it: `fkeys` gained a spurious serialization conflict and `rll` returned 850 where it should return 1050.

I also first tried fixing this inside `tts_orioledb_make_key()`. That removed the crash but let the over-long key into the tree silently, which is worse; it is not what this PR does.

## Tests

`toast_column_compress` gains a case covering all three inputs above plus a key that legitimately fits.

- regress 49/49
- isolation 35/35
- pgindent clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)