### PR TITLE
Isolate type drops by database

### DIFF
--- a/include/catalog/o_tables.h
+++ b/include/catalog/o_tables.h
@@ -213,7 +213,8 @@ extern void o_tables_move_all(OXid oxid, CommitSeqNo csn, Oid database_id, Oid o
 extern void o_tables_evict(Oid datoid, List **evicted);
 
 /* Drops all columns of a specific type */
-extern void o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid type_oid);
+extern void o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn,
+										  Oid datoid, Oid type_oid);
 
 /* Drops all temporary tables that left after crash */
 extern void o_tables_truncate_all_unlogged(void);

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -3660,7 +3660,8 @@ orioledb_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
 
 		fill_current_oxid_osnapshot_no_check(&oxid, &oSnapshot);
 
-		o_tables_drop_columns_by_type(oxid, oSnapshot.csn, objectId);
+		o_tables_drop_columns_by_type(oxid, oSnapshot.csn, MyDatabaseId,
+									  objectId);
 
 		tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(objectId));
 		Assert(tuple);

--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -113,6 +113,7 @@ typedef struct
 {
 	OXid		oxid;
 	CommitSeqNo csn;
+	Oid			datoid;
 	Oid			type_oid;
 	Form_pg_type type_data;
 } OTablesDropAllWithTypeArg;
@@ -2596,6 +2597,9 @@ o_tables_drop_columns_with_type_callback(OTable *o_table, void *arg)
 	bool		updated = false;
 	OTablesDropAllWithTypeArg *drop_arg = (OTablesDropAllWithTypeArg *) arg;
 
+	if (drop_arg->datoid != o_table->oids.datoid)
+		return;
+
 	/* Ignore search for rows of own class in table and base types */
 	if (drop_arg->type_data->typtype == TYPTYPE_BASE ||
 		(drop_arg->type_data->typtype == TYPTYPE_COMPOSITE &&
@@ -2626,7 +2630,8 @@ o_tables_drop_columns_with_type_callback(OTable *o_table, void *arg)
  * Drops all columns of a specific type
  */
 void
-o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid type_oid)
+o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid datoid,
+							  Oid type_oid)
 {
 	OTablesDropAllWithTypeArg arg;
 	HeapTuple	tuple;
@@ -2639,6 +2644,7 @@ o_tables_drop_columns_by_type(OXid oxid, CommitSeqNo csn, Oid type_oid)
 
 	arg.oxid = oxid;
 	arg.csn = csn;
+	arg.datoid = datoid;
 	arg.type_oid = type_oid;
 	arg.type_data = (Form_pg_type) GETSTRUCT(tuple);
 

--- a/test/t/types_test.py
+++ b/test/t/types_test.py
@@ -44,6 +44,71 @@ class TypesTest(BaseTest):
 		cur_deleted = next((x[1] for x in rows if x[0] == True), 0)
 		self.assertEqual((cur_total, cur_deleted), (total, deleted))
 
+	def test_drop_type_isolated_between_databases(self):
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE DATABASE type_source;")
+		node.safe_psql("type_source", """
+			CREATE EXTENSION orioledb;
+			CREATE TYPE shared_enum AS ENUM ('one', 'two');
+			CREATE DOMAIN shared_domain AS integer CHECK (VALUE > 0);
+			CREATE TYPE shared_composite AS (value integer);
+			CREATE TABLE o_test (
+				id integer PRIMARY KEY,
+				enum_value shared_enum NOT NULL,
+				domain_value shared_domain NOT NULL,
+				composite_value shared_composite NOT NULL
+			) USING orioledb;
+			INSERT INTO o_test VALUES (1, 'one', 1, ROW(1));
+		""")
+		node.safe_psql("CREATE DATABASE type_target TEMPLATE type_source;")
+
+		oid_query = """
+			SELECT 'shared_enum'::regtype::oid,
+				   'shared_domain'::regtype::oid,
+				   'shared_composite'::regtype::oid,
+				   'o_test'::regclass::oid;
+		"""
+		self.assertEqual(node.execute("type_source", oid_query),
+		                 node.execute("type_target", oid_query))
+
+		description_query = """
+			SELECT orioledb_table_description('o_test'::regclass);
+		"""
+		source_description = node.execute("type_source", description_query)
+		node.safe_psql("type_target", """
+			DROP TYPE shared_enum CASCADE;
+			DROP DOMAIN shared_domain CASCADE;
+			DROP TYPE shared_composite CASCADE;
+			INSERT INTO o_test (id) VALUES (2);
+		""")
+		self.assertEqual([(1, ), (2, )],
+		                 node.execute("type_target",
+		                              "SELECT * FROM o_test ORDER BY id;"))
+		self.assertEqual(source_description,
+		                 node.execute("type_source", description_query))
+
+		node.safe_psql("type_source", """
+			INSERT INTO o_test VALUES (2, 'two', 2, ROW(2));
+		""")
+		self.assertEqual([(1, 'one', 1, 1), (2, 'two', 2, 2)], node.execute(
+		    "type_source", """
+				SELECT id, enum_value::text, domain_value,
+					   (composite_value).value
+					FROM o_test ORDER BY id;
+			"""))
+
+		node.stop(['-m', 'immediate'])
+		node.start()
+		self.assertEqual(source_description,
+		                 node.execute("type_source", description_query))
+		self.assertEqual([(1, 'one', 1, 1), (2, 'two', 2, 2)], node.execute(
+		    "type_source", """
+				SELECT id, enum_value::text, domain_value,
+					   (composite_value).value
+					FROM o_test ORDER BY id;
+			"""))
+
 	def test_enum_index_recovery(self):
 		enum_amount = 0
 		enumoid_amount = 0


### PR DESCRIPTION
Filter OrioleDB table metadata by database OID before matching a dropped type OID, preventing same-OID columns in other databases from being marked as dropped. Add coverage for enum, domain, and composite types in template-cloned databases.