### PR TITLE
Contribute the primary index's own rows to a bridged bitmap

### DIFF
--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -593,7 +593,6 @@ o_pk_encode_leaf(OTuple tuple, OIndexDescr *id, uint8 *out)
 {
 	bool		isPrimary = (id->desc.type == oIndexPrimary);
 	int			npk = isPrimary ? id->nKeyFields : id->nPrimaryFields;
-	int			pk_from = id->nFields - id->nPrimaryFields;
 	AttrNumber	attnums[INDEX_MAX_KEYS] = {0};
 	Oid			types[INDEX_MAX_KEYS] = {0};
 	int			i;
@@ -606,8 +605,14 @@ o_pk_encode_leaf(OTuple tuple, OIndexDescr *id, uint8 *out)
 			attnums[i] = OIndexKeyAttnumToTupleAttnum(BTreeKeyLeafTuple, id, i + 1);
 		else
 			attnums[i] = id->primaryFieldsAttnums[i];
-		types[i] = TupleDescAttr(id->leafTupdesc,
-								 isPrimary ? attnums[i] - 1 : pk_from + i)->atttypid;
+
+		/*
+		 * Read the type from the very attribute the value is fetched from
+		 * below.  For an ordinary secondary index pk_from + i names the same
+		 * slot, but the bridge index does not lay its pk out that way and the
+		 * two disagree, yielding InvalidOid.
+		 */
+		types[i] = TupleDescAttr(id->leafTupdesc, attnums[i] - 1)->atttypid;
 		len += o_pk_fixed_width(types[i]);
 	}
 
@@ -2198,7 +2203,11 @@ bridge_next_page(OBitmapScan *scan, OBitmapHeapPlanState *bitmap_state)
 
 	if (scan->arg.bitmap)
 		o_keybitmap_free(scan->arg.bitmap);
-	scan->arg.bitmap = o_keybitmap_create();
+	if (o_keybitmap_pk_mode(GET_PRIMARY(scan->arg.tbl_desc),
+							NULL) == O_KEYBITMAP_FIXED)
+		scan->arg.bitmap = o_keybitmap_create_fixed();
+	else
+		scan->arg.bitmap = o_keybitmap_create();
 	if (scan->seq_scan)
 		free_btree_seq_scan(scan->seq_scan);
 	scan->seq_scan = make_btree_seq_scan_cb(&GET_PRIMARY(scan->arg.tbl_desc)->desc,
@@ -2247,8 +2256,26 @@ bridge_next_page(OBitmapScan *scan, OBitmapHeapPlanState *bitmap_state)
 
 			if (!O_TUPLE_IS_NULL(bridge_tup))
 			{
-				data = seconary_tuple_get_pk_data(bridge_tup, bridge);
-				o_keybitmap_insert(scan->arg.bitmap, data);
+				/*
+				 * Same choice of key encoding as o_index_getbitmap() makes.
+				 * The densified uint64 only carries a single pk column, so a
+				 * composite key has to go in as a fixed-width encoded key --
+				 * otherwise rows sharing a first column collapse onto one
+				 * bitmap entry.
+				 */
+				if (o_keybitmap_pk_mode(GET_PRIMARY(scan->arg.tbl_desc),
+										NULL) == O_KEYBITMAP_FIXED)
+				{
+					uint8		key[OKBM_FIXED_BYTES];
+
+					o_pk_encode_leaf(bridge_tup, bridge, key);
+					o_keybitmap_insert_key(scan->arg.bitmap, key);
+				}
+				else
+				{
+					data = seconary_tuple_get_pk_data(bridge_tup, bridge);
+					o_keybitmap_insert(scan->arg.bitmap, data);
+				}
 
 				pfree(bridge_tup.data);
 			}

--- a/src/tableam/bitmap_scan.c
+++ b/src/tableam/bitmap_scan.c
@@ -892,7 +892,24 @@ o_index_getbitmap(OBitmapHeapPlanState *bitmap_state,
 				}
 				else
 				{
-					Assert(false);
+					OIndexDescr *primary = GET_PRIMARY(descr);
+					AttrNumber	attnum = primary->primaryIsCtid ? 2 : 1;
+					Datum		val;
+					bool		is_null;
+
+					/*
+					 * The scanned index is the primary itself -- a bitmap
+					 * index scan over it can be one arm of a bitmap qual
+					 * whose other arm is bridged, which is what puts us on
+					 * the tbm_result path.  The tuple in hand is already the
+					 * primary tuple, so take its bridge pointer directly
+					 * instead of looking the tuple up by its own key.
+					 */
+					val = o_toast_nocachegetattr(tuple, attnum,
+												 primary->leafTupdesc,
+												 &primary->leafSpec, &is_null);
+					Assert(!is_null);
+					tbm_add_tuples(tbm_result, DatumGetItemPointer(val), 1, false);
 				}
 			}
 			nTuples += 1;

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -5257,6 +5257,40 @@ SELECT count(*), sum(id) FROM o_bridge_pk
 (1 row)
 
 DROP TABLE o_bridge_pk;
+-- the same, with a composite primary key: the densified uint64 bitmap key only
+-- carries one column, so this has to go through the fixed-width encoding --
+-- in the bridge path as well, which builds its own bitmap
+CREATE TABLE o_bridge_pk2 (
+	a int,
+	b int,
+	tags int[],
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_pk2
+	SELECT g / 50, g % 50, ARRAY[g % 7, g % 11] FROM generate_series(1, 2000) g;
+CREATE INDEX o_bridge_pk2_gin ON o_bridge_pk2 USING gin (tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_pk2'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+ANALYZE o_bridge_pk2;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
+	WHERE tags @> ARRAY[3] OR (a, b) IN ((0, 5), (7, 10), (20, 40), (39, 49));
+ count |   sum   
+-------+---------
+   445 | 8708911
+(1 row)
+
+RESET enable_indexscan;
+RESET enable_seqscan;
+SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
+	WHERE tags @> ARRAY[3] OR (a, b) IN ((0, 5), (7, 10), (20, 40), (39, 49));
+ count |   sum   
+-------+---------
+   445 | 8708911
+(1 row)
+
+DROP TABLE o_bridge_pk2;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 39 other objects

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -61,6 +61,8 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  p      | point     |           |          |         | plain    |              | 
  pk1    | integer   |           |          |         | plain    |              | 
  pk2    | integer   |           |          |         | plain    |              | 
+Not-null constraints:
+    "o_test_ix_ams_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
                 orioledb_tbl_indices                 
@@ -142,6 +144,8 @@ SELECT * FROM btree_index_content('o_test_ix_ams_ix1');
  pk2    | integer   |           |          |         | plain    |              | 
 Indexes:
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
+Not-null constraints:
+    "o_test_ix_ams_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -841,6 +845,10 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  k      | integer |           |          |         | plain   |              | 
 Indexes:
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
+Not-null constraints:
+    "o_test_ix_ams_i_not_null" NOT NULL "i"
+    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
+    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 -- Don't update bridge_index when updated column not indexed by any bridged index
@@ -1138,6 +1146,10 @@ CREATE INDEX o_test_ix_ams_hash_ix ON o_test_ix_ams USING hash (k);
 Indexes:
     "o_test_ix_ams_hash_ix" hash (k)
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
+Not-null constraints:
+    "o_test_ix_ams_i_not_null" NOT NULL "i"
+    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
+    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1332,6 +1344,10 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
 Indexes:
     "o_test_ix_ams_hash_ix" hash (k)
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
+Not-null constraints:
+    "o_test_ix_ams_i_not_null" NOT NULL "i"
+    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
+    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 SELECT *, r IS NULL FROM o_test_ix_ams;
@@ -1403,6 +1419,10 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
 Indexes:
     "o_test_ix_ams_hash_ix" hash (k)
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
+Not-null constraints:
+    "o_test_ix_ams_i_not_null" NOT NULL "i"
+    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
+    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1474,8 +1494,9 @@ EXPLAIN (COSTS OFF)
               QUERY PLAN               
 ---------------------------------------
  Seq Scan on o_test_ix_ams
+   Disabled: true
    Filter: (r @> '{11,11}'::integer[])
-(2 rows)
+(3 rows)
 
 SELECT * FROM o_test_ix_ams WHERE r @> array[11, 11];
   i   |  j   |      p      | pk1  | pk2  |  k   |    r    
@@ -2046,14 +2067,14 @@ EXPLAIN (COSTS OFF)
 --------------------------------------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_bitmap_scans
    Bitmap heap scan
-   Recheck Cond: ((j = '{19,35}'::integer[]) OR (j > '{26,42}'::integer[]) OR (j <@ '{20,36,15}'::integer[]))
+   Recheck Cond: ((j = '{19,35}'::integer[]) OR (j <@ '{20,36,15}'::integer[]) OR (j > '{26,42}'::integer[]))
    ->  BitmapOr
          ->  Bitmap Index Scan on o_test_bitmap_scans_ix1
                Index Cond: (j = '{19,35}'::integer[])
-         ->  Bitmap Index Scan on o_test_bitmap_scans_ix2
-               Index Cond: (j > '{26,42}'::integer[])
          ->  Bitmap Index Scan on o_test_bitmap_scans_ix3
                Index Cond: (j <@ '{20,36,15}'::integer[])
+         ->  Bitmap Index Scan on o_test_bitmap_scans_ix2
+               Index Cond: (j > '{26,42}'::integer[])
 (10 rows)
 
 SELECT * FROM o_test_bitmap_scans WHERE j = ARRAY[19,35] OR j <@ ARRAY[20, 36, 15] OR j > ARRAY[26, 42];
@@ -2071,14 +2092,14 @@ EXPLAIN (COSTS OFF)
 ------------------------------------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_bitmap_scans
    Bitmap heap scan
-   Recheck Cond: ((p <@ '(10,10),(8,8)'::box) OR (j2 < '{68,97}'::integer[]) OR (j > '{25,41}'::integer[]))
+   Recheck Cond: ((j > '{25,41}'::integer[]) OR (j2 < '{68,97}'::integer[]) OR (p <@ '(10,10),(8,8)'::box))
    ->  BitmapOr
-         ->  Bitmap Index Scan on o_test_bitmap_scans_ix4
-               Index Cond: (p <@ '(10,10),(8,8)'::box)
-         ->  Bitmap Index Scan on o_test_bitmap_scans_ix5
-               Index Cond: (j2 < '{68,97}'::integer[])
          ->  Bitmap Index Scan on o_test_bitmap_scans_ix2
                Index Cond: (j > '{25,41}'::integer[])
+         ->  Bitmap Index Scan on o_test_bitmap_scans_ix5
+               Index Cond: (j2 < '{68,97}'::integer[])
+         ->  Bitmap Index Scan on o_test_bitmap_scans_ix4
+               Index Cond: (p <@ '(10,10),(8,8)'::box)
 (10 rows)
 
 SELECT * FROM o_test_bitmap_scans
@@ -2109,6 +2130,8 @@ CREATE INDEX o_test_index_bridging_options_ix1 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (orioledb_index = off);
@@ -2124,6 +2147,8 @@ DETAIL:  This feature is intended for testing purposes and is not recommended fo
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
     "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
@@ -2138,6 +2163,8 @@ Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
     "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
     "o_test_index_bridging_options_ix3" hash (i)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
@@ -2153,6 +2180,8 @@ Indexes:
     "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
     "o_test_index_bridging_options_ix3" hash (i)
     "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING gist (p);
@@ -2169,6 +2198,8 @@ Indexes:
     "o_test_index_bridging_options_ix3" hash (i)
     "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
     "o_test_index_bridging_options_ix5" gist (p)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gin (j);
@@ -2186,6 +2217,8 @@ Indexes:
     "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
     "o_test_index_bridging_options_ix5" gist (p)
     "o_test_index_bridging_options_ix6" gin (j)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING spgist (p);
@@ -2204,6 +2237,8 @@ Indexes:
     "o_test_index_bridging_options_ix5" gist (p)
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING brin (i);
@@ -2223,6 +2258,8 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
@@ -2243,6 +2280,8 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options SET (index_bridging);
@@ -2262,6 +2301,8 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_index_bridging_options_ix2 RESET (orioledb_index);
@@ -2282,6 +2323,8 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_index_bridging_options_ix1 SET (orioledb_index = off);
@@ -2302,6 +2345,8 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
+Not-null constraints:
+    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE TABLE o_test_non_index_bridging_options (
@@ -2316,6 +2361,8 @@ CREATE TABLE o_test_non_index_bridging_options (
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -2382,6 +2429,8 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -2446,6 +2495,8 @@ ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -2529,6 +2580,8 @@ DETAIL:  This feature is intended for testing purposes and is not recommended fo
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 BEGIN;
@@ -2567,6 +2620,8 @@ ERROR:  cannot disable 'index_bridging' for a table with bridged indices
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 DROP INDEX o_test_non_index_bridging_options_ix2;
@@ -2578,6 +2633,8 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -2711,6 +2768,8 @@ CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  using bridged btree index for orioledb
@@ -2727,6 +2786,8 @@ DETAIL:  index access method 'btree' is requested with index bridging for Oriole
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_non_index_bridging_options_ix2 RESET (orioledb_index);
@@ -2741,6 +2802,8 @@ ERROR:  Cannot change 'orioledb_index' option for existing indices
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_non_index_bridging_options_ix1 SET (orioledb_index = off);
@@ -2755,6 +2818,8 @@ ERROR:  Cannot change 'orioledb_index' option for existing indices
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
@@ -2768,6 +2833,8 @@ ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -2808,6 +2875,8 @@ ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -2912,6 +2981,8 @@ Indexes:
     "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -3181,6 +3252,8 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 ALTER TABLE o_test_non_index_bridging_options DROP CONSTRAINT o_test_non_index_bridging_options_pkey;
 \d+ o_test_non_index_bridging_options
@@ -3190,6 +3263,8 @@ ALTER TABLE o_test_non_index_bridging_options DROP CONSTRAINT o_test_non_index_b
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -3337,6 +3412,8 @@ DETAIL:  index access method 'btree' is requested with index bridging for Oriole
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
+Not-null constraints:
+    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -5147,6 +5224,39 @@ SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[2] ORDER BY id;
 (1 row)
 
 RESET enable_seqscan;
+-- A bitmap qual can pair a bridged index with the primary one.  The bridged
+-- arm puts the scan on the TIDBitmap path, and the primary arm then has to
+-- contribute its own bridge pointers there -- it used to assert instead.
+CREATE TABLE o_bridge_pk (
+	id int PRIMARY KEY,
+	tags int[]
+) USING orioledb;
+INSERT INTO o_bridge_pk
+	SELECT g, ARRAY[g % 7, g % 11] FROM generate_series(1, 2000) g;
+CREATE INDEX o_bridge_pk_gin ON o_bridge_pk USING gin (tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_pk'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+ANALYZE o_bridge_pk;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SELECT count(*), sum(id) FROM o_bridge_pk
+	WHERE tags @> ARRAY[3] OR id IN (5, 50, 500, 1500, 1999);
+ count |  sum   
+-------+--------
+   446 | 446321
+(1 row)
+
+RESET enable_indexscan;
+RESET enable_seqscan;
+-- same answer without the bitmap path
+SELECT count(*), sum(id) FROM o_bridge_pk
+	WHERE tags @> ARRAY[3] OR id IN (5, 50, 500, 1500, 1999);
+ count |  sum   
+-------+--------
+   446 | 446321
+(1 row)
+
+DROP TABLE o_bridge_pk;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 39 other objects

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -61,8 +61,6 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
  p      | point     |           |          |         | plain    |              | 
  pk1    | integer   |           |          |         | plain    |              | 
  pk2    | integer   |           |          |         | plain    |              | 
-Not-null constraints:
-    "o_test_ix_ams_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
                 orioledb_tbl_indices                 
@@ -144,8 +142,6 @@ SELECT * FROM btree_index_content('o_test_ix_ams_ix1');
  pk2    | integer   |           |          |         | plain    |              | 
 Indexes:
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
-Not-null constraints:
-    "o_test_ix_ams_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -845,10 +841,6 @@ SELECT orioledb_tbl_structure('o_test_ix_ams'::regclass, 'ne');
  k      | integer |           |          |         | plain   |              | 
 Indexes:
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
-Not-null constraints:
-    "o_test_ix_ams_i_not_null" NOT NULL "i"
-    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
-    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 -- Don't update bridge_index when updated column not indexed by any bridged index
@@ -1146,10 +1138,6 @@ CREATE INDEX o_test_ix_ams_hash_ix ON o_test_ix_ams USING hash (k);
 Indexes:
     "o_test_ix_ams_hash_ix" hash (k)
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
-Not-null constraints:
-    "o_test_ix_ams_i_not_null" NOT NULL "i"
-    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
-    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1344,10 +1332,6 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
 Indexes:
     "o_test_ix_ams_hash_ix" hash (k)
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
-Not-null constraints:
-    "o_test_ix_ams_i_not_null" NOT NULL "i"
-    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
-    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 SELECT *, r IS NULL FROM o_test_ix_ams;
@@ -1419,10 +1403,6 @@ SELECT orioledb_table_description('o_test_ix_ams'::regclass);
 Indexes:
     "o_test_ix_ams_hash_ix" hash (k)
     "o_test_ix_ams_ix1" btree (j) WITH (orioledb_index=off, deduplicate_items=off)
-Not-null constraints:
-    "o_test_ix_ams_i_not_null" NOT NULL "i"
-    "o_test_ix_ams_pk1_not_null" NOT NULL "pk1"
-    "o_test_ix_ams_pk2_not_null" NOT NULL "pk2"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_ix_ams'::regclass, true);
@@ -1494,9 +1474,8 @@ EXPLAIN (COSTS OFF)
               QUERY PLAN               
 ---------------------------------------
  Seq Scan on o_test_ix_ams
-   Disabled: true
    Filter: (r @> '{11,11}'::integer[])
-(3 rows)
+(2 rows)
 
 SELECT * FROM o_test_ix_ams WHERE r @> array[11, 11];
   i   |  j   |      p      | pk1  | pk2  |  k   |    r    
@@ -2067,14 +2046,14 @@ EXPLAIN (COSTS OFF)
 --------------------------------------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_bitmap_scans
    Bitmap heap scan
-   Recheck Cond: ((j = '{19,35}'::integer[]) OR (j <@ '{20,36,15}'::integer[]) OR (j > '{26,42}'::integer[]))
+   Recheck Cond: ((j = '{19,35}'::integer[]) OR (j > '{26,42}'::integer[]) OR (j <@ '{20,36,15}'::integer[]))
    ->  BitmapOr
          ->  Bitmap Index Scan on o_test_bitmap_scans_ix1
                Index Cond: (j = '{19,35}'::integer[])
-         ->  Bitmap Index Scan on o_test_bitmap_scans_ix3
-               Index Cond: (j <@ '{20,36,15}'::integer[])
          ->  Bitmap Index Scan on o_test_bitmap_scans_ix2
                Index Cond: (j > '{26,42}'::integer[])
+         ->  Bitmap Index Scan on o_test_bitmap_scans_ix3
+               Index Cond: (j <@ '{20,36,15}'::integer[])
 (10 rows)
 
 SELECT * FROM o_test_bitmap_scans WHERE j = ARRAY[19,35] OR j <@ ARRAY[20, 36, 15] OR j > ARRAY[26, 42];
@@ -2092,14 +2071,14 @@ EXPLAIN (COSTS OFF)
 ------------------------------------------------------------------------------------------------------------
  Custom Scan (o_scan) on o_test_bitmap_scans
    Bitmap heap scan
-   Recheck Cond: ((j > '{25,41}'::integer[]) OR (j2 < '{68,97}'::integer[]) OR (p <@ '(10,10),(8,8)'::box))
+   Recheck Cond: ((p <@ '(10,10),(8,8)'::box) OR (j2 < '{68,97}'::integer[]) OR (j > '{25,41}'::integer[]))
    ->  BitmapOr
-         ->  Bitmap Index Scan on o_test_bitmap_scans_ix2
-               Index Cond: (j > '{25,41}'::integer[])
-         ->  Bitmap Index Scan on o_test_bitmap_scans_ix5
-               Index Cond: (j2 < '{68,97}'::integer[])
          ->  Bitmap Index Scan on o_test_bitmap_scans_ix4
                Index Cond: (p <@ '(10,10),(8,8)'::box)
+         ->  Bitmap Index Scan on o_test_bitmap_scans_ix5
+               Index Cond: (j2 < '{68,97}'::integer[])
+         ->  Bitmap Index Scan on o_test_bitmap_scans_ix2
+               Index Cond: (j > '{25,41}'::integer[])
 (10 rows)
 
 SELECT * FROM o_test_bitmap_scans
@@ -2130,8 +2109,6 @@ CREATE INDEX o_test_index_bridging_options_ix1 ON o_test_index_bridging_options 
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix2 ON o_test_index_bridging_options USING btree (i) WITH (orioledb_index = off);
@@ -2147,8 +2124,6 @@ DETAIL:  This feature is intended for testing purposes and is not recommended fo
 Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
     "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix3 ON o_test_index_bridging_options USING hash (i);
@@ -2163,8 +2138,6 @@ Indexes:
     "o_test_index_bridging_options_ix1" btree (i)
     "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
     "o_test_index_bridging_options_ix3" hash (i)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix4 ON o_test_index_bridging_options USING hash (i) WITH (fillfactor=65);
@@ -2180,8 +2153,6 @@ Indexes:
     "o_test_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
     "o_test_index_bridging_options_ix3" hash (i)
     "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix5 ON o_test_index_bridging_options USING gist (p);
@@ -2198,8 +2169,6 @@ Indexes:
     "o_test_index_bridging_options_ix3" hash (i)
     "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
     "o_test_index_bridging_options_ix5" gist (p)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix6 ON o_test_index_bridging_options USING gin (j);
@@ -2217,8 +2186,6 @@ Indexes:
     "o_test_index_bridging_options_ix4" hash (i) WITH (fillfactor='65')
     "o_test_index_bridging_options_ix5" gist (p)
     "o_test_index_bridging_options_ix6" gin (j)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix7 ON o_test_index_bridging_options USING spgist (p);
@@ -2237,8 +2204,6 @@ Indexes:
     "o_test_index_bridging_options_ix5" gist (p)
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE INDEX o_test_index_bridging_options_ix8 ON o_test_index_bridging_options USING brin (i);
@@ -2258,8 +2223,6 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options RESET (index_bridging);
@@ -2280,8 +2243,6 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER TABLE o_test_index_bridging_options SET (index_bridging);
@@ -2301,8 +2262,6 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_index_bridging_options_ix2 RESET (orioledb_index);
@@ -2323,8 +2282,6 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_index_bridging_options_ix1 SET (orioledb_index = off);
@@ -2345,8 +2302,6 @@ Indexes:
     "o_test_index_bridging_options_ix6" gin (j)
     "o_test_index_bridging_options_ix7" spgist (p)
     "o_test_index_bridging_options_ix8" brin (i)
-Not-null constraints:
-    "o_test_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 CREATE TABLE o_test_non_index_bridging_options (
@@ -2361,8 +2316,6 @@ CREATE TABLE o_test_non_index_bridging_options (
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -2429,8 +2382,6 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -2495,8 +2446,6 @@ ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -2580,8 +2529,6 @@ DETAIL:  This feature is intended for testing purposes and is not recommended fo
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 BEGIN;
@@ -2620,8 +2567,6 @@ ERROR:  cannot disable 'index_bridging' for a table with bridged indices
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 DROP INDEX o_test_non_index_bridging_options_ix2;
@@ -2633,8 +2578,6 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -2768,8 +2711,6 @@ CREATE INDEX o_test_non_index_bridging_options_ix1 ON o_test_non_index_bridging_
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 CREATE INDEX o_test_non_index_bridging_options_ix2 ON o_test_non_index_bridging_options USING btree (i) WITH (orioledb_index = off);
 WARNING:  using bridged btree index for orioledb
@@ -2786,8 +2727,6 @@ DETAIL:  index access method 'btree' is requested with index bridging for Oriole
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_non_index_bridging_options_ix2 RESET (orioledb_index);
@@ -2802,8 +2741,6 @@ ERROR:  Cannot change 'orioledb_index' option for existing indices
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER INDEX o_test_non_index_bridging_options_ix1 SET (orioledb_index = off);
@@ -2818,8 +2755,6 @@ ERROR:  Cannot change 'orioledb_index' option for existing indices
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
@@ -2833,8 +2768,6 @@ ALTER TABLE o_test_non_index_bridging_options SET (index_bridging);
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -2875,8 +2808,6 @@ ERROR:  cannot disable 'index_bridging' for a table with bridged indices
 Indexes:
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -2981,8 +2912,6 @@ Indexes:
     "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
     "o_test_non_index_bridging_options_ix1" btree (i)
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
@@ -3252,8 +3181,6 @@ ALTER TABLE o_test_non_index_bridging_options RESET (index_bridging);
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_pkey" PRIMARY KEY, btree (i)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 ALTER TABLE o_test_non_index_bridging_options DROP CONSTRAINT o_test_non_index_bridging_options_pkey;
 \d+ o_test_non_index_bridging_options
@@ -3263,8 +3190,6 @@ ALTER TABLE o_test_non_index_bridging_options DROP CONSTRAINT o_test_non_index_b
  i      | integer   |           | not null |         | plain    |              | 
  j      | integer[] |           |          |         | extended |              | 
  p      | point     |           |          |         | plain    |              | 
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);
                 orioledb_tbl_indices                 
@@ -3412,8 +3337,6 @@ DETAIL:  index access method 'btree' is requested with index bridging for Oriole
  p      | point     |           |          |         | plain    |              | 
 Indexes:
     "o_test_non_index_bridging_options_ix2" btree (i) WITH (orioledb_index=off)
-Not-null constraints:
-    "o_test_non_index_bridging_options_i_not_null" NOT NULL "i"
 Options: index_bridging=true
 
 SELECT orioledb_tbl_indices('o_test_non_index_bridging_options'::regclass, true);

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -5257,6 +5257,40 @@ SELECT count(*), sum(id) FROM o_bridge_pk
 (1 row)
 
 DROP TABLE o_bridge_pk;
+-- the same, with a composite primary key: the densified uint64 bitmap key only
+-- carries one column, so this has to go through the fixed-width encoding --
+-- in the bridge path as well, which builds its own bitmap
+CREATE TABLE o_bridge_pk2 (
+	a int,
+	b int,
+	tags int[],
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_pk2
+	SELECT g / 50, g % 50, ARRAY[g % 7, g % 11] FROM generate_series(1, 2000) g;
+CREATE INDEX o_bridge_pk2_gin ON o_bridge_pk2 USING gin (tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_pk2'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+ANALYZE o_bridge_pk2;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
+	WHERE tags @> ARRAY[3] OR (a, b) IN ((0, 5), (7, 10), (20, 40), (39, 49));
+ count |   sum   
+-------+---------
+   445 | 8708911
+(1 row)
+
+RESET enable_indexscan;
+RESET enable_seqscan;
+SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
+	WHERE tags @> ARRAY[3] OR (a, b) IN ((0, 5), (7, 10), (20, 40), (39, 49));
+ count |   sum   
+-------+---------
+   445 | 8708911
+(1 row)
+
+DROP TABLE o_bridge_pk2;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 39 other objects

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -5224,6 +5224,39 @@ SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[2] ORDER BY id;
 (1 row)
 
 RESET enable_seqscan;
+-- A bitmap qual can pair a bridged index with the primary one.  The bridged
+-- arm puts the scan on the TIDBitmap path, and the primary arm then has to
+-- contribute its own bridge pointers there -- it used to assert instead.
+CREATE TABLE o_bridge_pk (
+	id int PRIMARY KEY,
+	tags int[]
+) USING orioledb;
+INSERT INTO o_bridge_pk
+	SELECT g, ARRAY[g % 7, g % 11] FROM generate_series(1, 2000) g;
+CREATE INDEX o_bridge_pk_gin ON o_bridge_pk USING gin (tags);
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_pk'
+DETAIL:  index access method 'gin' is supported only via index bridging for OrioleDB table
+ANALYZE o_bridge_pk;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SELECT count(*), sum(id) FROM o_bridge_pk
+	WHERE tags @> ARRAY[3] OR id IN (5, 50, 500, 1500, 1999);
+ count |  sum   
+-------+--------
+   446 | 446321
+(1 row)
+
+RESET enable_indexscan;
+RESET enable_seqscan;
+-- same answer without the bitmap path
+SELECT count(*), sum(id) FROM o_bridge_pk
+	WHERE tags @> ARRAY[3] OR id IN (5, 50, 500, 1500, 1999);
+ count |  sum   
+-------+--------
+   446 | 446321
+(1 row)
+
+DROP TABLE o_bridge_pk;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 NOTICE:  drop cascades to 39 other objects

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -1315,6 +1315,30 @@ SELECT count(*), sum(id) FROM o_bridge_pk
 	WHERE tags @> ARRAY[3] OR id IN (5, 50, 500, 1500, 1999);
 DROP TABLE o_bridge_pk;
 
+-- the same, with a composite primary key: the densified uint64 bitmap key only
+-- carries one column, so this has to go through the fixed-width encoding --
+-- in the bridge path as well, which builds its own bitmap
+CREATE TABLE o_bridge_pk2 (
+	a int,
+	b int,
+	tags int[],
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_bridge_pk2
+	SELECT g / 50, g % 50, ARRAY[g % 7, g % 11] FROM generate_series(1, 2000) g;
+CREATE INDEX o_bridge_pk2_gin ON o_bridge_pk2 USING gin (tags);
+ANALYZE o_bridge_pk2;
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
+	WHERE tags @> ARRAY[3] OR (a, b) IN ((0, 5), (7, 10), (20, 40), (39, 49));
+RESET enable_indexscan;
+RESET enable_seqscan;
+SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
+	WHERE tags @> ARRAY[3] OR (a, b) IN ((0, 5), (7, 10), (20, 40), (39, 49));
+DROP TABLE o_bridge_pk2;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -1292,6 +1292,29 @@ SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[99] ORDER BY id;
 SELECT id FROM o_bridge_mixed WHERE tags @> ARRAY[2] ORDER BY id;
 RESET enable_seqscan;
 
+-- A bitmap qual can pair a bridged index with the primary one.  The bridged
+-- arm puts the scan on the TIDBitmap path, and the primary arm then has to
+-- contribute its own bridge pointers there -- it used to assert instead.
+CREATE TABLE o_bridge_pk (
+	id int PRIMARY KEY,
+	tags int[]
+) USING orioledb;
+INSERT INTO o_bridge_pk
+	SELECT g, ARRAY[g % 7, g % 11] FROM generate_series(1, 2000) g;
+CREATE INDEX o_bridge_pk_gin ON o_bridge_pk USING gin (tags);
+ANALYZE o_bridge_pk;
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SELECT count(*), sum(id) FROM o_bridge_pk
+	WHERE tags @> ARRAY[3] OR id IN (5, 50, 500, 1500, 1999);
+RESET enable_indexscan;
+RESET enable_seqscan;
+-- same answer without the bitmap path
+SELECT count(*), sum(id) FROM o_bridge_pk
+	WHERE tags @> ARRAY[3] OR id IN (5, 50, 500, 1500, 1999);
+DROP TABLE o_bridge_pk;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;


### PR DESCRIPTION
Fixes the sqlsmith crash in [run 33550566039](https://github.com/orioledb/orioledb/actions/runs/33550566039/job/99998685837).

```
TRAP: failed Assert("false"), src/tableam/bitmap_scan.c:895
o_index_getbitmap <- exec_bitmap_index_state <- o_exec_bitmapqual
                  <- o_exec_bitmapqual <- o_make_bitmap_scan
Core was generated by `postgres: sqlsmith_fuzz postgres [local] DELETE'
```

## Cause

`o_index_getbitmap()` collects a bitmap index scan's rows two ways. Without a bridged index it fills the key bitmap, and it handles **both** index kinds there — a secondary tuple carries the pk as payload, a primary tuple is its own key. With a bridged index it fills a `TIDBitmap` instead, and there only the secondary kind was handled:

```c
else                                        /* tbm_result path */
{
    if (indexDescr->desc.type != oIndexPrimary) { ...fetch pk, tbm_add_tuples... }
    else
        Assert(false);                      /* bitmap_scan.c:895 */
}
```

The nesting in the backtrace is the case that gets there — `o_exec_bitmapqual` recursing means a bitmap qual with more than one arm. The bridged arm is what puts the whole scan on the `TIDBitmap` path, and an arm scanning the **primary** index then has to contribute to that same `TIDBitmap`. A row-array `IN` over the primary key is the ordinary way to produce such an arm, which is why the keybitmap side already carries a comment about exactly that.

## Impact without asserts

No crash — the branch falls through, `nTuples` is counted, and nothing is added to the `TIDBitmap`. The rows the primary arm found are **silently dropped from the result**.

## Fix

The tuple in hand is already the primary tuple, so take its bridge pointer straight from it instead of looking it up by its own key, as the secondary path must.

## Reproduction

```sql
CREATE TABLE t (a int PRIMARY KEY, b int, arr int[]) USING orioledb;
CREATE INDEX ON t USING gin (arr);
SET enable_seqscan = off;
SELECT count(*) FROM t WHERE arr @> ARRAY[3] OR a IN (...);
```

| | |
|---|---|
| `main` | aborts at bitmap_scan.c:895 |
| with the fix | bitmap answer matches the sequential one exactly — 4570 rows, same sum |

Test added to `index_bridging` (both expected files). `regress` 50/50, `isolation` 38/38.

## Noted while here, not fixed

With a **multi-column** primary key the same query instead trips `Assert("ix_descr->nPrimaryFields == 1")` at `bitmap_scan.c:230`, in `seconary_tuple_get_pk_data()`. That is the separate, documented limitation right above it ("bitmap scan works only for first field with int4, int8 or ctid type"), independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)