### PR TITLE
Disable s3_mode and enable_rewind in production builds

### DIFF
--- a/doc/usage/configuration.mdx
+++ b/doc/usage/configuration.mdx
@@ -242,6 +242,10 @@ an `ERROR` instead, which is useful to catch unintended fallback in tests and CI
 
 ## Options for undo-based rewind (experimental)
 
+:::caution
+Rewind is an experimental feature available only in development builds (`IS_DEV=1`). On production builds `orioledb.enable_rewind` can't be turned on.
+:::
+
 ### `orioledb.enable_rewind`
 
 |             |     |

--- a/doc/usage/decoupled-storage.mdx
+++ b/doc/usage/decoupled-storage.mdx
@@ -19,6 +19,10 @@ S3 storage is not required to use OrioleDB. It is an optional feature that can b
 
 OrioleDB has experimental support for the storage of all tables and materialized views data in the S3 bucket. It is useful for splitting compute and data storage instances, for increasing data safety, and for scaling and changing the architecture of compute instances preserving all data.
 
+:::caution
+S3 mode is an experimental feature available only in development builds (`IS_DEV=1`). On production builds `orioledb.s3_mode` can't be turned on.
+:::
+
 Local storage implements caching of the data most often accessed. Also, it ensures that adding and updating data will be done at the speed of writing to local storage, rather than the S3 transfer rate. Data are synced with S3 asynchronously. However, all requirements of data integrity are ensured for all the data on S3 storage as well. So you can re-connect to the S3 bucket by another empty PostgreSQL instance (initialized with the utility described below) with the OrioleDB extension configured to use S3 with this bucket and get back all the data from S3 in the state of the last PostgreSQL checkpoint.
 
 To use S3 functionality, the following parameters should be set before creating orioledb tables and materialized views:

--- a/doc/usage/rewind.mdx
+++ b/doc/usage/rewind.mdx
@@ -15,6 +15,10 @@ This feature is experimental and imposes a significant performance penalty. It i
 
 ## Configuration
 
+:::caution
+Rewind is an experimental feature available only in development builds (`IS_DEV=1`). On production builds `orioledb.enable_rewind` can't be turned on.
+:::
+
 The following parameters control the rewind subsystem. These must be set in `postgresql.conf` or via `ALTER SYSTEM`.
 
 | Parameter | Type | Default | Range | Description |

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -430,29 +430,49 @@ static RmgrData rmgr =
 	.rm_decode = orioledb_decode
 };
 
-/*
- * We currently do not support restarting PG instance from within the extension
- * on certain systems. Refuse to enable rewind on those systems.
- */
+static bool
+orioledb_enable_s3_check_hook(bool *newval, void **extra, GucSource source)
+{
+#ifndef IS_DEV
+	if (*newval)
+	{
+		ereport(WARNING,
+				errmsg("orioledb.s3_mode is only available in development builds (IS_DEV=1), ignoring"));
+		*newval = false;
+	}
+#endif
+	return true;
+}
+
 static bool
 orioledb_enable_rewind_check_hook(bool *newval, void **extra, GucSource source)
 {
-#if defined(WIN32)
+#ifndef IS_DEV
 	if (*newval)
 	{
-		GUC_check_errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
-		GUC_check_errdetail("Rewind is not supported on Windows.");
-		return false;
+		ereport(WARNING,
+				errmsg("orioledb.enable_rewind is only available in development builds (IS_DEV=1), ignoring"));
+		*newval = false;
+	}
+/*
+	 * We currently do not support restarting PG instance from within the
+	 * extension on certain systems.
+	 */
+#elif defined(WIN32)
+	if (*newval)
+	{
+		ereport(WARNING,
+				errmsg("orioledb.enable_rewind is not supported on Windows, ignoring"));
+		*newval = false;
 	}
 #elif !defined(HAVE_SETSID)
 	if (*newval)
 	{
-		GUC_check_errcode(ERRCODE_FEATURE_NOT_SUPPORTED);
-		GUC_check_errdetail("Rewind is not supported on systems without setsid(2).");
-		return false;
+		ereport(WARNING,
+				errmsg("orioledb.enable_rewind is not supported on systems without setsid(2), ignoring"));
+		*newval = false;
 	}
 #endif
-	/* Supported system or newval == false */
 	return true;
 }
 
@@ -1003,7 +1023,7 @@ _PG_init(void)
 							 false,
 							 PGC_POSTMASTER,
 							 0,
-							 NULL,
+							 orioledb_enable_s3_check_hook,
 							 NULL,
 							 NULL);
 


### PR DESCRIPTION
Both orioledb.s3_mode and orioledb.enable_rewind are experimental features. In production builds (without IS_DEV=1) these values are ignored with a WARNING in the log.