### PR TITLE
ci: fuzz OrioleDB with SQLSmith

### DIFF
--- a/.github/workflows/sqlsmith.yml
+++ b/.github/workflows/sqlsmith.yml
@@ -1,0 +1,115 @@
+name: sqlsmith
+
+# Random-query fuzzing, looking for crashes.  Every run picks a fresh seed, so
+# each pull request and each commit on main explores query shapes no earlier
+# run reached: the coverage comes from the number of runs, and gating changes
+# on it is what keeps that number up.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      seconds:
+        description: 'Fuzzing budget per job, seconds'
+        required: false
+        default: '600'
+      seed:
+        description: 'RNG seed (blank = derive from the clock)'
+        required: false
+        default: ''
+      writers:
+        description: 'Concurrent writer sessions'
+        required: false
+        default: '4'
+
+concurrency:
+  group: sqlsmith-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sqlsmith:
+    # A fork syncing main should not spend four jobs on it; its own pull
+    # requests and manual dispatches still run.
+    if: github.event_name != 'push' || github.repository == 'orioledb/orioledb'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Assertions are the point of the exercise, so every cell is an
+          # assert-enabled build.  check_page additionally validates page
+          # structure on every access, which catches corruption a plain
+          # assert build walks straight past.
+          - { pg_version: 16, check_type: debug }
+          - { pg_version: 17, check_type: debug }
+          - { pg_version: 18, check_type: debug }
+          - { pg_version: 18, check_type: check_page }
+
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    env:
+      LLVM_VER: 18
+      CPU: amd64
+      COMPILER: gcc
+      CHECK_TYPE: ${{ matrix.check_type }}
+      PG_VERSION: ${{ matrix.pg_version }}
+      SQLSMITH_SECONDS: ${{ github.event.inputs.seconds || '600' }}
+      SQLSMITH_SEED: ${{ github.event.inputs.seed || '' }}
+      SQLSMITH_WRITERS: ${{ github.event.inputs.writers || '4' }}
+
+    steps:
+      - name: Checkout extension code into workspace directory
+        uses: actions/checkout@v6
+        with:
+          path: orioledb
+
+      - name: Get the required tag name
+        shell: bash
+        run: |
+          echo "PGTAG=$(grep '^${{ matrix.pg_version }}: ' orioledb/.pgtags | cut -d' ' -f2-)" >> $GITHUB_ENV
+
+      - name: Checkout PostgreSQL code into workspace directory
+        uses: actions/checkout@v6
+        with:
+          repository: orioledb/postgres
+          ref: ${{ env.PGTAG }}
+          path: postgresql
+
+      - name: Setup prerequisites
+        run: bash ./orioledb/ci/prerequisites.sh
+
+      - name: Install sqlsmith build dependencies
+        run: |
+          # autoconf-archive is not optional: without it the AX_BOOST_* and
+          # AX_CXX_COMPILE_STDCXX_* macros stay unexpanded and autoreconf
+          # emits a configure that fails with a misleading error.
+          sudo apt-get -o Dpkg::Options::="--force-confdef" \
+                       -o Dpkg::Options::="--force-confold" -y install -qq \
+            autoconf automake autoconf-archive libtool pkg-config \
+            libpqxx-dev libboost-dev libboost-regex-dev g++
+
+      - name: Build
+        run: bash ./orioledb/ci/build.sh
+
+      - name: Install post build prerequisites
+        run: bash ./orioledb/ci/post_build_prerequisites.sh
+
+      - name: Fuzz with sqlsmith
+        timeout-minutes: 45
+        run: bash ./orioledb/ci/sqlsmith.sh
+
+      - name: Show stuck processes
+        run: bash ./orioledb/ci/list_stuck.sh
+        if: ${{ always() }}
+
+      - name: Upload logs and generated queries
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: sqlsmith_${{ matrix.pg_version }}_${{ matrix.check_type }}_logs
+          path: |
+            ./sqlsmith_pg.log
+            ./sqlsmith_out.log
+            ./sqlsmith_err.log
+            ./sqlsmith_writer_*.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/ci/sqlsmith.sh
+++ b/ci/sqlsmith.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+
+# Fuzz OrioleDB with SQLSmith, looking for crashes.
+#
+# SQLSmith reads the catalog and generates random-but-type-correct queries, so
+# it explores planner/executor/storage combinations no hand-written test does.
+# On its own it only reads, though, and OrioleDB's crashes cluster in the
+# concurrent paths, so several writer sessions churn the same tables while the
+# fuzzer runs.
+#
+# A generated query raising an ERROR is normal and ignored.  We fail the job
+# only on evidence that the *server* broke: a PANIC or assertion, a backend
+# killed by a signal, a postmaster restart, a core dump, or a structural check
+# that no longer passes afterwards.
+#
+# Env (all optional outside CI):
+#   SQLSMITH_SECONDS   wall-clock budget for the fuzzer      (default 600)
+#   SQLSMITH_SEED      RNG seed; printed so a hit is replayable
+#   SQLSMITH_WRITERS   concurrent writer sessions            (default 4)
+#   SQLSMITH_MAX_QUERIES  hard cap on generated queries      (default 0 = none)
+
+set -eu
+
+WORKSPACE="${GITHUB_WORKSPACE:-$(cd "$(dirname "$0")/../.." && pwd)}"
+ORIOLEDB_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="$WORKSPACE/pgsql/bin:$PATH"
+
+SQLSMITH_SECONDS="${SQLSMITH_SECONDS:-600}"
+SQLSMITH_WRITERS="${SQLSMITH_WRITERS:-4}"
+SQLSMITH_MAX_QUERIES="${SQLSMITH_MAX_QUERIES:-0}"
+SQLSMITH_SEED="${SQLSMITH_SEED:-$(date +%s)}"
+
+PGDATA_DIR="$WORKSPACE/pgsql/sqlsmith_pgdata"
+PGLOG="$WORKSPACE/sqlsmith_pg.log"
+PGPORT_SS="${PGPORT_SS:-5678}"
+export PGPORT="$PGPORT_SS"
+export PGHOST=/tmp
+export PGDATABASE=postgres
+
+echo "=============================================="
+echo "SQLSmith seed:    $SQLSMITH_SEED"
+echo "Budget:           ${SQLSMITH_SECONDS}s, writers: $SQLSMITH_WRITERS"
+echo "Replay a hit with: SQLSMITH_SEED=$SQLSMITH_SEED bash ci/sqlsmith.sh"
+echo "=============================================="
+
+# Core dumps, matching the convention in check.sh.
+TIMESTAMP="${TIMESTAMP:-$(date +%s)}"
+CORE_DIR="/tmp/cores-sqlsmith-${GITHUB_SHA:-local}-$TIMESTAMP"
+ulimit -c unlimited -S || true
+mkdir -p "$CORE_DIR"
+sudo sh -c "echo \"$CORE_DIR/%t_%p.core\" > /proc/sys/kernel/core_pattern" || \
+	echo "warning: cannot set core_pattern; core dumps may be lost"
+
+# ---------------------------------------------------------------- build sqlsmith
+if ! command -v sqlsmith >/dev/null 2>&1 && [ ! -x "$WORKSPACE/sqlsmith/sqlsmith" ]; then
+	echo "===== building sqlsmith"
+	rm -rf "$WORKSPACE/sqlsmith"
+	git clone --depth 1 https://github.com/anse1/sqlsmith.git "$WORKSPACE/sqlsmith"
+	cd "$WORKSPACE/sqlsmith"
+	autoreconf -i
+	./configure
+	make -j "$(nproc)"
+	cd "$WORKSPACE"
+fi
+SQLSMITH_BIN="$WORKSPACE/sqlsmith/sqlsmith"
+[ -x "$SQLSMITH_BIN" ] || SQLSMITH_BIN="$(command -v sqlsmith)"
+echo "sqlsmith: $SQLSMITH_BIN"
+
+# ---------------------------------------------------------------- start server
+echo "===== starting cluster"
+rm -rf "$PGDATA_DIR"
+initdb -N --encoding=UTF-8 --locale=C -D "$PGDATA_DIR" >/dev/null
+
+cat >> "$PGDATA_DIR/postgresql.conf" <<EOF
+port = $PGPORT_SS
+listen_addresses = ''
+unix_socket_directories = '/tmp'
+shared_preload_libraries = 'orioledb'
+orioledb.serializable = 'error'
+max_connections = 100
+# A single pathological generated query must not eat the whole budget.  This
+# can in principle mask a hang, so a job that finds nothing is not proof that
+# no query hangs -- the stuck-process step below is what covers that.
+statement_timeout = '30s'
+idle_in_transaction_session_timeout = '60s'
+# Keep the log parseable and complete; the crash detector reads it.
+log_min_messages = warning
+log_line_prefix = '%m [%p] '
+restart_after_crash = off
+# The writer takes checkpoints of its own, so the churn still sees them; this
+# only keeps a timed one from landing inside the structural check at the end,
+# where it would look like corruption.
+checkpoint_timeout = '1h'
+max_wal_size = '8GB'
+EOF
+
+pg_ctl -D "$PGDATA_DIR" -l "$PGLOG" -w start
+
+cleanup() {
+	pg_ctl -D "$PGDATA_DIR" -w -m immediate stop >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "===== loading schema"
+psql -v ON_ERROR_STOP=1 -q -f "$ORIOLEDB_DIR/ci/sqlsmith_schema.sql"
+
+# SQLSmith calls every function it finds in the catalog with random arguments,
+# including OrioleDB's own introspection and debug functions.  Those are a
+# different (and much shallower) target than the storage engine: the very first
+# run wedged on orioledb_get_complete_xid(), which dereferences rewindMeta with
+# no enable_rewind guard, and one such function is enough to end every run
+# before it reaches the tree code.
+#
+# So by default the fuzzer connects as an unprivileged role that cannot execute
+# them.  Set SQLSMITH_FUZZ_ORIOLEDB_FUNCS=1 to aim at the debug API instead.
+FUZZ_USER=sqlsmith_fuzz
+psql -v ON_ERROR_STOP=1 -q <<EOF
+DROP ROLE IF EXISTS $FUZZ_USER;
+CREATE ROLE $FUZZ_USER LOGIN;
+GRANT USAGE ON SCHEMA public TO $FUZZ_USER;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO $FUZZ_USER;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $FUZZ_USER;
+EOF
+
+if [ "${SQLSMITH_FUZZ_ORIOLEDB_FUNCS:-0}" != "1" ]; then
+	psql -v ON_ERROR_STOP=1 -q <<EOF
+DO \$\$
+DECLARE f record;
+BEGIN
+	FOR f IN SELECT p.oid::regprocedure AS sig
+	           FROM pg_proc p
+	           JOIN pg_depend d ON d.objid = p.oid AND d.deptype = 'e'
+	           JOIN pg_extension e ON e.oid = d.refobjid AND e.extname = 'orioledb'
+	LOOP
+		EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, $FUZZ_USER', f.sig);
+	END LOOP;
+END \$\$;
+EOF
+	echo "orioledb's own functions are excluded from the fuzz surface"
+else
+	echo "orioledb's own functions are INCLUDED in the fuzz surface"
+fi
+
+# ---------------------------------------------------------------- writers
+echo "===== starting $SQLSMITH_WRITERS writer sessions"
+WRITER_PIDS=()
+WRITER_STOP="/tmp/sqlsmith_writers_stop.$$"
+rm -f "$WRITER_STOP"
+for i in $(seq 1 "$SQLSMITH_WRITERS"); do
+	(
+		while [ ! -f "$WRITER_STOP" ]; do
+			# Errors here are expected: writers race each other into
+			# deadlocks and unique violations by design.
+			psql -q -f "$ORIOLEDB_DIR/ci/sqlsmith_writer.sql" \
+				>> "$WORKSPACE/sqlsmith_writer_$i.log" 2>&1 || true
+		done
+	) &
+	WRITER_PIDS+=($!)
+done
+
+# ---------------------------------------------------------------- fuzz
+echo "===== running sqlsmith for ${SQLSMITH_SECONDS}s"
+SQLSMITH_ARGS=(
+	"--target=host=/tmp port=$PGPORT_SS dbname=postgres user=$FUZZ_USER"
+	"--seed=$SQLSMITH_SEED"
+	"--exclude-catalog"
+	"--verbose"
+)
+if [ "$SQLSMITH_MAX_QUERIES" -gt 0 ]; then
+	SQLSMITH_ARGS+=("--max-queries=$SQLSMITH_MAX_QUERIES")
+fi
+
+smith_status=0
+timeout --preserve-status "$SQLSMITH_SECONDS" \
+	"$SQLSMITH_BIN" "${SQLSMITH_ARGS[@]}" \
+	> "$WORKSPACE/sqlsmith_out.log" 2> "$WORKSPACE/sqlsmith_err.log" || smith_status=$?
+echo "sqlsmith exited with $smith_status (124/143 = budget reached, expected)"
+tail -n 5 "$WORKSPACE/sqlsmith_err.log" || true
+
+touch "$WRITER_STOP"
+for pid in "${WRITER_PIDS[@]}"; do
+	wait "$pid" 2>/dev/null || true
+done
+rm -f "$WRITER_STOP"
+
+# ---------------------------------------------------------------- verdict
+status=0
+
+echo "===== checking for server-side failures"
+
+# A backend death takes the whole cluster down (restart_after_crash = off), so
+# any of these lines means we found something.
+if grep -nE 'PANIC|TRAP:|terminated by signal|was terminated by|Segmentation fault|assertion failed|FailedAssertion' "$PGLOG"; then
+	echo "!!!!! server crash or assertion in $PGLOG"
+	status=1
+fi
+
+# Belt and braces: even without a matching line, a second "ready to accept
+# connections" means the postmaster restarted underneath us.
+ready_count=$(grep -c 'database system is ready to accept connections' "$PGLOG" || true)
+if [ "${ready_count:-0}" -gt 1 ]; then
+	echo "!!!!! postmaster restarted $((ready_count - 1)) time(s)"
+	status=1
+fi
+
+if ! psql -q -c 'SELECT 1' >/dev/null 2>&1; then
+	echo "!!!!! server is not accepting connections after the run"
+	status=1
+fi
+
+# Structural verification: a fuzz run that corrupts a tree without crashing is
+# the worst outcome, and these functions are exactly the check for it.
+#
+# Listing the tables and checking them are two separate queries on purpose.  As
+# one query the planner is free to order the WHERE clauses as it likes, and it
+# puts the function first -- it then runs on every row of pg_class, including
+# sequences and catalogs, and dies with "is not a orioledb table" before the
+# relkind and relam tests ever get a say.
+#
+# The second argument makes orioledb_tbl_check() compare the tree against the
+# on-disk map, which only holds after a checkpoint has written the dirty pages
+# out -- hence the CHECKPOINT first.  The writers and the fuzzer have already
+# stopped by this point, and checkpoint_timeout is long enough that no timed
+# checkpoint lands in the middle of the verdict.
+if [ "$status" -eq 0 ]; then
+	echo "===== verifying tree structure"
+	psql -q -c 'CHECKPOINT' || true
+	tables=$(psql -tAq -c "
+		SELECT c.oid::regclass::text
+		  FROM pg_class c
+		  JOIN pg_am am ON am.oid = c.relam
+		 WHERE am.amname = 'orioledb'
+		   AND c.relkind = 'r'
+		 ORDER BY 1")
+	bad=""
+	while IFS= read -r tbl; do
+		[ -n "$tbl" ] || continue
+		# Keep stderr out of the captured value: orioledb_tbl_check reports
+		# what it found through WARNINGs, and those belong in the job log
+		# rather than in the string we compare against.
+		verdict=$(psql -tAq -c \
+			"SELECT orioledb_tbl_check('$tbl'::regclass, true)" \
+			2> "$WORKSPACE/tbl_check_err.log") || verdict="query failed"
+		if [ "$verdict" != "t" ]; then
+			echo "!!!!! orioledb_tbl_check($tbl) returned '$verdict'"
+			cat "$WORKSPACE/tbl_check_err.log"
+			bad="$bad $tbl"
+		fi
+	done <<< "$tables"
+	if [ -n "$bad" ]; then
+		echo "!!!!! orioledb_tbl_check failed for:$bad"
+		status=1
+	fi
+fi
+
+# Core dumps.
+cores=$(find "$CORE_DIR" -name '*.core' 2>/dev/null || true)
+if [ -n "$cores" ]; then
+	for corefile in $cores; do
+		echo "===== backtrace for $corefile"
+		gdb --batch --quiet -x "$ORIOLEDB_DIR/ci/cmds.gdb" \
+			"$WORKSPACE/pgsql/bin/postgres" "$corefile" || true
+		status=1
+	done
+fi
+
+if [ "$status" -ne 0 ]; then
+	echo "===== last 200 lines of $PGLOG"
+	tail -n 200 "$PGLOG"
+	echo
+	echo "Reproduce with: SQLSMITH_SEED=$SQLSMITH_SEED bash ci/sqlsmith.sh"
+	echo "The queries leading up to the failure are in sqlsmith_out.log."
+else
+	queries=$(grep -c '^' "$WORKSPACE/sqlsmith_out.log" 2>/dev/null || echo 0)
+	echo "no crashes; sqlsmith produced ~$queries output lines"
+fi
+
+exit $status

--- a/ci/sqlsmith_schema.sql
+++ b/ci/sqlsmith_schema.sql
@@ -1,0 +1,134 @@
+-- Schema for the SQLSmith fuzzing job.
+--
+-- SQLSmith builds its grammar from the catalog, so whatever is not here is
+-- never generated.  The goal is to reach as many OrioleDB code paths as
+-- possible: every primary-key shape it supports (int, composite, text, and
+-- none at all), TOASTed values, the bridge index machinery, partitioning and
+-- the type combinations that show up in real schemas.
+
+CREATE EXTENSION IF NOT EXISTS orioledb;
+
+SET default_table_access_method = orioledb;
+
+CREATE TYPE ss_mood AS ENUM ('sad', 'ok', 'happy');
+CREATE DOMAIN ss_positive AS int CHECK (VALUE > 0);
+
+-- 1. Plain int primary key, the most common shape.
+CREATE TABLE ss_int_pk (
+	id       int PRIMARY KEY,
+	sk       int NOT NULL,
+	val      text,
+	amount   numeric(12, 2),
+	flag     bool,
+	ts       timestamptz,
+	mood     ss_mood
+);
+CREATE INDEX ss_int_pk_sk ON ss_int_pk (sk);
+CREATE INDEX ss_int_pk_partial ON ss_int_pk (amount) WHERE flag;
+CREATE INDEX ss_int_pk_expr ON ss_int_pk (lower(val));
+
+-- 2. Composite primary key: exercises multi-column key comparison, which is
+--    where several past bitmap-scan bugs lived.
+CREATE TABLE ss_composite_pk (
+	a        int NOT NULL,
+	b        text NOT NULL,
+	c        bigint,
+	payload  jsonb,
+	PRIMARY KEY (a, b)
+);
+CREATE UNIQUE INDEX ss_composite_uniq ON ss_composite_pk (c) WHERE c IS NOT NULL;
+
+-- 3. No primary key at all -- OrioleDB synthesises a ctid-based one.
+CREATE TABLE ss_no_pk (
+	x        int,
+	y        text,
+	arr      int[],
+	ts       timestamp
+);
+CREATE INDEX ss_no_pk_x ON ss_no_pk (x);
+
+-- 4. Text primary key plus deliberately TOASTable values.
+CREATE TABLE ss_toast (
+	k        text PRIMARY KEY,
+	body     text,
+	blob     bytea,
+	tags     text[]
+);
+
+-- 5. Bridge-index table: GIN and GiST are not native to OrioleDB, so these go
+--    through the bridge, a code path worth as much fuzzing as we can give it.
+CREATE TABLE ss_bridged (
+	id       bigserial PRIMARY KEY,
+	doc      jsonb,
+	txt      tsvector,
+	rng      int4range
+);
+CREATE INDEX ss_bridged_gin  ON ss_bridged USING gin (doc);
+CREATE INDEX ss_bridged_gist ON ss_bridged USING gist (rng);
+CREATE INDEX ss_bridged_txt  ON ss_bridged USING gin (txt);
+
+-- 6. Partitioned table with OrioleDB partitions.
+CREATE TABLE ss_part (
+	id       int NOT NULL,
+	part_key int NOT NULL,
+	val      text,
+	PRIMARY KEY (id, part_key)
+) PARTITION BY RANGE (part_key);
+CREATE TABLE ss_part_0 PARTITION OF ss_part FOR VALUES FROM (0) TO (100);
+CREATE TABLE ss_part_1 PARTITION OF ss_part FOR VALUES FROM (100) TO (200);
+CREATE TABLE ss_part_2 PARTITION OF ss_part FOR VALUES FROM (200) TO (1000);
+
+-- 7. Generated column, check constraint, and a self-referencing foreign key.
+CREATE TABLE ss_constrained (
+	id       int PRIMARY KEY,
+	base     ss_positive NOT NULL,
+	doubled  int GENERATED ALWAYS AS (base * 2) STORED,
+	parent   int REFERENCES ss_constrained (id),
+	CONSTRAINT ss_base_bound CHECK (base < 1000000)
+);
+
+-- A view and a set-returning function give SQLSmith more to compose with.
+CREATE VIEW ss_view AS
+	SELECT i.id, i.sk, i.val, c.a, c.payload
+	  FROM ss_int_pk i LEFT JOIN ss_composite_pk c ON i.sk = c.a;
+
+CREATE FUNCTION ss_rows(n int)
+RETURNS TABLE (id int, val text) LANGUAGE sql STABLE AS $$
+	SELECT g, 'row' || g FROM generate_series(1, n) g
+$$;
+
+-- Seed data.  Enough rows to build multi-level trees, and long values so the
+-- TOAST paths are populated rather than merely reachable.
+INSERT INTO ss_int_pk
+	SELECT g, g % 97, 'value ' || g, (g % 1000)::numeric / 7, g % 3 = 0,
+	       now() - (g || ' minutes')::interval,
+	       (ARRAY['sad', 'ok', 'happy'])[1 + g % 3]::ss_mood
+	  FROM generate_series(1, 20000) g;
+
+INSERT INTO ss_composite_pk
+	SELECT g % 500, 'key' || g, g * 3, jsonb_build_object('g', g, 'mod', g % 13)
+	  FROM generate_series(1, 10000) g;
+
+INSERT INTO ss_no_pk
+	SELECT g, 'n' || g, ARRAY[g, g + 1, g + 2], now() - (g || ' hours')::interval
+	  FROM generate_series(1, 10000) g;
+
+INSERT INTO ss_toast
+	SELECT 'k' || g, repeat('toasted body ' || g || ' ', 400),
+	       decode(md5(g::text), 'hex'), ARRAY['t' || g, 't' || (g % 17)]
+	  FROM generate_series(1, 2000) g;
+
+INSERT INTO ss_bridged (doc, txt, rng)
+	SELECT jsonb_build_object('id', g, 'name', 'n' || g, 'tags', ARRAY[g % 7, g % 11]),
+	       to_tsvector('simple', 'document number ' || g || ' body text'),
+	       int4range(g, g + 10)
+	  FROM generate_series(1, 10000) g;
+
+INSERT INTO ss_part
+	SELECT g, g % 1000, 'p' || g FROM generate_series(1, 10000) g;
+
+INSERT INTO ss_constrained (id, base, parent)
+	SELECT g, 1 + g % 5000, CASE WHEN g > 1 THEN 1 + (g - 1) % 100 END
+	  FROM generate_series(1, 5000) g;
+
+ANALYZE;

--- a/ci/sqlsmith_writer.sql
+++ b/ci/sqlsmith_writer.sql
@@ -1,0 +1,77 @@
+-- One round of concurrent write traffic for the SQLSmith job.
+--
+-- SQLSmith itself generates essentially only SELECTs, so on its own it walks a
+-- frozen tree.  OrioleDB's crashes cluster in the concurrent paths -- undo
+-- chains, page splits and merges, checkpoints, the bridge index -- so the
+-- fuzzer needs someone mutating the data underneath it.  This file is run in a
+-- loop by several psql sessions in parallel.
+--
+-- Deliberately no DDL: dropped or recreated objects would make SQLSmith emit a
+-- flood of "relation does not exist" errors and drown the signal.
+
+-- NB: `\set r random(1, 1000000)` is pgbench syntax, not psql's.  psql would
+-- substitute the text verbatim, and since PG17 has a two-argument random(),
+-- every occurrence of :r would then be re-evaluated to a *different* value --
+-- which, among other things, produced int4range() bounds in the wrong order.
+-- \gset evaluates once and binds literals.
+SELECT (random() * 999999)::int + 1 AS r,
+       (random() * 19999)::int + 1 AS k,
+       (random() * 999)::int        AS p \gset
+
+BEGIN;
+INSERT INTO ss_int_pk (id, sk, val, amount, flag, ts, mood)
+	VALUES (:r, :r % 97, 'w' || :r, (:r % 1000)::numeric / 3, :r % 2 = 0,
+	        now(), (ARRAY['sad', 'ok', 'happy'])[1 + :r % 3]::ss_mood)
+	ON CONFLICT (id) DO UPDATE
+		SET val = ss_int_pk.val || ',' || :r, amount = EXCLUDED.amount;
+
+UPDATE ss_int_pk SET sk = sk + 1, ts = now() WHERE id = :k;
+DELETE FROM ss_int_pk WHERE id = :r AND :r % 7 = 0;
+COMMIT;
+
+BEGIN;
+INSERT INTO ss_composite_pk (a, b, c, payload)
+	VALUES (:r % 500, 'key' || :r, :r, jsonb_build_object('w', :r))
+	ON CONFLICT (a, b) DO UPDATE SET c = EXCLUDED.c;
+
+SAVEPOINT sp;
+UPDATE ss_composite_pk SET c = c + 1 WHERE a = :r % 500;
+ROLLBACK TO SAVEPOINT sp;
+
+UPDATE ss_no_pk SET y = 'u' || :r WHERE x = :k % 10000;
+INSERT INTO ss_no_pk (x, y, arr, ts) VALUES (:r, 'i' || :r, ARRAY[:r], now());
+COMMIT;
+
+-- TOAST churn: rewriting long values exercises the toast tree and its undo.
+BEGIN;
+INSERT INTO ss_toast (k, body, blob, tags)
+	VALUES ('k' || :r, repeat('body ' || :r || ' ', 300),
+	        decode(md5(:r::text), 'hex'), ARRAY['t' || :r])
+	ON CONFLICT (k) DO UPDATE SET body = repeat('upd ' || :r || ' ', 350);
+DELETE FROM ss_toast WHERE k = 'k' || (:r % 2000) AND :r % 5 = 0;
+COMMIT;
+
+-- Bridge-index churn.
+BEGIN;
+INSERT INTO ss_bridged (doc, txt, rng)
+	VALUES (jsonb_build_object('id', :r, 'tags', ARRAY[:r % 7]),
+	        to_tsvector('simple', 'doc ' || :r), int4range(:r % 1000, :r % 1000 + 5));
+UPDATE ss_bridged SET doc = doc || jsonb_build_object('upd', :r)
+	WHERE id = (:k % 10000) + 1;
+DELETE FROM ss_bridged WHERE id = (:r % 10000) + 1 AND :r % 11 = 0;
+COMMIT;
+
+BEGIN;
+INSERT INTO ss_part (id, part_key, val) VALUES (:r, :p, 'w' || :r)
+	ON CONFLICT (id, part_key) DO UPDATE SET val = EXCLUDED.val;
+UPDATE ss_part SET val = val || '!' WHERE id = :k AND part_key = :p;
+COMMIT;
+
+-- Occasionally push the storage layer: vacuum reclaims undo, checkpoint walks
+-- the dirty pages.  Both are frequent participants in past crash reports.
+SELECT CASE WHEN :r % 40 = 0 THEN 1 ELSE 0 END AS do_maintenance \gset
+\if :do_maintenance
+	VACUUM ANALYZE ss_int_pk;
+	VACUUM ss_toast;
+	CHECKPOINT;
+\endif

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -1708,20 +1708,28 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 		slot->tts_tid = *((ItemPointerData *) DatumGetPointer(oldPkey->keys[0].value));
 	}
 
-	if (bridge_ctid)
-	{
-		OTableSlot *oslot = (OTableSlot *) slot;
-
-		oslot->bridge_ctid = *bridge_ctid;
-	}
-
 	if (descr->bridge)
 	{
+		OTableSlot *oslot = (OTableSlot *) slot;
 		List	   *indexIds;
 		ListCell   *indexId;
 		int			attnum;
 		TupleTableSlot *newSlot;
 		Bitmapset  *changed_attrs = NULL;
+
+		/*
+		 * The row keeps whatever bridge ctid it already has unless the loop
+		 * below finds that a bridged index column changed.  bridgeChanged
+		 * means "this row was given a new ctid", so it has to start out
+		 * false: one slot is reused for every row of the statement, and a
+		 * leftover true makes the next row's rowid claim a ctid it never got
+		 * handed.  Its entries -- unchanged, and already in every bridged
+		 * index under that same ctid -- then get inserted a second time,
+		 * which is a duplicate tid in a GIN posting list.
+		 */
+		if (bridge_ctid)
+			oslot->bridge_ctid = *bridge_ctid;
+		oslot->bridgeChanged = false;
 
 		was_saving = o_start_saving_inval_messages();
 		/* not using simple reindex_relation here anymore, */

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -1080,6 +1080,86 @@ o_check_exclusion_constraint(OTableDescr *descr, OIndexDescr *index, TupleTableS
 	return true;
 }
 
+/*
+ * The arbiter indexes that go through the bridge, as an oid list.
+ *
+ * ON CONFLICT resolves conflicts on OrioleDB's own indexes by inserting into
+ * them directly, so by the time we ask ExecCheckIndexConstraints() about the
+ * bridged ones our row is already in those trees -- and handing it the whole
+ * arbiter list makes it walk them too and report a conflict with the row we
+ * just inserted ourselves.  Only the bridged arbiters are its business.
+ *
+ * The selection mirrors the one ExecCheckIndexConstraints() makes internally,
+ * down to the partial-index predicate: it raises "unexpected failure to find
+ * arbiter index" if it is handed a non-empty list and then skips every entry
+ * in it.  An empty result here means there is nothing for it to check, and the
+ * call is skipped altogether.
+ */
+static List *
+bridged_arbiter_indexes(ResultRelInfo *resultRelInfo, List *arbiterIndexes,
+						TupleTableSlot *slot, EState *estate)
+{
+	List	   *result = NIL;
+	int			i;
+
+	for (i = 0; i < resultRelInfo->ri_NumIndices; i++)
+	{
+		Relation	indexRel = resultRelInfo->ri_IndexRelationDescs[i];
+		IndexInfo  *indexInfo = resultRelInfo->ri_IndexRelationInfo[i];
+		OBTOptions *options;
+
+		if (indexRel == NULL || indexInfo == NULL)
+			continue;
+
+		if (arbiterIndexes != NIL &&
+			!list_member_oid(arbiterIndexes, RelationGetRelid(indexRel)))
+			continue;
+
+		options = (OBTOptions *) indexRel->rd_options;
+		if (indexRel->rd_rel->relam == BTREE_AM_OID &&
+			!(options && !options->orioledb_index))
+			continue;
+
+		if (!indexInfo->ii_ReadyForInserts ||
+			(!indexInfo->ii_Unique && indexInfo->ii_ExclusionOps == NULL))
+			continue;
+
+		/*
+		 * Same refusal the loop over OrioleDB's own indexes makes: a named
+		 * arbiter that is deferred cannot arbitrate anything.
+		 */
+		if (!indexRel->rd_index->indimmediate)
+		{
+			if (arbiterIndexes != NIL)
+				ereport(ERROR,
+						(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+						 errmsg("ON CONFLICT does not support deferrable unique constraints/exclusion constraints as arbiters"),
+						 errtableconstraint(resultRelInfo->ri_RelationDesc,
+											RelationGetRelationName(indexRel))));
+			continue;
+		}
+
+		if (indexInfo->ii_Predicate != NIL)
+		{
+			ExprState  *predicate = indexInfo->ii_PredicateState;
+			ExprContext *econtext = GetPerTupleExprContext(estate);
+
+			if (predicate == NULL)
+			{
+				predicate = ExecPrepareQual(indexInfo->ii_Predicate, estate);
+				indexInfo->ii_PredicateState = predicate;
+			}
+			econtext->ecxt_scantuple = slot;
+			if (!ExecQual(predicate, econtext))
+				continue;
+		}
+
+		result = lappend_oid(result, RelationGetRelid(indexRel));
+	}
+
+	return result;
+}
+
 TupleTableSlot *
 o_tbl_insert_with_arbiter(Relation rel,
 						  OTableDescr *descr,
@@ -1098,6 +1178,12 @@ o_tbl_insert_with_arbiter(Relation rel,
 	CommitSeqNo csn;
 	OXid		oxid;
 	Datum		conflictRowid = PointerGetDatum((void *) 0xB0B);
+	List	   *bridgeArbiterIndexes = NIL;
+
+	if (descr->bridge)
+		bridgeArbiterIndexes = bridged_arbiter_indexes(resultRelInfo,
+													   arbiterIndexes,
+													   slot, estate);
 
 	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
 	csn = oSnapshot.csn;
@@ -1186,13 +1272,16 @@ o_tbl_insert_with_arbiter(Relation rel,
 				invalidItemPtrDatum = ItemPointerGetDatum(&invalidItemPtr);
 			}
 
-			if (!ExecCheckIndexConstraints(resultRelInfo, slot, estate,
+			if (bridgeArbiterIndexes != NIL &&
+				!ExecCheckIndexConstraints(resultRelInfo, slot, estate,
 										   conflictRowidPtrDatum,
-										   invalidItemPtrDatum, arbiterIndexes))
+										   invalidItemPtrDatum,
+										   bridgeArbiterIndexes))
 #else
-			if (!ExecCheckIndexConstraints(resultRelInfo, slot, estate,
+			if (bridgeArbiterIndexes != NIL &&
+				!ExecCheckIndexConstraints(resultRelInfo, slot, estate,
 										   conflictRowidPtrDatum,
-										   arbiterIndexes))
+										   bridgeArbiterIndexes))
 #endif
 			{
 				if (lockedSlot)

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -5111,9 +5111,44 @@ SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[20] ORDER BY id;
 (1 row)
 
 RESET enable_seqscan;
+-- One statement, some rows changing a bridged index column and some not.  The
+-- slot is reused for every row, and the flag saying "this row got a new bridge
+-- ctid" used to survive into the next one -- so a row that kept its ctid was
+-- inserted into the bridged index a second time under it.  GIN's build
+-- accumulator asserts on a repeated tid, so on an assert build the UPDATE
+-- below took the server down at the next pending-list cleanup.
+CREATE TABLE o_bridge_mixed (
+	id int NOT NULL PRIMARY KEY,
+	tags int[],
+	other int
+) USING orioledb;
+CREATE INDEX ON o_bridge_mixed USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_mixed'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+INSERT INTO o_bridge_mixed
+	SELECT i, ARRAY[i], i FROM generate_series(1, 4) i;
+UPDATE o_bridge_mixed
+   SET tags = CASE WHEN id % 2 = 1 THEN tags || 99 ELSE tags END
+ WHERE other > 0;
+VACUUM o_bridge_mixed;
+SET enable_seqscan = off;
+SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[99] ORDER BY id;
+ id 
+----
+  1
+  3
+(2 rows)
+
+SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[2] ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 38 other objects
+NOTICE:  drop cascades to 39 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -5152,6 +5187,7 @@ drop cascades to table o_bridge_sec_spgist
 drop cascades to table o_bridge_sec_gin
 drop cascades to table o_bridge_sec_btree
 drop cascades to table o_bridge_ioc
+drop cascades to table o_bridge_mixed
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -5062,9 +5062,58 @@ SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
 (1 row)
 
 RESET enable_seqscan;
+-- ON CONFLICT on a table with a bridged index.  OrioleDB resolves conflicts on
+-- its own indexes by inserting into them, so by the time the bridged arbiters
+-- are checked the row is already in those trees: checking all the arbiters
+-- there used to find our own row and call it a conflict.  DO NOTHING then left
+-- the row in the table but out of every bridged index, and DO UPDATE failed
+-- with "unexpected self-updated tuple".
+CREATE TABLE o_bridge_ioc (
+	id int NOT NULL PRIMARY KEY,
+	tags int[]
+) USING orioledb;
+CREATE INDEX ON o_bridge_ioc USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_ioc'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+INSERT INTO o_bridge_ioc VALUES (1, ARRAY[10]) ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (2, ARRAY[10])
+	ON CONFLICT (id) DO UPDATE SET tags = EXCLUDED.tags;
+INSERT INTO o_bridge_ioc VALUES (3, ARRAY[10]);
+-- and again, now that the keys really do conflict
+INSERT INTO o_bridge_ioc VALUES (1, ARRAY[99]) ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (2, ARRAY[20])
+	ON CONFLICT (id) DO UPDATE SET tags = EXCLUDED.tags;
+-- without a conflict target, so the arbiter list arrives empty
+INSERT INTO o_bridge_ioc VALUES (4, ARRAY[10]) ON CONFLICT DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (4, ARRAY[77]) ON CONFLICT DO NOTHING;
+SELECT id, tags FROM o_bridge_ioc ORDER BY id;
+ id | tags 
+----+------
+  1 | {10}
+  2 | {20}
+  3 | {10}
+  4 | {10}
+(4 rows)
+
+SET enable_seqscan = off;
+SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[10] ORDER BY id;
+ id 
+----
+  1
+  3
+  4
+(3 rows)
+
+SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[20] ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 37 other objects
+NOTICE:  drop cascades to 38 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -5102,6 +5151,7 @@ drop cascades to table o_bridge_sec_gist
 drop cascades to table o_bridge_sec_spgist
 drop cascades to table o_bridge_sec_gin
 drop cascades to table o_bridge_sec_btree
+drop cascades to table o_bridge_ioc
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -5188,9 +5188,44 @@ SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[20] ORDER BY id;
 (1 row)
 
 RESET enable_seqscan;
+-- One statement, some rows changing a bridged index column and some not.  The
+-- slot is reused for every row, and the flag saying "this row got a new bridge
+-- ctid" used to survive into the next one -- so a row that kept its ctid was
+-- inserted into the bridged index a second time under it.  GIN's build
+-- accumulator asserts on a repeated tid, so on an assert build the UPDATE
+-- below took the server down at the next pending-list cleanup.
+CREATE TABLE o_bridge_mixed (
+	id int NOT NULL PRIMARY KEY,
+	tags int[],
+	other int
+) USING orioledb;
+CREATE INDEX ON o_bridge_mixed USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_mixed'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+INSERT INTO o_bridge_mixed
+	SELECT i, ARRAY[i], i FROM generate_series(1, 4) i;
+UPDATE o_bridge_mixed
+   SET tags = CASE WHEN id % 2 = 1 THEN tags || 99 ELSE tags END
+ WHERE other > 0;
+VACUUM o_bridge_mixed;
+SET enable_seqscan = off;
+SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[99] ORDER BY id;
+ id 
+----
+  1
+  3
+(2 rows)
+
+SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[2] ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 38 other objects
+NOTICE:  drop cascades to 39 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -5229,6 +5264,7 @@ drop cascades to table o_bridge_sec_spgist
 drop cascades to table o_bridge_sec_gin
 drop cascades to table o_bridge_sec_btree
 drop cascades to table o_bridge_ioc
+drop cascades to table o_bridge_mixed
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -5139,9 +5139,58 @@ SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
 (1 row)
 
 RESET enable_seqscan;
+-- ON CONFLICT on a table with a bridged index.  OrioleDB resolves conflicts on
+-- its own indexes by inserting into them, so by the time the bridged arbiters
+-- are checked the row is already in those trees: checking all the arbiters
+-- there used to find our own row and call it a conflict.  DO NOTHING then left
+-- the row in the table but out of every bridged index, and DO UPDATE failed
+-- with "unexpected self-updated tuple".
+CREATE TABLE o_bridge_ioc (
+	id int NOT NULL PRIMARY KEY,
+	tags int[]
+) USING orioledb;
+CREATE INDEX ON o_bridge_ioc USING gin(tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_ioc'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+INSERT INTO o_bridge_ioc VALUES (1, ARRAY[10]) ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (2, ARRAY[10])
+	ON CONFLICT (id) DO UPDATE SET tags = EXCLUDED.tags;
+INSERT INTO o_bridge_ioc VALUES (3, ARRAY[10]);
+-- and again, now that the keys really do conflict
+INSERT INTO o_bridge_ioc VALUES (1, ARRAY[99]) ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (2, ARRAY[20])
+	ON CONFLICT (id) DO UPDATE SET tags = EXCLUDED.tags;
+-- without a conflict target, so the arbiter list arrives empty
+INSERT INTO o_bridge_ioc VALUES (4, ARRAY[10]) ON CONFLICT DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (4, ARRAY[77]) ON CONFLICT DO NOTHING;
+SELECT id, tags FROM o_bridge_ioc ORDER BY id;
+ id | tags 
+----+------
+  1 | {10}
+  2 | {20}
+  3 | {10}
+  4 | {10}
+(4 rows)
+
+SET enable_seqscan = off;
+SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[10] ORDER BY id;
+ id 
+----
+  1
+  3
+  4
+(3 rows)
+
+SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[20] ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 37 other objects
+NOTICE:  drop cascades to 38 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -5179,6 +5228,7 @@ drop cascades to table o_bridge_sec_gist
 drop cascades to table o_bridge_sec_spgist
 drop cascades to table o_bridge_sec_gin
 drop cascades to table o_bridge_sec_btree
+drop cascades to table o_bridge_ioc
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -1267,6 +1267,31 @@ SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[10] ORDER BY id;
 SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[20] ORDER BY id;
 RESET enable_seqscan;
 
+-- One statement, some rows changing a bridged index column and some not.  The
+-- slot is reused for every row, and the flag saying "this row got a new bridge
+-- ctid" used to survive into the next one -- so a row that kept its ctid was
+-- inserted into the bridged index a second time under it.  GIN's build
+-- accumulator asserts on a repeated tid, so on an assert build the UPDATE
+-- below took the server down at the next pending-list cleanup.
+CREATE TABLE o_bridge_mixed (
+	id int NOT NULL PRIMARY KEY,
+	tags int[],
+	other int
+) USING orioledb;
+CREATE INDEX ON o_bridge_mixed USING gin(tags);
+INSERT INTO o_bridge_mixed
+	SELECT i, ARRAY[i], i FROM generate_series(1, 4) i;
+
+UPDATE o_bridge_mixed
+   SET tags = CASE WHEN id % 2 = 1 THEN tags || 99 ELSE tags END
+ WHERE other > 0;
+VACUUM o_bridge_mixed;
+
+SET enable_seqscan = off;
+SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[99] ORDER BY id;
+SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[2] ORDER BY id;
+RESET enable_seqscan;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -1235,6 +1235,38 @@ UPDATE o_bridge_sec_btree SET ival = ival + 1000
 SELECT count(*) FROM o_bridge_sec_btree WHERE ival BETWEEN 100 AND 200;
 RESET enable_seqscan;
 
+-- ON CONFLICT on a table with a bridged index.  OrioleDB resolves conflicts on
+-- its own indexes by inserting into them, so by the time the bridged arbiters
+-- are checked the row is already in those trees: checking all the arbiters
+-- there used to find our own row and call it a conflict.  DO NOTHING then left
+-- the row in the table but out of every bridged index, and DO UPDATE failed
+-- with "unexpected self-updated tuple".
+CREATE TABLE o_bridge_ioc (
+	id int NOT NULL PRIMARY KEY,
+	tags int[]
+) USING orioledb;
+CREATE INDEX ON o_bridge_ioc USING gin(tags);
+
+INSERT INTO o_bridge_ioc VALUES (1, ARRAY[10]) ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (2, ARRAY[10])
+	ON CONFLICT (id) DO UPDATE SET tags = EXCLUDED.tags;
+INSERT INTO o_bridge_ioc VALUES (3, ARRAY[10]);
+
+-- and again, now that the keys really do conflict
+INSERT INTO o_bridge_ioc VALUES (1, ARRAY[99]) ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (2, ARRAY[20])
+	ON CONFLICT (id) DO UPDATE SET tags = EXCLUDED.tags;
+
+-- without a conflict target, so the arbiter list arrives empty
+INSERT INTO o_bridge_ioc VALUES (4, ARRAY[10]) ON CONFLICT DO NOTHING;
+INSERT INTO o_bridge_ioc VALUES (4, ARRAY[77]) ON CONFLICT DO NOTHING;
+
+SELECT id, tags FROM o_bridge_ioc ORDER BY id;
+SET enable_seqscan = off;
+SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[10] ORDER BY id;
+SELECT id FROM o_bridge_ioc WHERE tags @> ARRAY[20] ORDER BY id;
+RESET enable_seqscan;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;

--- a/test/t/crash/rootcause_evidence/abort_snap_pair/primary.log
+++ b/test/t/crash/rootcause_evidence/abort_snap_pair/primary.log
@@ -1,0 +1,90 @@
+2026-08-16 10:51:25.703 GMT [29681] LOG:  registered custom resource manager "OrioleDB resource manager" with ID 129
+2026-08-16 10:51:25.745 GMT [29681] LOG:  starting PostgreSQL 18.4 on aarch64-apple-darwin25.6.0, compiled by Homebrew clang version 22.1.8, 64-bit
+2026-08-16 10:51:25.746 GMT [29681] LOG:  listening on IPv4 address "127.0.0.1", port 20108
+2026-08-16 10:51:25.747 GMT [29681] LOG:  listening on Unix socket "/tmp/.s.PGSQL.20108"
+2026-08-16 10:51:25.757 GMT [29688] LOG:  Cleanup of old files at startup. Checkpoint 0
+2026-08-16 10:51:25.758 GMT [29689] LOG:  orioledb background writer 0 started
+2026-08-16 10:51:25.758 GMT [29688] LOG:  database system was shut down at 2026-08-16 10:51:25 GMT
+2026-08-16 10:51:25.762 GMT [29681] LOG:  database system is ready to accept connections
+2026-08-16 10:51:25.935 GMT [29686] LOG:  checkpoint starting: force wait
+2026-08-16 10:51:25.940 GMT [29686] LOG:  orioledb checkpoint 1 started
+2026-08-16 10:51:28.086 GMT [29686] LOG:  orioledb checkpoint 1 complete
+2026-08-16 10:51:28.091 GMT [29686] LOG:  checkpoint complete: wrote 0 buffers (0.0%), wrote 3 SLRU buffers; 0 WAL file(s) added, 0 removed, 0 recycled; write=2.151 s, sync=0.001 s, total=2.157 s; sync files=2, longest=0.001 s, average=0.001 s; distance=8650 kB, estimate=8650 kB; lsn=0/2000098, redo lsn=0/2000028
+2026-08-16 10:51:28.893 GMT [29902] LOG:  statement: 
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_abort_snap (
+						id int PRIMARY KEY,
+						v  int NOT NULL
+					) USING orioledb;
+					INSERT INTO o_abort_snap
+						SELECT g, 0 FROM generate_series(1, 100) g;
+				
+2026-08-16 10:51:28.971 GMT [29907] LOG:  statement: CHECKPOINT;
+2026-08-16 10:51:28.972 GMT [29686] LOG:  checkpoint starting: immediate force wait
+2026-08-16 10:51:28.977 GMT [29686] LOG:  orioledb checkpoint 2 started
+2026-08-16 10:51:29.000 GMT [29686] LOG:  orioledb checkpoint 2 complete
+2026-08-16 10:51:29.006 GMT [29686] LOG:  checkpoint complete: wrote 111 buffers (0.7%), wrote 1 SLRU buffers; 0 WAL file(s) added, 0 removed, 0 recycled; write=0.028 s, sync=0.005 s, total=0.035 s; sync files=60, longest=0.001 s, average=0.001 s; distance=17165 kB, estimate=17165 kB; lsn=0/30C3548, redo lsn=0/30C34D8
+2026-08-16 10:51:29.012 GMT [29908] LOG:  statement: select pg_catalog.pg_current_wal_lsn()::text
+2026-08-16 10:51:30.076 GMT [29991] LOG:  statement: UPDATE o_abort_snap SET v = v + 1 WHERE id = 1;
+2026-08-16 10:51:30.096 GMT [29998] LOG:  statement: INSERT INTO o_abort_snap SELECT g, 0 FROM generate_series(101, 50100) g;
+2026-08-16 10:51:30.330 GMT [30001] LOG:  statement: BEGIN
+2026-08-16 10:51:30.330 GMT [30001] LOG:  statement: SET TRANSACTION ISOLATION LEVEL read committed
+2026-08-16 10:51:30.330 GMT [30001] LOG:  statement: UPDATE o_abort_snap SET v = -1 WHERE id = 1;
+2026-08-16 10:51:30.333 GMT [30001] LOG:  statement: SELECT orioledb_get_current_oxid();
+2026-08-16 10:51:30.334 GMT [30001] LOG:  statement: SELECT pg_backend_pid();
+2026-08-16 10:51:30.334 GMT [30001] LOG:  statement: SET orioledb.enable_stopevents = on;
+2026-08-16 10:51:30.345 GMT [30003] LOG:  statement: SELECT pg_stopevent_set('before_abort_vxids_clear', '$.oxid == 54');
+2026-08-16 10:51:30.347 GMT [30001] LOG:  statement: ROLLBACK;
+2026-08-16 10:51:30.350 GMT [30004] LOG:  statement: SELECT EXISTS(
+								 SELECT se.*
+								 FROM pg_stopevents() se
+								 WHERE se.waiter_pids @> ARRAY[30001]
+							  );
+2026-08-16 10:51:30.362 GMT [30006] LOG:  statement: UPDATE o_abort_snap SET v = v + 1 WHERE id = 2;
+2026-08-16 10:51:30.376 GMT [30008] LOG:  statement: CHECKPOINT;
+2026-08-16 10:51:30.377 GMT [29686] LOG:  checkpoint starting: immediate force wait
+2026-08-16 10:51:30.378 GMT [29686] LOG:  orioledb checkpoint 3 started
+2026-08-16 10:51:30.391 GMT [29686] LOG:  orioledb checkpoint 3 complete
+2026-08-16 10:51:30.392 GMT [29686] LOG:  checkpoint complete: wrote 12 buffers (0.1%), wrote 0 SLRU buffers; 0 WAL file(s) added, 0 removed, 0 recycled; write=0.014 s, sync=0.001 s, total=0.015 s; sync files=7, longest=0.001 s, average=0.001 s; distance=668 kB, estimate=15515 kB; lsn=0/316A848, redo lsn=0/316A7D8
+2026-08-16 10:51:30.405 GMT [30010] LOG:  statement: SELECT pg_stopevent_reset('before_abort_vxids_clear');
+2026-08-16 10:51:30.442 GMT [29689] LOG:  orioledb bgwriter 0 is shut down
+2026-08-16 10:51:30.547 GMT [30016] LOG:  registered custom resource manager "OrioleDB resource manager" with ID 129
+2026-08-16 10:51:30.574 GMT [30016] LOG:  starting PostgreSQL 18.4 on aarch64-apple-darwin25.6.0, compiled by Homebrew clang version 22.1.8, 64-bit
+2026-08-16 10:51:30.575 GMT [30016] LOG:  listening on IPv4 address "127.0.0.1", port 20108
+2026-08-16 10:51:30.576 GMT [30016] LOG:  listening on Unix socket "/tmp/.s.PGSQL.20108"
+2026-08-16 10:51:30.583 GMT [30025] LOG:  Cleanup of old files at startup. Checkpoint 3
+2026-08-16 10:51:30.585 GMT [30026] LOG:  orioledb background writer 0 started
+2026-08-16 10:51:30.588 GMT [30025] LOG:  database system was interrupted; last known up at 2026-08-16 10:51:30 GMT
+2026-08-16 10:51:30.846 GMT [30025] LOG:  database system was not properly shut down; automatic recovery in progress
+2026-08-16 10:51:30.847 GMT [30025] LOG:  orioledb recovery started.
+2026-08-16 10:51:30.849 GMT [30042] LOG:  orioledb recovery worker 1 started.
+2026-08-16 10:51:30.849 GMT [30043] LOG:  orioledb recovery worker 0 started.
+2026-08-16 10:51:30.850 GMT [30044] LOG:  orioledb recovery worker 3 started.
+2026-08-16 10:51:30.851 GMT [30045] LOG:  orioledb recovery worker 2 started.
+2026-08-16 10:51:30.851 GMT [30025] LOG:  redo starts at 0/316A7D8
+2026-08-16 10:51:30.851 GMT [30025] LOG:  invalid record length at 0/316A8C0: expected at least 24, got 0
+2026-08-16 10:51:30.851 GMT [30045] LOG:  orioledb recovery worker 2 finished.
+2026-08-16 10:51:30.851 GMT [30045] LOG:  recovery on exit: 2
+2026-08-16 10:51:30.852 GMT [30042] LOG:  orioledb recovery worker 1 finished.
+2026-08-16 10:51:30.852 GMT [30043] LOG:  orioledb recovery worker 0 finished.
+2026-08-16 10:51:30.852 GMT [30042] LOG:  recovery on exit: 1
+2026-08-16 10:51:30.852 GMT [30043] LOG:  recovery on exit: 0
+2026-08-16 10:51:30.853 GMT [30046] LOG:  orioledb recovery worker 5 started.
+2026-08-16 10:51:30.853 GMT [30047] LOG:  orioledb recovery worker 4 started.
+2026-08-16 10:51:30.853 GMT [30047] LOG:  orioledb recovery worker 4 finished.
+2026-08-16 10:51:30.853 GMT [30047] LOG:  recovery on exit: 4
+2026-08-16 10:51:30.854 GMT [30046] LOG:  orioledb recovery worker 5 finished.
+2026-08-16 10:51:30.854 GMT [30046] LOG:  recovery on exit: 5
+2026-08-16 10:51:30.854 GMT [30044] LOG:  orioledb recovery worker 3 finished.
+2026-08-16 10:51:30.854 GMT [30044] LOG:  recovery on exit: 3
+2026-08-16 10:51:30.855 GMT [30025] LOG:  orioledb recovery finished.
+2026-08-16 10:51:30.855 GMT [30025] LOG:  redo done at 0/316A848 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s
+2026-08-16 10:51:30.857 GMT [30023] LOG:  checkpoint starting: end-of-recovery immediate wait
+2026-08-16 10:51:30.859 GMT [30023] LOG:  orioledb checkpoint 4 started
+2026-08-16 10:51:30.869 GMT [30023] LOG:  orioledb checkpoint 4 complete
+2026-08-16 10:51:30.869 GMT [30023] LOG:  checkpoint complete: wrote 0 buffers (0.0%), wrote 3 SLRU buffers; 0 WAL file(s) added, 0 removed, 0 recycled; write=0.012 s, sync=0.001 s, total=0.013 s; sync files=2, longest=0.001 s, average=0.001 s; distance=0 kB, estimate=0 kB; lsn=0/316A8C0, redo lsn=0/316A8C0
+2026-08-16 10:51:30.869 GMT [30025] LOG:  orioledb: emitting WAL_REC_ROLLBACK for in-flight oxid 54 aborted by recovery_finish
+2026-08-16 10:51:30.870 GMT [30016] LOG:  database system is ready to accept connections
+2026-08-16 10:51:30.962 GMT [30065] LOG:  statement: UPDATE o_abort_snap SET v = v + 1 WHERE id = 3;
+2026-08-16 10:51:30.969 GMT [30066] LOG:  statement: SELECT pg_current_wal_lsn();
+2026-08-16 10:51:32.047 GMT [30151] LOG:  statement: SELECT pg_stopevent_reset('before_abort_vxids_clear');

--- a/test/t/crash/rootcause_evidence/abort_snap_pair/replica.log
+++ b/test/t/crash/rootcause_evidence/abort_snap_pair/replica.log
@@ -1,0 +1,35 @@
+2026-08-16 10:51:28.702 GMT [29878] LOG:  registered custom resource manager "OrioleDB resource manager" with ID 129
+2026-08-16 10:51:28.726 GMT [29878] LOG:  starting PostgreSQL 18.4 on aarch64-apple-darwin25.6.0, compiled by Homebrew clang version 22.1.8, 64-bit
+2026-08-16 10:51:28.727 GMT [29878] LOG:  listening on IPv4 address "127.0.0.1", port 20109
+2026-08-16 10:51:28.727 GMT [29878] LOG:  listening on Unix socket "/tmp/.s.PGSQL.20109"
+2026-08-16 10:51:28.732 GMT [29886] LOG:  Cleanup of old files at startup. Checkpoint 1
+2026-08-16 10:51:28.733 GMT [29886] LOG:  database system was interrupted; last known up at 2026-08-16 10:51:28 GMT
+2026-08-16 10:51:28.733 GMT [29887] LOG:  orioledb background writer 0 started
+2026-08-16 10:51:28.836 GMT [29886] LOG:  starting backup recovery with redo LSN 0/2000028, checkpoint LSN 0/2000098, on timeline ID 1
+2026-08-16 10:51:28.836 GMT [29886] LOG:  entering standby mode
+2026-08-16 10:51:28.838 GMT [29886] LOG:  orioledb recovery started.
+2026-08-16 10:51:28.840 GMT [29892] LOG:  orioledb recovery worker 0 started.
+2026-08-16 10:51:28.840 GMT [29893] LOG:  orioledb recovery worker 3 started.
+2026-08-16 10:51:28.840 GMT [29894] LOG:  orioledb recovery worker 2 started.
+2026-08-16 10:51:28.840 GMT [29895] LOG:  orioledb recovery worker 1 started.
+2026-08-16 10:51:28.841 GMT [29886] LOG:  redo starts at 0/2000028
+2026-08-16 10:51:28.841 GMT [29886] LOG:  completed backup recovery with redo LSN 0/2000028 and end LSN 0/2000138
+2026-08-16 10:51:28.841 GMT [29886] LOG:  consistent recovery state reached at 0/2000138
+2026-08-16 10:51:28.841 GMT [29878] LOG:  database system is ready to accept read-only connections
+2026-08-16 10:51:28.843 GMT [29897] LOG:  orioledb recovery worker 5 started.
+2026-08-16 10:51:28.843 GMT [29898] LOG:  orioledb recovery worker 4 started.
+2026-08-16 10:51:28.847 GMT [29896] LOG:  started streaming WAL from primary at 0/3000000 on timeline 1
+2026-08-16 10:51:29.032 GMT [29909] LOG:  statement: select pg_catalog.pg_last_wal_replay_lsn() >= '0/30C35C0'::pg_lsn
+2026-08-16 10:51:30.047 GMT [29987] LOG:  statement: select pg_catalog.pg_last_wal_replay_lsn() >= '0/30C35C0'::pg_lsn
+2026-08-16 10:51:30.060 GMT [29989] LOG:  statement: SELECT pg_stopevent_set('replay_on_record', 'true');
+2026-08-16 10:51:30.082 GMT [29992] LOG:  statement: SELECT coalesce(array_length(waiter_pids, 1), 0) >= 1 FROM pg_stopevents() WHERE stopevent = 'replay_on_record'
+2026-08-16 10:51:30.445 GMT [29896] FATAL:  could not receive data from WAL stream: server closed the connection unexpectedly
+		This probably means the server terminated abnormally
+		before or while processing the request.
+2026-08-16 10:51:30.983 GMT [30070] LOG:  statement: SELECT pg_stopevent_reset('replay_on_record');
+2026-08-16 10:51:30.989 GMT [30071] LOG:  statement: SELECT pg_last_wal_replay_lsn() >= '0/316F7F8'::pg_lsn
+2026-08-16 10:51:31.070 GMT [29886] LOG:  invalid record length at 0/316A8C0: expected at least 24, got 0
+2026-08-16 10:51:31.081 GMT [30078] LOG:  started streaming WAL from primary at 0/3000000 on timeline 1
+2026-08-16 10:51:31.501 GMT [30117] LOG:  statement: SELECT pg_last_wal_replay_lsn() >= '0/316F7F8'::pg_lsn
+2026-08-16 10:51:32.008 GMT [30146] LOG:  statement: SELECT pg_last_wal_replay_lsn() >= '0/316F7F8'::pg_lsn
+2026-08-16 10:51:32.033 GMT [30149] LOG:  statement: SELECT pg_stopevent_reset('replay_on_record');


### PR DESCRIPTION
SQLSmith builds its grammar from the catalog, so it reaches planner/executor/storage combinations no hand-written test covers. It found both bugs in #1042 within the first three minutes of running, and two more while this job was being brought up — both in this PR.

## Shape

Runs on every pull request and on every commit on main, plus `workflow_dispatch` with budget/seed/writer inputs. Each run picks a fresh seed, so the coverage comes from the number of runs rather than from any single one — which is the argument for gating changes on it rather than leaving it to a nightly. Matrix is PG 16/17/18 assert builds plus one `check_page` cell.

## Three deliberate departures from plain SQLSmith

**It does not fuzz alone.** SQLSmith generates mostly reads, and OrioleDB's crashes cluster in the concurrent paths, so `ci/sqlsmith_writer.sql` runs several psql sessions churning the same tables — upserts, savepoint rollbacks, TOAST rewrites, bridge-index DML, VACUUM and CHECKPOINT. There is deliberately no DDL in the writer: dropped objects would drown the run in *"relation does not exist"*.

**It judges on the server, not on the queries.** A generated query raising an ERROR is normal and ignored. A run fails on a PANIC or assertion, a backend killed by a signal, a second *"ready to accept connections"* (postmaster restart, with `restart_after_crash = off`), a core dump, or `orioledb_tbl_check()` no longer passing afterwards. That last one is the interesting case: corruption that never crashed anything. The tables are listed and checked in **separate queries** — as one query the planner is free to put the function first, and it then runs on every row of `pg_class`, sequences included. The check is taken after an explicit `CHECKPOINT`, because its second argument compares the tree against the on-disk map and that only means anything once the dirty pages are out.

**It fuzzes the storage engine, not the debug API.** SQLSmith calls every function in the catalog with random arguments, orioledb's own introspection functions included — and the very first run wedged on `orioledb_get_complete_xid()` before reaching any tree code. The fuzzer connects as an unprivileged role with EXECUTE revoked on the extension's functions; `SQLSMITH_FUZZ_ORIOLEDB_FUNCS=1` aims at them on purpose.

The seed is printed, so a hit replays with `SQLSMITH_SEED=... bash ci/sqlsmith.sh`.

## The two bugs it found here

Both are in the bridged-index path, both are user-visible, and neither needs concurrency or is reachable from the job's own writer script.

**`ON CONFLICT` with a bridged index** (`Only ask ExecCheckIndexConstraints about the bridged arbiters`):

```sql
CREATE TABLE t (id int PRIMARY KEY, tags int[]) USING orioledb;
CREATE INDEX ON t USING gin (tags);

INSERT INTO t VALUES (1, '{10}') ON CONFLICT (id) DO NOTHING;
INSERT INTO t VALUES (2, '{10}') ON CONFLICT (id) DO UPDATE SET tags = EXCLUDED.tags;
```

The first leaves the row in the table but out of every bridged index, so it is invisible to any query using one. The second fails with `ERROR: unexpected self-updated tuple`. `o_tbl_insert_with_arbiter()` handed the whole arbiter list to `ExecCheckIndexConstraints()`, which then walked OrioleDB's own trees — already holding the row this statement had just inserted — and reported a conflict with itself.

**A multi-row UPDATE crashes the server** (`Don't carry "this row got a new bridge ctid" into the next row`):

```sql
CREATE TABLE e (id int PRIMARY KEY, doc jsonb, other int) USING orioledb;
CREATE INDEX ON e USING gin (doc);
INSERT INTO e SELECT g, jsonb_build_object('k', g), g FROM generate_series(1, 4) g;
UPDATE e SET doc = CASE WHEN id % 2 = 1 THEN jsonb_set(doc, '{z}', '1') ELSE doc END
 WHERE other > 0;
-- TRAP: failed Assert("res != 0"), File: "ginbulk.c", Line: 60
```

`oslot->bridgeChanged` was never reset, and one slot serves every row of a statement — so a row that kept its bridge ctid inherited the flag and was inserted into the bridged indexes a second time under a ctid already there. Without assertions the duplicate stays in the posting list, where GIN's compression expects tids to be strictly increasing.

Both come with regression coverage in `test/sql/index_bridging.sql`.