### PR TITLE
Resolve the lock-only chain before the seq scan asks whose version it is (ORI-229)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/restartpoint_ddl_window_test.py \
 						test/t/s3_test.py \
 						test/t/schema_test.py \
+						test/t/seq_scan_own_write_test.py \
 						test/t/seq_scan_resowner_test.py \
 						test/t/seq_scan_undo_test.py \
 						test/t/temp_local_pool_test.py \

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -2193,7 +2193,29 @@ btree_seq_scan_getnext_internal(BTreeSeqScan *scan, MemoryContext mctx,
 
 				if (cmp == 0)
 				{
-					if (XACT_INFO_OXID_IS_CURRENT(tuphdr->xactInfo))
+					BTreeLeafTuphdr nonLockTuphdr = *tuphdr;
+
+					/*
+					 * The live version overrides whatever the historical page
+					 * image holds for this key -- but only if it is ours, and
+					 * the header on the page does not answer that on its own.
+					 * A concurrent transaction may have placed a FOR KEY
+					 * SHARE lock on top of our own version, which the two
+					 * modes allow, and then the header describes the locker.
+					 * Deciding on it emits the historical version instead,
+					 * and the transaction stops seeing its own write.
+					 *
+					 * Resolve the chain first, exactly as
+					 * fetch_our_tuple_from_page() does for the iterator. This
+					 * only runs where both images hold the same key, so it
+					 * costs nothing on a scan with no historical image at
+					 * all.
+					 */
+					(void) find_non_lock_only_undo_record(scan->desc->undoType,
+														  &nonLockTuphdr);
+
+					if (!XACT_INFO_IS_LOCK_ONLY(nonLockTuphdr.xactInfo) &&
+						XACT_INFO_OXID_IS_CURRENT(nonLockTuphdr.xactInfo))
 					{
 						BTREE_PAGE_LOCATOR_NEXT(scan->histImg, &scan->histLoc);
 						break;

--- a/test/t/seq_scan_own_write_test.py
+++ b/test/t/seq_scan_own_write_test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-import unittest
-
 from .base_test import BaseTest
 
 FAT = "x" * 180
@@ -42,8 +40,6 @@ class SeqScanOwnWriteTest(BaseTest):
 	-- the row is ours, and only the raw header says otherwise.
 	"""
 
-	@unittest.skip("the bug is not fixed yet: the merge decides by the raw "
-	               "leaf header instead of resolving the lock-only chain")
 	def test_sequential_scan_sees_own_write_under_a_key_share_lock(self):
 		node = self.node
 		node.start()

--- a/test/t/seq_scan_own_write_test.py
+++ b/test/t/seq_scan_own_write_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import unittest
+
+from .base_test import BaseTest
+
+FAT = "x" * 180
+BASE = 30
+
+
+class SeqScanOwnWriteTest(BaseTest):
+	"""A sequential scan misses the scanning transaction's own write.
+
+	btree_seq_scan_getnext_internal() merges the live leaf image with a
+	historical one, and where both hold the same key it decides which to emit
+	with
+
+	    if (XACT_INFO_OXID_IS_CURRENT(tuphdr->xactInfo))
+
+	read off the *raw* leaf header.  A concurrent FOR KEY SHARE lock puts a
+	lock-only undo record on top of our own version -- KEY SHARE and NO KEY
+	UPDATE do not conflict -- so that header describes the locker, the test
+	answers "not mine", and the scan emits the historical version instead.
+
+	The iterator asks the same question through find_non_lock_only_undo_record()
+	and gets it right, with a comment naming this exact hazard, which is why
+	the reported shape is "the index scan finds the row, the sequential scan
+	does not" (ORI-229 / orioledb#982).
+
+	Reaching that branch needs a historical page image, and one is only loaded
+	when the leaf's own csn is at or after the scan's snapshot -- i.e. a
+	*page-level* change committed by someone else after we took our snapshot.
+	A row update does not make one; a split does.  Order matters: the split
+	has to happen before our own write, so the image it leaves behind predates
+	it and emitting from it actually loses the write.
+
+	Instrumented, the losing decision reads
+
+	    ORI229PROBE: cmp==0 lockOnly=1 raw=0 resolved=1
+
+	-- the row is ours, and only the raw header says otherwise.
+	"""
+
+	@unittest.skip("the bug is not fixed yet: the merge decides by the raw "
+	               "leaf header instead of resolving the lock-only chain")
+	def test_sequential_scan_sees_own_write_under_a_key_share_lock(self):
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_seq (\n"
+		    "  id int NOT NULL,\n"
+		    "  v int NOT NULL,\n"
+		    "  pad text NOT NULL,\n"
+		    "  PRIMARY KEY (id)\n"
+		    ") USING orioledb;\n"
+		    "INSERT INTO o_seq SELECT g, 0, '%s' "
+		    "FROM generate_series(1, %d) g;" % (FAT, BASE))
+		node.safe_psql('postgres', "CHECKPOINT;")
+
+		scanner = node.connect()
+		splitter = node.connect()
+		locker = node.connect()
+
+		scanner.execute("SET enable_indexscan = off;")
+		scanner.execute("SET enable_bitmapscan = off;")
+		scanner.begin('repeatable read')
+		# a live sequential scan, so a concurrent page change has a reason to
+		# keep the old page image
+		scanner.execute(
+		    "DECLARE cur NO SCROLL CURSOR FOR SELECT id, v FROM o_seq;")
+		scanner.execute("FETCH 1 FROM cur;")
+
+		# split the page under our snapshot, before our own write
+		splitter.begin()
+		splitter.execute("INSERT INTO o_seq SELECT g, 0, '%s' "
+		                 "FROM generate_series(%d, %d) g;" %
+		                 (FAT, BASE + 1, BASE + 120))
+		splitter.commit()
+
+		scanner.execute("UPDATE o_seq SET v = 42 WHERE id = 1;")
+
+		# a lock-only record on top of our own version
+		locker.begin()
+		locker.execute("SELECT id FROM o_seq WHERE id = 1 FOR KEY SHARE;")
+
+		rows = scanner.execute("SELECT id, v FROM o_seq WHERE id = 1;")
+		try:
+			self.assertEqual(
+			    rows, [(1, 42)], "the sequential scan did not see the "
+			    "transaction's own write")
+		finally:
+			for con in (locker, splitter, scanner):
+				try:
+					con.rollback()
+					con.close()
+				except Exception:
+					pass
+		node.stop()


### PR DESCRIPTION
A sequential scan could stop seeing the scanning transaction's own write, while an index scan on the same row still found it — the shape reported as ORI-229 / #982.

## The defect

`btree_seq_scan_getnext_internal()` merges the live leaf image with a historical one. Where both hold the same key it decided which to emit from the **raw** leaf header:

```c
if (XACT_INFO_OXID_IS_CURRENT(tuphdr->xactInfo))
```

A concurrent transaction may hold a `FOR KEY SHARE` lock on top of our own version — `KEY SHARE` and `NO KEY UPDATE` do not conflict — and then that header describes the locker, not us. The test answers "not mine", the scan takes the historical branch, and the transaction is handed a version of its own row from before it wrote.

The iterator makes the same decision in `fetch_our_tuple_from_page()` ("the live version overrides whatever we could have from the undo log page image") and resolves the chain first, which **74f2acc2** taught it to do for exactly this reason:

> Look for non-lock-only undo record for that tuple, as there might be FOR KEY SHARE locks placed by concurrent transactions.

`scan.c`'s copy of that decision has not been touched since af569861, the initial public release, so that fix never reached it.

Every other site asking the same question is already careful:

| site | header resolved? |
|---|---|
| `iterator.c:594`, `fetch_our_tuple_from_page()` | yes — `find_non_lock_only_undo_record()` plus `!XACT_INFO_IS_LOCK_ONLY` (74f2acc2) |
| `iterator.c:785`, version walk | yes — resolved on entry at `iterator.c:722` |
| `modify.c:1206`, `page_unique_check()` | yes — resolved one line above |
| `operations.c` (7 sites), `indexam/handler.c:374` | n/a — modify callbacks, handed an already resolved `xactInfo` |
| **`scan.c:2196`** | **no — fixed here** |

The extra work only happens where both images hold the same key, so a scan with no historical image — the ordinary case — pays nothing.

## The test

`test/t/seq_scan_own_write_test.py` builds the state deterministically, and the ordering is the fiddly part:

1. a live sequential scan fixes an RR snapshot — a page image is only kept if someone needs it;
2. another session **splits the page** and commits — a page-level image is only produced by a structural change, not by a row update;
3. we write our row — **after** the split, so the image predates the write and emitting from it actually loses it;
4. a third session takes `FOR KEY SHARE` on that row — the lock-only record on top;
5. the scan has to still see our write.

Without the fix it reads `(1, 0)` where the transaction wrote `42`. With the split *before* our write the wrong branch is still taken but the result happens to be right, which is what made two earlier constructions look clean.

Instrumented at the decision point (probe kept on branch `debug/ori229-probe`, not for merging):

```
ORI229PROBE: cmp==0 lockOnly=1 raw=0 resolved=1
```

— the row is ours, and only the raw header says otherwise.

## What this does and does not explain

Only the scanning transaction's own writes are affected: for other transactions' versions, taking the historical branch is correct, and cross-transaction visibility goes through `o_find_tuple_version()` untouched. So this can account for read-own-writes misses (ORI-229), for lost updates inside a read-modify-write statement such as `UPDATE ... SET val = CONCAT(val, ',', e)` over an unindexed column — the recomputation starts from the stale value and the transaction's own earlier element disappears — and for spurious upsert conflicts. It does not touch G1c/G2 (ORI-242).

One caveat I have not closed: the reproducer takes an explicit `FOR KEY SHARE`, while the jepsen append workload takes no row locks and has no foreign keys, and `RowLockKeyShare` only arises from `LockTupleKeyShare` in `tuple_lock_mode_to_row_lock_mode()`. So this being *the* cause of ORI-229 as that workload reproduces it is not established — it may be one of several holes. The decisive check is to run `ci/rr_append_hunt.py` on a build with this fix and see whether read-own-writes still turns up.

## Testing

`regresscheck` 49/49, `isolationcheck` 35/35, `testgrescheck_part_1` (301 tests) — all green with the fix; the new test fails without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)