### PR TITLE
Don't end a bitmap walk when its internal page is re-read

### DIFF
--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -386,6 +386,7 @@ seq_int_partial_ensure(BTreeSeqScan *scan, BTreePageItemLocator *loc)
 	if (!scan->context.partial.isPartial)
 		return true;
 
+
 	if (!partial_load_chunk(&scan->context.partial, scan->context.img,
 							loc->chunkOffset, NULL))
 	{
@@ -1079,6 +1080,7 @@ internal_skip_to_next_key(BTreeSeqScan *scan, Page page,
 		scan->intPartialFailed = true;
 }
 
+
 /*
  * Gets the next downlink with it's keyrange (low and high keys of the
  * keyrange).
@@ -1273,6 +1275,17 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 						return false;
 					}
 					Assert(!scan->intPartialFailed);
+
+					/*
+					 * The page has just been re-read and intLoc positioned on
+					 * it, so say so: without this the next pass re-enters the
+					 * "load the next internal page" block above, and its jump
+					 * path reads firstPageIsLoaded together with a rightmost
+					 * image as "the tree is fully scanned" and ends the scan
+					 * with downlinks still unvisited.  For a bitmap scan that
+					 * silently drops every remaining key of the walk.
+					 */
+					pageIsLoaded = true;
 					continue;
 				}
 

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1082,6 +1082,49 @@ internal_skip_to_next_key(BTreeSeqScan *scan, Page page,
 
 
 /*
+ * Params for STOPEVENT_SEQ_SCAN_INT_NEXT_KEY: enough to tell whether the
+ * get_next_key() below is about to materialize a chunk it has not read yet.
+ * A test that wants the on-demand load to lose its race has to park exactly
+ * there -- where the chunk boundary falls is a property of the data, not
+ * something the test can arrange by choosing keys.  "firstPass" says the
+ * page was loaded in this very iteration, which is when the walk's local
+ * "the page is loaded" state is the one that can go stale.
+ */
+static Jsonb *
+seq_int_next_key_stopevent_params(BTreeSeqScan *scan, Page page,
+								  BTreePageItemLocator *loc, bool firstPass)
+{
+	JsonbParseState *state = NULL;
+	PartialPageState *partial = &scan->context.partial;
+	BTreePageItemLocator next = *loc;
+	bool		lastInChunk;
+	bool		nextChunkLoaded = true;
+	Jsonb	   *res;
+	MemoryContext mctx = MemoryContextSwitchTo(stopevents_cxt);
+
+	lastInChunk = (loc->itemOffset + 1 >= loc->chunkItemsCount);
+	if (lastInChunk)
+	{
+		BTREE_PAGE_LOCATOR_NEXT(page, &next);
+		if (BTREE_PAGE_LOCATOR_IS_VALID(page, &next) && partial->isPartial)
+			nextChunkLoaded = partial->chunkIsLoaded[next.chunkOffset];
+	}
+
+	pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	btree_desc_stopevent_params_internal(scan->desc, &state);
+	jsonb_push_int8_key(&state, "level", PAGE_GET_LEVEL(page));
+	jsonb_push_int8_key(&state, "chunkOffset", loc->chunkOffset);
+	jsonb_push_bool_key(&state, "isPartial", partial->isPartial);
+	jsonb_push_bool_key(&state, "lastInChunk", lastInChunk);
+	jsonb_push_bool_key(&state, "nextChunkLoaded", nextChunkLoaded);
+	jsonb_push_bool_key(&state, "firstPass", firstPass);
+	res = JsonbValueToJsonb(pushJsonbValue(&state, WJB_END_OBJECT, NULL));
+	MemoryContextSwitchTo(mctx);
+
+	return res;
+}
+
+/*
  * Gets the next downlink with it's keyrange (low and high keys of the
  * keyrange).
  *
@@ -1109,6 +1152,7 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 
 		while (true)
 		{
+			bool		pageLoadedAtEntry = pageIsLoaded;
 
 			/* Try to load next internal page if needed */
 			if (!pageIsLoaded)
@@ -1248,7 +1292,14 @@ get_next_downlink(BTreeSeqScan *scan, uint64 *downlink,
 				 * internal locator
 				 */
 				if (!scan->intPartialFailed)
+				{
+					STOPEVENT(STOPEVENT_SEQ_SCAN_INT_NEXT_KEY,
+							  seq_int_next_key_stopevent_params(scan,
+																scan->context.img,
+																&scan->intLoc,
+																!pageLoadedAtEntry));
 					get_next_key(scan, &scan->intLoc, keyRangeHigh, scan->context.img);
+				}
 
 				if (scan->intPartialFailed)
 				{

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -28,6 +28,7 @@ load_page_refind
 after_ionum_set
 build_index_placeholder_inserted
 seq_scan_load_internal_page
+seq_scan_int_next_key
 before_get_waiters_with_tuples
 before_modify_oxid_get_csn
 sk_modify_pending

--- a/test/t/parallel_bitmap_scan_test.py
+++ b/test/t/parallel_bitmap_scan_test.py
@@ -13,10 +13,12 @@
 # read-only bitmap and the cooperative primary fetch stay correct while the tree
 # changes shape underneath the scan.
 
+import time
 import unittest
 
 from .base_test import BaseTest
 from .base_test import ThreadQueryExecutor
+from .base_test import wait_stopevent
 from .base_test import wait_stopevent
 
 # An always-true but per-row-expensive filter makes the parallel bitmap path
@@ -267,6 +269,81 @@ class ParallelBitmapScanTest(BaseTest):
 			dml_con.commit()
 
 			self.assertEqual(result, reference)
+		finally:
+			scan_con.close()
+			ctrl_con.close()
+			dml_con.close()
+
+	def test_bitmap_scan_survives_chunk_load_race(self):
+		"""Park on the chunk boundary, then bump the page under the scan.
+
+		The load that has to lose its race is the on-demand read of the chunk
+		holding the *next* downlink, and which downlink that is depends on
+		where the chunk boundaries fall -- so the stop event reports it
+		(lastInChunk, nextChunkLoaded) and the test parks exactly there.
+
+		Ids are sparse so the mutation can insert *between* existing rows
+		across the whole range: that splits leaves everywhere, so whichever
+		level-1 page the scan is holding gets a downlink inserted into it.
+		The inserted rows do not match, so the answer does not move.
+		"""
+		node = self.node
+		node.safe_psql(
+		    'postgres', f"""
+			DROP TABLE IF EXISTS o_chunk;
+			CREATE TABLE o_chunk (id int8 NOT NULL, val int8 NOT NULL,
+				PRIMARY KEY (id)) USING orioledb WITH (index_bridging);
+			INSERT INTO o_chunk SELECT i * 10, i % 1000
+				FROM generate_series(1, {NROWS}) i;
+			CREATE INDEX o_chunk_val ON o_chunk USING btree (val)
+				WITH (orioledb_index = off);
+			ANALYZE o_chunk;
+			CHECKPOINT;
+		""")
+		sql = f"SELECT id FROM o_chunk WHERE (val < 50) AND {FILTER}"
+		reference = sorted(r[0] for r in node.execute('postgres', sql))
+		self.assertGreater(len(reference), 500)
+
+		scan_con = node.connect()
+		ctrl_con = node.connect()
+		dml_con = node.connect()
+		try:
+			scan_con.execute("SET orioledb.enable_stopevents = true;")
+			for g in ("SET enable_seqscan = off;",
+			          "SET enable_indexscan = off;",
+			          "SET enable_indexonlyscan = off;",
+			          "SET max_parallel_workers_per_gather = 0;"):
+				scan_con.execute(g)
+			scan_pid = scan_con.pid
+
+			node.safe_psql(
+			    'postgres',
+			    "SELECT orioledb_evict_pages('o_chunk'::regclass::oid, 0);")
+			ctrl_con.execute(
+			    "SELECT pg_stopevent_set('seq_scan_int_next_key',\n"
+			    "'$.treeName == \"o_chunk_pkey\" && $.isPartial == true"
+			    " && $.firstPass == true && $.lastInChunk == true"
+			    " && $.nextChunkLoaded == false');")
+			ctrl_con.commit()
+
+			scan = ThreadQueryExecutor(scan_con, sql)
+			scan.start()
+			try:
+				deadline = time.time() + 30
+				while not node.execute(
+				    "SELECT EXISTS(SELECT 1 FROM pg_stopevents() se"
+				    " WHERE se.waiter_pids @> ARRAY[%d])" % scan_pid)[0][0]:
+					self.assertLess(time.time(), deadline,
+					                "the scan never parked")
+					time.sleep(0.01)
+				dml_con.execute("INSERT INTO o_chunk SELECT i * 10 + 5, 500 "
+				                f"FROM generate_series(1, {NROWS}) i;")
+				dml_con.commit()
+			finally:
+				ctrl_con.execute(
+				    "SELECT pg_stopevent_reset('seq_scan_int_next_key');")
+
+			self.assertEqual(sorted(r[0] for r in scan.join()), reference)
 		finally:
 			scan_con.close()
 			ctrl_con.close()


### PR DESCRIPTION
Rebased on main now that #1088 has landed. Two commits, and **no injection GUC** — the test drives the real race.

## 1. `Don't end a bitmap walk when its internal page is re-read`

`get_next_downlink()` reads a level-1 page partially in FETCH mode and loads the chunk holding a downlink on demand. When that load loses its race with a concurrent modification of the page, the page is re-read whole and the walk retries — but the retry `continue`d **without recording that the page is loaded**, so the next pass re-entered the "load the next internal page" block above it.

There the bitmap jump path reads `firstPageIsLoaded` together with a rightmost image as *"the tree is fully scanned"* and returns false, ending the walk with the page's downlinks still unvisited. For a bitmap scan that is a silent wrong answer. The sibling handler for the same latch, a few lines above, **is** already guarded by `pageIsLoaded`; only this one was not.

The local goes stale only when the page was loaded in that same iteration — the first call of a fresh scan. A later call starts with the local already true and re-reads harmlessly. That is why it takes a bridged bitmap scan, which builds a fresh scan per bitmap page, to lose a whole page of keys.

Counters from the failing CI run — a bitmap page whose rows went missing, against a healthy one:

```
lost:    exit=1  pf: set=1 inblock=1 pre=0 fl=1   loop=2 locOk=1 rvOk=0
healthy: exit=8  pf: set=0 inblock=0 pre=0 fl=0   loop=1 locOk=1 rvOk=1
```

That is `test_bridged_survives_mutation` losing ids 2038–2049 — with `MaxHeapTuplesPerPage = 291`, precisely the offsets of one TIDBitmap page.

## 2. `Cover the internal-page re-read with a real concurrent test`

Nothing a test can say in SQL decides whether a given downlink needs a chunk that has not been read yet — that depends on where the chunk boundaries fall. So export it: `STOPEVENT_SEQ_SCAN_INT_NEXT_KEY` fires immediately before the on-demand read and reports `chunkOffset`, `isPartial`, `lastInChunk`, `nextChunkLoaded`, and `firstPass` — the last one saying the page was loaded in this very iteration, which is when the walk's local state is the one that can go stale.

The test parks where all of that holds at once and splits leaves from another session, so the page it is holding gets a downlink inserted into it and the pending read loses its race. Its ids are **sparse** for that reason: the mutation inserts *between* existing rows across the whole range, so whichever level-1 page the scan is on gets modified. The inserted rows do not match the qual, so the answer must not move. The park is waited for with a deadline rather than forever, so a condition that stops matching fails the test instead of hanging it.

| | result |
|---|---|
| without commit 1 | **5 failures out of 5** |
| with it | **3 passes out of 3** |

The chain, from the markers used while developing it:

```
in-block retry taken; after reload rm=1 fl=1
pass2: pageIsLoaded=0 fl=1 rm=1      (1 once the fix is in)
exit1
```

## Checks

- regress 50/50, isolation 38/38
- `parallel_bitmap_scan_test` 7/7, `parallel_test` 2/2
- pgindent, yapf

🤖 Generated with [Claude Code](https://claude.com/claude-code)