### PR TITLE
Compare plain integer index keys without the cached comparator

### DIFF
--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -82,6 +82,26 @@ typedef struct OHashFn
 extern OHashFn o_default_hash_fn;
 
 /*
+ * Datum comparisons that can bypass the cached comparator.
+ *
+ * o_call_comparator() has to guard against catalog invalidations and set up a
+ * SortSupportData before every call, which dwarfs the comparison itself for
+ * plain fixed-width types.  When a field's type and operator class are one of
+ * the builtins below, and no cross-type comparison is involved, the datums
+ * can be compared inline instead.  Only types whose btree ordering is the
+ * plain arithmetic one are listed: float and numeric orderings have NaN /
+ * display-scale rules that the comparator implements.
+ */
+typedef enum
+{
+	OIndexFieldFastCmpNone = 0,
+	OIndexFieldFastCmpInt2,
+	OIndexFieldFastCmpInt4,
+	OIndexFieldFastCmpInt8,
+	OIndexFieldFastCmpOid
+} OIndexFieldFastCmp;
+
+/*
  * The index field descriptor
  */
 typedef struct
@@ -100,6 +120,9 @@ typedef struct
 	OComparator *comparator;
 	OExclusionFn *exclusion_fn;
 	OHashFn    *hash_fn;
+
+	/* Inline comparison this field's datums qualify for, if any. */
+	OIndexFieldFastCmp fastCmp;
 } OIndexField;
 
 typedef struct AttrNumberMap

--- a/src/tableam/descr.c
+++ b/src/tableam/descr.c
@@ -37,6 +37,7 @@
 #include "utils/stopevent.h"
 
 #include "access/nbtree.h"
+#include "catalog/pg_opclass_d.h"
 #include "catalog/pg_opfamily.h"
 #include "common/hashfn.h"
 #include "executor/functions.h"
@@ -1905,6 +1906,29 @@ o_find_toastable_attrs(OTableDescr *tableDescr)
  * index/table metadata (datoid argument), not implicitly from the current
  * backend database.
  */
+/*
+ * Which inline comparison, if any, a field with this type and operator class
+ * qualifies for.  Restricted to the default btree operator classes: another
+ * class over the same type may order it differently.
+ */
+static OIndexFieldFastCmp
+field_fast_cmp_kind(Oid inputtype, Oid opclassoid)
+{
+	switch (opclassoid)
+	{
+		case INT2_BTREE_OPS_OID:
+			return inputtype == INT2OID ? OIndexFieldFastCmpInt2 : OIndexFieldFastCmpNone;
+		case INT4_BTREE_OPS_OID:
+			return inputtype == INT4OID ? OIndexFieldFastCmpInt4 : OIndexFieldFastCmpNone;
+		case INT8_BTREE_OPS_OID:
+			return inputtype == INT8OID ? OIndexFieldFastCmpInt8 : OIndexFieldFastCmpNone;
+		case OID_BTREE_OPS_OID:
+			return inputtype == OIDOID ? OIndexFieldFastCmpOid : OIndexFieldFastCmpNone;
+		default:
+			return OIndexFieldFastCmpNone;
+	}
+}
+
 void
 oFillFieldOpClassAndComparator(OIndexField *field, Oid datoid, Oid opclassoid,
 							   Oid exacttype, Oid exclusion_op, Oid hash_fn_oid)
@@ -1926,6 +1950,14 @@ oFillFieldOpClassAndComparator(OIndexField *field, Oid datoid, Oid opclassoid,
 	field->opfamily = opclass->opfamily;
 	field->comparator = o_find_opclass_comparator(opclass, field->collation,
 												  exacttype);
+
+	/*
+	 * A cross-type comparator does not compare two datums of the field's own
+	 * type, so the inline comparison would be reading the wrong width.
+	 */
+	field->fastCmp = (exacttype == opclass->inputtype)
+		? field_fast_cmp_kind(opclass->inputtype, opclassoid)
+		: OIndexFieldFastCmpNone;
 	if (OidIsValid(exclusion_op))
 		field->exclusion_fn = o_find_exclusion_op_fn(exclusion_op);
 	if (hash_fn_oid == O_DEFAULT_HASH_FN_OID)

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -589,6 +589,78 @@ cmp_inclusive2(uint8 f1, uint8 f2)
 	return cmp1 - cmp2;
 }
 
+/*
+ * Compare two datums of the field's own type without going through the cached
+ * comparator.  Returns false when the field does not qualify, leaving *result
+ * untouched; the caller then falls back to o_call_comparator().
+ *
+ * The sign convention matches the comparator: the field's ASC/DESC direction
+ * is applied by the caller, as before.
+ */
+static inline bool
+o_field_fast_cmp(OIndexField *field, Datum left, Datum right, int *result)
+{
+	switch (field->fastCmp)
+	{
+		case OIndexFieldFastCmpInt2:
+			{
+				int16		l = DatumGetInt16(left),
+							r = DatumGetInt16(right);
+
+				*result = (l < r) ? -1 : ((l > r) ? 1 : 0);
+				return true;
+			}
+		case OIndexFieldFastCmpInt4:
+			{
+				int32		l = DatumGetInt32(left),
+							r = DatumGetInt32(right);
+
+				*result = (l < r) ? -1 : ((l > r) ? 1 : 0);
+				return true;
+			}
+		case OIndexFieldFastCmpInt8:
+			{
+				int64		l = DatumGetInt64(left),
+							r = DatumGetInt64(right);
+
+				*result = (l < r) ? -1 : ((l > r) ? 1 : 0);
+				return true;
+			}
+		case OIndexFieldFastCmpOid:
+			{
+				Oid			l = DatumGetObjectId(left),
+							r = DatumGetObjectId(right);
+
+				*result = (l < r) ? -1 : ((l > r) ? 1 : 0);
+				return true;
+			}
+		case OIndexFieldFastCmpNone:
+			break;
+	}
+	return false;
+}
+
+/*
+ * o_call_comparator() with the inline shortcut in front of it.
+ */
+static inline int
+o_cmp_field_datums(OIndexField *field, Datum left, Datum right)
+{
+	int			cmp;
+
+	if (o_field_fast_cmp(field, left, right, &cmp))
+	{
+		/* The shortcut must agree with the comparator it stands in for. */
+		Assert(cmp == 0
+			   ? o_call_comparator(field->comparator, left, right) == 0
+			   : ((cmp < 0) ==
+				  (o_call_comparator(field->comparator, left, right) < 0)));
+		return cmp;
+	}
+
+	return o_call_comparator(field->comparator, left, right);
+}
+
 int
 o_idx_cmp_range_key_to_value(OBTreeValueBound *bound1, OIndexField *field,
 							 Datum value, bool isnull)
@@ -605,7 +677,7 @@ o_idx_cmp_range_key_to_value(OBTreeValueBound *bound1, OIndexField *field,
 			if (bound1->exclusion_fn)
 				cmp = o_call_exclusion_fn(bound1->exclusion_fn, bound1->value, value, field->collation);
 			else
-				cmp = o_call_comparator(field->comparator, bound1->value, value);
+				cmp = o_cmp_field_datums(field, bound1->value, value);
 		}
 		else
 		{
@@ -694,7 +766,7 @@ o_idx_cmp_tuples(OIndexDescr *id,
 
 			if (!isnull1 && !isnull2)
 			{
-				cmp = o_call_comparator(field->comparator, value1, value2);
+				cmp = o_cmp_field_datums(field, value1, value2);
 				if (!field->ascending)
 					cmp = -cmp;
 			}


### PR DESCRIPTION
Every ordered index scan compares each row it reads against the scan's end
bound, and `o_call_comparator()` is a heavy way to do that: it arms the
catalog-invalidation guard and zeroes a `SortSupportData` before dispatching an
indirect call -- all to compare two int4s.

This records, when the index field descriptor is built, whether the field's
type and operator class are one of the plain integer builtins whose btree
ordering is the arithmetic one, and compares such datums inline.

* Only the default `int2`/`int4`/`int8`/`oid` btree operator classes qualify --
  another class over the same type may order it differently.  Float and numeric
  are deliberately absent: their orderings have NaN / display-scale rules that
  only the comparator implements.
* Cross-type comparators are excluded, since they do not compare two datums of
  the field's own type.
* Under `cassert` the shortcut is checked against the comparator it stands in
  for, on every call.  `regresscheck`, `isolationcheck` and both `testgrescheck`
  parts run with that check active and it never fires.

### Measurements

sysbench `sbtest1` (10M rows), covering primary-key range scan
(`SELECT count(c) ... WHERE id BETWEEN ? AND ?`), server-side plpgsql loop,
`plan_cache_mode = force_generic_plan`, best of 3, A/B/A/B with a full rebuild
per phase.

| build | 101-row range | 10001-row range |
|---|---|---|
| without | 47.87 us | 251.0 ns/row |
| **with** | **46.87 us** | **244.5 ns/row** |
| without | 47.88 us | 251.1 ns/row |
| **with** | **46.90 us** | **245.2 ns/row** |

**-2.1%** and **-2.6%** respectively -- a modest but reproducible win, and the
scan returns identical results in every phase.

### Tests

`regresscheck` 49/49, `isolationcheck` 35/35, `testgrescheck_part_1` 44/44,
`testgrescheck_part_2` 2/2, all on PG18 with `--enable-cassert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)