### PR TITLE
Fix the invalid check workflow: expressions have no arithmetic

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,6 +49,7 @@ jobs:
           SEL_PG: ${{ github.event.inputs.pg_version || 'all' }}
           SEL_COMP: ${{ github.event.inputs.compiler || 'all' }}
           SEL_CT: ${{ github.event.inputs.check_type || 'all' }}
+          REPEATS: ${{ github.event.inputs.repeats || '1' }}
         run: |
           import os, json, itertools
 
@@ -69,6 +70,12 @@ jobs:
           except ValueError:
               fanout = 1
           fanout = max(1, fanout)
+
+          try:
+              repeats = int(os.environ.get("REPEATS") or 1)
+          except ValueError:
+              repeats = 1
+          repeats = max(1, repeats)
 
           # A dispatch may narrow the matrix to the cell being chased.  Any
           # narrowing selects out of the *full* matrix, since the point is to
@@ -99,6 +106,23 @@ jobs:
               ]
               if not cells:
                   raise SystemExit(f"::error::no matrix cell matches {sel}")
+
+              # The check step's budget scales with the repeat count.  It is
+              # computed here because GitHub expressions have no arithmetic:
+              # multiplying in the workflow makes the file fail to parse.
+              for cell in cells:
+                  ct = cell["check_type"]
+                  base = (150 if ct.startswith("valgrind_")
+                          else 60 if ct == "dm_log_writes"
+                          else 40 if ct == "sanitize"
+                          else 30)
+                  budget = base * repeats
+                  if budget > 350:
+                      print(f"::warning::{ct} needs {budget} min for "
+                            f"{repeats} repeats, over the 6h job limit; "
+                            f"capping at 350")
+                      budget = 350
+                  cell["timeout"] = budget
               limit = max(1, 256 // len(cells))
               if fanout > limit:
                   print(f"::warning::jobs={fanout} would need {fanout * len(cells)} "
@@ -206,7 +230,7 @@ jobs:
         run: bash ./orioledb/ci/post_build_prerequisites.sh
 
       - name: Check
-        timeout-minutes: ${{ (startsWith(matrix.check_type, 'valgrind_') && 150 || (matrix.check_type == 'dm_log_writes' && 60 || (matrix.check_type == 'sanitize' && 40 || 30))) * fromJSON(github.event.inputs.repeats || '1') }}
+        timeout-minutes: ${{ matrix.timeout }}
         env:
           REPEATS: ${{ github.event.inputs.repeats || '1' }}
         run: |


### PR DESCRIPTION
**main's `check` workflow is currently unparsable — no check job runs at all.** My mistake in #1077.

The repeat count was multiplied into `timeout-minutes` inside a `${{ }}` expression. GitHub's expression language has no arithmetic operators, so `*` made the whole file invalid:

```
check.yml:209:179: parser did not reach end of input after parsing the expression.
13 remaining token(s) in the input: "*", "IDENT", "(", ...
```

([run 32907706241](https://github.com/orioledb/orioledb/actions/runs/32907706241) — zero jobs, run named after the file path, which is what an invalid workflow looks like.)

## Fix

Compute the budget in the matrix generator, which is ordinary Python, and pass it through as `matrix.timeout`. That also retires the nested ternary the timeout used to be written as, and gives somewhere to notice that a large repeat count cannot fit in a job at all — valgrind at three repeats wants 450 minutes against a 6h ceiling, so it caps and warns.

## Verified

`actionlint` is clean on the changed block (the remaining notes are pre-existing: custom `blacksmith-*` runner labels, and an unquoted `$GITHUB_ENV` in a step I did not touch).

Generator run standalone:

| inputs | jobs | timeouts |
|---|---|---|
| push | 30 | 30 / 40 / 60 / 150 — unchanged |
| dispatch, `repeats=1` | 30 | 30 / 40 / 60 / 150 |
| `check_type=sanitize`, `repeats=5` | 12 | 200 |
| `check_type=valgrind_1`, `repeats=3` | 12 | 350 + warning that 450 was wanted |
| one cell, `jobs=8`, `repeats=5` | 8 | 200 |

## On how this got through

I validated that the YAML parses and that the Python generator behaves, and took that for validation of the change. Neither touches expression syntax. `actionlint` catches it in a second and is now the thing to run on any workflow edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)