### PR TITLE
Release a subtransaction's logical xid when it rolls back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \
 						test/t/recovery_heap_verdict_test.py \
+						test/t/recovery_heap_xid_binding_test.py \
 						test/t/recovery_item_rollback_test.py \
 						test/t/recovery_row_lock_test.py \
 						test/t/reindex_test.py \

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/include_indices_test.py \
 						test/t/indices_build_test.py \
 						test/t/logical_test.py \
+						test/t/logical_xid_leak_test.py \
 						test/t/logical_xid_subxacts_test.py \
 						test/t/merge_into_test.py \
 						test/t/multi_insert_test.py \

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -138,7 +138,7 @@ typedef struct
 {
 	LogicalXidCtx ctx;
 	SubTransactionId subid;
-} PrevLogicalXidEntry;
+}			PrevLogicalXidEntry;
 
 static List *prevLogicalXids = NIL; /* stack of PrevLogicalXidEntry for all
 									 * xids on subxact's chain, for correct
@@ -704,6 +704,24 @@ oxid_subxact_callback(
 								 get_current_oxid_if_any(),
 								 logicalXidContext.xid,
 								 GetTopTransactionIdIfAny());
+
+							/*
+							 * Give back the id this subtransaction assigned
+							 * at its start: the restore below drops it, and
+							 * nothing else ever reclaims it --
+							 * release_assigned_logical_xids() only walks the
+							 * current context and the stacked parents.  Every
+							 * rolled back subtransaction otherwise costs one
+							 * slot of the shared bitmap for good.
+							 *
+							 * Only when this subtransaction pushed something,
+							 * mirroring setup_prev_logical_xid_ctx(): if it
+							 * did not, the current id belongs to the whole
+							 * transaction and has to survive up to the
+							 * top-level commit record.
+							 */
+							if (prev_logical_xid_pushed_by(mySubid))
+								release_logical_xid(&logicalXidContext);
 
 							setup_prev_logical_xid_ctx(mySubid);
 						}

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -138,7 +138,7 @@ typedef struct
 {
 	LogicalXidCtx ctx;
 	SubTransactionId subid;
-}			PrevLogicalXidEntry;
+} PrevLogicalXidEntry;
 
 static List *prevLogicalXids = NIL; /* stack of PrevLogicalXidEntry for all
 									 * xids on subxact's chain, for correct

--- a/test/t/logical_xid_leak_test.py
+++ b/test/t/logical_xid_leak_test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+
+# with orioledb.logical_xid_buffers = 1 the shared bitmap holds
+# 1 * (BLCKSZ / 4) * 32 = 65536 logical xids
+BUDGET = 65536
+
+
+class LogicalXidLeakTest(BaseTest):
+	"""Rolling back a subtransaction leaks its logical xid.
+
+	SUBXACT_EVENT_ABORT_SUB restored the parent's context without releasing
+	the subtransaction's logical xid, and release_assigned_logical_xids() only
+	walks the current context and the stacked parents -- so nothing ever
+	reclaimed it.  The shared bitmap then runs out after exactly its budget of
+	rollbacks and every later subtransaction fails with "not enough logical
+	xids", which is a cluster that ordinary use has broken: rolling back to a
+	savepoint per conflicting insert is the usual upsert fallback.
+
+	The bitmap is shrunk to one block so the budget is reachable in a test;
+	in production it is 64 blocks, i.e. 4.2M rollbacks.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.node.append_conf('postgresql.conf',
+		                      "orioledb.logical_xid_buffers = 1\n")
+
+	def test_rolled_back_subtransactions_do_not_exhaust_logical_xids(self):
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_x (id int NOT NULL, v int NOT NULL,\n"
+		    "  PRIMARY KEY (id)) USING orioledb;\n"
+		    "INSERT INTO o_x VALUES (1, 0);")
+
+		# each iteration opens a subtransaction, writes OrioleDB data in it and
+		# rolls it back -- the PL/pgSQL exception block is just a cheap way to
+		# drive SUBXACT_EVENT_ABORT_SUB many times
+		node.safe_psql(
+		    'postgres', "DO $$\n"
+		    "BEGIN\n"
+		    "  FOR i IN 1..%d LOOP\n"
+		    "    BEGIN\n"
+		    "      UPDATE o_x SET v = v + 1 WHERE id = 1;\n"
+		    "      RAISE EXCEPTION 'rollback';\n"
+		    "    EXCEPTION WHEN OTHERS THEN\n"
+		    "      NULL;\n"
+		    "    END;\n"
+		    "  END LOOP;\n"
+		    "END $$;" % (BUDGET + 4096))
+
+		# the bitmap must still hand out ids afterwards
+		node.safe_psql(
+		    'postgres', "BEGIN;\n"
+		    "SAVEPOINT s;\n"
+		    "UPDATE o_x SET v = v + 1 WHERE id = 1;\n"
+		    "RELEASE SAVEPOINT s;\n"
+		    "COMMIT;")
+		self.assertEqual(
+		    node.execute("SELECT v FROM o_x WHERE id = 1;")[0][0], 1)
+		node.stop()

--- a/test/t/recovery_heap_xid_binding_test.py
+++ b/test/t/recovery_heap_xid_binding_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+
+
+class RecoveryHeapXidBindingTest(BaseTest):
+	"""Crash recovery rolls back half of a committed transaction.
+
+	This is what losing the logical xid at RELEASE SAVEPOINT costs beyond
+	logical decoding, and it is why that defect is a data-loss bug rather than
+	a replication one.
+
+	A transaction that owns a heap xid writes no OrioleDB finish record of its
+	own: replay settles it from the builtin commit record, and can only apply
+	that verdict to the oxid if some record carried the (oxid, heap xid) pair.
+	Two records normally carry it, and this transaction has neither:
+
+	  * add_xid_wal_record() samples GetTopTransactionIdIfAny() when a
+	    container's first record is buffered, so a transaction that acquires
+	    its heap xid *after* its last OrioleDB change has every WAL_REC_XID
+	    carrying InvalidTransactionId;
+	  * wal_joint_commit() is written at XACT_EVENT_PRE_COMMIT only while a
+	    logical xid is held -- and a transaction whose first OrioleDB write
+	    happened inside a savepoint is handed back an invalid one when that
+	    savepoint is released.
+
+	Replay then applies the changes and never learns whose they are, so
+	recovery_finish() rolls them back while PostgreSQL, which took the builtin
+	commit record at face value, considers the transaction committed.  On an
+	unfixed build:
+
+	    XID(oxid=53 lxid=192 heapXid=0)  UPDATE o_bind
+	    XID(oxid=53 lxid=0   heapXid=0)  UPDATE o_bind
+	    XACT_COMMIT xl_xid=755
+
+	    value before crash: 555
+	    value after crash recovery: 0      <- OrioleDB half rolled back
+	    heap row after crash recovery: 1   <- heap half survived
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.node.append_conf(
+		    'postgresql.conf', "checkpoint_timeout = 1h\n"
+		    "max_wal_size = 10GB\n")
+
+	def test_committed_changes_survive_a_late_heap_xid(self):
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_bind (\n"
+		    "  id int NOT NULL,\n"
+		    "  v int NOT NULL,\n"
+		    "  PRIMARY KEY (id)\n"
+		    ") USING orioledb;\n"
+		    "CREATE TABLE h_bind (id int PRIMARY KEY);\n"
+		    "INSERT INTO o_bind SELECT g, 0 FROM generate_series(1, 4) g;\n")
+		node.safe_psql('postgres', "CHECKPOINT;")
+
+		con = node.connect()
+		con.begin()
+		# first OrioleDB write inside a subtransaction: releasing it used to
+		# take the transaction's logical xid away
+		con.execute("SAVEPOINT s1;")
+		con.execute("UPDATE o_bind SET v = 1 WHERE id = 1;")
+		con.execute("RELEASE SAVEPOINT s1;")
+		# ... more OrioleDB work, still with no heap xid, so its WAL_REC_XID
+		# carries InvalidTransactionId ...
+		con.execute("UPDATE o_bind SET v = 555 WHERE id = 2;")
+		# ... and only now a heap xid, which no OrioleDB record has seen
+		con.execute("INSERT INTO h_bind VALUES (1);")
+		con.commit()
+		con.close()
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+
+		self.assertEqual(
+		    node.execute("SELECT v FROM o_bind WHERE id = 2;")[0][0], 555,
+		    "crash recovery rolled back the OrioleDB half of a committed "
+		    "transaction")
+		self.assertEqual(
+		    node.execute("SELECT v FROM o_bind WHERE id = 1;")[0][0], 1)
+		self.assertEqual(node.execute("SELECT count(*) FROM h_bind;")[0][0], 1)
+		node.stop()


### PR DESCRIPTION
Reworked on top of #981 (49f9ed38), which took the logical-xid handoff fix — my first commit duplicated it, and its implementation is the better one: tagging each stacked context with the `SubTransactionId` that pushed it makes push and pop symmetric in general, where mine only special-cased an empty stack.

What is left here is what #981 does not do, plus one test.

## The leak

Rolling back a subtransaction leaks its logical xid. The abort path restores the parent's context without releasing the id the subtransaction assigned at its start, and nothing else reclaims it — `release_assigned_logical_xids()` only walks the current context and the stacked parents.

Measured against `main` **after** #981 landed:

```
FATAL:  not enough logical xids
CONTEXT:  PL/pgSQL function inline_code_block line 4 during statement block entry
server closed the connection unexpectedly
```

The shared bitmap runs out after exactly its budget of rollbacks — 65535 of 65536 with `orioledb.logical_xid_buffers = 1` — and every later subtransaction dies with that, taking the connection with it. At the default 64 blocks it is 4.2M rolled back subtransactions, and rolling back to a savepoint per conflicting insert is the ordinary upsert fallback, so a busy cluster gets there on its own.

The fix gives the id back, and only when this subtransaction pushed something, mirroring `setup_prev_logical_xid_ctx()`: if it did not push, the current id belongs to the whole transaction and has to survive to the top-level commit record, which is exactly what #981 established.

## The test that came along

`test/t/recovery_heap_xid_binding_test.py` covers the **crash-recovery** side of the handoff #981 fixed, which its own tests do not: they check what logical decoding emits, this checks what survives a crash. It passes on current main — it is a guard, not a failing case.

Before #981, the same defect did this:

```
XID(oxid=53 lxid=192 heapXid=0)  UPDATE o_bind
XID(oxid=53 lxid=0   heapXid=0)  UPDATE o_bind
XACT_COMMIT xl_xid=755

value before crash: 555
value after crash recovery: 0      <- OrioleDB half rolled back
heap row after crash recovery: 1   <- heap half survived
```

A transaction that owns a heap xid writes no OrioleDB finish record, so replay settles it from the builtin commit record — and can only apply that verdict if some record carried the (oxid, heap xid) pair. `wal_joint_commit()` normally carries it and is written only while a logical xid is held; `WAL_REC_XID` samples the heap xid when a container's first record is buffered, so a transaction acquiring its xid after its last OrioleDB change has every one of them carrying `InvalidTransactionId`. With neither, `recovery_finish()` rolls the changes back while PostgreSQL considers the transaction committed.

## Testing

`test/t/logical_xid_leak_test.py` drives the budget plus a margin of rolled back subtransactions from a PL/pgSQL exception block; it fails on `main` today and passes with this. `regresscheck` 49/49 and `isolationcheck` 35/35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)