### PR TITLE
Keep the parent image for iterators built by o_btree_find_tuples_start()

### DIFF
--- a/src/btree/iterator.c
+++ b/src/btree/iterator.c
@@ -352,7 +352,14 @@ o_btree_find_tuples_start(BTreeDescr *desc, void *key,
 	OBTreeFindPageContext *context;
 	BTreePageHeader *header;
 	OTuple		result;
-	uint16		findFlags = BTREE_PAGE_FIND_FETCH;
+
+	/*
+	 * find_right_page()/find_left_page() navigate items[index - 1] through
+	 * parentImg, which find_page() only binds there for a KEEP_PARENT caller.
+	 * Without it the parent locator keeps pointing into the shared page and
+	 * the first sibling step reads a downlink from foreign memory.
+	 */
+	uint16		findFlags = BTREE_PAGE_FIND_FETCH | BTREE_PAGE_FIND_KEEP_PARENT;
 	OFindPageResult findResult PG_USED_FOR_ASSERTS_ONLY;
 
 	it = (BTreeIterator *) palloc(sizeof(BTreeIterator));

--- a/test/expected/iterator.out
+++ b/test/expected/iterator.out
@@ -49,6 +49,34 @@ SELECT unnest(orioledb_test_back_refind_skip_tail('o_back_refind'::regclass, 100
 (10 rows)
 
 DROP TABLE o_back_refind;
+-- A PG18 skip array is the one case where switch_to_next_range() recomputes
+-- ostate->exact, so a single scan can hold both kinds of range: the first binds
+-- the whole key and builds the iterator through o_btree_find_tuples_start(), a
+-- later one is a range and reuses that iterator to step to a sibling page.  The
+-- step reads the parent locator through parentImg, so the iterator has to have
+-- asked find_page() to keep it there.
+CREATE TABLE o_skip_step (
+	a int,
+	b int,
+	pad text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_skip_step
+	SELECT g % 10, g / 10, repeat('x', 400) FROM generate_series(1, 10000) g;
+ANALYZE o_skip_step;
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+SET enable_indexonlyscan = off;
+SELECT count(pad) FROM o_skip_step WHERE b = 500;
+ count 
+-------
+    10
+(1 row)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET enable_indexonlyscan;
+DROP TABLE o_skip_step;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA iterator CASCADE;
 RESET search_path;

--- a/test/sql/iterator.sql
+++ b/test/sql/iterator.sql
@@ -33,6 +33,30 @@ SELECT unnest(orioledb_test_back_refind_skip_tail('o_back_refind'::regclass, 100
 
 DROP TABLE o_back_refind;
 
+-- A PG18 skip array is the one case where switch_to_next_range() recomputes
+-- ostate->exact, so a single scan can hold both kinds of range: the first binds
+-- the whole key and builds the iterator through o_btree_find_tuples_start(), a
+-- later one is a range and reuses that iterator to step to a sibling page.  The
+-- step reads the parent locator through parentImg, so the iterator has to have
+-- asked find_page() to keep it there.
+CREATE TABLE o_skip_step (
+	a int,
+	b int,
+	pad text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_skip_step
+	SELECT g % 10, g / 10, repeat('x', 400) FROM generate_series(1, 10000) g;
+ANALYZE o_skip_step;
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+SET enable_indexonlyscan = off;
+SELECT count(pad) FROM o_skip_step WHERE b = 500;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+RESET enable_indexonlyscan;
+DROP TABLE o_skip_step;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA iterator CASCADE;
 RESET search_path;


### PR DESCRIPTION
Found by an aggressive TPC-C stress run on an assert build of `main` (`bdd9f464`), with a core dump saved.

```
TRAP: failed Assert("loc.chunk == NULL || ((Pointer) loc.chunk >= context->parentImg
      && (Pointer) loc.chunk < context->parentImg + ORIOLEDB_BLCKSZ)"), src/btree/find.c:1609

find_right_page <- btree_iterator_check_load_next_page <- o_btree_iterator_fetch
                <- o_iterate_index (index_scan.c:812) <- ExecModifyTable
```

Statement: TPC-C DELIVERY, `UPDATE orders SET o_carrier_id = $1 WHERE (o_w_id, o_d_id, o_id) IN (...)`.

## Cause

There are two iterator constructors and only one asked for the parent:

| | |
|---|---|
| `o_btree_iterator_create()` (iterator.c:1021) | `findFlags \|= BTREE_PAGE_FIND_KEEP_PARENT` |
| `o_btree_find_tuples_start()` (iterator.c:355) | `findFlags = BTREE_PAGE_FIND_FETCH;` — no `KEEP_PARENT` |

Both hand the iterator to `btree_iterator_check_load_next_page()`, which steps to siblings via `find_right_page()`/`find_left_page()`. Those navigate `items[index - 1]` through `parentImg`, and `find_page()` binds the locator there only for a `KEEP_PARENT` caller — the fastpath deferral (`parentImgDeferred`) is gated on the same flag. So the locator kept pointing into the shared page.

The core confirms each step: `flags = 0x200` (FETCH had already become IMAGE via `iterator_maybe_switch_to_image()`), `parentImgDeferred = false`, `items[1].locator.chunk = 0xe8f84a658400` against `parentImg = 0xaf2e6623e5b0`, and `parentPartial.src = 0xe8f84a658000` — the locator addressed the source page, not the copy, at +0x400.

## Why it matters without asserts

There is no crash at that point in a `--disable-cassert` build. `find_right_page()` runs `BTREE_PAGE_LOCATOR_IS_VALID`/`NEXT` against `parentImg` while `loc.chunk` addresses a different page, reading a downlink from unrelated memory. It only acts on one when `DOWNLINK_IS_IN_MEMORY()` and the key equals the hikey, so it usually re-descends and hides the problem — but a match steps the scan to the wrong page.

The broken constructor's only caller is `o_iterate_index()` for exact bounds with array keys (`index_scan.c:787`), i.e. an ordinary index scan over an `IN` list — not an exotic path.

Same shape as the gap noted in #1051 (producer gated on `KEEP_PARENT`, consumer reached without it), but a different and more commonly hit violator.

## Tests

`regress` 50/50, `isolation` 38/38.

No deterministic regression test here: the plans I could construct for a composite-key `IN` list chose bitmap or parallel seq scans rather than the ordered index scan that reaches this constructor, so the reproducer remains the stress run plus the core. Happy to keep digging for one if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)