### PR TITLE
Fix an incomplete split from one side only when refinding by hint

### DIFF
--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1396,9 +1396,20 @@ retry:
 
 			if (O_PAGE_IS(p, BROKEN_SPLIT))
 			{
+				/*
+				 * The flag says this page is the *right* half of a split its
+				 * left sibling never finished, so the fix has to run from the
+				 * sibling: that is what the call below does, and it leaves
+				 * nothing for a second one to do.  Handing this same page to
+				 * o_btree_split_fix_and_unlock() treated it as the *left*
+				 * half instead, on a page the call above has already
+				 * unlocked, and read a rightLink it has no reason to hold --
+				 * reaching RIGHTLINK_GET_BLKNO(InvalidRightLink), an invalid
+				 * block number, straight into O_GET_IN_MEMORY_PAGE().
+				 * find_page() has always fixed this the one way.
+				 */
 				o_btree_split_fix_for_right_page_and_unlock(desc, intCxt.blkno);
 				intCxt.haveLock = false;
-				o_btree_split_fix_and_unlock(desc, intCxt.blkno);
 				goto retry;
 			}
 		}

--- a/test/t/incomplete_split_test.py
+++ b/test/t/incomplete_split_test.py
@@ -397,6 +397,64 @@ class SplitTest(BaseTest):
 
 		self.stopAll()
 
+	def test_incomplete_leaf_delete_by_hint_fix(self):
+		"""
+		A modify that refinds its leaf by location hint must fix an incomplete
+		split the way a full descent does.
+
+		BROKEN_SPLIT says the page is the *right* half of a split its left
+		sibling never finished, so the fix runs from the sibling and leaves
+		nothing for a second call.  refind_page() used to hand the same page to
+		the left-half fixer as well, which reads a rightLink the page has no
+		reason to hold: RIGHTLINK_GET_BLKNO(InvalidRightLink) is not a block
+		number, and O_GET_IN_MEMORY_PAGE() aborts on it.  Issue #1054.
+
+		Splitting in the *middle* of the committed keys is what makes the state
+		reachable.  A split above them all -- what appending rows does -- leaves
+		the broken half empty, so no hint can ever point at it.  Here the failed
+		insert of a middle key moves four committed rows onto the page that keeps
+		the flag, and a DELETE of one of them arrives by the hint its own index
+		scan produced.
+		"""
+		node = self.node
+		self.insertToSplitTable(node, 10, 50, 4)
+
+		con1 = self.createConnection()
+		con1.execute("SET orioledb.enable_stopevents = true;")
+		con2 = self.createConnection()
+		con2.execute("SELECT pg_stopevent_set('split_fail', 'true');")
+
+		# Fails, and leaves a page carrying BROKEN_SPLIT with an invalid
+		# rightLink of its own, holding the keys 30, 34, 38 and 42.
+		con1.begin()
+		try:
+			con1.execute(
+			    "INSERT INTO o_split VALUES (repeat('x', 708) || '32');")
+			self.assertTrue(False)
+		except AssertionError:
+			raise
+		except Exception:
+			pass
+		finally:
+			con1.commit()
+		con2.execute("SELECT pg_stopevent_reset('split_fail');")
+		self.checkSplitTable(11, False)
+
+		# The DELETE's index scan hands the modify a hint on that page, so the
+		# modify refinds it instead of descending afresh.
+		con3 = self.createConnection()
+		con3.execute("SET enable_seqscan = off;")
+		con3.begin()
+		con3.execute(
+		    "DELETE FROM o_split WHERE id = repeat('x', 708) || '34';")
+		con3.commit()
+
+		self.checkSplitTable(10, True)
+		self.assertEqual(
+		    con3.execute("SELECT count(*) FROM o_split "
+		                 "WHERE id = repeat('x', 708) || '34';")[0][0], 0)
+		self.stopAll()
+
 	def createConnection(self):
 		connection = self.node.connect()
 		self.connections.append(connection)


### PR DESCRIPTION
Fixes #1054.

A page carrying `BROKEN_SPLIT` is the **right** half of a split its left sibling
never finished, so the fix has to run from the sibling.
`o_btree_split_fix_for_right_page_and_unlock()` does exactly that — unlocks this
page, locks the left one, checks that its rightLink still points here, finishes
the split from there — and leaves nothing for a second call to do.

`refind_page()` then handed the same page to `o_btree_split_fix_and_unlock()`,
which is the *left*-half fixer.  It reads the page's own rightLink, and a page
that is not itself mid-split holds `InvalidRightLink`, so
`RIGHTLINK_GET_BLKNO()` yields `OInvalidInMemoryBlkno` and
`O_GET_IN_MEMORY_PAGE()` aborts on it.  That is the crash, with
`rightBlkno = 4294967295` in the backtrace:

```
TRAP: failed Assert("OInMemoryBlknoIsValid(rightBlkno)"), src/btree/insert.c:286
#6  o_btree_fix_page_split (left_blkno=5058)     rightBlkno = 4294967295
#7  o_btree_split_fix_and_unlock                 insert.c:339
#8  refind_page                                  find.c:1421
#9  o_btree_normal_modify   BTreeOperationUpdate
    UPDATE ss_composite_pk SET c = c + 1 WHERE a = 54207 % 500;
```

A modify by primary key is the shape that reaches it: it refinds its leaf by the
location hint its own index scan produced, so it goes through `refind_page()`
rather than a fresh descent.  The call also ran on a page the first one had
already unlocked, against `o_btree_split_fix_and_unlock()`'s stated contract that
the left page be locked.

`find_page()` has always fixed this the one way, at `find.c:1030`; this makes
`refind_page()` match and lets its `retry` re-descend.

## Deterministic test

`test/t/incomplete_split_test.py::test_incomplete_leaf_delete_by_hint_fix`.

Splitting in the **middle** of the committed keys is what makes the state
reachable, and it is why a first attempt at this test proved nothing.  Appending
rows — what the neighbouring tests do — splits above every committed key, so the
half that keeps the flag ends up empty and no hint can ever point at it.  I
checked with `orioledb_tbl_structure()`:

```
appending rows:                     splitting a middle key:
Page 2: Rightlink = 3               Page 2: broken split, Rightlink is invalid
        Item 0: ('x..x46')                  Item 0: ('x..x30')   <- committed rows
        Item 1: ('x..x50')                  Item 1: ('x..x34')      on the flagged
Page 3: broken split, sparse                Item 2: ('x..x38')      page
        (no items)                          Item 3: ('x..x42')
                                    Page 3: Item 0: ('x..x46'), Item 1: ('x..x50')
```

So the test fails the insert of one middle key, which moves four committed rows
onto the page that keeps the flag, and then `DELETE`s one of them.  Without the
fix it aborts on exactly the fuzzer's assertion at `insert.c:286`; with it the row
goes and the tree checks out.

## Verification

- the new test: crashes without the fix, passes with it, **3/3** for determinism
- `incomplete_split_test` 12/12
- `regresscheck` 49/49, `isolationcheck` 35/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)