### PR TITLE
ci: do not fail a valgrind job on a posix_spawn child killed at node stop

### DIFF
--- a/ci/check_output.sh
+++ b/ci/check_output.sh
@@ -80,11 +80,26 @@ done
 # show valgrind logs if needed
 if [ $CHECK_TYPE = "valgrind_1" ] || [ $CHECK_TYPE = "valgrind_2" ]; then
 	for f in ` find . -name pid-*.log ` ; do
-		if grep -q 'Command: [^ ]*/postgres' $f && grep -E -q '(Process terminating|ERROR SUMMARY: [1-9])' $f; then
-			echo "========= Contents of $f"
-			cat $f
-			status=1
+		if ! grep -q 'Command: [^ ]*/postgres' $f; then
+			continue
 		fi
+		if ! grep -E -q '(Process terminating|ERROR SUMMARY: [1-9])' $f; then
+			continue
+		fi
+		# A process killed inside posix_spawn is the short-lived child
+		# postgres forked to run an external command (archive_command,
+		# restore_command).  Valgrind follows it, copies the parent's command
+		# line into the header, and reports the SIGTERM that stops the node as
+		# a termination.  With no errors of its own it says nothing about
+		# orioledb, and whether the child is alive at the moment the node stops
+		# is a race, so this failed a job at random.
+		if grep -q '__spawni_child' $f && grep -q 'ERROR SUMMARY: 0 errors' $f; then
+			echo "skipping $f: posix_spawn child killed at node stop, no errors"
+			continue
+		fi
+		echo "========= Contents of $f"
+		cat $f
+		status=1
 	done
 fi
 


### PR DESCRIPTION
`check_output.sh` fails a valgrind job when any `pid-*.log` contains `Process terminating`. One class of those logs is not a backend at all.

Postgres forks through `posix_spawn` to run an external command (`archive_command`, `restore_command`). Valgrind follows the child and copies the *parent's* command line into the log header, so the log looks like a postgres process; when the node is stopped, the child gets SIGTERM:

```
Command: .../pgsql/bin/postgres -D .../recovery-recovery_target_time_tgsb/data
Process terminating with default action of signal 15 (SIGTERM)
   at pthread_sigmask
   by sigprocmask
   by __spawni_child (spawni.c:289)
   by clone
ERROR SUMMARY: 0 errors from 0 contexts
```

The signal takes its *default* action because `posix_spawn` has already reset the child's handlers — that, plus the `__spawni_child` frame, is what identifies it. There are no errors, and nothing of ours is involved.

Whether that child is alive at the exact moment the node stops is a race, which is why this failed at random: it took down `check (amd64, 18, clang, valgrind_1)` on #977 while passing on #1011, #879 and #1051 — and #977 contains every commit #1011 has, so the code was not the difference.

The skip is deliberately narrow: only when the terminating stack contains `__spawni_child` **and** valgrind reports `ERROR SUMMARY: 0 errors`. A backend that dies has a real stack and does not match either condition, so real terminations still fail the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)