### PR TITLE
Do not let a swallowed participant error hang replica replay

### DIFF
--- a/include/catalog/indices.h
+++ b/include/catalog/indices.h
@@ -92,6 +92,14 @@ typedef struct oIdxShared
 	 * indtuples is the total number of tuples that made it into the index.
 	 */
 	int			nparticipantsdone;
+
+	/*
+	 * Set by a participant whose build raised, so the leader stops waiting
+	 * for a report that is never coming.  A participant that swallows its
+	 * error and just leaves would otherwise park the leader in
+	 * _o_index_parallel_heapscan() forever.
+	 */
+	bool		participantfailed;
 	int			nrecoveryworkersjoined;
 
 	double		reltuples;
@@ -107,6 +115,9 @@ typedef struct oIdxShared
 	char		o_table_serialized[FLEXIBLE_ARRAY_MEMBER];
 	/* old_o_table_serialized follows */
 } oIdxShared;
+
+extern void o_index_parallel_report_participant_failure(shm_toc *toc);
+extern bool o_index_parallel_participant_failed(oIdxShared *btshared);
 
 extern void o_define_index_validate(ORelOids oids, Relation index, IndexInfo *indexInfo, OTable *o_table);
 extern void o_define_index(Relation heap, Relation index, Oid indoid, bool reindex,

--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -1316,6 +1316,7 @@ _o_index_begin_parallel(oIdxBuildState *buildstate, bool isconcurrent, int reque
 		ConditionVariableInit(&btshared->recoveryjoinedcv);
 	btshared->nrecoveryworkersjoined = 0;
 	btshared->nparticipantsdone = 0;
+	btshared->participantfailed = false;
 	btshared->reltuples = 0.0;
 	memset(btshared->indtuples, 0, INDEX_MAX_KEYS * sizeof(double));
 	orioledb_parallelscan_initialize_inner((ParallelTableScanDesc) &(btshared->poscan));
@@ -1433,6 +1434,17 @@ _o_index_begin_parallel(oIdxBuildState *buildstate, bool isconcurrent, int reque
 								"aborting build to avoid replica hang")));
 
 			/*
+			 * The probe above only catches a worker that died.  A worker
+			 * whose build raised swallows the error and stays alive, so it
+			 * never joins and never will; it reports that here instead.
+			 */
+			if (o_index_parallel_participant_failed(btshared))
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("orioledb: parallel index build failed in a "
+								"participating worker before it joined")));
+
+			/*
 			 * We wait on a condition variable that will wake us as soon as
 			 * the pause ends, but we use a timeout so we can check the
 			 * ShutdownRequestPending periodically too.
@@ -1496,6 +1508,45 @@ _o_index_parallel_estimate_shared(Size o_table_size)
  * as a worker, we should end up here just as workers are finishing).
  *
  */
+/*
+ * Tell the leader that this participant's build raised, so it stops waiting
+ * for a report that is never coming.  Safe to call even when the leader has
+ * already given up: we still hold the DSM mapping, and a leader that is gone
+ * simply never reads the flag.
+ */
+/* Has any participant reported that its build raised? */
+bool
+o_index_parallel_participant_failed(oIdxShared *btshared)
+{
+	bool		failed;
+
+	SpinLockAcquire(&btshared->mutex);
+	failed = btshared->participantfailed;
+	SpinLockRelease(&btshared->mutex);
+
+	return failed;
+}
+
+void
+o_index_parallel_report_participant_failure(shm_toc *toc)
+{
+	oIdxShared *btshared = shm_toc_lookup(toc, PARALLEL_KEY_BTREE_SHARED, true);
+
+	if (btshared == NULL)
+		return;
+
+	SpinLockAcquire(&btshared->mutex);
+	btshared->participantfailed = true;
+	SpinLockRelease(&btshared->mutex);
+
+	/*
+	 * The leader may be parked in either of its two waits -- for participants
+	 * to join, or for them to finish sorting -- so wake both.
+	 */
+	ConditionVariableBroadcast(&btshared->recoveryjoinedcv);
+	ConditionVariableBroadcast(&btshared->workersdonecv);
+}
+
 static void
 _o_index_parallel_heapscan(oIdxBuildState *buildstate)
 {
@@ -1513,6 +1564,22 @@ _o_index_parallel_heapscan(oIdxBuildState *buildstate)
 	for (;;)
 	{
 		SpinLockAcquire(&btshared->mutex);
+		if (btshared->participantfailed)
+		{
+			SpinLockRelease(&btshared->mutex);
+			ConditionVariableCancelSleep();
+
+			/*
+			 * A participant's build raised.  Its sorted output is missing, so
+			 * finishing here would merge an incomplete result into a live
+			 * index; fail the whole build instead.  In recovery the caller
+			 * catches this, leaves the index in its BUILDING state and lets
+			 * replay go on.
+			 */
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("parallel index build failed in a participating worker")));
+		}
 		if (btshared->nparticipantsdone == nparticipanttuplesorts)
 		{
 			SpinLockRelease(&btshared->mutex);
@@ -1546,6 +1613,15 @@ _o_index_leader_participate_as_worker(oIdxBuildState *buildstate)
 	oIdxLeader *btleader = buildstate->btleader;
 	oIdxSpool  *leaderworker;
 	int			worker_sortmem;
+
+	/*
+	 * Holding the leader here lets a test hand the whole heap to the
+	 * participants, so a participant -- not the leader -- is the one that
+	 * evaluates a failing index expression.  That is the ordering that parks
+	 * the leader in _o_index_parallel_heapscan() waiting for a report the
+	 * participant will never send.
+	 */
+	STOPEVENT(STOPEVENT_INDEX_BUILD_LEADER_PARTICIPATE, NULL);
 
 	/* Allocate memory and initialize private spool */
 	leaderworker = (oIdxSpool *) palloc0(sizeof(oIdxSpool));

--- a/src/recovery/worker.c
+++ b/src/recovery/worker.c
@@ -706,6 +706,17 @@ recovery_queue_process(shm_mq_handle *queue, int id)
 					edata = CopyErrorData();
 					FlushErrorState();
 
+					/*
+					 * Swallowing the error keeps this worker alive, but the
+					 * leader is still counting reports.  Tell it the build
+					 * failed, or it parks in _o_index_parallel_heapscan()
+					 * forever and the startup process parks behind it in
+					 * delay_if_queued_for_idxbuild() -- replay stops for
+					 * good.  Harmless in the case this catch was written for,
+					 * where the leader has already given up.
+					 */
+					o_index_parallel_report_participant_failure(toc);
+
 					ereport(LOG,
 							(errmsg("orioledb recovery worker %d: parallel index "
 									"build (DSM segment %u) aborted mid-flight: "

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -9,6 +9,7 @@ checkpoint_table_start
 checkpoint_before_post_process
 checkpoint_before_start
 checkpoint_before_replay_start
+index_build_leader_participate
 index_insert
 ioc_before_update
 modify_start

--- a/test/t/concurrent_index_test.py
+++ b/test/t/concurrent_index_test.py
@@ -468,6 +468,61 @@ class ConcurrentIndexTest(BaseTest):
 			except Exception:
 				pass
 
+	def test_cic_streaming_replica_participant_fails(self):
+		"""
+		Same failing expression as above, but with the ordering forced so a
+		*participant* of the replica's parallel build evaluates the bad row,
+		not the leader.  The participant swallows the error to survive a
+		leader that already tore the segment down, so it must still report the
+		failure -- otherwise the leader waits for a report that never comes,
+		the startup process waits behind the leader, and replay stops for
+		good.
+		"""
+		master = self.node
+		master.append_conf('orioledb.enable_stopevents = true\n')
+		master.start()
+		try:
+			with self.getReplica().start() as replica:
+				master.safe_psql("""
+					CREATE EXTENSION orioledb;
+					CREATE TABLE o_cic_part (a int, b int) USING orioledb;
+					INSERT INTO o_cic_part VALUES (1, 0);
+				""")
+				self.catchup_orioledb(replica)
+
+				# Hold the replica's build leader out of its own scan, so the
+				# single failing row falls to a participant.
+				replica.safe_psql(
+				    "SELECT pg_stopevent_set('index_build_leader_participate', 'true')"
+				)
+
+				_, _, err = master.psql(
+				    "CREATE INDEX CONCURRENTLY o_cic_part_idx "
+				    "ON o_cic_part ((a/b));")
+				self.assertIn(b"division by zero", err)
+
+				# Wait until the leader is actually parked, then let it go.
+				while replica.execute(
+				    "SELECT count(*) FROM pg_stopevents() "
+				    "WHERE stopevent = 'index_build_leader_participate' "
+				    "AND waiter_pids <> '{}'")[0][0] == 0:
+					time.sleep(0.1)
+				replica.safe_psql(
+				    "SELECT pg_stopevent_reset('index_build_leader_participate')"
+				)
+
+				# Replay must go on.
+				master.safe_psql("INSERT INTO o_cic_part VALUES (5, 1);")
+				self.catchup_orioledb(replica)
+				self.assertEqual(
+				    replica.execute("SELECT count(*) FROM o_cic_part;")[0][0],
+				    2)
+		finally:
+			try:
+				master.stop()
+			except Exception:
+				pass
+
 	def test_cic_streaming_replica_failing_expr(self):
 		"""
 		CIC on the primary may fail at validate-scan when the index


### PR DESCRIPTION
## The bug

A recovery worker that joins a parallel index build catches whatever the build raises, logs it and drops the message, so a leader that already tore the DSM segment down does not take the worker with it. The catch is not limited to that case: it also swallows a **genuine build failure** — an index expression dividing by zero, say — after which the worker neither joins nor reports done, while staying alive.

Both of the leader's waits then never end. Their liveness probes ask whether a worker *process exited*, which a worker that swallowed its error has not. The startup process parks behind the leader in `delay_if_queued_for_idxbuild()`, whose own escape hatch asks the same question about the leader. Replay stops for good.

Observed on a sanitizer CI cell ([run 32776682994](https://github.com/orioledb/orioledb/actions/runs/32776682994/job/97589321421)) as `concurrent_index-cic_streaming_replica_failing_expr` timing out, with the leader in `_o_index_parallel_heapscan()` and the startup process waiting on the build queue.

## The fix

The participant records the failure in `oIdxShared` on its way out and wakes **both** of the leader's condition variables — they sleep on different ones depending on whether it had joined yet. Each wait checks the flag and fails the build, which in recovery is caught for a BUILDING secondary, logged as deferred, and lets replay continue: the state the replica should mirror anyway.

Deliberately a failure flag and **not** a `nparticipantsdone` bump — the missing sorted output would otherwise be merged into a live index.

## The test

The hang needs a *participant*, not the leader, to evaluate the failing expression. Which of them draws the row is a race, and off a sanitizer build the leader almost always wins, so the existing `cic_streaming_replica_failing_expr` exercises the benign ordering and passes.

A new stop event where the leader joins its own scan fixes the ordering: holding it there hands the whole heap to the participants, and the wedge reproduces in seconds without a sanitizer.

## What is and is not verified

- The new test **discriminates**: it times out with the participant's failure report removed, passes with it.
- Measured which wait it covers, by disabling each guard separately: it covers `_o_index_parallel_heapscan()` — the wait in the CI stack.
- The `_o_index_begin_parallel()` wait is guarded on the same flag but **has no test**. Reaching it needs a participant to fail during attach, which cannot be forced from SQL without an injection GUC. Kept as defensive.
- regress 50/50, isolation 38/38, `concurrent_index` 12/12, plus 33 tests across the other stopevent-using modules (the `stopevents.txt` change regenerates headers).
- Not reproduced under the sanitizer cell itself; that is what CI on this PR will show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)