### PR TITLE
Stop a bridged bitmap page from being retired by rows it did not want

### DIFF
--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -1882,7 +1882,25 @@ o_exec_bitmap_fetch(OBitmapScan *scan, CustomScanState *node)
 					pfree(tuple.data);
 				}
 
-				BRIDGE_NEXT_TUPLE(bridge_iter);
+				/*
+				 * Only a row the bitmap accepted stands for one of this
+				 * page's offsets.  The primary scan does not only ever hand
+				 * back wanted rows: when a leaf changes shape underneath it,
+				 * btree_seq_scan falls back to a plain range iterator, which
+				 * is no longer key-directed and walks everything from the
+				 * downlink's low key onwards.  Counting those against
+				 * page_ntuples retires the page before its wanted rows are
+				 * reached, and they are lost with no error -- a page whose
+				 * first examined rows all miss loses every row it held.
+				 *
+				 * Rows the bitmap rejects are therefore just skipped.  A page
+				 * that never reaches page_ntuples is retired where the
+				 * primary scan runs out, which is handled above -- the same
+				 * exit that already covers the opposite skew, where dead
+				 * bridge_ctids leave fewer live PKs than offsets.
+				 */
+				if (in_bitmap)
+					BRIDGE_NEXT_TUPLE(bridge_iter);
 			}
 		}
 

--- a/test/t/parallel_bitmap_scan_test.py
+++ b/test/t/parallel_bitmap_scan_test.py
@@ -17,6 +17,7 @@ import unittest
 
 from .base_test import BaseTest
 from .base_test import ThreadQueryExecutor
+from .base_test import wait_stopevent
 
 # An always-true but per-row-expensive filter makes the parallel bitmap path
 # win, so the planner picks Gather over a parallel custom bitmap scan.
@@ -201,6 +202,75 @@ class ParallelBitmapScanTest(BaseTest):
 			    "SELECT orioledb_evict_pages('o_bm'::regclass::oid, 0);")
 
 		self._run_parked("val < 50", mutate, bridged=True)
+
+	# A bridged bitmap page is retired once page_ntuples rows have been seen,
+	# which assumes the primary scan only ever hands back rows the keybitmap
+	# wants.  It does not: when a leaf changes shape underneath it,
+	# btree_seq_scan falls back to a plain range iterator that walks everything
+	# from the downlink's low key on.  Those rows used to consume the page's
+	# quota, so a page whose first examined rows all miss lost every row it
+	# held -- silently.
+	#
+	# Park the writer instead of the scan: stop events are enabled only in the
+	# inserting session, so it stops inside page_split with the rightmost leaf
+	# half-split, and the scan (lock-free, and with stop events off) reads
+	# through that state.  The insert only adds non-matching rows, so the
+	# answer must not move.
+	#
+	# The scan is parallel here to match the rest of the file, but this is not
+	# about parallelism: with max_parallel_workers_per_gather = 0 the row is
+	# lost just the same.
+	def test_bridged_survives_split_in_progress(self):
+		node = self.node
+		self._load(bridged=True)
+		cond = "val < 50"
+		reference = self._reference(cond)
+		self.assertGreater(len(reference), 500)
+
+		scan_con = node.connect()
+		ctrl_con = node.connect()
+		dml_con = node.connect()
+		try:
+			# Deliberately not _scan_setup(): the scanner must NOT enable stop
+			# events, or it would park on page_split itself.
+			for g in ("SET enable_seqscan = off;",
+			          "SET enable_indexscan = off;",
+			          "SET enable_indexonlyscan = off;",
+			          "SET parallel_setup_cost = 0;",
+			          "SET parallel_tuple_cost = 0;",
+			          "SET min_parallel_table_scan_size = 0;",
+			          "SET min_parallel_index_scan_size = 0;",
+			          "SET max_parallel_workers_per_gather = 3;"):
+				scan_con.execute(g)
+			self._assert_parallel_plan(scan_con, cond)
+			self._evict()
+
+			dml_con.execute("SET orioledb.enable_stopevents = true;")
+			# Read the pid before the thread takes the connection: asking for
+			# it later runs a query on a connection that is already busy.
+			dml_pid = dml_con.pid
+			ctrl_con.execute("SELECT pg_stopevent_set('page_split',\n"
+			                 "'$.treeName == \"o_bm_pkey\"');")
+			ctrl_con.commit()
+
+			ins = ThreadQueryExecutor(
+			    dml_con, "INSERT INTO o_bm SELECT i, 500 FROM "
+			    "generate_series(1000000, 1080000) i;")
+			ins.start()
+			try:
+				wait_stopevent(node, dml_pid)
+				result = sorted(
+				    r[0] for r in scan_con.execute(self._scan_sql(cond)))
+			finally:
+				ctrl_con.execute("SELECT pg_stopevent_reset('page_split');")
+				ins.join()
+			dml_con.commit()
+
+			self.assertEqual(result, reference)
+		finally:
+			scan_con.close()
+			ctrl_con.close()
+			dml_con.close()
 
 	# Two parallel bitmap scans parked at once; cross DML lands while both are
 	# parked, then both are released together.


### PR DESCRIPTION
Fixes the silent row loss behind the flaky `test_bridged_survives_mutation` (added by #977). **Not introduced by #977** — see below.

## The defect

A bridged bitmap scan runs one primary scan per TIDBitmap page and retires the page once `page_ntuples` rows have gone by. That count is the number of *bitmap offsets* on the page, so the accounting is only valid while the primary scan hands back exactly the rows the keybitmap asked for.

It does not always. When a leaf changes shape underneath it, `btree_seq_scan` falls back to a plain range iterator over the downlink's key range — no longer key-directed, it walks everything from the range's low key onwards. Those rows were counted against the quota too, so the page was retired before its wanted rows were reached. A page whose first examined rows all miss lost **every row it held**, with no error.

The fix counts only rows the bitmap accepted. A page that never reaches `page_ntuples` is retired where the primary scan runs out — the exit that already handles the opposite skew, where dead `bridge_ctid`s leave fewer live PKs than offsets.

## Evidence

Traced on a deterministic reproducer:

```
BMTRACE leafcheck: result=1 imgRightmost=0 rangeHighNull=1 items=143   <- leaf changed, fallback iterator built
BMTRACE iterset:   iterate_internal_page returns with iter
BMTRACE reject:    row not in bitmap, cur_tuple=0 page_ntuples=1       <- one miss burns the whole quota
BMPROBE end blk=687 keys=1 emitted=0 key=200000 direct=FOUND           <- row present, point lookup finds it
```

`direct=FOUND` is a point lookup on the primary at that exact instant: the row is there and reachable; the scan just stopped looking.

This also matches the CI failure shape — run 33101147412 lost ids 2038–2049, which with `MaxHeapTuplesPerPage = 291` is exactly block 7 offsets 1–12, i.e. one whole bitmap page.

## Test

`test_bridged_survives_split_in_progress` stops waiting for the race and creates the state directly: stop events are enabled **only in the writer**, so it parks inside `page_split` with the rightmost leaf half-split, while the scan — lock-free, stop events off — reads through that state. The insert adds only non-matching rows, so the answer must not move.

Without the fix it loses the last matching row **every time** (verified by removing the fix and re-running).

## Why this is not a #977 regression

| arm, over the same half-finished split | result before the fix |
|---|---|
| bridged + parallel bitmap | loses the row |
| bridged + serial bitmap | loses the row |
| native + parallel bitmap | ok |
| native + serial bitmap | ok |
| bridged + seq scan | ok |
| bridged + index scan | ok |

The serial bridged scan fails identically, and `bridge_next_page()` — the per-bitmap-page primary scan — was added by `ed909d53` (2026-06-10), well before #977 merged. #977 only added the test that exposes it.

## Checks

- new test: fails without the change, passes with it
- the pre-existing flaky reproducer (scan overlapped with insert + checkpoint + evict): **0/60 failures**, was 2/60 and 4/52 before
- regress 50/50, isolation 38/38
- `parallel_bitmap_scan_test`, `index_bridging_test`, `parallel_test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)