### PR TITLE
Don't let load_page() borrow a caller's KEEP_PARENT flag

### DIFF
--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1042,6 +1042,18 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 				}
 			}
 
+			/*
+			 * A caller that steps to siblings navigates items[index - 1]
+			 * through parentImg, so the descent must hand it back bound to
+			 * parentImg -- unless the fastpath deliberately deferred the copy
+			 * (parentImgDeferred), which find_right_page()/find_left_page()
+			 * materialize before use.
+			 */
+			if ((imageFlag || keepParentFlag) && context->index > 0 &&
+				!context->parentImgDeferred)
+				ASSERT_PARENT_LOCATOR_LOCAL(context,
+											context->items[context->index - 1].locator);
+
 			O_TUPLE_SET_NULL(context->insertTuple);
 			return OFindPageResultSuccess;
 		}
@@ -1513,6 +1525,18 @@ retry:
 	context->items[context->index].locator = loc;
 	context->items[context->index].blkno = intCxt.blkno;
 	context->items[context->index].pageChangeCount = intCxt.pageChangeCount;
+
+	/*
+	 * refind_page() re-finds one page by a cached hint; it never revisits the
+	 * parent slot.  A caller that steps to siblings therefore keeps whatever
+	 * the previous descent left in items[index - 1], so enforce the parent
+	 * invariant here too rather than only where find_page() builds it.
+	 */
+	if ((BTREE_PAGE_FIND_IS(context, IMAGE) ||
+		 BTREE_PAGE_FIND_IS(context, KEEP_PARENT)) &&
+		context->index > 0 && !context->parentImgDeferred)
+		ASSERT_PARENT_LOCATOR_LOCAL(context,
+									context->items[context->index - 1].locator);
 	return OFindPageResultSuccess;
 }
 

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1692,6 +1692,7 @@ load_page(OBTreeFindPageContext *context)
 	bool		was_fetch = false;
 	bool		was_image = false;
 	bool		was_keep_lokey = false;
+	bool		was_keep_parent = false;
 	OReadPageResult read_result;
 	uint32		chkpNum = 0;
 
@@ -1823,6 +1824,21 @@ load_page(OBTreeFindPageContext *context)
 	was_keep_lokey = BTREE_PAGE_FIND_IS(context, KEEP_LOKEY);
 	if (was_keep_lokey)
 		BTREE_PAGE_FIND_UNSET(context, KEEP_LOKEY);
+
+	/*
+	 * The descent below is a scratch use of the caller's context: it re-finds
+	 * the parent of the page being loaded and overwrites the item slots.  A
+	 * caller that navigates siblings (KEEP_PARENT) must not have that flag
+	 * observed here -- it would make find_page() maintain parentImg for a
+	 * descent the caller never asked for, rebinding the caller's parent image
+	 * mid-flight, and it leaves refind_page() returning with a parent slot
+	 * that belongs to neither descent.  Save and clear it like every other
+	 * flag this function borrows.
+	 */
+	was_keep_parent = BTREE_PAGE_FIND_IS(context, KEEP_PARENT);
+	if (was_keep_parent)
+		BTREE_PAGE_FIND_UNSET(context, KEEP_PARENT);
+
 	was_downlink_location = BTREE_PAGE_FIND_IS(context, DOWNLINK_LOCATION);
 	if (!was_downlink_location)
 		BTREE_PAGE_FIND_SET(context, DOWNLINK_LOCATION);
@@ -1882,6 +1898,8 @@ load_page(OBTreeFindPageContext *context)
 		BTREE_PAGE_FIND_SET(context, IMAGE);
 	if (was_keep_lokey)
 		BTREE_PAGE_FIND_SET(context, KEEP_LOKEY);
+	if (was_keep_parent)
+		BTREE_PAGE_FIND_SET(context, KEEP_PARENT);
 	if (!was_downlink_location)
 		BTREE_PAGE_FIND_UNSET(context, DOWNLINK_LOCATION);
 


### PR DESCRIPTION
Refs #1050. **This does not close it** — see "What this does not fix" below.

## The defect

`load_page()` re-finds the parent of the page it is loading by borrowing the caller's `OBTreeFindPageContext` as scratch space. It saves and restores every find flag it changes for that scratch descent — `MODIFY`, `FETCH`, `IMAGE`, `KEEP_LOKEY`, `DOWNLINK_LOCATION` — except **`KEEP_PARENT`**.

A caller that navigates siblings sets `KEEP_PARENT`, so the scratch descent runs as one too:

- `find_page()` maintains `context->parentImg` for a descent the caller never asked for, rebinding the caller's parent image and locator onto the *scratch* descent's parent mid-flight;
- `refind_page()` returns leaving the parent slot pointing at a page belonging to neither descent.

The window is the on-disk downlink path, so it only opens once eviction has pushed downlinks out — which is why a fuzzer with concurrent writers finds it and the regression suite does not.

The fix saves and clears `KEEP_PARENT` like the rest.

## Enforcing the invariant

`ASSERT_PARENT_LOCATOR_LOCAL()` documents that the parent locator a sibling step navigates must point into `parentImg`, but it had **no users**, so nothing enforced it at the producers. This gives it two: `find_page()` and `refind_page()` both check before returning success, unless the fastpath deliberately deferred the copy (`parentImgDeferred`), which `find_right_page()` / `find_left_page()` materialize before use.

`refind_page()` needs its own check because it re-finds a single page by a cached hint and never revisits the parent slot — it hands back whatever the previous descent left there.

## Evidence

Measured on **PG 18 built with `-DCHECK_PAGE_STRUCT -DCHECK_PAGE_STATS`**, the configuration #1050 was reported from.

Workload: 300k rows; a forced index-only scan of a secondary index (the `KEEP_PARENT` path that steps to siblings); `orioledb.main_buffers = 8MB` against a 141 MB relation so eviction puts downlinks on disk; four concurrent writers inserting, updating and deleting to split pages. 120 s per run, four reader and four writer sessions.

| build | assertion failures | backend crashes |
|---|---|---|
| pure `main` | 0 | 0 |
| `main` + producer asserts, **without** this fix | **47** | **27** |
| `main` + producer asserts, **with** this fix | **0** | **0** |

Each run was checked for validity before its result was trusted — reader query counts, zero reader errors, the plan actually being `Forward index only scan of: o_stress_val_idx`, and the relation size exceeding `main_buffers`. (An earlier run of this harness reported a clean 0 that was worthless: an `integer out of range` in the data generator had loaded 0 rows.)

Suites with this patch:

| | PG 16.14 | PG 18.4 |
|---|---|---|
| `regresscheck` | 50/50 | 50/50 |
| `isolationcheck` | 37/37 | 37/37 |

`testgrescheck` parts 1–3 also pass. PG 17 is not covered — I removed that install mid-investigation and did not rebuild it; happy to add it if you want the matrix complete before merge.

## What this does not fix

The crash reported in #1050 is the **consumer-side** assertion in `find_right_page()`. That one does **not** reproduce under this workload on an unpatched tree (0 traps on pure `main` above). What is fixed and proven here is a *producer* of the same broken invariant, reachable through the same on-disk downlink path.

So this is worth having on its own — it removes a live cross-contamination of a caller's parent image, and it makes the invariant enforced rather than aspirational, which means a future occurrence traps at the producer with the offending descent still on the stack instead of only when a sibling step consumes it. But the issue should stay open until the consumer path is accounted for.

This is complementary to #1051, which guards the consumers; it does not overlap with it.
