### PR TITLE
Don't retry a checkpoint that failed part way through

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,7 @@ TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
 						test/t/move_database_test.py \
 						test/t/database_template_test.py
 TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
+						test/t/checkpoint_error_test.py \
 						test/t/checkpoint_eviction_test.py \
 						test/t/checkpoint_same_trx_test.py \
 						test/t/checkpoint_split1_test.py \

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -506,6 +506,7 @@ extern XLogRecPtr replay_until_lsn;
 #ifdef IS_DEV
 extern XLogRecPtr debug_recovery_crash_lsn;
 extern int	debug_commit_window_ms;
+extern bool debug_checkpoint_error;
 #endif
 
 /* For page eviction/read checkpoint test only */

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -1815,6 +1815,25 @@ o_tables_rel_try_lock_extended(ORelOids *oids, int lockmode,
 	return false;
 }
 
+/*
+ * LockAcquire() with dontWait, that also declines to raise an error when the
+ * shared lock table has no room left: the caller gets LOCKACQUIRE_NOT_AVAIL
+ * for that too and can retry.
+ */
+static LockAcquireResult
+lock_acquire_no_wait_no_memory_error(const LOCKTAG *locktag, LOCKMODE lockmode)
+{
+	return LockAcquireExtended(locktag, lockmode,
+							   false,	/* sessionLock */
+							   true,	/* dontWait */
+							   false,	/* reportMemoryError */
+							   NULL /* locallockp */
+#if PG_VERSION_NUM >= 180000
+							   ,false	/* logLockFailure */
+#endif
+		);
+}
+
 void
 o_tables_rel_lock_extended(ORelOids *oids, int lockmode, bool checkpoint)
 {
@@ -1835,8 +1854,17 @@ o_tables_rel_lock_extended(ORelOids *oids, int lockmode, bool checkpoint)
 		 * latch wait, so the deadlock detector sees no cycle.  Keep draining
 		 * between attempts, like acquire_chkp_lock_drain() does for the
 		 * checkpoint-coordination LWLocks.
+		 *
+		 * Ask for no memory error either, so that a lock table with no room
+		 * left is one more reason to come back in a moment rather than an
+		 * ERROR.  The checkpointer cannot take one: it would be caught by the
+		 * checkpointer's own sigsetjmp and turned into a retry of the same
+		 * checkpoint number, which o_perform_checkpoint() explains it cannot
+		 * survive.  And the room is transient -- it is other backends' locks
+		 * that filled the table.
 		 */
-		while (LockAcquire(&locktag, lockmode, false, true) == LOCKACQUIRE_NOT_AVAIL)
+		while (lock_acquire_no_wait_no_memory_error(&locktag, lockmode) ==
+			   LOCKACQUIRE_NOT_AVAIL)
 		{
 			AbsorbSyncRequests();
 			pg_usleep(1000L);

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -184,6 +184,13 @@ static int	file_extents_len_off_cmp(const void *a, const void *b);
 static int	file_extents_off_len_cmp(const void *a, const void *b);
 static int	file_extents_writeback_cmp(const void *a, const void *b);
 
+/*
+ * Set while a checkpoint has rotated part of the trees onto its checkpoint
+ * number and not yet all of them.  See o_perform_checkpoint().
+ */
+static bool checkpoint_rotation_in_progress = false;
+
+static void o_perform_checkpoint_guts(int flags);
 static void sort_checkpoint_map_file(BTreeDescr *descr, int cur_chkp_index);
 static void sort_checkpoint_tmp_file(BTreeDescr *descr, int cur_chkp_index);
 static inline void checkpoint_ix_init_state(CheckpointState *state, BTreeDescr *descr);
@@ -1612,8 +1619,69 @@ get_checkpoint_xlog_ptr(void)
 		return GetXLogInsertRecPtr();
 }
 
+/*
+ * Make a checkpoint of all the OrioleDB trees.
+ *
+ * An error must not escape the part of this that rotates the trees onto the
+ * new checkpoint number.  PostgreSQL's checkpointer treats a failed checkpoint
+ * as "try again in a second", and the retry starts over with the same
+ * checkpoint number -- but in the middle of the rotation part of the trees
+ * have moved onto that number and the rest have not.  Each tree writes the
+ * *.map / *.tmp files of checkpoint N through the seq buf in slot N % 2, whose
+ * pages checkpoint_init_new_seq_bufs() allocates up front and checkpoint_ix()
+ * frees once it has finalized them; a tree the failed attempt got through
+ * therefore has the slots of N and N + 1 the other way round from a tree it
+ * never reached.  The retry then re-allocates a slot that is still allocated
+ * (issue #1053), and concurrent backends, which pick the slot to record a
+ * freed extent in from how far the checkpointer has got, write into pages the
+ * failed attempt has already freed.
+ *
+ * Rolling that back is not possible: for the trees that did complete, the map
+ * file of checkpoint N is written and the seq bufs that produced it are gone.
+ * So report the error and let the process exit instead, which restarts the
+ * cluster and rebuilds all of this state from the last checkpoint on disk.
+ * That is the same stance the seq buf failures below already take, and far
+ * cheaper than the alternative: without assertions the retry silently leaks
+ * the pages it re-allocates and lets backends write through a freed one.
+ *
+ * Outside that window an error is harmless and stays an error: before it
+ * nothing has moved yet, and after it every tree has, so the retry -- with the
+ * next checkpoint number by then -- finds all of them in the same state.
+ */
 void
 o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
+{
+	PG_TRY();
+	{
+		o_perform_checkpoint_guts(flags);
+	}
+	PG_CATCH();
+	{
+		if (!checkpoint_rotation_in_progress)
+			PG_RE_THROW();
+
+		/*
+		 * Log the original error first -- it is the one that says what
+		 * actually went wrong -- and only then give up, so both ends of the
+		 * story are in the log.
+		 */
+		EmitErrorReport();
+		FlushErrorState();
+
+		ereport(FATAL,
+				(errmsg("OrioleDB checkpoint %u failed",
+						checkpoint_state->lastCheckpointNumber + 1),
+				 errdetail("A checkpoint that failed part way through cannot "
+						   "be rolled back or retried.")));
+	}
+	PG_END_TRY();
+
+	if (next_CheckPoint_hook)
+		next_CheckPoint_hook(redo_pos, flags);
+}
+
+static void
+o_perform_checkpoint_guts(int flags)
 {
 	CheckpointTablesArg chkp_tbl_arg;
 	CheckpointControl control;
@@ -1743,7 +1811,16 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 	before_writing_xids_file(cur_chkp_num);
 	start_write_xids(cur_chkp_num);
 
+	/* From here on a failure cannot be retried -- see o_perform_checkpoint() */
+	checkpoint_rotation_in_progress = true;
+
 	checkpoint_sys_trees(flags, cur_chkp_num, &chkp_tbl_arg);
+
+#ifdef IS_DEV
+	if (debug_checkpoint_error)
+		ereport(ERROR,
+				(errmsg("orioledb.debug_checkpoint_error is set")));
+#endif
 
 	/*
 	 * Restore stop events (they were suppressed only for the sys-tree
@@ -1924,6 +2001,9 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 	checkpoint_state->completed = false;
 	chkp_inc_changecount_after(checkpoint_state);
 
+	/* Every tree has rotated now, so a failure below is retryable again */
+	checkpoint_rotation_in_progress = false;
+
 	LWLockRelease(&checkpoint_state->oTablesMetaLock);
 
 	/*
@@ -2050,9 +2130,6 @@ o_perform_checkpoint(XLogRecPtr redo_pos, int flags)
 
 	MemoryContextResetOnly(chkp_main_context);
 	MemoryContextSwitchTo(prev_context);
-
-	if (next_CheckPoint_hook)
-		next_CheckPoint_hook(redo_pos, flags);
 }
 
 void

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -173,6 +173,7 @@ static char *replay_until_lsn_string;
 XLogRecPtr	debug_recovery_crash_lsn = InvalidXLogRecPtr;
 static char *debug_recovery_crash_lsn_string;
 int			debug_commit_window_ms = 0;
+bool		debug_checkpoint_error = false;
 #endif
 
 /* For page eviction/read checkpoint test only */
@@ -1209,6 +1210,19 @@ _PG_init(void)
 							PGC_USERSET,
 							GUC_UNIT_MS,
 							NULL, NULL, NULL);
+	DefineCustomBoolVariable("orioledb.debug_checkpoint_error",
+							 "Makes every checkpoint fail once it is done with"
+							 " the system trees.",
+							 "For tests of what an error part way through a"
+							 " checkpoint leaves behind.  Never set this on a"
+							 " real cluster.",
+							 &debug_checkpoint_error,
+							 false,
+							 PGC_SIGHUP,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
 #endif							/* IS_DEV */
 
 	if (orioledb_s3_mode)

--- a/test/t/checkpoint_error_test.py
+++ b/test/t/checkpoint_error_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import time
+
+from testgres.enums import NodeStatus
+
+from .base_test import BaseTest
+
+
+class CheckpointErrorTest(BaseTest):
+	"""
+	An error raised in the middle of an OrioleDB checkpoint (issue #1053).
+
+	PostgreSQL's checkpointer catches an ERROR and simply tries the checkpoint
+	again a second later, with the very same checkpoint number.  OrioleDB has
+	already rotated part of its per-tree state to that number by then -- the
+	seq buf slot a tree writes its *.map / *.tmp file through is picked as
+	`checkpoint number % 2`, and its pages are allocated up front -- and
+	nothing rolls that back, so the retry walks into state the failed attempt
+	built and asserts on an already allocated slot.
+	"""
+
+	def create_table(self, node):
+		node.safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql(
+		    'postgres', "CREATE TABLE o_test (\n"
+		    "	id integer NOT NULL,\n"
+		    "	val text,\n"
+		    "	PRIMARY KEY (id)\n"
+		    ") USING orioledb;\n")
+		node.safe_psql(
+		    'postgres', "INSERT INTO o_test\n"
+		    "	(SELECT id, id || 'val' FROM generate_series(1, 2000) id);")
+
+	def test_checkpoint_error_does_not_retry(self):
+		"""
+		Whatever else goes wrong, the checkpoint must not be tried again.
+
+		orioledb.debug_checkpoint_error stands in for the error the fuzzer hit,
+		and raises it in the same place: with the system trees already rotated
+		onto this checkpoint number, and no user table touched yet.
+		"""
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "orioledb.debug_checkpoint_error = on\n")
+		node.start()
+		self.create_table(node)
+
+		with self.assertRaises(Exception):
+			node.safe_psql('postgres', "CHECKPOINT;")
+
+		# The checkpointer took the cluster down with it instead of coming
+		# back for another go at the same checkpoint number.
+		deadline = time.time() + 30
+		while node.status() == NodeStatus.Running and time.time() < deadline:
+			time.sleep(0.1)
+		self.assertNotEqual(node.status(), NodeStatus.Running)
+		node.is_started = False
+
+		with open(node.pg_log_file) as f:
+			log = f.read()
+		self.assertIn("OrioleDB checkpoint 1 failed", log)
+		self.assertNotIn("TRAP", log)
+		self.assertEqual(log.count("orioledb checkpoint 1 started"), 1)
+
+		node.append_conf('postgresql.conf',
+		                 "orioledb.debug_checkpoint_error = off\n")
+		node.start()
+		self.assertEqual(
+		    node.execute('postgres', "SELECT count(*) FROM o_test;")[0][0],
+		    2000)
+		node.safe_psql('postgres', "CHECKPOINT;")
+		node.stop()

--- a/test/t/checkpoint_error_test.py
+++ b/test/t/checkpoint_error_test.py
@@ -6,6 +6,7 @@ import time
 from testgres.enums import NodeStatus
 
 from .base_test import BaseTest
+from .base_test import ThreadQueryExecutor
 
 
 class CheckpointErrorTest(BaseTest):
@@ -71,4 +72,75 @@ class CheckpointErrorTest(BaseTest):
 		    node.execute('postgres', "SELECT count(*) FROM o_test;")[0][0],
 		    2000)
 		node.safe_psql('postgres', "CHECKPOINT;")
+		node.stop()
+
+	def fill_lock_table(self, con):
+		"""
+		Leave the shared lock table with no room left.
+
+		Session-level advisory locks live in the same table as the per-tree
+		userlocks the checkpointer takes, and are not released when the
+		transaction that ran out of room aborts, so they stay for as long as
+		the connection does.
+		"""
+		with self.assertRaises(Exception):
+			con.execute("SELECT pg_advisory_lock(i) "
+			            "FROM generate_series(1, 1000000) i;")
+		con.rollback()
+		self.assertGreater(
+		    con.execute(
+		        "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';")
+		    [0][0], 0)
+
+	def test_checkpoint_with_no_lock_table_room(self):
+		"""
+		A full lock table is what the checkpointer ran into in the wild, and
+		it is transient -- it is other backends\' locks that filled it.  So it
+		has to wait for room rather than fail.
+		"""
+		node = self.node
+		# The smallest lock table the server accepts, so that a single session
+		# can fill it below.
+		node.append_conf(
+		    'postgresql.conf', "max_connections = 10\n"
+		    "max_locks_per_transaction = 10\n")
+		node.start()
+		self.create_table(node)
+		node.safe_psql('postgres', "CHECKPOINT;")
+
+		# Both connections have to be open before the lock table fills up: a
+		# fresh backend cannot lock its own database to log in afterwards.
+		con_hold = node.connect()
+		con_chkp = node.connect()
+
+		self.fill_lock_table(con_hold)
+
+		# The checkpointer gets through the system trees, which take no
+		# heavyweight locks, and then has to wait for room for the lock on the
+		# first user table.
+		t = ThreadQueryExecutor(con_chkp, "CHECKPOINT;")
+		t.start()
+		t.join(2)
+		self.assertTrue(t.is_alive(),
+		                "the checkpoint did not wait for the lock table")
+
+		con_hold.execute("SELECT pg_advisory_unlock_all();")
+		con_hold.commit()
+		t.join()
+
+		# A second one, to show the first left nothing behind for it.
+		con_chkp.execute("CHECKPOINT;")
+		con_hold.close()
+		con_chkp.close()
+
+		self.assertEqual(
+		    node.execute('postgres', "SELECT count(*) FROM o_test;")[0][0],
+		    2000)
+
+		# And what it wrote must still come back after a crash.
+		node.stop(['-m', 'immediate'])
+		node.start()
+		self.assertEqual(
+		    node.execute('postgres', "SELECT count(*) FROM o_test;")[0][0],
+		    2000)
 		node.stop()


### PR DESCRIPTION
Fixes #1053.

## What actually happened

The assertion is not about tree re-initialisation, and the two crashes in the
report are **one event**. The proof is two lines the backtrace could not give,
from the full `sqlsmith_pg.log` artifact of the failing job:

```
21:55:16.098 [24739] LOG:   orioledb checkpoint 257 started
21:55:16.177 [24739] ERROR:  out of shared memory
             [24739] HINT:   You might need to increase "max_locks_per_transaction".
21:55:17.180 [24739] LOG:   orioledb checkpoint 257 started      <-- the same number
             TRAP: failed Assert("!OInMemoryBlknoIsValid(shared->pages[0])")
```

`CheckpointerMain` catches an ERROR and simply tries again a second later, and
`lastCheckpointNumber` only advances at the very end of `o_perform_checkpoint()`,
so the retry runs with checkpoint number 257 again. By then part of the trees
have already rotated their per-checkpoint state onto that number and the rest
have not: a tree writes the `*.map` / `*.tmp` files of checkpoint N through the
seq buf in slot `N % 2`, whose two pages `checkpoint_init_new_seq_bufs()`
allocates up front and `checkpoint_ix()` frees once it has finalised them. The
retry therefore re-allocates a slot that is still allocated.

That also accounts for the second assertion in the report, the one in a backend
at `seq_buf_rw` under `free_extent_for_checkpoint` — one second later, in the
same run. `get_checkpoint_number()` answers `lastCheckpointNumber + 1` for a tree
the checkpointer has not passed and `+ 2` for one it has. The retry moves the
published position back to the system trees, so a user tree the *failed* attempt
had already rotated looks unprocessed again, the backend picks slot `257 % 2`,
and those are exactly the pages the failed attempt freed.

For the record, the slot parity proves nothing on its own — I spent a while
arguing the retry hypothesis away on the grounds that it "would crash on the
other slot". It crashes on the slot the failed attempt allocated, which is the
same one by construction.

## Deterministic reproducer

Three seconds, no fuzzer. Session-level advisory locks live in the same shared
lock table as the per-tree userlocks the checkpointer takes, and are not released
when the transaction that ran out of room aborts:

```sql
-- max_locks_per_transaction = 10, max_connections = 10, one session throughout
-- (with the table full, a fresh backend cannot lock its database to log in)
SELECT pg_advisory_lock(i) FROM generate_series(1, 1000000) i;  -- ERROR, table now full
CHECKPOINT;                        -- the checkpointer fails part way through
SELECT pg_advisory_unlock_all();
CHECKPOINT;                        -- TRAP, identical to CI
```

## The fix, in two parts

**1. An error must not escape the checkpoint.** Rolling the partial rotation
back is not possible: for the trees that did complete, the map file of
checkpoint N is written and the seq bufs that produced it are gone. So the body
moves to `o_perform_checkpoint_guts()` and the wrapper reports the original
error and exits:

```
ERROR:  out of shared memory
FATAL:  OrioleDB checkpoint 2 failed
DETAIL: A checkpoint that failed part way through cannot be rolled back or retried.
LOG:    checkpointer process (PID 47674) exited with exit code 1
```

This is the stance the `ereport(FATAL)` seq buf failures a few lines below
already take, and it is much cheaper than what a build without assertions does
today: leak the pages the retry re-allocates, then let backends write through a
freed one.

Only inside the rotation window, though — from `checkpoint_sys_trees()` to the
point where `lastCheckpointNumber` advances. Before it nothing has moved yet,
and after it every tree has, so a retry finds them all in the same state and the
error stays an ordinary error. `s3_perform_backup()`, the last thing a
checkpoint does, relies on that, and `s3_test.test_s3_checkpoint_checksum_error`
pins it.

**This is still the part worth arguing about** — inside the window it turns a
configuration level error into a cluster restart. I could not find a middle
ground that is actually sound; skipping the already-rotated trees on the retry
is not, because the retry re-pins `replayStartPtr` and changes made to those
trees in between would end up in neither the image nor the replay.

**2. The trigger need not be an error at all.**
`o_tables_rel_lock_extended()` already retries the per-tree lock when the
checkpointer cannot take it right away, but `LockAcquire()` *raises* on a full
lock table instead of returning `LOCKACQUIRE_NOT_AVAIL`, and that escapes the
loop. The table was full of other backends' locks and empties again as they
finish, so this asks for no memory error and lets the existing drain-and-retry
loop handle it. With this, the common case never reaches part 1.

## Tests

`test/t/checkpoint_error_test.py`, two of them, and each fails without its own
half of the fix (measured both ways):

- `test_checkpoint_with_no_lock_table_room` — the reproducer above; asserts the
  checkpointer waits rather than fails. Without part 2 the cluster goes down.
- `test_checkpoint_error_does_not_retry` — uses a new dev-only GUC
  `orioledb.debug_checkpoint_error` (`PGC_SIGHUP`, `#ifdef IS_DEV`) to raise an
  error in the same place the fuzzer's landed, with the system trees already
  rotated and no user table touched. Asserts the checkpointer exits, that the
  log has no `TRAP`, and that checkpoint 1 was started exactly once. Without
  part 1 the checkpointer keeps retrying and the test fails.

`regresscheck` and `isolationcheck` are green locally; the PG 16/17 build of the
`LockAcquireExtended()` call is only covered by CI, since PG 18 added its
`logLockFailure` parameter and that is what I build against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
