### PR TITLE
ENGOPS-511 Fix False Positive Crash

### DIFF
--- a/test/antithesis/jepsen/Dockerfile
+++ b/test/antithesis/jepsen/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /src
 # 2026-07-29: use antithesis-instrumented sql workload
 RUN git clone --depth=1 https://github.com/pmbauer/jepsen-sql.git sql \
     && cd sql \
+    # pin to v0.1.1sb-SNAPSHOT
+    && git checkout fc117a6e6c10b7408dfe49dad6bd6cadbcb0541a \
     && lein install
 
 # 2026-07-29: use antithesis-instrumented postgres driver
@@ -21,7 +23,7 @@ WORKDIR /src/jepsen-postgres
 RUN git init \
     && git remote add origin https://github.com/pmbauer/jepsen-postgres.git \
     && git fetch --depth=1 origin "${JEPSEN_POSTGRES_REF}" \
-    && git checkout --detach FETCH_HEAD \
+    && git checkout 1b99cd9dd11df56a2e45ec7c5638dae82c54446f \
     && cd postgres \
     && lein jar \
     && mkdir -p /opt/jepsen \

--- a/test/antithesis/jepsen/test/v1/jepsen-postgres/finally_jepsen-results
+++ b/test/antithesis/jepsen/test/v1/jepsen-postgres/finally_jepsen-results
@@ -198,7 +198,7 @@
           0))
 
       (:missing results-read)
-      ;; Crashed run. The singleton driver's exit code handles this case
+      ;; Crashed run. The singleton driver owns the exit code behavior for this case
       (do (log "no results at " results-file ": nothing to evaluate")
           0)
 

--- a/test/antithesis/jepsen/test/v1/jepsen-postgres/singleton_driver_jepsen-postgres
+++ b/test/antithesis/jepsen/test/v1/jepsen-postgres/singleton_driver_jepsen-postgres
@@ -59,7 +59,27 @@ rc=$?
 # NB invalid results (1) are model failures.
 # Those are reported per-anomaly by finally_jepsen-results,
 # so we return 0 for both case 0 and 1
+#
+# For 255
+#
+# When there are network partitions during setup, jepsen hard fails
+# resulting in a false-positive property failure.
+#
+# Ideally, there would be a way to run the jepsen setup before fault
+# injection starts. The jepsen workload could emit the setup_complete signal,
+# but that would mean we couldn't use the test template harness and need
+# to build a container entry point that provides similar functionality.
+#
+# Ideally jepsen would have Client/setup! separated from core/run-case!
+# Were setup and execution separated, we would ideally make
+# two java calls, one to setup the db run during "first_" to initialize the
+# db, and a second to run the tests.
+# But, calling Client/setup! is baked into the with-client+nemesis-setup-teardown macro.
+# Separating setup from test execution is a bit of a refactor that is only
+# needed when executed under Antithesis.
+# For now, we explicitly ignore crashed jepsen processes as the only observed
+# crash is during a startup network partition.
 case "$rc" in
-0 | 1) exit 0 ;;
+0 | 1 | 255) exit 0 ;;
 *) exit "$rc" ;;
 esac


### PR DESCRIPTION
# Description

The jepsen client fails on startup under some network faults.  This is a false positive.  We either need to make this not a failure or fix the test workload so the failure no longer occurs.

[Example log event](https://supabase.antithesis.com/search?search=v5veyJxIjp7Im4iOnsiciI6eyJoIjpbeyJoIjpbeyJjIjp0cnVlLCJmIjoibW9tZW50LnZ0aW1lIiwibyI6Im1hdGNoZXMiLCJ2IjoiMzAuNTk3ODgyODE4NjYzNDkzIn1dLCJvIjoib3IifSx7ImgiOlt7ImMiOnRydWUsImYiOiJtb21lbnQuaW5wdXRfaGFzaCIsIm8iOiJtYXRjaGVzIiwidiI6IjEyMjczOTU1MjY0MTI0MTUzNDIifV0sIm8iOiJvciJ9XSwibyI6ImFuZCJ9LCJ0Ijp7ImciOmZhbHNlLCJtIjoiIn0sInkiOiJub25lIn19LCJzIjoiMmE4ZTc2MzJhNzM5NWYyMzE3ODU2NTkwNGMxNDI4ZWYtNTgtMTEifQ). This always happens during test setup in the presence of a 10s+ network partition. The jepsen client handles network partitions as expected behavior during test execution, but is brittle during setup.

## Aproaches

Ultimately choosing option D

### A. Suppress faults in `singleton_` driver

https://antithesis.com/docs/product/writing_tests/controlling_faults/#pausing-faults

If we invoke ANTITHESIS_STOP_FAULTS with a guess of 10+ seconds prior to starting the java process, giving time to start and initialize this could work.  Except ANTITHESIS_STOP_FAULTS is time based, brittle, and this would be a bit of an abuse of the intent for this escape hatch's existence.

Option C is preferred to this hack.

### B. Retries around idempotent DB initialization (tried, considered non viable)

If we want to keep setup under test, we could make the client robust to partitions even during setup with a combination of retries and extending connection timeouts.

We tried this, and are aborting this approach as brittle and requires significant refactoring of jepsen to make viable.

simple retries on sql errors are not sufficient because the network partition causes a socket timeout, closing the postgres connection. The Client/setup! callback where retries can be controlled inside jepsen-io/sql is passed a pre-existing connection with no way to reconstruct the passed connection without significant changes to jepsen core.

In jepsen-io/postgres, extending the connection timeout from 10 to 60 seconds reduces the number of crashes, but does not eliminate them.  Antithesis simply keeps forcing longer network partitions until we hit the new threshold.

### C. Refactor jepsen core, separate setup and execution stages

The test template lifecycle

- `setup_complete` signal received
- `first_` scripts run
- faults start
- driver scripts run
- faults stop
- `finally_` scripts run (we have anomaly assertions here)

Ideally, there would be a way to run the jepsen setup stage in `first_` before faults start. _There is another alternative where we don't rely on the test template lifcycle, but then jepsen would need to emit the setup_complete signal itself and the workload container would need to put logic in its entrypoint to duplicate the functionality the test template framework provides us and handle catalog registration and anomaly property assertions at the end._

This solution would have `Client/setup!` execution separated from `core/run-case!` and two modes to drive jepsen - "setup" and "run".

Were setup and test execution separated, we would ideally make two java calls, one to setup the db run during "first_" to initialize the db, and a second to run the tests.

But, calling `Client/setup!` is baked into the `with-client+nemesis-setup-teardown` macro along with the calls to `Client/invoke!`.

Separating setup from test execution is a bit of a refactor that is only needed when executed under Antithesis and it's not certain such a fundamental lifecycle change would be acceptable in core.

### D. (approach taken) Ignore jepsen client crashes, no longer have them fail

It is observed that the only time we are seeing jepsen crashes is during setup and in the presence of network faults preventing the `create table if not exist` SQL statements from executing.

In this case, could distinguish the crash case and simply return a 0 value from the workload driver rather than propagate 255.

Downside is our test runs are ~1.4% less efficient as we currently see 197 false positive failures out of 13684 driver executions in a 4 hour run.

## Changes

- option D
- explicitly pin jepsen-io/sql and jepsen-io/postgres dependencies.  When trying out option B, I needed a way to invalidate caches in CI and we should have been explicitly pinning the versions anyway.  These dependencies are not available in clojars, maven central, they use lein without the git sha dependency plugin, and we need to build them from source.