### PR TITLE
Fix non-terminating loop in row_lock_conflicts()

### DIFF
--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1878,8 +1878,26 @@ row_lock_conflicts(BTreeLeafTuphdr *pageTuphdr,
 			prev_tuphdr = curTuphdr;
 			if (!get_prev_leaf_header_from_undo_if_exists(undoType, &prev_tuphdr))
 			{
-				/* Undo gone — skip deletion, treat as end of chain */
-				goto next_record;
+				/*
+				 * Undo gone — end of chain.  Return like the !delete_record
+				 * path; we cannot advance curTuphdr here, so falling through
+				 * to next_record would spin forever when
+				 * retainedUndoLocation <= undoLocation < minProcRetainLocation.
+				 */
+				if (curTuphdr.chainHasLocks)
+				{
+					clean_chain_has_locks_flag(undoType,
+											   lastLockOnlyUndoLocation,
+											   pageTuphdr,
+											   blkno);
+					lastLockOnlyUndoLocation = InvalidUndoLocation;
+				}
+				if (!result)
+				{
+					*conflictTuphdr = finalTuphdr;
+					*conflictUndoLocation = finalUndoLocation;
+				}
+				return result;
 			}
 			if (!UndoLocationIsValid(curUndoLocation))
 			{
@@ -1914,7 +1932,6 @@ row_lock_conflicts(BTreeLeafTuphdr *pageTuphdr,
 			}
 		}
 
-next_record:
 		if (!UndoLocationIsValid(undoLocation) ||
 			undoLocation < retainedUndoLocation)
 		{


### PR DESCRIPTION
In the delete_record branch of row_lock_conflicts(), when the previous undo record of a committed/aborted lock-only record has already been recycled, get_prev_leaf_header_from_undo_if_exists() returns false. The old code reacted with `goto next_record`, but that path never advances curTuphdr/undoLocation (the advance block is gated on !delete_record), so the loop re-evaluates with identical state.

The only reachable exit (exit A) requires undoLocation < retainedUndoLocation, which is unsatisfiable when
retainedUndoLocation <= undoLocation < minProcRetainLocation -- exactly the invariant break observed in the field (per the GDB snapshot in orioledb#1072). The result is an infinite CPU spin with no wait event, matching the reported "Infinite run at row_lock_conflicts" symptom.

Replace the goto with a real end-of-chain return, mirroring the existing !delete_record branch that handles the same "prev-undo gone" condition: clean the chainHasLocks flag if set, restore final conflict pointers, and return. The now-unused next_record label is removed.

This is a defense-in-depth robustness fix: the loop must never spin regardless of how the retain pointers arose. It can possibly fix orioledb#1072, though a deterministic reproduction is still pending and the underlying retain-pointer invariant (Layer 1) is a separate investigation.