### PR TITLE
[ENGPRO-169] antithesis: add slack callback, parameterize email

### DIFF
--- a/.github/workflows/antithesis-jepsen.yml
+++ b/.github/workflows/antithesis-jepsen.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Validate, push, and launch RR and RC runs
         env:
           ANTITHESIS_API_KEY: ${{ secrets.ANTITHESIS_API_KEY }}
+          ANTITHESIS_REPORT_EMAIL: ${{ secrets.ANTITHESIS_REPORT_EMAIL }}
+          ANTITHESIS_SLACK_CALLBACK_URL: ${{ secrets.ANTITHESIS_SLACK_CALLBACK_URL }}
+          ANTITHESIS_SLACK_TOKEN: ${{ secrets.ANTITHESIS_SLACK_TOKEN }}
           DURATION_MINUTES: ${{ steps.target.outputs.duration_minutes }}
           ORIOLEDB_REF: ${{ steps.target.outputs.ref }}
           TARGET_BRANCH: ${{ steps.target.outputs.branch }}

--- a/test/antithesis/launch-jepsen.sh
+++ b/test/antithesis/launch-jepsen.sh
@@ -161,7 +161,9 @@ for index in "${!modes[@]}"; do
 			--description "$description" \
 			--source "$source_name" \
 			--duration "${duration_minutes}m" \
-			--recipients 'paul.bauer@supabase.io' \
+			--recipients "${ANTITHESIS_REPORT_EMAIL}" \
+			--param antithesis.integrations.slack.callback_url="${ANTITHESIS_SLACK_CALLBACK_URL}" \
+			--param antithesis.integrations.slack.token="${ANTITHESIS_SLACK_TOKEN}" \
 			--webhook basic_test
 	)"
 	printf '%s\n' "$launch_output"


### PR DESCRIPTION
Adds slack notifications to CI jobs.  NB also making the email a secret so it doesn't leak in logs.  Mine's already public 🤦, but we'll use an internal mailing list for real.

<!-- start git-machete generated -->

# Based on PR #1084

## Chain of upstream PRs as of 2026-08-27

* PR #1084:
  `main` ← `pmbauer/add-initial-antithesis-workload`

  * **PR #1086 (THIS ONE)**:
    `pmbauer/add-initial-antithesis-workload` ← `pmbauer/add-slack-notifications`

<!-- end git-machete generated -->
