### PR TITLE
Reserve the xid record before sizing the savepoint rollback flush

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/seq_scan_resowner_test.py \
 						test/t/seq_scan_undo_test.py \
 						test/t/temp_local_pool_test.py \
+						test/t/wal_savepoint_buffer_test.py \
 						test/t/toast_index_test.py \
 						test/t/trigger_test.py \
 						test/t/unlogged_test.py \

--- a/src/recovery/wal.c
+++ b/src/recovery/wal.c
@@ -686,8 +686,16 @@ add_rollback_to_savepoint_wal_record(SubTransactionId parentSubid)
 	CommitSeqNo csn;
 
 	Assert(!is_recovery_process());
-	flush_local_wal_if_needed(sizeof(*rec));
+
+	/*
+	 * Drop the buffer's xid before sizing the flush, not after.
+	 * XID_RESERVED_LENGTH is what flush_local_wal_if_needed() sets aside for
+	 * the xid record, and it reads as zero while contains_xid is set, so
+	 * clearing the flag afterwards asks add_xid_wal_record_if_needed() for
+	 * sizeof(WALRecXid) bytes that nothing reserved.
+	 */
 	local_wal.contains_xid = false;
+	flush_local_wal_if_needed(sizeof(*rec));
 	Assert(local_wal.buffer_offset + sizeof(*rec) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE);
 
 	add_xid_wal_record_if_needed();

--- a/test/t/wal_savepoint_buffer_test.py
+++ b/test/t/wal_savepoint_buffer_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import unittest
+
+from .base_test import BaseTest
+
+
+class WalSavepointBufferTest(BaseTest):
+
+	def test_rollback_to_savepoint_at_buffer_end(self):
+		"""
+		A ROLLBACK TO SAVEPOINT whose record lands in the last bytes of the
+		local WAL buffer must not overrun it.
+
+		The record is written after add_xid_wal_record_if_needed(), so the
+		buffer has to have room for both.  Only the last sizeof(WALRecXid)
+		bytes of the 8192-byte buffer expose a miscount, and the rollback
+		record itself flushes the buffer, so the offset it sees is exactly
+		what has been written since the previous rollback.  Sweeping the
+		number and size of the intervening updates walks that total across
+		the end of the buffer; an assert build aborts on the offending
+		iteration.
+		"""
+		node = self.node
+		node.start()
+		node.safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql(
+		    'postgres', """
+			CREATE TABLE wal_sp (id int PRIMARY KEY, v text) USING orioledb;
+			INSERT INTO wal_sp SELECT g, 'x' FROM generate_series(1, 500) g;
+		""")
+		node.safe_psql(
+		    'postgres', """
+			DO $$
+			DECLARE
+				n int;
+				pad int;
+				k int;
+			BEGIN
+				FOR n IN 405..450 LOOP
+					FOR pad IN 1..70 LOOP
+						BEGIN
+							FOR k IN 1..n LOOP
+								UPDATE wal_sp SET v = 'a' WHERE id = k;
+							END LOOP;
+							UPDATE wal_sp SET v = repeat('b', pad)
+								WHERE id = 1;
+							RAISE EXCEPTION 'rollback to savepoint';
+						EXCEPTION WHEN OTHERS THEN
+							NULL;
+						END;
+					END LOOP;
+				END LOOP;
+			END $$;
+		""")
+		self.assertEqual(
+		    500,
+		    int(node.execute('postgres', "SELECT count(*) FROM wal_sp")[0][0]))
+		node.stop()


### PR DESCRIPTION
Found by the SQLSmith job on an unrelated pull request:

```
TRAP: failed Assert("local_wal.buffer_offset + sizeof(*rec) + XID_RESERVED_LENGTH <= LOCAL_WAL_BUFFER_SIZE")
      src/recovery/wal.c:691
```

`add_rollback_to_savepoint_wal_record()` sized the local WAL buffer flush and then dropped the buffer's xid:

```c
flush_local_wal_if_needed(sizeof(*rec));
local_wal.contains_xid = false;
```

`XID_RESERVED_LENGTH` is `contains_xid ? 0 : sizeof(WALRecXid)`, and it is what `flush_local_wal_if_needed()` sets aside for the xid record. With the flag still set, the flush reserved nothing for it; clearing the flag on the next line then made `add_xid_wal_record_if_needed()` write 17 bytes nobody had accounted for. The assertion sitting between the two lines states precisely the invariant that had just been broken, and without assertions the write runs past the end of the 8192-byte buffer.

The fix moves the clear ahead of the sizing. Emitted WAL is unchanged.

**Why it stayed hidden.** The window is the last `sizeof(WALRecXid)` = 17 bytes of 8192, so roughly one rollback in 480, and only when the buffer already carries an xid.

**The test reaches it deterministically.** The rollback record flushes the buffer, so the offset it sees next time is exactly what has been written since the previous one. Sweeping the number of intervening updates moves that total in ~19-byte steps and sweeping the size of the last one fills in the bytes between, which walks the total across the end of the buffer. On unfixed code it aborts at offset 8155, the first byte of the window; with the fix the same sweep completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)