### PR TITLE
Stop crash recovery from rolling back half of a committed transaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,9 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/pg_dump_restore_test.py \
 						test/t/parallel_test.py \
 						test/t/recovery_heap_verdict_test.py \
+						test/t/recovery_heap_xid_binding_test.py \
 						test/t/recovery_item_rollback_test.py \
+						test/t/recovery_livelock_test.py \
 						test/t/recovery_row_lock_test.py \
 						test/t/reindex_test.py \
 						test/t/restartpoint_ddl_window_test.py \

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,6 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/recovery_heap_verdict_test.py \
 						test/t/recovery_heap_xid_binding_test.py \
 						test/t/recovery_item_rollback_test.py \
-						test/t/recovery_livelock_test.py \
 						test/t/recovery_row_lock_test.py \
 						test/t/reindex_test.py \
 						test/t/restartpoint_ddl_window_test.py \

--- a/include/recovery/internal.h
+++ b/include/recovery/internal.h
@@ -61,11 +61,14 @@ typedef enum
 	RecoveryMsgTypeLeaderParallelIndexBuild,
 	RecoveryMsgTypeWorkerParallelIndexBuild,
 	RecoveryMsgTypeInit,
-	RecoveryMsgTypeReinsert
+	RecoveryMsgTypeReinsert,
+	RecoveryMsgTypeBindHeapXid
 } RecoveryMsgType;
 
 #define RECOVERY_MODIFY_OXID (0x0100)
 #define RECOVERY_MODIFY_OIDS (0x0200)
+/* the oxid above rides on a heap xid, which follows it */
+#define RECOVERY_MODIFY_HEAP_XID (0x0400)
 
 #define RECOVERY_QUEUE_BUF_SIZE (8 * 1024)
 
@@ -88,6 +91,20 @@ typedef struct
 	RecoveryMsgHeader header;
 	XLogRecPtr	ptr;
 } RecoveryMsgPtr;
+
+/*
+ * Tells a worker which heap xid an oxid it already works on rides on.
+ *
+ * Sent only when the leader learns the binding after that worker has already
+ * been given modifies for the oxid; when it is known beforehand the binding
+ * travels on the modify message itself (RECOVERY_MODIFY_HEAP_XID).
+ */
+typedef struct
+{
+	RecoveryMsgHeader header;
+	OXid		oxid;
+	TransactionId xid;
+} RecoveryMsgBindXid;
 
 typedef struct
 {

--- a/include/recovery/recovery.h
+++ b/include/recovery/recovery.h
@@ -21,6 +21,8 @@
 extern void o_recovery_start_hook(void);
 extern void orioledb_redo(XLogReaderState *record);
 extern void o_xact_redo_hook(TransactionId xid, XLogRecPtr lsn, bool commit);
+extern void recovery_bind_heap_xid(OXid oxid, TransactionId xid,
+								   int worker_id);
 extern void o_recovery_finish_hook(bool cleanup);
 extern void o_emit_recovery_finish_rollbacks(void);
 

--- a/include/recovery/wal.h
+++ b/include/recovery/wal.h
@@ -236,6 +236,7 @@ extern bool local_wal_is_empty(void);
 extern XLogRecPtr flush_local_wal(bool isCommit, bool withXactTime);
 extern XLogRecPtr wal_commit(OXid oxid, TransactionId logicalXid,
 							 bool isAutonomous);
+extern void wal_bind_heap_xid(OXid oxid, TransactionId logicalXid);
 extern XLogRecPtr wal_joint_commit(OXid oxid, TransactionId logicalXid,
 								   TransactionId xid, bool subTransaction);
 extern void wal_after_commit(void);

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -783,6 +783,7 @@ static bool replay_container(Pointer startPtr, Pointer endPtr,
 static void worker_send_modify(int worker_id, BTreeDescr *desc,
 							   RecoveryMsgType recType,
 							   OTuple tuple, int tuple_len);
+static void workers_send_bind_heap_xid(void);
 static void workers_send_oxid_finish(XLogRecPtr ptr, bool needsFeedback,
 									 bool commit);
 static void workers_send_savepoint(SubTransactionId parentSubId);
@@ -1966,15 +1967,27 @@ recovery_finish(int worker_id)
 			if (TransactionIdIsValid(cur_state->xid) &&
 				TransactionIdDidCommit(cur_state->xid))
 			{
-				CommitSeqNo csn;
+				CommitSeqNo csn = COMMITSEQNO_MAX_NORMAL - 1;
 
 				for (i = 0; i < (int) UndoLogsCount; i++)
 					precommit_undo_stack((UndoLogType) i, recovery_oxid, true);
 				for (i = 0; i < (int) UndoLogsCount; i++)
 					on_commit_undo_stack((UndoLogType) i, recovery_oxid, true);
-				set_oxid_csn(recovery_oxid, COMMITSEQNO_COMMITTING);
-				csn = pg_atomic_fetch_add_u64(&TRANSAM_VARIABLES->nextCommitSeqNo, 1);
-				set_oxid_csn(recovery_oxid, csn);
+
+				/*
+				 * Publishing the verdict is the leader's alone.  Workers now
+				 * reach this with a heap xid too -- they are told the binding
+				 * so that they do not undo a committed transaction -- and
+				 * every process settling the same oxid would settle it
+				 * several times over, which spins set_oxid_xlog_ptr()
+				 * forever.
+				 */
+				if (worker_id < 0)
+				{
+					set_oxid_csn(recovery_oxid, COMMITSEQNO_COMMITTING);
+					csn = pg_atomic_fetch_add_u64(&TRANSAM_VARIABLES->nextCommitSeqNo, 1);
+					set_oxid_csn(recovery_oxid, csn);
+				}
 				walk_checkpoint_stacks(cur_state, csn,
 									   InvalidSubTransactionId,
 									   flush_undo_pos);
@@ -4526,7 +4539,18 @@ replay_on_record(WalReaderState *r, WalRecord *rec)
 			 */
 			if (TransactionIdIsValid(rec->heapXid) &&
 				!TransactionIdIsValid(cur_recovery_xid_state->xid))
+			{
 				cur_recovery_xid_state->xid = rec->heapXid;
+
+				/*
+				 * The heap xid can be acquired after some of this
+				 * transaction's changes were already dispatched -- those
+				 * workers adopted the oxid without it.  Top them up; workers
+				 * that have not seen the oxid get it with their first modify.
+				 */
+				if (!ctx->single)
+					workers_send_bind_heap_xid();
+			}
 			break;
 
 		case WAL_REC_SWITCH_LOGICAL_XID:
@@ -5241,6 +5265,7 @@ worker_send_modify(int worker_id, BTreeDescr *desc,
 	delay_rels_queued_for_idxbuild(oids);
 
 	max_msg_size = MAXALIGN(sizeof(RecoveryMsgHeader) + sizeof(OXid)
+							+ sizeof(TransactionId)
 							+ sizeof(ORelOids) + 1
 							+ sizeof(int) + 1) + MAXALIGN(tuple_len);
 
@@ -5268,6 +5293,24 @@ worker_send_modify(int worker_id, BTreeDescr *desc,
 		header->type |= RECOVERY_MODIFY_OXID;
 		state->oxid = cur_recovery_xid_state->oxid;
 		cur_recovery_xid_state->used_by[worker_id] = true;
+
+		/*
+		 * A transaction that owns a heap xid writes no OrioleDB finish
+		 * record, so at the end of replay its fate is read off the heap xid
+		 * -- and only the leader parses that out of WAL.  A worker without it
+		 * sees an in-progress oxid, concludes the transaction cannot have
+		 * committed, and undoes changes it committed.  Hand the binding over
+		 * here, on the message that makes this worker adopt the oxid in the
+		 * first place, so only workers that actually apply something for the
+		 * transaction ever hear about it.
+		 */
+		if (TransactionIdIsValid(cur_recovery_xid_state->xid))
+		{
+			memcpy(data, &cur_recovery_xid_state->xid, sizeof(TransactionId));
+			data += sizeof(TransactionId);
+			state->queue_buf_len += sizeof(TransactionId);
+			header->type |= RECOVERY_MODIFY_HEAP_XID;
+		}
 	}
 
 	if (!ORelOidsIsEqual(state->oids, oids) || state->type != type)
@@ -5417,6 +5460,44 @@ workers_send_rollback_to_savepoint(XLogRecPtr ptr,
 /*
  * Sends commit or rollback message to workers with active the oxid in the pool.
  */
+/*
+ * Record, on this process's recovery xid state, which heap xid an oxid rides
+ * on.  Called by a worker for an oxid it already applies changes for.
+ */
+void
+recovery_bind_heap_xid(OXid oxid, TransactionId xid, int worker_id)
+{
+	recovery_switch_to_oxid(oxid, worker_id);
+	Assert(cur_recovery_xid_state != NULL);
+	if (!TransactionIdIsValid(cur_recovery_xid_state->xid))
+		cur_recovery_xid_state->xid = xid;
+}
+
+/*
+ * Tell the workers that already took on the current oxid which heap xid it
+ * rides on.  Pure information: it waits for nothing and does not change when
+ * anything is applied.
+ */
+static void
+workers_send_bind_heap_xid(void)
+{
+	RecoveryMsgBindXid msg;
+	int			i;
+
+	Assert(cur_recovery_xid_state != NULL);
+	Assert(TransactionIdIsValid(cur_recovery_xid_state->xid));
+
+	msg.header.type = RecoveryMsgTypeBindHeapXid;
+	msg.oxid = cur_recovery_xid_state->oxid;
+	msg.xid = cur_recovery_xid_state->xid;
+
+	for (i = 0; i < recovery_pool_size_guc; i++)
+	{
+		if (cur_recovery_xid_state->used_by[i])
+			worker_send_msg(i, (Pointer) &msg, sizeof(msg));
+	}
+}
+
 static void
 workers_send_oxid_finish(XLogRecPtr ptr, bool needsFeedback, bool commit)
 {

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -228,6 +228,47 @@ add_local_modify(uint8 record_type, OTuple record1, OffsetNumber length1, OTuple
 	local_wal.has_material_changes = true;
 }
 
+/*
+ * Put the (oxid, heap xid) binding on the wire.
+ *
+ * A transaction that owns a heap xid writes no finish record of its own: its
+ * verdict reaches replay through the builtin commit record, and replay can
+ * only apply it to the oxid if some record carried the pair.  Two things
+ * normally carry it, and both can be absent at once:
+ *
+ *   - add_xid_wal_record() samples GetTopTransactionIdIfAny() when a
+ *     container's first record is buffered, so a transaction that acquires
+ *     its heap xid after its last OrioleDB change has every WAL_REC_XID
+ *     carrying InvalidTransactionId;
+ *   - wal_joint_commit() is gated on a logical xid, which a released
+ *     subtransaction hands back to a parent that may not have one.
+ *
+ * Replay then has an oxid whose changes it applies and whose verdict it never
+ * learns: recovery_finish() rolls those changes back while the builtin half
+ * of the transaction stays committed.  Emitting a bare WAL_REC_XID here --
+ * after the buffered changes, so the heap xid is sampled once it exists --
+ * closes that, and costs one small record only for transactions that would
+ * otherwise be unsettleable.
+ */
+void
+wal_bind_heap_xid(OXid oxid, TransactionId logicalXid)
+{
+	Assert(!is_recovery_process());
+	Assert(OXidIsValid(oxid));
+	Assert(TransactionIdIsValid(GetTopTransactionIdIfAny()));
+
+	/* nothing of ours will be replayed, so nothing needs settling */
+	if (!local_wal.has_material_changes)
+		return;
+
+	if (!local_wal_is_empty())
+		flush_local_wal(false, false);
+
+	Assert(local_wal_is_empty() && !local_wal.contains_xid);
+	add_xid_wal_record(oxid, logicalXid);
+	flush_local_wal(false, false);
+}
+
 XLogRecPtr
 wal_commit(OXid oxid, TransactionId logicalXid, bool isAutonomous)
 {

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -417,6 +417,22 @@ recovery_queue_process(shm_mq_handle *queue, int id)
 					memcpy(&oxid, data + data_pos, sizeof(OXid));
 					data_pos += sizeof(OXid);
 					recovery_switch_to_oxid(oxid, id);
+
+					if (recovery_header->type & RECOVERY_MODIFY_HEAP_XID)
+					{
+						TransactionId heapXid;
+
+						/*
+						 * Which heap xid this oxid rides on.  We need it
+						 * because such a transaction writes no OrioleDB
+						 * finish record: at the end of replay our
+						 * recovery_finish() reads its fate from the heap xid,
+						 * and without it we would undo changes it committed.
+						 */
+						memcpy(&heapXid, data + data_pos, sizeof(TransactionId));
+						data_pos += sizeof(TransactionId);
+						recovery_bind_heap_xid(oxid, heapXid, id);
+					}
 				}
 
 				if (recovery_header->type & RECOVERY_MODIFY_OIDS)
@@ -589,6 +605,14 @@ recovery_queue_process(shm_mq_handle *queue, int id)
 				MemoryContextSwitchTo(prev_context);
 
 				data_pos += sizeof(RecoveryMsgWorkerIdxBuild);
+			}
+			else if (type == RecoveryMsgTypeBindHeapXid)
+			{
+				RecoveryMsgBindXid *bind;
+
+				bind = (RecoveryMsgBindXid *) (data + data_pos);
+				recovery_bind_heap_xid(bind->oxid, bind->xid, id);
+				data_pos += sizeof(RecoveryMsgBindXid);
 			}
 			else if (type == RecoveryMsgTypeCommit)
 			{

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -2571,6 +2571,16 @@ undo_xact_callback(XactEvent event, void *arg)
 									 get_current_logical_xid(),
 									 heapXid, false);
 				}
+				else if (TransactionIdIsValid(heapXid))
+				{
+					/*
+					 * No joint commit record will tie this oxid to the heap
+					 * xid, and the WAL_REC_XID records already on the wire
+					 * may predate the xid.  Bind them explicitly, or replay
+					 * has no way to settle this transaction.
+					 */
+					wal_bind_heap_xid(oxid, get_current_logical_xid());
+				}
 
 				break;
 

--- a/test/t/recovery_heap_xid_binding_test.py
+++ b/test/t/recovery_heap_xid_binding_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from .base_test import BaseTest
+
+
+class RecoveryHeapXidBindingTest(BaseTest):
+	"""Crash recovery rolls back half of a committed transaction.
+
+	A transaction that owns a heap xid writes no OrioleDB finish record of its
+	own -- its verdict reaches replay through the builtin commit record, and
+	replay can only apply that verdict to the oxid if some record carried the
+	(oxid, heap xid) pair.  Two records normally carry it, and both can be
+	missing at once:
+
+	  * add_xid_wal_record() samples GetTopTransactionIdIfAny() when a
+	    container's first record is buffered, so a transaction that acquires
+	    its heap xid *after* its last OrioleDB change has every WAL_REC_XID
+	    carrying InvalidTransactionId;
+	  * wal_joint_commit() is written at XACT_EVENT_PRE_COMMIT only while a
+	    logical xid is held, and RELEASE SAVEPOINT hands that back to a parent
+	    which -- if the transaction's first OrioleDB write happened inside the
+	    subtransaction -- has none.
+
+	Replay then applies the transaction's changes and never learns its
+	verdict, so recovery_finish() rolls them back while PostgreSQL considers
+	the transaction committed.  The WAL of the losing run reads:
+
+	    XID(oxid=53 lxid=192 heapXid=0)  UPDATE o_t
+	    XID(oxid=53 lxid=0   heapXid=0)  UPDATE o_t
+	    XACT_COMMIT xl_xid=755
+
+	-- a committed transaction whose OrioleDB half nothing can settle.
+
+	Note this reproduces only while RELEASE SAVEPOINT can take the logical xid
+	away.  Fixing that (orioledb/orioledb#1045) keeps the logical xid, so
+	wal_joint_commit() fires again and carries the binding, and no SQL shape
+	reaches the bare-binding path any more.  The assertion is kept as a guard
+	on the property itself: a committed transaction's OrioleDB changes must
+	survive crash recovery, whichever record told replay whose they were.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.node.append_conf(
+		    'postgresql.conf', "checkpoint_timeout = 1h\n"
+		    "max_wal_size = 10GB\n")
+
+	def test_committed_changes_survive_a_late_heap_xid(self):
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_bind (\n"
+		    "  id int NOT NULL,\n"
+		    "  v int NOT NULL,\n"
+		    "  PRIMARY KEY (id)\n"
+		    ") USING orioledb;\n"
+		    "CREATE TABLE h_bind (id int PRIMARY KEY);\n"
+		    "INSERT INTO o_bind SELECT g, 0 FROM generate_series(1, 4) g;\n")
+		node.safe_psql('postgres', "CHECKPOINT;")
+
+		con = node.connect()
+		con.begin()
+		# first OrioleDB write inside a subtransaction: releasing it hands the
+		# logical xid back to a parent that has none
+		con.execute("SAVEPOINT s1;")
+		con.execute("UPDATE o_bind SET v = 1 WHERE id = 1;")
+		con.execute("RELEASE SAVEPOINT s1;")
+		# ... more OrioleDB work, still with no heap xid, so its WAL_REC_XID
+		# carries InvalidTransactionId ...
+		con.execute("UPDATE o_bind SET v = 555 WHERE id = 2;")
+		# ... and only now a heap xid, which no OrioleDB record has seen
+		con.execute("INSERT INTO h_bind VALUES (1);")
+		con.commit()
+		con.close()
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+
+		self.assertEqual(
+		    node.execute("SELECT v FROM o_bind WHERE id = 2;")[0][0], 555,
+		    "crash recovery rolled back the OrioleDB half of a committed "
+		    "transaction")
+		self.assertEqual(
+		    node.execute("SELECT v FROM o_bind WHERE id = 1;")[0][0], 1)
+		self.assertEqual(node.execute("SELECT count(*) FROM h_bind;")[0][0], 1)
+		node.stop()


### PR DESCRIPTION
In **parallel** crash recovery a committed transaction could come back with its OrioleDB changes rolled back and its heap changes intact. Two things are missing, one on the wire and one between the leader and its workers.

A transaction that owns a heap xid writes no OrioleDB finish record — `XACT_EVENT_COMMIT` takes the `set_oxid_xlog_ptr()` branch — so `recovery_finish()` decides its fate from the heap xid.

## 1. The workers never learn the heap xid

`state->xid` is only ever set on the leader, from `rec->heapXid` while parsing WAL. A worker's recovery xid state is created by `recovery_switch_to_oxid()` from a message that carries no xid, so at the end of replay every worker sees an in-progress oxid with no xid, concludes it cannot have committed, and applies undo. Measured with a probe on that path:

```
ABORTPROBE: worker 1 aborts oxid 52 xid 0 at recovery_finish
ABORTPROBE: worker 2 aborts oxid 52 xid 0 at recovery_finish
```

The binding now travels on the message that makes a worker adopt the oxid in the first place (`RECOVERY_MODIFY_HEAP_XID`, next to the oxid), so only workers that actually apply one of the transaction's changes hear about it. When the heap xid is acquired after some changes were already dispatched, exactly the workers in `used_by[]` get an explicit bind message.

Publishing the verdict stays the leader's alone: workers now reach the heap-verdict path in `recovery_finish()` too, and every process settling the same oxid would settle it repeatedly, which spins `set_oxid_xlog_ptr()` forever — the hazard the comment there already describes. A worker runs the undo bookkeeping and stops.

Two alternatives were tried and **measured to break parallel recovery**, so they are called out in the commit message rather than left for someone to rediscover:

* settling the oxid at the builtin commit record — it makes the leader do `workers_send_oxid_finish()` / `workers_synchronize()` at points the leader-to-worker ordering does not expect, and workers wedge in `recovery_queue_process()` (see #1044);
* broadcasting the binding to all workers — `recovery_switch_to_oxid()` in a worker *creates* state, with retain-undo and xmin entries, for oxids it never touches.

## 2. Sometimes no record carries the heap xid at all

Both records that normally carry it can be missing at once:

* `add_xid_wal_record()` samples `GetTopTransactionIdIfAny()` when a container's first record is buffered, so a transaction that acquires its heap xid **after** its last OrioleDB change has every `WAL_REC_XID` carrying `InvalidTransactionId`;
* `wal_joint_commit()` is gated on a logical xid, which `RELEASE SAVEPOINT` hands back to a parent that has none if the transaction's first OrioleDB write happened inside the subtransaction (that gate is #1045).

```
XID(oxid=53 lxid=192 heapXid=0)  UPDATE o_t
XID(oxid=53 lxid=0   heapXid=0)  UPDATE o_t
XACT_COMMIT xl_xid=755

value before crash: 555
value after crash recovery: 0      <- OrioleDB half rolled back
heap row after crash recovery: 1   <- heap half survived
```

A bare `WAL_REC_XID` is emitted at `PRE_COMMIT` in that case, after flushing the buffered changes so the heap xid is sampled once it exists. One shape stays out of reach and is documented: `XACT_EVENT_PRE_COMMIT` runs before `PreCommit_on_commit_actions()`.

## Testing

* `test/t/recovery_heap_xid_binding_test.py` — fails with `0 != 555` without either half of this PR.
* `recovery_test.py` 57/57, `regresscheck` 49/49, `isolationcheck` 35/35, `testgrescheck_part_1` (302 tests) all green.

Related: #1045 (the logical-xid gate above, independent and green) and #1044 (the crash-recovery livelock, still draft — its diagnosis holds, its remedy does not, and this PR is the piece it was missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)