### PR TITLE
Updated docs to clarify vacuum usage

### DIFF
--- a/doc/intro.mdx
+++ b/doc/intro.mdx
@@ -127,7 +127,9 @@ In-memory pages in OrioleDB are connected with direct links to the storage pages
 
 ### MVCC is based on the UNDO log concept
 
-In OrioleDB, old versions of tuples do not cause bloat in the main storage system, but eviction into the undo log comprising undo chains. Page-level undo records allow the system to easily reclaim space occupied by deleted tuples as soon as possible. Together with page-mergins, these mechanisms eliminate bloat in the majority of cases. Dedicated VACUUMing of tables is not needed as well, removing a significant and common cause of system performance deterioration and database outages.
+In OrioleDB, old versions of tuples do not cause bloat in the main storage system, but eviction into the undo log comprising undo chains. Page-level undo records allow the system to easily reclaim space occupied by deleted tuples as soon as possible. Together with page-mergins, these mechanisms eliminate bloat in the majority of cases. Dedicated VACUUMing of tables is not needed as well\*, removing a significant and common cause of system performance deterioration and database outages.
+
+\* VACUUM and ANALYZE are still required for maintaining [bridged indexes](usage/getting-started.mdx#experimental-support-of-indexes-other-than-btree) (i.e. non-btree indexes) and for keeping planner statistics up to date.
 
 ### Copy-on-write checkpoints and row-level WAL
 


### PR DESCRIPTION
Using \* because our docasaurus don't have plugin for footnotes or tooltips at the moment 
Fixes #286