### PR TITLE
Identify a historical page by its hikey when stepping sideways

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,8 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/vacuum_test.py \
 						test/t/transaction_test.py \
 						test/t/page_pool_test.py \
-						test/t/bitmap_partition_test.py
+						test/t/bitmap_partition_test.py \
+						test/t/undo_image_chain_test.py
 TESTGRESCHECKS_PART_3 = test/t/rewind_time_test.py
 
 # perf/*_perf.py -- see perf/README.md.

--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -200,8 +200,7 @@ extern void make_waiter_undo_record(BTreeDescr *desc, OInMemoryBlkno blkno,
 extern void get_page_from_undo(BTreeDescr *desc, UndoLocation undo_loc, Pointer key,
 							   BTreeKeyType kind, Pointer dest,
 							   bool *is_left, bool *is_right, OFixedKey *lokey,
-							   OFixedKey *page_lokey, OTuple *page_hikey,
-							   bool *is_differential);
+							   OFixedKey *page_lokey, OTuple *page_hikey);
 extern UndoLocation page_add_image_to_undo(BTreeDescr *desc, Pointer p,
 										   CommitSeqNo imageCsn,
 										   OTuple *splitKey, LocationIndex splitKeyLen);

--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1664,6 +1664,41 @@ refresh_context_leaf_lokey(OBTreeFindPageContext *context,
 }
 
 /*
+ * Is the page in context->img the same historical page as the one described by
+ * the arguments?
+ *
+ * Several current leaves can resolve to one historical page -- one wide
+ * pre-split image serves all of them -- and its rows have to be emitted once.
+ * What says whether that happened is the range the chain walk arrived at, not
+ * which undo record it stopped on: the walk both overwrites the image and
+ * switches which predecessor's history it follows, so the record it ends on
+ * identifies neither the contents nor the page.
+ *
+ * The hikey is the part of that range which is both available and sufficient.
+ * Available, because it is in the image itself, whatever the walk did to get
+ * there -- unlike the lokey, which a full split image cannot give for its right
+ * half at all.  Sufficient, because every reconstruction in one walk is to the
+ * same csn, and at one moment the tree's page boundaries are unique: equal
+ * hikeys are the same page, different hikeys are different pages.  Being
+ * rightmost is such a boundary too, and at most one page has it.
+ */
+static bool
+img_is_same_historical_page(OBTreeFindPageContext *context, bool rightmost,
+							OTuple hikey)
+{
+	OTuple		imgHikey;
+
+	if (O_PAGE_IS(context->img, RIGHTMOST) != rightmost)
+		return false;
+	if (rightmost)
+		return true;
+
+	BTREE_PAGE_GET_HIKEY(imgHikey, context->img);
+	return o_btree_cmp(context->desc, &imgHikey, BTreeKeyNonLeafKey,
+					   &hikey, BTreeKeyNonLeafKey) == 0;
+}
+
+/*
  * Find the left sibling of the current page.
  *
  * Expected new page hikey (lokey for old page) will be saved to hikey_buf.
@@ -1680,6 +1715,8 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 			   *item;
 	int			level;
 	UndoLocation prevLoc;
+	OFixedKey	prevHikey;
+	bool		prevRightmost;
 	Jsonb	   *params;
 	OTuple		imgHikey;
 	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
@@ -1706,6 +1743,16 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 	item = &context->items[context->index];
 
 	prevLoc = context->imgUndoLoc;
+	clear_fixed_key(&prevHikey);
+	prevRightmost = O_PAGE_IS(context->img, RIGHTMOST);
+	if (!prevRightmost)
+	{
+		OTuple		leavingHikey;
+
+		BTREE_PAGE_GET_HIKEY(leavingHikey, context->img);
+		copy_fixed_key(desc, &prevHikey, leavingHikey);
+	}
+
 	while (true)
 	{
 		/* Nothing to do with leftmost page */
@@ -1768,8 +1815,10 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 												   true);
 
 					if (success &&
-						context->imgUndoLoc != InvalidUndoLocation &&
-						prevLoc == context->imgUndoLoc)
+						UndoLocationIsValid(prevLoc) &&
+						UndoLocationIsValid(context->imgUndoLoc) &&
+						img_is_same_historical_page(context, prevRightmost,
+													prevHikey.tuple))
 					{
 						parentItem->locator = loc;
 						refresh_context_leaf_lokey(context, &loc);
@@ -1804,7 +1853,10 @@ find_left_page(OBTreeFindPageContext *context, OFixedKey *hikey)
 		parentItem = &context->items[context->index - 1];
 		item = &context->items[context->index];
 
-		if (prevLoc != InvalidUndoLocation && prevLoc == context->imgUndoLoc)
+		if (UndoLocationIsValid(prevLoc) &&
+			UndoLocationIsValid(context->imgUndoLoc) &&
+			img_is_same_historical_page(context, prevRightmost,
+										prevHikey.tuple))
 			continue;
 
 		if (COMMITSEQNO_IS_INPROGRESS(context->csn) &&

--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -2403,10 +2403,10 @@ undo_it_find_internal(UndoIterator *undoIt, void *key, BTreeKeyType kind)
 		/* Load the next page item from page-level undo item */
 		if (undoIt->it->scanDir == ForwardScanDirection)
 			get_page_from_undo(desc, undoLocation, key, kind,
-							   undoIt->image, &left, &right, NULL, NULL, NULL, NULL);
+							   undoIt->image, &left, &right, NULL, NULL, NULL);
 		else
 			get_page_from_undo(desc, undoLocation, key, kind,
-							   undoIt->image, &left, &right, &undoIt->lokey, NULL, NULL, NULL);
+							   undoIt->image, &left, &right, &undoIt->lokey, NULL, NULL);
 
 		undoIt->rightmost = (undoIt->rightmost && right) || O_PAGE_IS(undoIt->image, RIGHTMOST);
 		undoIt->leftmost = (undoIt->leftmost && left) || O_PAGE_IS(undoIt->image, LEFTMOST);

--- a/src/btree/page_contents.c
+++ b/src/btree/page_contents.c
@@ -69,10 +69,6 @@ read_page_from_undo(BTreeDescr *desc, Page img, UndoLocation undo_loc,
 	CommitSeqNo page_csn;
 	UndoLocation rec_undo_location;
 	bool		is_left = true;
-	bool		is_differential;
-	bool		imageIdentityLatched = false;
-	UndoLocation imageIdentityLoc = InvalidUndoLocation;
-	bool		imageIdentityIsLeft = true;
 	OFixedKey	stepLokey;
 	UndoLogType undoType PG_USED_FOR_ASSERTS_ONLY = GET_PAGE_LEVEL_UNDO_TYPE(desc->undoType);
 
@@ -85,18 +81,10 @@ read_page_from_undo(BTreeDescr *desc, Page img, UndoLocation undo_loc,
 	{
 		/* Read page image from page-level undo item */
 		clear_fixed_key(&stepLokey);
-		is_differential = false;
 		get_page_from_undo(desc, undo_loc, key, keyType, img,
 						   &is_left, NULL, lokey ? &stepLokey : NULL,
-						   NULL, NULL, &is_differential);
+						   NULL, NULL);
 
-		/* Latch the image identity at the first differential record */
-		if (is_differential && !imageIdentityLatched)
-		{
-			imageIdentityLatched = true;
-			imageIdentityLoc = undo_loc;
-			imageIdentityIsLeft = is_left;
-		}
 
 		/* Keep the tightest bound reported so far -- see above */
 		if (lokey && !O_TUPLE_IS_NULL(stepLokey.tuple) &&
@@ -126,9 +114,6 @@ read_page_from_undo(BTreeDescr *desc, Page img, UndoLocation undo_loc,
 
 	/* Page-level undo item should be retained */
 	Assert(UNDO_REC_EXISTS(undoType, undo_loc));
-
-	if (imageIdentityLatched)
-		return O_UNDO_GET_IMAGE_LOCATION(imageIdentityLoc, imageIdentityIsLeft);
 
 	return O_UNDO_GET_IMAGE_LOCATION(undo_loc, is_left);
 }

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -393,7 +393,7 @@ load_first_historical_page(BTreeSeqScan *scan)
 
 		(void) get_page_from_undo(scan->desc, header->undoLocation, key, kind,
 								  scan->histImg, NULL, NULL, NULL,
-								  lokeyPtr, &hikey.tuple, NULL);
+								  lokeyPtr, &hikey.tuple);
 
 		if (!O_PAGE_IS(scan->histImg, RIGHTMOST))
 			copy_fixed_hikey(scan->desc, &hikey, scan->histImg);
@@ -458,7 +458,7 @@ load_next_historical_page(BTreeSeqScan *scan)
 		(void) get_page_from_undo(scan->desc, header->undoLocation,
 								  (Pointer) &prevHikey.tuple, BTreeKeyNonLeafKey,
 								  scan->histImg, NULL, NULL, NULL,
-								  NULL, NULL, NULL);
+								  NULL, NULL);
 		header = (BTreePageHeader *) scan->histImg;
 	}
 	BTREE_PAGE_LOCATOR_FIRST(scan->histImg, &scan->histLoc);

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1428,8 +1428,7 @@ void
 get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 				   BTreeKeyType kind, Pointer dest,
 				   bool *is_left, bool *is_right, OFixedKey *lokey,
-				   OFixedKey *page_lokey, OTuple *page_hikey,
-				   bool *is_differential)
+				   OFixedKey *page_lokey, OTuple *page_hikey)
 {
 	/*
 	 * Read enough bytes to cover the peek header and (if this is a full
@@ -1448,10 +1447,6 @@ get_page_from_undo(BTreeDescr *desc, UndoLocation undoLocation, Pointer key,
 
 	undo_read(undoType, undoLocation, sizeof(header), (Pointer) &header);
 	left_loc = undoLocation + MAXALIGN(sizeof(header));
-
-	if (is_differential != NULL)
-		*is_differential = (header.type == UndoPageImageMergeDiff ||
-							header.type == UndoPageImageSplitDiff);
 
 	if (header.type == UndoPageImageMergeDiff)
 	{

--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -428,6 +428,104 @@ class MergeTest(BaseTest):
 			con.rollback()
 			con.close()
 
+	def test_split_diff_over_full_image_chain(self):
+		"""
+		A page-level undo chain must not mix a full image with a differential one.
+
+		A full image (UndoPageImageSplit) carries the whole page, so applying it
+		overwrites whatever the chain walk has built.  A differential split
+		(UndoPageImageSplitDiff) carries no page bytes at all and transforms the
+		image the walk is holding, in place.  Mixed, the differential record is
+		applied to a base it was not computed against, and the bound the walk
+		narrowed from its split key survives into a page the full image has
+		since widened back -- so a backward scan re-reads the same leaves and
+		returns every row several times.  Issue #1055.
+
+		page_add_image_to_undo() picks the kind at write time: a split that
+		drops no tuple writes a differential image, unless a sequential scan is
+		registered on the tree, in which case it writes a full one.  So a cursor
+		held open over a sequential scan decides the first split, and closing it
+		decides the second -- no timing involved.  The old REPEATABLE READ
+		snapshot held throughout retains the undo, so neither split may take the
+		branch that writes no image at all.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', "CREATE TABLE IF NOT EXISTS o_mixed_chain ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb;"
+		    "TRUNCATE o_mixed_chain;")
+		# Two free slots between each pair of keys, so both rounds of
+		# interleaved inserts split the same leaves.
+		node.execute("INSERT INTO o_mixed_chain "
+		             "(SELECT id * 4, repeat('x', 100) "
+		             "FROM generate_series(1, 5000) id);")
+		expected = [i * 4 for i in range(1, 5001)]
+
+		con_snap = node.connect()
+		try:
+			con_snap.begin()
+			con_snap.execute(
+			    "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+			# Takes the snapshot and starts retaining undo.  The read finishes,
+			# so it leaves no sequential scan registered.
+			self.assertEqual(
+			    con_snap.execute("SELECT count(*) FROM o_mixed_chain;")[0][0],
+			    len(expected))
+
+			# Round one: split every leaf while a sequential scan is parked on
+			# the tree, which forces a full image.
+			con_hold = node.connect()
+			try:
+				con_hold.begin()
+				con_hold.execute("SET enable_indexscan = off;")
+				con_hold.execute("SET enable_bitmapscan = off;")
+				con_hold.execute("DECLARE ch NO SCROLL CURSOR FOR "
+				                 "SELECT id FROM o_mixed_chain;")
+				self.assertEqual(len(con_hold.execute("FETCH 1 FROM ch;")), 1)
+				node.execute("INSERT INTO o_mixed_chain "
+				             "(SELECT id * 4 + 1, repeat('y', 100) "
+				             "FROM generate_series(1, 5000) id);")
+				con_hold.execute("CLOSE ch;")
+			finally:
+				con_hold.rollback()
+				con_hold.close()
+
+			# Round two: nothing is parked now, so the same leaves split into
+			# differential images stacked on the full ones.
+			node.execute("INSERT INTO o_mixed_chain "
+			             "(SELECT id * 4 + 2, repeat('z', 100) "
+			             "FROM generate_series(1, 5000) id);")
+
+			con_snap.execute("SET enable_seqscan = off;")
+			con_snap.execute("SET enable_bitmapscan = off;")
+			forward = [
+			    r[0] for r in con_snap.execute(
+			        "SELECT id FROM o_mixed_chain ORDER BY id;")
+			]
+			backward = [
+			    r[0] for r in con_snap.execute(
+			        "SELECT id FROM o_mixed_chain ORDER BY id DESC;")
+			]
+			# Compare the sizes first: the failure is a flood of duplicates, and
+			# the count says so in one line.
+			self.assertEqual(len(forward), len(expected))
+			self.assertEqual(len(backward), len(expected))
+			self.assertEqual(forward, expected)
+			self.assertEqual(backward, list(reversed(expected)))
+		finally:
+			# An assert-enabled build catches the same defect as an ordering
+			# assertion in the backend instead of returning the rows, so the
+			# connection may already be gone by now.  Don't let tearing it down
+			# mask what failed.
+			try:
+				con_snap.rollback()
+				con_snap.close()
+			except Exception:
+				pass
+
 	def test_split_diff_update_grow(self):
 		"""
 		A single UPDATE that grows every row, forcing in-statement page splits

--- a/test/t/undo_image_chain_test.py
+++ b/test/t/undo_image_chain_test.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+Reading an old snapshot through every shape of page-level undo chain.
+
+A page-level undo record either carries page bytes or it does not:
+
+    UndoPageImageCompact    full   page compaction
+    UndoPageImageSplit      full   split, when it drops a tuple or a sequential
+                                   scan is registered on the tree
+    UndoPageImageSplitDiff  diff   split, otherwise -- split key only
+    UndoPageImageMerge      full   merge, when it drops a tuple
+    UndoPageImageMergeDiff  diff   merge, otherwise -- boundary key only
+
+Applying a full record overwrites the image the chain walk carries; a
+differential one transforms it in place.  So what matters is the composition of
+a chain and, just as much, *where the reader's snapshot sits in it*: the walk
+applies records while the page csn is at or above the snapshot csn and stops
+below, so the same chain gives a reader that predates its full image a shared
+page, and a reader that postdates it the narrow halves.  Both readings have to
+be right, and #1055 was the first of them going wrong.
+
+Two facts, both measured with elog probes at the five write sites, shape these
+cases:
+
+  * A page's *first* image is always a full one.  A differential record is only
+    written when the page already carries a retained undo location, and an
+    operation on a page that has none writes no image at all (it freezes the
+    page instead).  So there is no such thing as a purely differential chain,
+    and every case that wants a differential record has to seed a full one
+    first.
+  * Which is why the snapshot position is the interesting axis: seeded before
+    the full image, a reader walks through it; seeded after, it stops above it.
+
+Every case therefore checks both positions.  A snapshot's own view, captured
+when it is taken, must come back unchanged through every read path -- payload
+included, since a read that returns the right keys with a stale version is
+exactly what an isolation checker reports.
+"""
+
+import unittest
+
+from .base_test import BaseTest
+
+ROWS = 2000
+PAD = 100
+SAMPLE_COUNT = 5
+
+
+class UndoImageChainTest(BaseTest):
+
+	def setUp(self):
+		super().setUp()
+		self.node.start()
+		self.node.safe_psql('postgres',
+		                    "CREATE EXTENSION IF NOT EXISTS orioledb;")
+
+	# ------------------------------------------------------------------ helpers
+
+	def _make(self, table, fillfactor=None, step=1):
+		with_clause = ("WITH (fillfactor = %d)" %
+		               fillfactor if fillfactor is not None else "")
+		self.node.safe_psql(
+		    'postgres', "DROP TABLE IF EXISTS %s;"
+		    "CREATE TABLE %s ("
+		    "    id int NOT NULL,"
+		    "    payload text NOT NULL,"
+		    "    PRIMARY KEY (id)"
+		    ") USING orioledb %s;" % (table, table, with_clause))
+		self.node.execute("INSERT INTO %s "
+		                  "(SELECT id * %d, repeat('v0', %d) "
+		                  "FROM generate_series(1, %d) id);" %
+		                  (table, step, PAD, ROWS))
+
+	def _snapshot(self, table):
+		"""
+		Open a REPEATABLE READ snapshot and capture the view it must keep.
+
+		The capturing read finishes, so the snapshot leaves no sequential scan
+		registered on the tree: only its retained undo matters from here on.
+		"""
+		con = self.node.connect()
+		con.begin()
+		con.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+		view = con.execute("SELECT id, payload FROM %s ORDER BY id;" % table)
+		self.assertTrue(len(view) > 0)
+		return con, view
+
+	class _ParkedSeqScan:
+		"""A sequential scan parked on a cursor keeps numSeqScans raised, which
+		is what makes a split write a full image instead of a differential one."""
+
+		def __init__(self, test, table):
+			self.con = test.node.connect()
+			self.con.begin()
+			self.con.execute("SET enable_indexscan = off;")
+			self.con.execute("SET enable_bitmapscan = off;")
+			self.con.execute("DECLARE ch NO SCROLL CURSOR FOR "
+			                 "SELECT id FROM %s;" % table)
+			test.assertEqual(len(self.con.execute("FETCH 1 FROM ch;")), 1)
+
+		def __enter__(self):
+			return self
+
+		def __exit__(self, *exc):
+			try:
+				self.con.execute("CLOSE ch;")
+				self.con.rollback()
+			finally:
+				self.con.close()
+			return False
+
+	def _park_seq_scan(self, table):
+		return self._ParkedSeqScan(self, table)
+
+	def _interleave(self, table, offset, step, payload):
+		"""Insert keys between the existing ones, splitting every leaf."""
+		self.node.execute("INSERT INTO %s "
+		                  "(SELECT id * %d + %d, repeat('%s', %d) "
+		                  "FROM generate_series(1, %d) id);" %
+		                  (table, step, offset, payload, PAD, ROWS))
+
+	def _rewrite(self, table, payload):
+		"""Grow every row: compacts the leaves and splits some of them."""
+		self.node.execute("UPDATE %s SET payload = repeat('%s', %d);" %
+		                  (table, payload, PAD + 10))
+
+	def _drop_third(self, table):
+		"""Settled deletes, so a later merge has tuples to drop."""
+		self.node.safe_psql('postgres',
+		                    "DELETE FROM %s WHERE MOD(id, 3) = 0;" % table)
+
+	def _merge(self, table):
+		"""CHECKPOINT's page-merge pass, on a table sparse enough to merge."""
+		self.node.execute("CHECKPOINT;")
+
+	def _verify(self, con, table, view, label):
+		"""The snapshot's captured view must come back through every path."""
+		ids = [r[0] for r in view]
+		pairs = sorted((r[0], r[1]) for r in view)
+
+		plans = (
+		    ("seq", "SET LOCAL enable_indexscan = off;"
+		     "SET LOCAL enable_bitmapscan = off;"),
+		    ("index", "SET LOCAL enable_seqscan = off;"
+		     "SET LOCAL enable_bitmapscan = off;"),
+		    ("bitmap", "SET LOCAL enable_seqscan = off;"
+		     "SET LOCAL enable_indexscan = off;"),
+		)
+		for plan, prep in plans:
+			where = "%s/%s" % (label, plan)
+			rows, distinct = con.execute(
+			    prep +
+			    "SELECT count(*), count(DISTINCT id) FROM %s;" % table)[0]
+			self.assertEqual((where, rows), (where, len(ids)))
+			self.assertEqual((where, distinct), (where, len(ids)))
+			got = sorted(
+			    (r[0], r[1])
+			    for r in con.execute(prep +
+			                         "SELECT id, payload FROM %s;" % table))
+			self.assertEqual((where, got == pairs), (where, True))
+
+		# Ordered reads in both directions.  A dropped range or a duplicate
+		# shows up in the length first, which keeps the message short.
+		con.execute("SET enable_seqscan = off;")
+		con.execute("SET enable_bitmapscan = off;")
+		forward = [
+		    r[0] for r in con.execute("SELECT id FROM %s ORDER BY id;" % table)
+		]
+		backward = [
+		    r[0]
+		    for r in con.execute("SELECT id FROM %s ORDER BY id DESC;" % table)
+		]
+		self.assertEqual((label, 'forward', len(forward)),
+		                 (label, 'forward', len(ids)))
+		self.assertEqual((label, 'backward', len(backward)),
+		                 (label, 'backward', len(ids)))
+		self.assertEqual(forward, ids)
+		self.assertEqual(backward, list(reversed(ids)))
+
+		# Point lookups: the shape a key/value workload reads with.
+		stride = max(1, len(view) // SAMPLE_COUNT)
+		for key, payload in view[::stride][:SAMPLE_COUNT]:
+			self.assertEqual(
+			    [(payload, )],
+			    con.execute("SELECT payload FROM %s WHERE id = %d;" %
+			                (table, key)))
+		con.execute("RESET enable_seqscan;")
+		con.execute("RESET enable_bitmapscan;")
+
+	def _run(self, table, seed, rest, fillfactor=None, step=1):
+		"""
+		Run a chain shape against two readers.
+
+		`seed` writes the chain's full image; `rest` stacks the rest on top.
+		One snapshot is taken before the seed, so its walk applies that full
+		image, and one after it, so its walk stops above it.  Both must read
+		their own view back.
+		"""
+		self._make(table, fillfactor=fillfactor, step=step)
+		before, before_view = self._snapshot(table)
+		try:
+			seed(table)
+			after, after_view = self._snapshot(table)
+			try:
+				rest(table)
+				self._verify(before, table, before_view, 'before-seed')
+				self._verify(after, table, after_view, 'after-seed')
+			finally:
+				self._close(after)
+		finally:
+			self._close(before)
+		self.assertTrue(
+		    self.node.execute(
+		        "SELECT orioledb_tbl_check('%s'::regclass, true)" %
+		        table)[0][0])
+
+	@staticmethod
+	def _close(con):
+		# An assert-enabled build can catch the defect inside the backend before
+		# it returns rows, so the connection may already be gone.
+		try:
+			con.rollback()
+			con.close()
+		except Exception:
+			pass
+
+	# --------------------------------------------------- split-only chains
+
+	def test_split_diff_above_split_full(self):
+		"""
+		The #1055 shape.  Measured: SplitFull=194, then SplitDiff=97.
+
+		Several current leaves resolve to the one full historical page, so the
+		identity a sideways step deduplicates on must name that page -- for the
+		reader that predates it.  The reader that postdates it stops above the
+		full image and sees the narrow halves, which must stay distinct.
+		"""
+		self._run('o_uic_diff_over_full',
+		          seed=lambda t: self._parked_interleave(t, 1, 4, 'v1'),
+		          rest=lambda t: self._interleave(t, 2, 4, 'v2'),
+		          step=4)
+
+	def test_split_full_above_split_full(self):
+		"""Two full split images, no differential record.  Measured: SplitFull."""
+		self._run('o_uic_full_over_full',
+		          seed=lambda t: self._parked_interleave(t, 1, 4, 'v1'),
+		          rest=lambda t: self._parked_interleave(t, 2, 4, 'v2'),
+		          step=4)
+
+	def test_split_diff_above_compact(self):
+		"""
+		A differential split above a full compaction image.
+
+		Measured: Compact=288 and SplitFull=96 from the rewrite, then
+		SplitDiff=96.
+		"""
+		self._run('o_uic_diff_over_compact',
+		          seed=lambda t: self._rewrite(t, 'v1'),
+		          rest=lambda t: self._interleave(t, 1, 4, 'v2'),
+		          step=4)
+
+	def test_two_split_diffs_above_split_full(self):
+		"""
+		Two differential splits stacked on one full image -- the case where each
+		record names its own split key and the walk must keep the tightest bound
+		rather than the oldest (#1036).
+
+		Measured: SplitFull, then SplitDiff twice.
+		"""
+
+		def rest(table):
+			self._interleave(table, 2, 8, 'v2')
+			self._interleave(table, 3, 8, 'v3')
+
+		self._run('o_uic_two_diffs',
+		          seed=lambda t: self._parked_interleave(t, 1, 8, 'v1'),
+		          rest=rest,
+		          step=8)
+
+	def test_long_alternating_chain(self):
+		"""
+		Four records deep, alternating full and differential.
+
+		Measured: SplitFull=386 and SplitDiff=195 over the same leaves.  A rule
+		that looks only at the newest differential record, or only at the record
+		the walk stops on, gets this wrong at some depth.
+		"""
+
+		def rest(table):
+			self._interleave(table, 2, 8, 'v2')
+			self._parked_interleave(table, 3, 8, 'v3')
+			self._interleave(table, 4, 8, 'v4')
+
+		self._run('o_uic_long_alt',
+		          seed=lambda t: self._parked_interleave(t, 1, 8, 'v1'),
+		          rest=rest,
+		          step=8)
+
+	# --------------------------------------------------- merge chains
+
+	def test_merge_full_alone(self):
+		"""
+		A full merge image: settled deletes give the merge tuples to drop.
+
+		Measured: MergeFull=792.
+		"""
+		self._run('o_uic_merge_full',
+		          seed=self._drop_third,
+		          rest=self._merge,
+		          fillfactor=10)
+
+	def test_merge_diff_above_full(self):
+		"""
+		A differential merge image above the full images that seeded it.
+
+		Measured: Compact and SplitFull from the rewrite, then MergeDiff -- the
+		merge drops nothing, and the pages already carry a retained image, so it
+		writes the boundary key only.
+		"""
+		self._run('o_uic_merge_diff',
+		          seed=lambda t: self._rewrite(t, 'v1'),
+		          rest=self._merge,
+		          fillfactor=10)
+
+	def test_split_diff_above_merge_full(self):
+		"""A differential split above a full merge image.  Measured: MergeFull=792,
+		then SplitDiff=14."""
+
+		def seed(table):
+			self._drop_third(table)
+			self._merge(table)
+
+		self._run('o_uic_diff_over_mergefull',
+		          seed=seed,
+		          rest=lambda t: self._interleave(t, 1, 4, 'v2'),
+		          fillfactor=10,
+		          step=4)
+
+	def test_split_diff_above_merge_diff(self):
+		"""A differential split above a differential merge.  Measured: MergeDiff,
+		then SplitDiff=9."""
+
+		def seed(table):
+			self._rewrite(table, 'v1')
+			self._merge(table)
+
+		self._run('o_uic_diff_over_mergediff',
+		          seed=seed,
+		          rest=lambda t: self._interleave(t, 1, 4, 'v2'),
+		          fillfactor=10,
+		          step=4)
+
+	def test_merge_diff_above_split_full(self):
+		"""
+		A differential merge above a full split image.  Measured: SplitFull=12,
+		then MergeDiff=8.
+
+		The two merge halves walk into their own predecessors' histories and
+		converge on the seed's one full image, so a sideways step that identified
+		a historical page by the record it stopped on took them for one page and
+		skipped a half: twelve rows of four thousand, on the backward scan only.
+		Issue #1056.
+		"""
+		self._run('o_uic_mergediff_over_full',
+		          seed=lambda t: self._parked_interleave(t, 1, 4, 'v1'),
+		          rest=lambda t: (self._rewrite(t, 'v2'), self._merge(t)),
+		          fillfactor=10,
+		          step=4)
+
+	def test_merge_then_split_chain(self):
+		"""
+		Merge and split records in one chain: the pages are merged and then
+		split again under the same readers.
+
+		Measured: SplitFull, MergeDiff, then SplitDiff.
+		"""
+
+		def rest(table):
+			self._merge(table)
+			self._interleave(table, 1, 4, 'v2')
+
+		self._run('o_uic_merge_and_split',
+		          seed=lambda t: self._parked_rewrite(t, 'v1'),
+		          rest=rest,
+		          fillfactor=10,
+		          step=4)
+
+	# --------------------------------------------------- composed helpers
+
+	def _parked_interleave(self, table, offset, step, payload):
+		with self._park_seq_scan(table):
+			self._interleave(table, offset, step, payload)
+
+	def _parked_rewrite(self, table, payload):
+		with self._park_seq_scan(table):
+			self._rewrite(table, payload)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/test/t/undo_image_chain_test.py
+++ b/test/t/undo_image_chain_test.py
@@ -125,6 +125,45 @@ class UndoImageChainTest(BaseTest):
 		self.node.execute("UPDATE %s SET payload = repeat('%s', %d);" %
 		                  (table, payload, PAD + 10))
 
+	def _rewrite_by(self, table, payload, pad):
+		"""Rewrite every row at a given length."""
+		self.node.execute("UPDATE %s SET payload = repeat('%s', %d);" %
+		                  (table, payload, pad))
+
+	def _rounds(self, table, pattern, step, first_offset=1):
+		"""
+		One operation per character of `pattern`, in order:
+
+		    'd'  interleave a round of keys: a split that writes a differential
+		         image, nothing having parked a sequential scan
+		    'f'  the same with a cursor parking a sequential scan, so the split
+		         has to write a full image instead
+		    'r'  rewrite every row a little longer: compaction, a full image
+
+		Returns the next free interleave offset, so a caller can split a pattern
+		across two calls without the two colliding.
+		"""
+		offset = first_offset
+		for i, kind in enumerate(pattern, start=first_offset):
+			if kind in 'df':
+				payload = 'v%d' % (i % 10)
+				if kind == 'f':
+					self._parked_interleave(table, offset, step, payload)
+				else:
+					self._interleave(table, offset, step, payload)
+				offset += 1
+			else:
+				self._rewrite_by(table, 'w%d' % (i % 10), PAD + i)
+		return offset
+
+	def _deep(self, table, pattern, step=16):
+		"""Run a pattern as one chain: its first round seeds the full image."""
+		self._run(
+		    table,
+		    seed=lambda t: self._rounds(t, pattern[:1], step),
+		    rest=lambda t: self._rounds(t, pattern[1:], step, first_offset=2),
+		    step=step)
+
 	def _drop_third(self, table):
 		"""Settled deletes, so a later merge has tuples to drop."""
 		self.node.safe_psql('postgres',
@@ -385,6 +424,42 @@ class UndoImageChainTest(BaseTest):
 		          rest=rest,
 		          fillfactor=10,
 		          step=4)
+
+	# --------------------------------------------------- deep chains
+
+	def test_deep_chain_mixed(self):
+		"""
+		Fifteen rounds, alternating differential splits and compactions above the
+		seeding full image.
+
+		Measured walk depth 11, distributed over 2, 4, 5, 6, 8, 9, 10 and 11 --
+		different leaves reach different depths in one run, so a single pass
+		covers a range of them rather than one number.
+		"""
+		self._deep('o_uic_deep_mixed', 'fddrrddrrddrrdd')
+
+	def test_deep_chain_full_in_the_middle(self):
+		"""
+		The same depth with a full split image half way down the chain, so the
+		walk applies differential records, then a record that overwrites the page
+		whole, then more differential ones.
+
+		Measured walk depth 11.  This is the shape a rule keyed on "did the walk
+		pass a differential record" gets wrong: by the time the walk ends, the
+		narrowing those records applied is long overwritten.
+		"""
+		self._deep('o_uic_deep_middle_full', 'fddrrddfrddrrdd')
+
+	def test_deep_chain_all_full(self):
+		"""
+		Control at the same depth with no differential record at all: parked
+		splits and compactions only.
+
+		Measured walk depth 11.  Every leaf that reaches a given record holds its
+		bytes, so the identity is unambiguous -- if this one ever fails, the
+		defect is not in telling differential records apart.
+		"""
+		self._deep('o_uic_deep_all_full', 'frfrfrfrfrfrfrf')
 
 	# --------------------------------------------------- composed helpers
 


### PR DESCRIPTION
Two silent wrong-answer bugs when an old snapshot reads through a page-level undo
chain, and the suite that found the second one.  Fixes #1055 and #1056.

## What goes wrong

`read_page_from_undo()` tells a caller stepping sideways which historical page it
ended up holding, so that several current leaves resolving to one such page emit
its rows once — the shortcut in `find_left_page()`.  It answered with an undo
record location, and no record location can carry that answer:

- **The record the walk stops on cannot tell two halves apart.**  Both halves of a
  differential split keep their own narrow contents while their chains converge on
  the same older record; a differential merge sends each half into a *different*
  predecessor's history, which can converge again.  Either way the two stop on one
  record and one half is skipped whole — #1036 for splits, #1056 for merges.
- **The first differential record, which #1036 switched to, cannot tell that the
  contents stopped being per-half.**  A full image further down overwrites the
  page whole, and every leaf reaching it then holds the same bytes; each still
  reports a differential record of its own, nothing deduplicates, and one wide
  page is emitted once per current leaf — #1055.

Symptoms, both deterministic and both silent without assertions:

| | |
|---|---|
| #1055 | backward ordered scan returns **14880 rows where 5000 exist**, 5000 distinct |
| #1056 | backward ordered scan **loses 12 rows of 4000**, in four runs of three |

Forward index, bitmap and sequential scans of the same snapshot at the same
instant are correct in both, by count and by row version.  With
`--enable-cassert` neither returns the wrong rows: both trip the ordering
assertion at `iterator.c:1343`.

## The fix

Identify the historical page by the **hikey** of the page the walk arrived at.

The range is what identifies a page, and the hikey is the part of that range which
is both available and sufficient.  Available, because it is in the image itself
however the walk got there — unlike the lokey, which a full split image cannot
supply for its right half at all.  Sufficient, because every reconstruction in one
walk is to one csn, and at one moment the tree's page boundaries are unique: equal
hikeys are the same page, different hikeys are different pages.  Being rightmost is
such a boundary too, and at most one page has it.

This **replaces** rather than adds to what was there: #1036's identity latching and
`get_page_from_undo()`'s `is_differential` out-parameter, which existed only to
feed that latch, are both removed.  Net effect on the engine is `find.c +55`,
everything else smaller.

Rules tried and disproved by measurement before this one, so they are not tried
again:

| rule | #1036 | #1055 | #1056 |
|---|---|---|---|
| record the walk stopped on (pre-#1036) | loses | correct | loses |
| first differential record + side (#1036) | correct | duplicates | loses |
| ... cleared by a bytes-carrying record | correct | correct | loses |
| ... unless that record was a merge | correct | correct | duplicates |
| **hikey** | **correct** | **correct** | **correct** |

## The tests

`test/t/merge_test.py::test_split_diff_over_full_image_chain` is #1055's
reproducer, and `test/t/undo_image_chain_test.py` is a new module covering
fourteen chain compositions from an old snapshot: differential over full, full
over full, differential over compaction, two differentials over one full, a full
merge alone, differential merge over full, differential split over each kind of
merge image, differential merge over full split, merge and split in one chain, and
three chains ten records deep.

Two things came out of *measuring* the write sites with probes rather than
assuming, and they shape the module:

- **A page's first image is always a full one.**  A differential record is only
  written when the page already carries a retained undo location, and an operation
  on a page with none writes no image at all.  So a purely differential chain does
  not exist, and #1055's mixed chain is not a corner case — it is the only way a
  differential record is ever reached.  My first draft of these tests measured
  `Skipped=291` and zero differential images, i.e. it tested nothing.
- **Which makes the snapshot position an axis of its own**: the walk applies
  records down to the snapshot csn and stops, so a reader predating the chain's
  full image holds the shared page and one postdating it holds the narrow halves.
  Every case checks both.

Depth also had to be measured.  Ten rounds of interleaved inserts reach a walk only
four records deep, because a leaf that has just split has room and the next round
does not split it again; alternating interleaves with rewrites gets to eleven,
spread over 2, 4, 5, 6, 8, 9, 10 and 11 within one run.  The all-full deep case is
a control: it passes with and without the fix, so a failure there would mean the
defect is not about telling differential records apart.

Every case verifies the snapshot's captured view — ids *and* payloads, so a stale
version cannot pass as a right key set — through sequential, forward index,
backward index and bitmap reads, ordered reads in both directions, and point
lookups, then `orioledb_tbl_check()`.

## Verification

- the new module 14/14; **12 of the 14 fail without the fix**
- `merge_test` 14/14, including #1036's own `test_split_diff_backward_scan_across_split`
- `regresscheck` 49/49, `isolationcheck` 35/35
- standalone reproducers for #1055, #1056 and #1036's scenario all read back correctly

## Not covered

Chains built from concurrent modification *during* a scan.  Measured: these deep
chains exercise the descent walk (`read_page_from_undo()`, which feeds the
identity), and never the iterator's own combined-page reconstruction — its walk was
entered zero times.  That path needs a scan parked mid-flight, which is the next
thing worth covering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
