### PR TITLE
Eliminate flake in pg_tests -> recovery

### DIFF
--- a/ci/check.sh
+++ b/ci/check.sh
@@ -260,6 +260,11 @@ elif [ $CHECK_TYPE = "pg_tests" ]; then
         if [ $PG_VERSION != "16" ]; then
             make -C src/test/subscription installcheck-oriole -j $(nproc) || status=$?
             make -C src/test/recovery installcheck-oriole -j $(nproc) || status=$?
+            if [ -f src/test/recovery/tmp_check/regression.diffs ]; then
+              python3 ../orioledb/ci/filter_regression_diff.py --diff src/test/recovery/tmp_check/regression.diffs > src/test/recovery_filtered.diffs
+              rm src/test/recovery/tmp_check/regression.diffs
+              [ -s src/test/recovery_filtered.diffs ] || rm -f src/test/recovery_filtered.diffs
+            fi
         fi
     fi
     pg_ctl -D $GITHUB_WORKSPACE/pgsql/pgdata -l pg.log stop

--- a/ci/filter_regression_diff.py
+++ b/ci/filter_regression_diff.py
@@ -169,6 +169,10 @@ skip_hunk_errors = {
 	# both shapes.
 	r"ERROR:  role \"regress_user11\" (already exists|does not exist|cannot be dropped because some objects depend on it)":
 	["generated_stored", "generated_virtual"],
+	# Same race, constraint-level variant: both CREATE USER statements
+	# pass the existence check, then the second hits the unique index.
+	r"ERROR:  duplicate key value violates unique constraint \"pg_authid_rolname_index\"":
+	["generated_stored", "generated_virtual"],
 	# Same regress_user11 race, OID-based variant: when the other test's
 	# concurrent DROP USER removes the role's pg_authid tuple between this
 	# DROP USER's catalog lookup and its delete, the error names the role by


### PR DESCRIPTION
027_stream_regress runs pg_regress with the full parallel_schedule. generated_stored and generated_virtual can race on CREATE/DROP of regress_user11; the catalog-level variant (duplicate key on pg_authid_rolname_index) was not caught by the filter, and recovery test diffs were not filtered at all.

----- residual contents -----
diff -U3 /home/runner/_work/orioledb/orioledb/postgresql/src/test/regress/expected/generated_stored.out /home/runner/_work/orioledb/orioledb/postgresql/src/test/recovery/tmp_check/results/generated_stored.out
--- /home/runner/_work/orioledb/orioledb/postgresql/src/test/regress/expected/generated_stored.out	2026-09-02 07:58:25.560605490 +0000
+++ /home/runner/_work/orioledb/orioledb/postgresql/src/test/recovery/tmp_check/results/generated_stored.out	2026-09-02 08:16:04.132603244 +0000
@@ -611,6 +611,8 @@
 INSERT INTO gtest10a (a) VALUES (1);
 -- privileges
 CREATE USER regress_user11;
+ERROR:  duplicate key value violates unique constraint "pg_authid_rolname_index"
 CREATE TABLE gtest11 (a int PRIMARY KEY, b int, c int GENERATED ALWAYS AS (b * 2) STORED);
 INSERT INTO gtest11 VALUES (1, 10), (2, 20);
 GRANT SELECT (a, c) ON gtest11 TO regress_user11;



