### PR TITLE
Stop replay from waiting on a transaction that will never finish

### DIFF
--- a/include/recovery/recovery.h
+++ b/include/recovery/recovery.h
@@ -28,6 +28,8 @@ extern Size recovery_shmem_needs(void);
 extern void recovery_shmem_init(Pointer ptr, bool found);
 extern bool is_recovery_process(void);
 extern CommitSeqNo recovery_map_oxid_csn(OXid oxid, bool *found);
+extern bool recovery_can_rollback_conflict(UndoLogType undoType, OXid oxid,
+										   UndoLocation undoLocation);
 extern void idx_workers_shutdown(void);
 extern void recovery_send_worker_oids(dsm_handle seg_handle);
 extern bool recovery_idx_workers_all_alive(void);

--- a/src/btree/modify.c
+++ b/src/btree/modify.c
@@ -485,6 +485,30 @@ wait_for_tuple(BTreeDescr *desc, OTuple tuple, OXid oxid,
 	wait_for_oxid(oxid, false);
 }
 
+/*
+ * Refuse to continue when replay meets a conflicting version it may not take
+ * back.  See recovery_can_rollback_conflict(), which decides that; anything it
+ * rejects is a page state replay should not have been able to reach, and
+ * saying so beats spinning on it forever.
+ */
+static void
+o_btree_modify_reject_recovery_conflict(BTreeDescr *desc, OXid oxid,
+										BTreeLeafTuphdr *conflictTupHdr)
+{
+	UndoMeta   *meta = get_undo_meta_by_type(desc->undoType);
+
+	ereport(ERROR,
+			(errcode(ERRCODE_DATA_CORRUPTED),
+			 errmsg("orioledb recovery met a conflicting version of "
+					"unfinished transaction " UINT64_FORMAT,
+					(uint64) oxid),
+			 errdetail("Undo location " UINT64_FORMAT " against the undo "
+					   "[" UINT64_FORMAT ", " UINT64_FORMAT ") the checkpoint retained.",
+					   (uint64) UndoLocationGetValue(conflictTupHdr->undoLocation),
+					   (uint64) pg_atomic_read_u64(&meta->checkpointRetainStartLocation),
+					   (uint64) pg_atomic_read_u64(&meta->checkpointRetainEndLocation))));
+}
+
 static ConflictResolution
 o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 {
@@ -545,6 +569,7 @@ o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 		else
 		{
 			CommitSeqNo csn;
+			bool		rollbackConflict;
 
 			/*
 			 * Test hook: parks the backend here, with the leaf-page-content
@@ -570,7 +595,23 @@ o_btree_modify_handle_conflicts(BTreeModifyInternalContext *context)
 				return ConflictResolutionRetry;
 			}
 
-			if (COMMITSEQNO_IS_ABORTED(csn))
+			/*
+			 * Replay never waits for a conflicting transaction, so decide
+			 * here whether this version can be taken back.  The check either
+			 * approves the rollback or raises -- see its comment.
+			 */
+			rollbackConflict = COMMITSEQNO_IS_ABORTED(csn);
+			if (!rollbackConflict && is_recovery_process() &&
+				COMMITSEQNO_IS_INPROGRESS(csn))
+			{
+				if (!recovery_can_rollback_conflict(desc->undoType, oxid,
+													context->conflictTupHdr.undoLocation))
+					o_btree_modify_reject_recovery_conflict(desc, oxid,
+															&context->conflictTupHdr);
+				rollbackConflict = true;
+			}
+
+			if (rollbackConflict)
 			{
 				/*
 				 * Transaction changes should be undone by the transaction

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -1837,9 +1837,22 @@ row_lock_conflicts(BTreeLeafTuphdr *pageTuphdr,
 				 * transactions.
 				 */
 				csn = oxid_get_csn(oxid, false);
+
+				/*
+				 * A locker replay cannot settle would hold its lock for the
+				 * rest of recovery, and waiting for it is exactly what makes
+				 * the conflict retry spin.  Where the checkpoint vouches for
+				 * the locker its lock is void, so drop the record as if the
+				 * transaction had finished.  Where it does not, leave the
+				 * conflict standing: o_btree_modify_handle_conflicts() raises
+				 * on it rather than quietly ignoring a row lock.
+				 */
 				if (COMMITSEQNO_IS_ABORTED(csn) ||
 					COMMITSEQNO_IS_NORMAL(csn) ||
-					COMMITSEQNO_IS_FROZEN(csn))
+					COMMITSEQNO_IS_FROZEN(csn) ||
+					(is_recovery_process() &&
+					 recovery_can_rollback_conflict(undoType, oxid,
+													curTuphdr.undoLocation)))
 				{
 					delete_record = true;
 				}

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -1615,6 +1615,48 @@ is_recovery_process(void)
 	return iam_recovery;
 }
 
+/*
+ * May replay take back a version left by an unfinished transaction?
+ *
+ * Replay never waits for one: it is serialized, so nobody is going to finish
+ * that transaction while the startup process holds still, and the startup
+ * process cannot even be cancelled -- the wait degenerates into a spin that
+ * never ends and the cluster never opens.
+ *
+ * A version replay did not apply itself can only have come from a checkpoint
+ * image, put there by a transaction that was in flight when the checkpoint
+ * captured the page.  The checkpoint names those transactions in its xids
+ * file and retains exactly their undo, so both halves of that story are
+ * checkable, and both must hold.  Relative to the record being replayed such
+ * a version is the future: take it back, and let forward replay put it there
+ * again if WAL says so.
+ *
+ * The undo position is filled in even for an insertion, which has no previous
+ * version to point at: it is stored alongside the InvalidUndoLocation flag
+ * rather than instead of it.
+ */
+bool
+recovery_can_rollback_conflict(UndoLogType undoType, OXid oxid,
+							   UndoLocation undoLocation)
+{
+	RecoveryXidState *state;
+	UndoMeta   *meta;
+	UndoLocation location;
+	bool		found;
+
+	Assert(is_recovery_process());
+
+	state = hash_search(recovery_xid_state_hash, &oxid, HASH_FIND, &found);
+	if (!found || !state->checkpoint_xid)
+		return false;
+
+	location = UndoLocationGetValue(undoLocation);
+	meta = get_undo_meta_by_type(undoType);
+
+	return location >= pg_atomic_read_u64(&meta->checkpointRetainStartLocation) &&
+		location < pg_atomic_read_u64(&meta->checkpointRetainEndLocation);
+}
+
 CommitSeqNo
 recovery_map_oxid_csn(OXid oxid, bool *found)
 {

--- a/test/t/recovery_livelock_test.py
+++ b/test/t/recovery_livelock_test.py
@@ -9,6 +9,8 @@ import time
 from testgres import NodeStatus
 
 from .base_test import BaseTest
+from .base_test import ThreadQueryExecutor
+from .base_test import wait_checkpointer_stopevent
 
 
 class RecoveryLivelockTest(BaseTest):
@@ -49,7 +51,8 @@ class RecoveryLivelockTest(BaseTest):
 	def setUp(self):
 		super().setUp()
 		self.node.append_conf(
-		    'postgresql.conf', "checkpoint_timeout = 1h\n"
+		    'postgresql.conf', "orioledb.enable_stopevents = true\n"
+		    "checkpoint_timeout = 1h\n"
 		    "max_wal_size = 10GB\n")
 
 	def test_recovery_livelock_on_orphaned_joint_commit(self):
@@ -158,9 +161,124 @@ class RecoveryLivelockTest(BaseTest):
 		self.assertEqual(node.execute("SELECT count(*) FROM h_drop;")[0][0], 1)
 		node.stop()
 
+	def test_replay_conflict_with_unsettled_version(self):
+		"""The same spin reached without any heap xid: a transaction that
+		WAL mentions and never finishes.
+
+		A checkpoint pins replayStartPtr and only afterwards walks the tables
+		and writes their images, so a change made in between is both in the
+		image and above the point replay starts from -- replay applies it a
+		second time.  Park the checkpointer in that window and put two
+		transactions in it.
+
+		B opens first and writes enough rows to overflow its 8 KB local WAL
+		buffer, which puts its WAL_REC_XID on the wire.  That matters: an oxid
+		the checkpoint named but WAL never mentions is settled ABORTED by
+		read_xids() (!state->wal_xid) and page_item_rollback() disposes of it
+		on the first try.  Once WAL does mention it, recovery_map_oxid_csn()
+		answers with the stored COMMITSEQNO_INPROGRESS instead, and B never
+		writes a finish record.
+
+		A then takes the contended row and commits, so its records are
+		replayed; B touches the same row after A released it and never
+		finishes, so B's mark is what the image carries.  Replay re-applies
+		A's record onto that image and conflicts with an oxid it cannot
+		settle.
+		"""
+		node = self.prepare_unsettled(
+		    "UPDATE o_unsettled SET v = 100 WHERE id = 1;")
+		self.assert_recovery_completes(node)
+
+	def test_replay_conflict_with_unsettled_row_lock(self):
+		"""Same shape, but B leaves only a row lock.
+
+		row_lock_conflicts() drops a locker's record once it can see the
+		locker finished.  One that replay cannot settle keeps its lock for the
+		rest of recovery, so the conflict is reported again on every retry.
+		"""
+		node = self.prepare_unsettled(
+		    "SELECT * FROM o_unsettled WHERE id = 1 FOR SHARE;")
+		self.assert_recovery_completes(node)
+
+	def prepare_unsettled(self, b_marks_row):
+		"""Run A and B inside the checkpoint's double-apply window, then crash."""
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_unsettled (\n"
+		    "  id int NOT NULL,\n"
+		    "  v int NOT NULL,\n"
+		    "  PRIMARY KEY (id)\n"
+		    ") USING orioledb;\n"
+		    "INSERT INTO o_unsettled SELECT g, 0 "
+		    "FROM generate_series(1, 2000) g;\n")
+		node.safe_psql('postgres', "CHECKPOINT;")
+
+		ctl = node.connect()
+		ctl.execute("SELECT pg_stopevent_set('checkpoint_table_start',\n"
+		            "format(E'$.table.reloid == \\045s',\n"
+		            "'o_unsettled'::regclass::oid)::jsonpath);")
+		ctl.commit()
+
+		con_ck = node.connect()
+		t_ck = ThreadQueryExecutor(con_ck, "CHECKPOINT;")
+		t_ck.start()
+		wait_checkpointer_stopevent(node)
+
+		# replayStartPtr is pinned; o_unsettled's image is not written yet.
+
+		# B overflows its local WAL buffer, so replay sees this oxid exists.
+		con_b = node.connect()
+		con_b.begin()
+		con_b.execute(
+		    "UPDATE o_unsettled SET v = 7 WHERE id BETWEEN 100 AND 1600;")
+
+		# A takes the contended row and commits: its records are replayed.
+		con_a = node.connect()
+		con_a.begin()
+		con_a.execute("UPDATE o_unsettled SET v = 1 WHERE id = 1;")
+		con_a.commit()
+		con_a.close()
+
+		# B marks the row after A released it, and never finishes.
+		con_b.execute(b_marks_row)
+
+		ctl.execute("SELECT pg_stopevent_reset('checkpoint_table_start');")
+		t_ck.join()
+		con_ck.close()
+
+		node.stop(['-m', 'immediate'])
+		con_b.close()
+		ctl.close()
+		return node
+
+	def assert_recovery_completes(self, node):
+		try:
+			node.start(params=['-t', '20'])
+			opened = self.wait_until_accepting(node, timeout=20)
+		except Exception:
+			opened = self.wait_until_accepting(node, timeout=20)
+		if not opened:
+			self.report_stuck(node)
+			self.kill_cluster(node)
+		self.assertTrue(
+		    opened, "cluster did not finish crash recovery: replay is "
+		    "livelocked in o_btree_modify_handle_conflicts()")
+		self.assertEqual(
+		    node.execute("SELECT v FROM o_unsettled WHERE id = 1;")[0][0], 1)
+
 	def wait_until_accepting(self, node, timeout):
+		"""Wait for the cluster to open.
+
+		Give up as soon as replay reports that its conflict retry is not
+		converging: from there the cluster never opens, and sitting out the
+		whole timeout only makes the failure slower to report.
+		"""
 		deadline = time.time() + timeout
 		while time.time() < deadline:
+			if self.saw_non_convergence(node):
+				return False
 			try:
 				if node.status() != NodeStatus.Running:
 					time.sleep(0.5)
@@ -189,23 +307,44 @@ class RecoveryLivelockTest(BaseTest):
 			pass
 		print("data dir kept at", node.data_dir)
 
-	def kill_cluster(self, node):
-		"""Take a livelocked cluster down.  A fast shutdown never completes --
-		the startup process is not at an interrupt point -- so go straight to
-		immediate, and fall back to signalling the postmaster by hand."""
+	def saw_non_convergence(self, node):
+		log = os.path.join(node.logs_dir, "postgresql.log")
 		try:
-			node.stop(['-m', 'immediate'])
-			return
+			with open(log) as f:
+				return "not converging" in f.read()
 		except Exception:
-			pass
+			return False
+
+	def kill_cluster(self, node):
+		"""Take a livelocked cluster down.
+
+		A fast shutdown never completes -- the startup process is not at an
+		interrupt point -- and an immediate one reports success while leaving
+		the children running, including the recovery worker burning a core.
+		So collect the children first and signal them all by hand.
+		"""
 		try:
 			with open(os.path.join(node.data_dir, "postmaster.pid")) as f:
 				pid = int(f.readline().strip())
 		except Exception:
 			return
+
+		victims = [pid] + self.child_pids(pid)
 		for sig in (signal.SIGQUIT, signal.SIGKILL):
-			try:
-				os.kill(pid, sig)
-			except Exception:
-				pass
+			for victim in victims:
+				try:
+					os.kill(victim, sig)
+				except OSError:
+					pass
 			time.sleep(1)
+
+	def child_pids(self, pid):
+		out = subprocess.run(["ps", "-eo", "pid=,ppid="],
+		                     capture_output=True,
+		                     text=True).stdout
+		kids = []
+		for line in out.splitlines():
+			fields = line.split()
+			if len(fields) == 2 and fields[1] == str(pid):
+				kids.append(int(fields[0]))
+		return kids


### PR DESCRIPTION
Fixes the ORI-257 crash-recovery livelock: replay spins on one WAL record at 100% CPU and the cluster never opens.

```
LOG:  orioledb: modify conflict retry is not converging:
      oxid 53, conflicting oxid 52, 10000 retries, recovery 1
```

## Why it happens

`o_btree_modify_handle_conflicts()` waits for a conflicting transaction that is neither committed nor aborted. During replay that wait can never end — recovery is serialized, the conflicting transaction has no owning process, so `wait_for_tuple()` returns immediately and the retry comes straight back. A backend could be cancelled out of this; the startup process cannot.

The conflicting version can only have come from a checkpoint image. A checkpoint pins `replayStartPtr` and only afterwards walks the tables, so a change made in between is both in the image and above where replay begins — replay meets it while re-applying an older record for the same row.

`read_xids()` normally saves us: an oxid the checkpoint named but WAL never mentions settles as `COMMITSEQNO_ABORTED` (`!state->wal_xid`), and `page_item_rollback()` converges on the first try. The hole is a transaction WAL *does* mention and never finishes — one whose 8 KB local WAL buffer overflowed before the crash. Then `wal_xid` is true, `recovery_map_oxid_csn()` returns the stored `COMMITSEQNO_INPROGRESS`, and nothing settles it during redo.

## The change

New policy predicate `recovery_can_rollback_conflict()`. A version left by an unfinished transaction may be taken back when both hold:

1. the oxid is `state->checkpoint_xid` — the checkpoint captured it mid-flight;
2. its undo position is in `[checkpointRetainStartLocation, checkpointRetainEndLocation)` — the undo the checkpoint deliberately retained.

Relative to the record being replayed such a version is the future: roll it back, and let forward replay put it there again if WAL says so. If either fails, replay is looking at a page state it should not be able to reach — `ereport(ERROR)` rather than spin.

Two call sites:

- `o_btree_modify_handle_conflicts()` — the in-progress branch now routes into the same rollback the ABORTED branch uses.
- `row_lock_conflicts()` — a **lock-only** conflict is *dropped from the chain* like a finished locker's record, not rolled back. `page_item_rollback()` is written around the chain's non-lock-only header and aborts (signal 6) if handed a lock record.

Note `UndoLocationGetValue()`: `InvalidUndoLocation` is a flag bit, and an insert stores its undo position alongside it rather than instead of it.

## Tests

Two cases added to `test/t/recovery_livelock_test.py` — B leaves a new version, and B leaves only a row lock. They belong there because it is the same failure, `o_btree_modify_handle_conflicts()` retrying against an oxid replay cannot settle, reached without a heap xid.

Both park the checkpointer at `checkpoint_table_start` to land inside the double-apply window, overflow B's local WAL buffer so replay sees the oxid exists, and crash with B unfinished.

| | without the fix | with it |
|---|---|---|
| the two new cases | FAIL, `not converging` | OK |
| whole file (4 tests) | 52.7 s, 2 failures | 8.4 s, all OK |

That file's `kill_cluster()` also had to learn to collect the postmaster's children before signalling — an immediate shutdown reports success while leaving the spinning recovery worker on a core, so a failing run used to leak a busy cluster.

regress 50/50, isolation 38/38, and 18 recovery / replication / checkpoint testgres modules (174 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)