### PR TITLE
Rebuild a secondary index on its own relnode when its table moves tablespace

### DIFF
--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1040,6 +1040,24 @@ btree_relnode_undo_callback(UndoLogType undoType, UndoLocation location,
 				 * ORelOids -- so this is correct in recovery too.  Only on
 				 * commit: an aborted create's marker is removed by the
 				 * register_delete pending-delete instead.
+				 *
+				 * NB: reloid == relnode identifies a bridge only by
+				 * convention -- o_bridge_new_relnode() sets reloid to the
+				 * relnode it allocated -- and an ordinary index matches it
+				 * too until its first rewrite, since CREATE INDEX leaves
+				 * relfilenode == oid.  Dropping such a tree while pg_class
+				 * still points at that relnode unlinks a live relation file:
+				 * that is how issue #906 turned the moved table unreadable
+				 * ("could not open file ..." from every plan over it) on top
+				 * of emptying the index.  Every path that drops an index tree
+				 * at commit now gives the index a fresh relnode first, so the
+				 * locator dropped here is always stale -- but the test itself
+				 * is still a heuristic, not an identity.  Making it exact
+				 * means marking the bridge in RelnodeUndoStackItem, which
+				 * changes the undo record layout and so needs an
+				 * ORIOLEDB_BINARY_VERSION bump; that was left out of the #906
+				 * fix deliberately rather than changing an on-disk format as
+				 * a side effect of a correctness fix.
 				 */
 				dropBridgeMarker = (stage == OUndoCallbackStageCommit &&
 									dropTrees[i].oids.reloid == dropTrees[i].oids.relnode);

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -2885,7 +2885,44 @@ redefine_indices(Relation rel, OTable *new_o_table, bool primary, Oid oldRelnode
 			{
 				o_define_index_validate(new_o_table->oids, ind, NULL, NULL);
 				relation_close(ind, AccessShareLock);
-				o_define_index(rel, NULL, ind->rd_rel->oid, false,
+
+				/*
+				 * "ALTER TABLE ... SET TABLESPACE" (oldRelnode is the table's
+				 * pre-move relnode) rewrote the table under a new relnode, so
+				 * every secondary index is rebuilt just below.  Give it a
+				 * relnode of its own first.
+				 *
+				 * orioledb_relation_set_new_filenode() already queued all of
+				 * the old table's trees -- this index's included -- for
+				 * removal at commit, and an OrioleDB tree is identified by
+				 * (datoid, relnode, tablespace).  A secondary index keeps its
+				 * own tablespace across the move, so rebuilding it in place
+				 * would give the new tree the exact key that is queued for
+				 * the drop: the commit would then delete the index that was
+				 * just built, leaving it empty, and unlink the index's
+				 * relation file while pg_class still points at it.
+				 *
+				 * Only ctid tables need this here.  A table with a primary
+				 * key reaches assign_new_oids() through the primary pass's
+				 * o_define_index(), and that already gives every index a new
+				 * relnode; the primary pass below covers only toast for the
+				 * tables that miss it.
+				 *
+				 * The new relnode stays in the index's own tablespace, which
+				 * is where the index remains: SET TABLESPACE moves only the
+				 * table's storage.
+				 */
+				if (!primary && OidIsValid(oldRelnode) &&
+					!new_o_table->has_primary)
+				{
+					Relation	iRel = index_open(indexOid, AccessExclusiveLock);
+
+					RelationSetNewRelfilenode(iRel, iRel->rd_rel->relpersistence);
+					index_close(iRel, AccessExclusiveLock);
+					CommandCounterIncrement();
+				}
+
+				o_define_index(rel, NULL, indexOid, false,
 							   InvalidIndexNumber, oldRelnode,
 							   false, NULL);
 				closed = true;

--- a/test/t/tablespace_test.py
+++ b/test/t/tablespace_test.py
@@ -46,3 +46,123 @@ class TablespaceTest(BaseTest):
 		    node.execute('postgres', "SELECT count(*) FROM o_ts;")[0][0],
 		    20000)
 		node.stop()
+
+	def test_secondary_index_survives_table_tablespace_move(self):
+		"""
+		ALTER TABLE ... SET TABLESPACE moves only the table's own storage;
+		a secondary index keeps its own tablespace and must keep working.
+		The move rewrites the table under a new relnode, so the index is
+		rebuilt -- but it must be rebuilt in the tablespace it still lives in
+		instead of being unlinked and left behind, which made even a plain
+		count(*) fail with "could not open file ...".
+		"""
+		ts1_dir = tempfile.mkdtemp(prefix='oriole_ts1_')
+		ts2_dir = tempfile.mkdtemp(prefix='oriole_ts2_')
+		self.addCleanup(shutil.rmtree, ts1_dir, ignore_errors=True)
+		self.addCleanup(shutil.rmtree, ts2_dir, ignore_errors=True)
+
+		node = self.node
+		node.start()
+
+		node.safe_psql('postgres',
+		               f"CREATE TABLESPACE ots1 LOCATION '{ts1_dir}';")
+		node.safe_psql('postgres',
+		               f"CREATE TABLESPACE ots2 LOCATION '{ts2_dir}';")
+		# The database itself lives in ots1, so the table and its index both
+		# default to ots1 and only the table is moved away.
+		node.safe_psql('postgres',
+		               "CREATE DATABASE ts_move_db TABLESPACE ots1;")
+		node.safe_psql('ts_move_db', "CREATE EXTENSION orioledb;")
+		node.safe_psql(
+		    'ts_move_db', """
+			CREATE TABLE test_tbl (id int, val int, data text) USING orioledb;
+			CREATE INDEX test_tbl_data_idx ON test_tbl (data);
+			INSERT INTO test_tbl
+				SELECT x, 2 * x, 'test' || x FROM generate_series(1, 1000) x;
+		""")
+		node.safe_psql('ts_move_db', "CHECKPOINT;")
+
+		node.safe_psql('ts_move_db',
+		               "ALTER TABLE test_tbl SET TABLESPACE ots2;")
+
+		self.assertEqual(
+		    node.execute('ts_move_db', "SELECT count(*) FROM test_tbl;")[0][0],
+		    1000)
+		with node.connect('ts_move_db') as con:
+			con.execute("SET enable_seqscan = off;")
+			self.assertEqual(
+			    con.execute("SELECT count(*) FROM test_tbl "
+			                "WHERE data = 'test500';")[0][0], 1)
+
+		# The rebuilt index must also survive a checkpoint and a restart.
+		node.safe_psql('ts_move_db', "CHECKPOINT;")
+		node.restart()
+
+		self.assertEqual(
+		    node.execute('ts_move_db', "SELECT count(*) FROM test_tbl;")[0][0],
+		    1000)
+		with node.connect('ts_move_db') as con:
+			con.execute("SET enable_seqscan = off;")
+			self.assertEqual(
+			    con.execute("SELECT count(*) FROM test_tbl "
+			                "WHERE data = 'test500';")[0][0], 1)
+		node.stop()
+
+	def test_secondary_index_in_own_tablespace_survives_table_move(self):
+		"""
+		The index's own tablespace is the one it must be rebuilt in, which is
+		not necessarily either side of the table's move.  Here the table goes
+		ots1 -> pg_default while the index stays pinned to ots2.
+		"""
+		ts1_dir = tempfile.mkdtemp(prefix='oriole_ts1_')
+		ts2_dir = tempfile.mkdtemp(prefix='oriole_ts2_')
+		self.addCleanup(shutil.rmtree, ts1_dir, ignore_errors=True)
+		self.addCleanup(shutil.rmtree, ts2_dir, ignore_errors=True)
+
+		node = self.node
+		node.start()
+
+		node.safe_psql('postgres',
+		               f"CREATE TABLESPACE ots1 LOCATION '{ts1_dir}';")
+		node.safe_psql('postgres',
+		               f"CREATE TABLESPACE ots2 LOCATION '{ts2_dir}';")
+		node.safe_psql('postgres', "CREATE EXTENSION orioledb;")
+		node.safe_psql(
+		    'postgres', """
+			CREATE TABLE t_split (id int, data text)
+				USING orioledb TABLESPACE ots1;
+			CREATE INDEX t_split_data_idx ON t_split (data) TABLESPACE ots2;
+			INSERT INTO t_split
+				SELECT x, 'w' || x FROM generate_series(1, 500) x;
+		""")
+		node.safe_psql('postgres', "CHECKPOINT;")
+
+		node.safe_psql('postgres',
+		               "ALTER TABLE t_split SET TABLESPACE pg_default;")
+
+		# The index stayed in ots2 and must still resolve rows there.
+		self.assertEqual(
+		    node.execute(
+		        'postgres', """
+			SELECT ts.spcname FROM pg_class c
+				JOIN pg_tablespace ts ON ts.oid = c.reltablespace
+				WHERE c.relname = 't_split_data_idx';
+		""")[0][0], 'ots2')
+		with node.connect('postgres') as con:
+			con.execute("SET enable_seqscan = off;")
+			self.assertEqual(
+			    con.execute("SELECT count(*) FROM t_split "
+			                "WHERE data = 'w250';")[0][0], 1)
+
+		node.safe_psql('postgres', "CHECKPOINT;")
+		node.restart()
+
+		with node.connect('postgres') as con:
+			con.execute("SET enable_seqscan = off;")
+			self.assertEqual(
+			    con.execute("SELECT count(*) FROM t_split "
+			                "WHERE data = 'w250';")[0][0], 1)
+		self.assertEqual(
+		    node.execute('postgres', "SELECT count(*) FROM t_split;")[0][0],
+		    500)
+		node.stop()


### PR DESCRIPTION
Fixes #906.

## What breaks

`ALTER TABLE ... SET TABLESPACE` on an OrioleDB table **without a primary key** leaves every secondary index empty, and then leaves the table unreadable.

```sql
CREATE DATABASE testdb TABLESPACE user_ts1;
\c testdb
CREATE EXTENSION orioledb;
CREATE TABLE test_tbl(id int, val int, data text) USING orioledb;
CREATE INDEX test_tbl_data_idx ON test_tbl (data);
INSERT INTO test_tbl SELECT x, 2 * x, 'test'||x FROM generate_series(1, 1000) x;
CHECKPOINT;
ALTER TABLE test_tbl SET TABLESPACE user_ts2;

SET enable_seqscan = off;
SELECT count(*) FROM test_tbl WHERE data = 'test500';   -- 0, expected 1
CHECKPOINT;
SELECT count(*) FROM test_tbl;
-- ERROR: could not open file "pg_tblspc/16384/PG_17_202406281/16386/16481"
```

The wrong-results window is the dangerous half: until the checkpoint removes the file there is no error at all, just an index that silently returns nothing.

## Root cause

`orioledb_relation_set_new_filenode()` queues all of the moved table's trees for removal at commit, the secondary index's included. `redefine_indices()` then rebuilds that index **reusing its existing relfilenode**.

An OrioleDB tree is identified by `(datoid, relnode, tablespace)`, and a secondary index keeps its own tablespace across the move — `SET TABLESPACE` moves only the table's storage. So the rebuilt tree receives the exact key already queued for the drop, and the commit deletes the index it has just built.

Confirmed at the commit boundary: the index returns all rows inside the transaction and zero rows immediately after `COMMIT`.

The same commit-time drop also unlinks the index's relation file, via `o_bridge_drop_relnode_marker()`. That path identifies a bridge index as `reloid == relnode`, and an index still on its first relfilenode has `relfilenode == oid` too. `pg_class` keeps pointing at the unlinked relnode, so after the next checkpoint every plan over the table fails — including a plain `count(*)`, since the planner sizes the index.

Tables **with** a primary key are unaffected: their primary pass reaches `assign_new_oids()`, which already reassigns every index's relfilenode. The ctid path only reimplements that for toast, as its own comment notes.

## The fix

`redefine_indices()` gives each secondary index a relnode of its own before rebuilding it, in the tablespace the index still lives in. Restricted to ctid tables, since the primary-key path is already covered by `assign_new_oids()`.

## Deliberately not fixed

The `reloid == relnode` bridge-marker check is left as-is, with a comment recording that it is a convention rather than an identity. Every path that drops an index tree at commit now assigns a fresh relnode first, so the locator it drops is always stale. Making the check exact means marking the bridge in `RelnodeUndoStackItem`, which changes the undo record layout and therefore needs an `ORIOLEDB_BINARY_VERSION` bump — that seemed wrong to fold into a correctness fix, so it is flagged for maintainers instead.

## Tests

The existing `tablespace` regression test passes both with and without this fix: it never scans a secondary index after a *committed* move without an intervening rebuild, which is why this went unnoticed. Coverage is added in `test/t/tablespace_test.py` instead, which can restart the cluster — one test for an index sharing the table's tablespace, one for an index pinned to a third tablespace the table never touches.

## Verification

Built against the `.pgtags` patch sets for each major.

| | PG 16.14 | PG 17.10 | PG 18.4 |
|---|---|---|---|
| New tests **without** fix | FAIL (2) | FAIL (2) | FAIL (2) |
| New tests **with** fix | PASS | PASS | PASS |
| `regresscheck` | 50/50 | 50/50 | 50/50 |
| `isolationcheck` | — | 37/37 | — |
| Ad-hoc scenario matrix | 14/14 | 14/14 | 14/14 |

The scenario matrix covers PK tables, an index pinned to a third tablespace, repeated moves, `ALTER TABLE ALL IN TABLESPACE`, multiple/unique indexes with toast, and a restart after each.

`testgrescheck` parts 1–3 were run on PG 17: part 3 clean; part 1 has one failure (`incomplete_split_test.test_incomplete_leaf_delete_by_hint_fix`) and part 2 has three (`multi_insert_test` concurrency). All four reproduce identically on unmodified `main` and are unrelated to tablespaces.

Not run locally: the valgrind, sanitizer, `check_page`, `pg_upgrade` and s3 CI jobs.
