### PR TITLE
Keep the check job names as they were

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -123,6 +123,9 @@ jobs:
                             f"capping at 350")
                       budget = 350
                   cell["timeout"] = budget
+                  # Only used to decide whether the job name needs a copy
+                  # number; see the name: below.
+                  cell["copies"] = fanout
               limit = max(1, 256 // len(cells))
               if fanout > limit:
                   print(f"::warning::jobs={fanout} would need {fanout * len(cells)} "
@@ -190,6 +193,12 @@ jobs:
 
   check:
     needs: matrix
+    # Spelled out because GitHub builds the default name from every matrix
+    # value, and timeout/copies/run are bookkeeping rather than something a
+    # reader of the job list wants to see.  A copy number appears only when
+    # copies were actually asked for.
+    # Quoted: an unquoted " #" would start a YAML comment mid-expression.
+    name: "check (${{ matrix.cpu }}, ${{ matrix.pg_version }}, ${{ matrix.compiler }}, ${{ matrix.check_type }})${{ matrix.copies > 1 && format(' #{0}', matrix.run) || '' }}"
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}


### PR DESCRIPTION
GitHub builds a matrix job's default name from **every** value in the cell, so the `timeout` and `run` fields I added in #1077/#1078 leaked into it:

```
check (amd64, 16, clang, sanitize, 40, 1)
```

Both are bookkeeping. Spell the name out instead, and append a copy number only when copies were actually requested:

| | job name |
|---|---|
| ordinary push | `check (amd64, 16, clang, sanitize)` — as before |
| `jobs=3` on one cell | `check (amd64, 17, clang, sanitize) #1` … `#3` |

## One trap worth noting

The name must be quoted. Unquoted, the `" #"` in `format(' #{0}', matrix.run)` starts a YAML comment and truncates the expression mid-string — `actionlint` catches it as `got unexpected EOF while lexing end of string literal`.

## Verified

`actionlint` clean on the change (remaining notes are pre-existing: custom `blacksmith-*` runner labels, an unquoted `$GITHUB_ENV` in an untouched step). Names rendered from the generator's actual output for both the default and fan-out cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)