### PR TITLE
Assert that leafPagesNum does not wrap when a leaf merge decrements it

### DIFF
--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -257,7 +257,22 @@ btree_try_merge_pages(BTreeDescr *desc,
 	ppool_free_page(desc->ppool, right_blkno, true);
 
 	if (O_PAGE_IS(left, LEAF))
-		pg_atomic_fetch_sub_u32(&BTREE_GET_META(desc)->leafPagesNum, 1);
+	{
+		uint32		prevLeafPagesNum PG_USED_FOR_ASSERTS_ONLY;
+
+		/*
+		 * This is the only place leafPagesNum is decremented, and it is
+		 * unsigned: one decrement more than the splits that incremented it
+		 * wraps the count to ~4.29e9 pages, which the relation-size functions
+		 * report as tens of terabytes.  The count is also checkpointed into
+		 * the tree's .map header, so a wrapped value survives restart and
+		 * only goes away on REINDEX -- by which point nothing points at the
+		 * merge that caused it.  Catch the imbalance here instead.
+		 */
+		prevLeafPagesNum =
+			pg_atomic_fetch_sub_u32(&BTREE_GET_META(desc)->leafPagesNum, 1);
+		Assert(prevLeafPagesNum > 0);
+	}
 
 	END_CRIT_SECTION();
 


### PR DESCRIPTION
Refs #817. **This does not fix it** — I could not reproduce a wrapped counter. What it does is make the next occurrence diagnosable.

## Why the sizes in #817 look like that

`btree_try_merge_pages()` holds the **only** decrement of a tree's `leafPagesNum`, and the counter is unsigned:

```c
if (O_PAGE_IS(left, LEAF))
    pg_atomic_fetch_sub_u32(&BTREE_GET_META(desc)->leafPagesNum, 1);
```

One decrement more than the splits that incremented it wraps the count to ~4.29e9 pages. `orioledb_calculate_relation_size()` multiplies that by `ORIOLEDB_BLCKSZ`, which is how a small table comes to report 9088 GB or 13 TB.

It does not stay in memory, either: checkpointing copies `leafPagesNum` into the tree's `.map` header, so a wrapped count is persisted, survives a restart, and clears only on a REINDEX that rebuilds the tree. That matches the report exactly — restart had no effect, REINDEX fixed it — and it means that by the time anyone notices, the merge that caused it is long gone and there is nothing left to diagnose.

## What this adds

An assert that the counter was non-zero before the decrement, so an imbalance stops at the merge responsible instead of surfacing days later as a nonsense size. Assert-only; no behaviour change in production builds.

## What I could not reproduce

Three workloads on PG 18, each instrumented to log every leaf-merge decrement with the counter's prior value:

| workload | leaf merges | lowest prior value | wrapped? |
|---|---|---|---|
| Churn on a non-toasted table | 7970 | 3 | no |
| Churn against a real 109 MB toast tree (20k rows, 5120 B payloads) | 8352 | 3 | no |
| Eviction before any checkpoint, then merges | 1938 | 3 | no |

Reported sizes stayed consistent with the data across checkpoints and restarts in all three. So plain churn, toast trees, and evict-before-checkpoint are all ruled out as triggers; the reporter's scenario involved a TPC-C run followed by days of idle time, which points more at background checkpointer-driven merges than at anything a foreground workload reaches.

## Verification

The assert was checked in both directions rather than assumed:

- **It fires:** with a deliberate extra decrement injected at the same site, it trips on the first leaf merge.
- **It does not misfire:** without the injection, the same churn workload (8000+ merges) completes clean.

| | PG 16.14 | PG 18.4 |
|---|---|---|
| `regresscheck` | 50/50 | 50/50 |
| `isolationcheck` | 37/37 | 37/37 |

PG 17 is not covered — I no longer have that install in this container; happy to add it if you want the matrix complete.

Note the still-open question on the issue: the build hash was never supplied, so I cannot tell whether the code that produced those sizes is still present.
