### PR TITLE
Fix the way ctid numbering during index rebuild

### DIFF
--- a/include/btree/btree.h
+++ b/include/btree/btree.h
@@ -503,6 +503,7 @@ extern void o_btree_init(BTreeDescr *descr);
 extern void o_btree_cleanup_pages(OInMemoryBlkno root, OInMemoryBlkno metaPageBlkno,
 								  uint32 rootPageChangeCount);
 extern ItemPointerData btree_ctid_get_and_inc(BTreeDescr *desc);
+extern ItemPointerData btree_ctid_from_seq(uint64 ctid);
 extern ItemPointerData btree_bridge_ctid_get_and_inc(BTreeDescr *desc, bool *overflow);
 extern void btree_ctid_update_if_needed(BTreeDescr *desc, ItemPointerData ctid);
 extern void btree_desc_stopevent_params_internal(BTreeDescr *desc,

--- a/include/btree/page_contents.h
+++ b/include/btree/page_contents.h
@@ -395,6 +395,7 @@ extern void page_cut_first_key(Page node);
 
 typedef struct ItemPointerData ItemPointerData;
 extern ItemPointerData btree_ctid_get_and_inc(BTreeDescr *desc);
+extern ItemPointerData btree_ctid_from_seq(uint64 ctid);
 extern void btree_ctid_update_if_needed(BTreeDescr *desc, ItemPointerData ctid);
 
 extern void copy_fixed_tuple(BTreeDescr *desc, OFixedTuple *dst, OTuple src);

--- a/src/btree/btree.c
+++ b/src/btree/btree.c
@@ -263,20 +263,35 @@ o_btree_check_size_of_tuple(int len, char *relation_name, bool index)
 						relation_name)));
 }
 
+/*
+ * The ctid a given position of a ctid primary key's sequence stands for.
+ *
+ * Offsets run from FirstOffsetNumber to MaxOffsetNumber - 1, so every ctid
+ * this hands out is a valid ItemPointer.  Everything that assigns ctids has
+ * to go through here
+ */
 ItemPointerData
-btree_ctid_get_and_inc(BTreeDescr *desc)
+btree_ctid_from_seq(uint64 ctid)
 {
-	BTreeMetaPage *metaPageBlkno = BTREE_GET_META(desc);
 	ItemPointerData result;
-	uint64		ctid = pg_atomic_fetch_add_u64(&metaPageBlkno->ctid, 1);
-
-	Assert(ORootPageIsValid(desc) && OMetaPageIsValid(desc));
 	Assert(ctid / (MaxOffsetNumber - FirstOffsetNumber) < InvalidBlockNumber);
 
 	ItemPointerSet(&result,
 				   (uint32) (ctid / (MaxOffsetNumber - FirstOffsetNumber)),
 				   (OffsetNumber) (ctid % (MaxOffsetNumber - FirstOffsetNumber) + FirstOffsetNumber));
+
 	return result;
+}
+
+ItemPointerData
+btree_ctid_get_and_inc(BTreeDescr *desc)
+{
+	BTreeMetaPage *metaPageBlkno = BTREE_GET_META(desc);
+	uint64		ctid = pg_atomic_fetch_add_u64(&metaPageBlkno->ctid, 1);
+
+	Assert(ORootPageIsValid(desc) && OMetaPageIsValid(desc));
+
+	return btree_ctid_from_seq(ctid);
 }
 
 void

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -1929,9 +1929,7 @@ rebuild_indices_worker_heap_scan(OTableDescr *old_descr, OTableDescr *descr,
 				if (idx->primaryIsCtid)
 				{
 					Assert(ctid);
-					primarySlot->tts_tid.ip_posid = (OffsetNumber) (*ctid + 1);
-					BlockIdSet(&primarySlot->tts_tid.ip_blkid,
-							   (uint32) ((*ctid + 1) >> 16));
+					primarySlot->tts_tid = btree_ctid_from_seq(*ctid);
 					(*ctid)++;
 				}
 				if (idx->bridging && bridge_ctid)

--- a/test/t/indices_build_test.py
+++ b/test/t/indices_build_test.py
@@ -106,6 +106,34 @@ class IndicesBuildTest(BaseTest):
 		    500)
 		node.stop()
 
+	def test_rebuild_ctid_offset_wraparound(self):
+		node = self.node
+		node.start()
+		node.safe_psql("""
+			CREATE EXTENSION orioledb;
+			CREATE TABLE o_ctid_wrap
+			(
+				key int NOT NULL,
+				val int,
+				PRIMARY KEY (key)
+			) USING orioledb;
+			INSERT INTO o_ctid_wrap
+				SELECT i, i FROM generate_series(1, 66000) i;
+		""")
+
+		# Dropping the primary key rebuilds the table on a ctid primary key, so
+		# every row is handed a freshly generated ctid.
+		node.safe_psql("""
+			ALTER TABLE o_ctid_wrap DROP CONSTRAINT o_ctid_wrap_pkey;
+		""")
+		# Analyze would call for sort for ctids.  For 66000 there was an overflow
+		# before the patch and ctid became invalid (OffsetNumber = 0).  Now this
+		# analyze must be ok.
+		node.safe_psql("""
+			ANALYZE o_ctid_wrap;
+		""")
+		node.stop()
+
 	def test_drop_primary_recovery(self):
 		node = self.node
 		node.start()


### PR DESCRIPTION
rebuild_indices_worker_heap_scan() assigned the new ctids itself: posid = seq + 1, blkno = (seq + 1) >> 16. OffsetNumber is 16 bits, so the 65536th row got invalid offset 0.

Every other ctid comes from btree_ctid_get_and_inc(), which counts offsets from FirstOffsetNumber.  This patch makes
rebuild_indices_worker_heap_scan() do the same.