### PR TITLE
Fix pending truncates file corruption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/parallel_test.py \
 						test/t/parallel_ordered_scan_test.py \
 						test/t/parallel_bitmap_scan_test.py \
+						test/t/pending_truncates_test.py \
 						test/t/recovery_heap_verdict_test.py \
 						test/t/recovery_heap_xid_binding_test.py \
 						test/t/recovery_item_rollback_test.py \

--- a/sql/orioledb--1.8--1.9_dev.sql
+++ b/sql/orioledb--1.8--1.9_dev.sql
@@ -17,3 +17,8 @@ CREATE FUNCTION orioledb_test_corrupt_page_undo(relid oid)
 RETURNS text
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_check_pending_truncates()
+RETURNS VOID
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -801,7 +801,7 @@ add_pending_truncate(ORelOids relOids, int numTrees, OIndexKey *trees)
 	offset += length;
 	length = sizeof(numTrees);
 
-	if (FileWrite(pendingTruncatesFile, (Pointer) &numTrees, length, 0,
+	if (FileWrite(pendingTruncatesFile, (Pointer) &numTrees, length, offset,
 				  WAIT_EVENT_BUFFILE_WRITE) != length)
 		ereport(FATAL, (errcode_for_file_access(),
 						errmsg("could not write pending truncates file %s: %m",
@@ -810,7 +810,7 @@ add_pending_truncate(ORelOids relOids, int numTrees, OIndexKey *trees)
 	offset += length;
 	length = sizeof(*trees) * numTrees;
 
-	if (FileWrite(pendingTruncatesFile, (Pointer) &trees, length, 0,
+	if (FileWrite(pendingTruncatesFile, (Pointer) trees, length, offset,
 				  WAIT_EVENT_BUFFILE_WRITE) != length)
 		ereport(FATAL, (errcode_for_file_access(),
 						errmsg("could not write pending truncates file %s: %m",
@@ -895,6 +895,8 @@ check_pending_truncates(void)
 							errmsg("could not read pending truncates file %s: %m",
 								   PENDING_TRUNCATES_FILENAME)));
 
+		offset += length;
+
 		for (int i = 0; i < numTrees; i++)
 			cleanup_btree_files(trees[i], true);
 	}
@@ -906,6 +908,25 @@ check_pending_truncates(void)
 	if (trees)
 		pfree(trees);
 }
+
+#ifdef IS_DEV
+
+/*
+ * SQL wrapper for pending_truncates_test.  Runs check_pending_truncates()
+ * synchronously in the calling backend, instead of waiting for the
+ * bgwriter's next cycle, so the test can process a pending-truncates record
+ * deterministically right after a backup ends.
+ */
+PG_FUNCTION_INFO_V1(orioledb_check_pending_truncates);
+
+Datum
+orioledb_check_pending_truncates(PG_FUNCTION_ARGS)
+{
+	check_pending_truncates();
+	PG_RETURN_VOID();
+}
+
+#endif
 
 void
 btree_relnode_undo_callback(UndoLogType undoType, UndoLocation location,

--- a/test/t/pending_truncates_test.py
+++ b/test/t/pending_truncates_test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+Regression test for add_pending_truncate() (src/btree/undo.c).
+
+When a DROP TABLE commits while a backup is in progress, OrioleDB defers
+the file cleanup of the dropped table's trees: it records the tree list
+into a "pending truncates" file, to be replayed by check_pending_truncates()
+once the backup ends.  add_pending_truncate() wrote the tree count and the
+tree list at a hardcoded file offset of 0 instead of the running offset (and
+wrote the address of the local "trees" pointer instead of the array it
+points to).  That corrupts the file: check_pending_truncates() reads back a
+garbage tree count for the record, which both skips the real cleanup and
+can make it read far past the end of the (tiny) file, raising a FATAL error
+that kills the backend that triggered it.
+"""
+
+import os
+
+from .base_test import BaseTest
+
+
+class PendingTruncatesTest(BaseTest):
+
+	def test_drop_table_during_backup_is_cleaned_up(self):
+		node = self.node
+		node.append_conf('postgresql.conf',
+		                 "orioledb.debug_disable_bgwriter = true\n")
+		node.start()
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_test (\n"
+		    "	id integer NOT NULL PRIMARY KEY,\n"
+		    "	val text\n"
+		    ") USING orioledb;\n"
+		    "INSERT INTO o_test\n"
+		    "	(SELECT id, id || 'val' FROM generate_series(1, 100, 1) id);\n")
+
+		con = node.connect(autocommit=True)
+		datoid = con.execute(
+		    "SELECT oid FROM pg_database WHERE datname = current_database();"
+		)[0][0]
+		# o_test's own on-disk storage is its primary key's tree, not the
+		# relnode recorded against pg_class for the table itself.
+		relnode = con.execute(
+		    "SELECT relfilenode FROM pg_class WHERE relname = 'o_test_pkey';"
+		)[0][0]
+		fname = f"{node.data_dir}/orioledb_data/{datoid}/{relnode}"
+		self.assertTrue(os.path.exists(fname))
+
+		# pg_backup_start/pg_backup_stop must run on the same connection:
+		# the backup is tied to the session that started it, and gets
+		# aborted if that session disconnects.
+		con.execute("SELECT pg_backup_start('pending_truncates_test', true);")
+		con.execute("DROP TABLE o_test;")
+		con.execute("SELECT pg_backup_stop(wait_for_archive => false);")
+
+		# Replay the pending-truncates file deterministically, instead of
+		# waiting for the (disabled) bgwriter's next cycle.  With the bug,
+		# this reads a garbage tree count off the corrupted file and raises
+		# a FATAL error that kills this connection.
+		con.execute("SELECT orioledb_check_pending_truncates();")
+		con.close()
+
+		node.stop()
+
+		self.assertFalse(
+		    os.path.exists(fname),
+		    "o_test_pkey's file should have been cleaned up by "
+		    "check_pending_truncates() once the backup ended")


### PR DESCRIPTION
add_pending_truncate() wrote the tree count and tree list at file offset 0 instead of the running offset, and wrote the trees pointer itself instead of the array it points to.
check_pending_truncates() never advanced past the tree list it just read, so it misparsed the next record.

Together these corrupt the pending truncates file, so files of a table dropped during a backup can be left uncleaned, or crash the reader on replay.