### PR TITLE
Don't let load_page() leak the caller's find flags into its scratch descent

### DIFF
--- a/src/btree/find.c
+++ b/src/btree/find.c
@@ -1042,6 +1042,18 @@ find_page(OBTreeFindPageContext *context, void *key, BTreeKeyType keyType,
 				}
 			}
 
+			/*
+			 * A caller that steps to siblings navigates items[index - 1]
+			 * through parentImg, so the descent must hand it back bound to
+			 * parentImg -- unless the fastpath deliberately deferred the copy
+			 * (parentImgDeferred), which find_right_page()/find_left_page()
+			 * materialize before use.
+			 */
+			if ((imageFlag || keepParentFlag) && context->index > 0 &&
+				!context->parentImgDeferred)
+				ASSERT_PARENT_LOCATOR_LOCAL(context,
+											context->items[context->index - 1].locator);
+
 			O_TUPLE_SET_NULL(context->insertTuple);
 			return OFindPageResultSuccess;
 		}
@@ -1513,6 +1525,18 @@ retry:
 	context->items[context->index].locator = loc;
 	context->items[context->index].blkno = intCxt.blkno;
 	context->items[context->index].pageChangeCount = intCxt.pageChangeCount;
+
+	/*
+	 * refind_page() re-finds one page by a cached hint; it never revisits the
+	 * parent slot.  A caller that steps to siblings therefore keeps whatever
+	 * the previous descent left in items[index - 1], so enforce the parent
+	 * invariant here too rather than only where find_page() builds it.
+	 */
+	if ((BTREE_PAGE_FIND_IS(context, IMAGE) ||
+		 BTREE_PAGE_FIND_IS(context, KEEP_PARENT)) &&
+		context->index > 0 && !context->parentImgDeferred)
+		ASSERT_PARENT_LOCATOR_LOCAL(context,
+									context->items[context->index - 1].locator);
 	return OFindPageResultSuccess;
 }
 

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1687,11 +1687,7 @@ load_page(OBTreeFindPageContext *context)
 	int			target_level;
 	Page		page;
 	char		pg_attribute_aligned(sizeof(uint32)) buf[ORIOLEDB_BLCKSZ];
-	bool		was_modify;
-	bool		was_downlink_location;
-	bool		was_fetch = false;
-	bool		was_image = false;
-	bool		was_keep_lokey = false;
+	uint16		saved_flags;
 	OReadPageResult read_result;
 	uint32		chkpNum = 0;
 
@@ -1808,24 +1804,33 @@ load_page(OBTreeFindPageContext *context)
 		STOPEVENT(STOPEVENT_LOAD_PAGE_REFIND, params);
 	}
 
-	/* re-find parent page (it might be changed due to concurrent operations) */
+	/*
+	 * Re-find the parent page (it might have changed due to concurrent
+	 * operations).  That descent is a scratch use of the caller's context: it
+	 * needs its own flags, and nothing it does to them may be visible to the
+	 * caller afterwards -- find_page() maintains parentImg for a KEEP_PARENT
+	 * caller, clears the LOKEY_* results a KEEP_LOKEY caller is about to
+	 * read, and leaves refind_page() handing back a parent slot that belongs
+	 * to neither descent.
+	 *
+	 * So save the whole flags word and put it back, rather than listing the
+	 * flags to preserve one by one: that list is what went wrong here, and a
+	 * flag added later would silently join the ones already missing from it.
+	 */
+	saved_flags = context->flags;
 	csn = context->csn;
-	was_modify = BTREE_PAGE_FIND_IS(context, MODIFY);
-	was_image = BTREE_PAGE_FIND_IS(context, IMAGE);
-	BTREE_PAGE_FIND_UNSET(context, IMAGE);
-	if (!was_modify)
+
+	if (!BTREE_PAGE_FIND_IS(context, MODIFY))
 	{
-		was_fetch = BTREE_PAGE_FIND_IS(context, FETCH);
-		Assert(was_fetch || was_image);
+		Assert(BTREE_PAGE_FIND_IS(context, FETCH) ||
+			   BTREE_PAGE_FIND_IS(context, IMAGE));
 		BTREE_PAGE_FIND_UNSET(context, FETCH);
 		BTREE_PAGE_FIND_SET(context, MODIFY);
 	}
-	was_keep_lokey = BTREE_PAGE_FIND_IS(context, KEEP_LOKEY);
-	if (was_keep_lokey)
-		BTREE_PAGE_FIND_UNSET(context, KEEP_LOKEY);
-	was_downlink_location = BTREE_PAGE_FIND_IS(context, DOWNLINK_LOCATION);
-	if (!was_downlink_location)
-		BTREE_PAGE_FIND_SET(context, DOWNLINK_LOCATION);
+	BTREE_PAGE_FIND_UNSET(context, IMAGE);
+	BTREE_PAGE_FIND_UNSET(context, KEEP_LOKEY);
+	BTREE_PAGE_FIND_UNSET(context, KEEP_PARENT);
+	BTREE_PAGE_FIND_SET(context, DOWNLINK_LOCATION);
 	context->csn = COMMITSEQNO_INPROGRESS;
 	if (PAGE_GET_LEVEL(page) != target_level)
 		ereport(PANIC, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
@@ -1872,18 +1877,7 @@ load_page(OBTreeFindPageContext *context)
 
 	/* restore context state */
 	context->csn = csn;
-	if (!was_modify)
-	{
-		if (was_fetch)
-			BTREE_PAGE_FIND_SET(context, FETCH);
-		BTREE_PAGE_FIND_UNSET(context, MODIFY);
-	}
-	if (was_image)
-		BTREE_PAGE_FIND_SET(context, IMAGE);
-	if (was_keep_lokey)
-		BTREE_PAGE_FIND_SET(context, KEEP_LOKEY);
-	if (!was_downlink_location)
-		BTREE_PAGE_FIND_UNSET(context, DOWNLINK_LOCATION);
+	context->flags = saved_flags;
 
 	context_index = context->index;
 	parent_blkno = context->items[context_index].blkno;

--- a/test/t/eviction_test.py
+++ b/test/t/eviction_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import re
 import unittest
 
 from .base_test import BaseTest
@@ -10,6 +11,13 @@ from .base_test import wait_checkpointer_stopevent
 from .base_test import wait_bgwriter_stopevent
 
 INDEX_NOT_LOADED_TMPLT = "Index {relname}_pkey: not loaded"
+
+# 400-byte keys fit ~19 entries to a page, so the index below reaches three
+# levels (leaves, one internal level, root) while the data stays small.  The
+# internal level is the point: the invariant tested there is about the parent
+# slot, items[index - 1].
+KEEP_PARENT_ROWS = 2000
+KEEP_PARENT_KEYLEN = 400
 
 
 class EvictionTest(BaseTest):
@@ -28,6 +36,73 @@ class EvictionTest(BaseTest):
 				return True
 
 		return False
+
+	def test_index_only_scan_over_evicted_tree(self):
+		"""An ordered index-only scan of a tree whose downlinks are on disk.
+
+		load_page() re-finds the parent of the page it loads by borrowing the
+		caller's find context as scratch space, so whatever that descent does
+		to the context's flags must not be visible to the caller.  A caller
+		that navigates siblings sets KEEP_PARENT, and letting the scratch
+		descent see it rebinds the caller's parent image and locator onto a
+		descent it never asked for.
+
+		Nothing here is a race: orioledb_evict_pages() puts the downlinks on
+		disk, which is the path load_page() serves, and the first descent
+		after it is enough.  Before the fix this aborted the backend on
+		ASSERT_PARENT_LOCATOR_LOCAL() in refind_page().
+		"""
+		node = self.node
+		node.start()
+		node.safe_psql(
+		    'postgres', f"""
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE o_keep_parent (
+				id int8 NOT NULL,
+				val text NOT NULL,
+				PRIMARY KEY (id)
+			) USING orioledb;
+			INSERT INTO o_keep_parent
+				SELECT i, lpad(i::text, {KEEP_PARENT_KEYLEN}, '0')
+				FROM generate_series(1, {KEEP_PARENT_ROWS}) i;
+			CREATE INDEX o_keep_parent_val ON o_keep_parent (val);
+			ANALYZE o_keep_parent;
+			CHECKPOINT;
+		""")
+
+		# A root sitting directly above the leaves would leave no parent slot
+		# to corrupt, and this would pass for the wrong reason.  Say so.
+		root = node.execute(
+		    'postgres', "SELECT orioledb_idx_structure("
+		    "'o_keep_parent'::regclass, 'o_keep_parent_val', 'n', 1)")[0][0]
+		m = re.search(r"level = (\d+)", root)
+		self.assertIsNotNone(m, "could not read the index root level")
+		self.assertGreaterEqual(
+		    int(m.group(1)), 2,
+		    "index is too shallow to exercise the parent slot")
+
+		node.safe_psql(
+		    'postgres',
+		    "SELECT orioledb_evict_pages('o_keep_parent'::regclass::oid, 0);")
+
+		con = node.connect()
+		try:
+			con.execute("SET enable_seqscan = off;")
+			con.execute("SET enable_bitmapscan = off;")
+			# Pin the serial plan: it is the one that walks the secondary
+			# index with KEEP_PARENT.
+			con.execute("SET max_parallel_workers_per_gather = 0;")
+
+			plan = "\n".join(r[0] for r in con.execute(
+			    "EXPLAIN (COSTS OFF) SELECT count(val) FROM o_keep_parent;"))
+			self.assertIn("index only scan of: o_keep_parent_val", plan)
+
+			self.assertEqual(
+			    con.execute("SELECT count(val) FROM o_keep_parent;")[0][0],
+			    KEEP_PARENT_ROWS)
+		finally:
+			con.close()
+		node.stop()
 
 	def test_eviction_txn(self):
 		node = self.node


### PR DESCRIPTION
Builds on **#1074 by @OffgridwithJD** — the defect, the `KEEP_PARENT` diagnosis and the `ASSERT_PARENT_LOCATOR_LOCAL()` enforcement are theirs, and their authorship is kept in the commit. This adds a deterministic regression test, and generalises the fix after that test showed the same hole is open for other flags.

Refs #1050. **Does not close it** — this fixes a producer of the broken invariant; the crash reported there is on the consumer side.

## The defect

`load_page()` re-finds the parent of the page it is loading by borrowing the caller's `OBTreeFindPageContext` as scratch space, so nothing that descent does to the context may be visible to the caller afterwards. It preserved the flags it knew about one by one — `MODIFY`, `FETCH`, `IMAGE`, `KEEP_LOKEY`, `DOWNLINK_LOCATION` — and the list was incomplete.

`KEEP_PARENT` was missing. A caller that navigates siblings sets it, so the scratch descent ran as one too: `find_page()` maintained `context->parentImg` for a descent nobody asked for, rebinding the caller's parent image and locator mid-flight, and `refind_page()` returned leaving the parent slot pointing at a page belonging to neither descent.

## Why save the whole flags word

`LOKEY_EXISTS`, `LOKEY_SIBLING` and `LOKEY_UNDO` are missing from that list too, and adding `KEEP_PARENT` does not help them: `find_page()` clears all three on entry, and a `KEEP_LOKEY` caller reads them afterwards — `btree_seq_scan` decides from `LOKEY_EXISTS` whether it has a low bound at all (scan.c:1812).

So this saves `context->flags` and restores it, instead of enumerating what to preserve. The enumeration is what failed, and a flag added later would silently join the ones already missing from it. The scratch descent's own requirements are now stated positively where it starts. Net −30 lines, six `was_*` locals gone.

## Test — no concurrency, no buffer tuning

`EvictionTest.test_index_only_scan_over_evicted_tree`.

The window is the on-disk downlink path plus a `KEEP_PARENT` caller, and both are set statically:

- a **400-byte key** fits ~19 entries to a page, so the secondary index is three levels deep at **2000 rows** — the internal level is the point, since the invariant is about `items[index - 1]`;
- **`orioledb_evict_pages()`** puts the downlinks on disk, so `orioledb.main_buffers` is left alone;
- a serial ordered index-only scan of that index is the `KEEP_PARENT` caller, and its first descent is already enough.

It also reads the index root level from `orioledb_idx_structure()` and fails with *"index is too shallow to exercise the parent slot"* rather than passing for the wrong reason if the tree ever stops having an internal level.

| | result |
|---|---|
| test without the `io.c` change | **3 crashes out of 3**, ~1.9 s each |
| test with it | **3 passes out of 3** |

The abort is the `ASSERT_PARENT_LOCATOR_LOCAL()` check in `refind_page()`, `find.c:1539`.

Worth recording, since #1074 reports otherwise: this needs **no concurrent writers and no fuzzer**. The four-writer, 120-second, 141 MB harness there is not what makes it reproduce — depth and eviction are. With a 400-byte key it still fires at 300 rows; 2000 is a margin.

## Checks

- regress 50/50, isolation 38/38
- `eviction_test` (16), `checkpoint_eviction_test` (7), `eviction_bgwriter_test` (3), `merge_test` (13) — all green
- pgindent and yapf clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)