### PR TITLE
Reclaim undo files by what the retain set still needs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/wal_savepoint_buffer_test.py \
 						test/t/toast_index_test.py \
 						test/t/trigger_test.py \
+						test/t/undo_cleanup_test.py \
 						test/t/unlogged_test.py \
 						test/t/vacuum_test.py \
 						test/t/transaction_test.py \

--- a/include/transam/oxid.h
+++ b/include/transam/oxid.h
@@ -34,6 +34,13 @@ typedef struct
 	pg_atomic_uint64 checkpointRetainXmin;
 	pg_atomic_uint64 checkpointRetainXmax;
 	pg_atomic_uint64 cleanedXmin;
+
+	/*
+	 * Lowest xidmap file number that may still exist.  See
+	 * o_buffers_unlink_dead_files().
+	 */
+	pg_atomic_uint64 cleanedFileCursor;
+	pg_atomic_uint64 cleanedGapFileCursor;
 	pg_atomic_uint64 cleanedCheckpointXmin;
 	pg_atomic_uint64 cleanedCheckpointXmax;
 

--- a/include/transam/undo.h
+++ b/include/transam/undo.h
@@ -178,6 +178,14 @@ typedef struct
 	 * during the last cleanup.
 	 */
 	pg_atomic_uint64 cleanedLocation;
+
+	/*
+	 * Lowest undo file number that may still exist.  Advanced only past files
+	 * that were actually unlinked, so nothing can be skipped; see
+	 * o_buffers_unlink_dead_files().
+	 */
+	pg_atomic_uint64 cleanedFileCursor;
+	pg_atomic_uint64 cleanedGapFileCursor;
 	pg_atomic_uint64 cleanedCheckpointStartLocation;
 	pg_atomic_uint64 cleanedCheckpointEndLocation;
 

--- a/include/utils/o_buffers.h
+++ b/include/utils/o_buffers.h
@@ -56,9 +56,10 @@ extern void o_buffers_unlink_blocks_range(OBuffersDesc *desc,
 										  uint32 tag,
 										  int64 firstBlockNumber,
 										  int64 lastBlockNumber);
-extern void unlink_unretained_o_buffers(OBuffersDesc *desc, uint32 tag,
+extern void o_buffers_unlink_dead_files(OBuffersDesc *desc, uint32 tag,
 										int64 itemsPerBlock,
-										int64 cleanupStart, int64 cleanupEnd,
+										pg_atomic_uint64 *belowCursor,
+										pg_atomic_uint64 *gapCursor,
 										int64 chkpRetainStart,
 										int64 chkpRetainEnd,
 										int64 transactionRetainStart);

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -288,6 +288,8 @@ checkpoint_shmem_init(Pointer ptr, bool found)
 			pg_atomic_init_u64(&undo_meta->minProcTransactionRetainLocation, 0);
 			pg_atomic_init_u64(&undo_meta->minProcReservedLocation, 0);
 			pg_atomic_init_u64(&undo_meta->cleanedLocation, 0);
+			pg_atomic_init_u64(&undo_meta->cleanedFileCursor, 0);
+			pg_atomic_init_u64(&undo_meta->cleanedGapFileCursor, 0);
 			pg_atomic_init_u64(&undo_meta->checkpointRetainStartLocation, 0);
 			pg_atomic_init_u64(&undo_meta->checkpointRetainEndLocation, 0);
 			pg_atomic_init_u64(&undo_meta->cleanedCheckpointStartLocation, 0);
@@ -303,6 +305,8 @@ checkpoint_shmem_init(Pointer ptr, bool found)
 		pg_atomic_init_u64(&xid_meta->checkpointRetainXmin, FirstNormalTransactionId);
 		pg_atomic_init_u64(&xid_meta->checkpointRetainXmax, FirstNormalTransactionId);
 		pg_atomic_init_u64(&xid_meta->cleanedXmin, FirstNormalTransactionId);
+		pg_atomic_init_u64(&xid_meta->cleanedFileCursor, 0);
+		pg_atomic_init_u64(&xid_meta->cleanedGapFileCursor, 0);
 		pg_atomic_init_u64(&xid_meta->cleanedCheckpointXmin, FirstNormalTransactionId);
 		pg_atomic_init_u64(&xid_meta->cleanedCheckpointXmax, FirstNormalTransactionId);
 

--- a/src/transam/oxid.c
+++ b/src/transam/oxid.c
@@ -1543,14 +1543,14 @@ advance_global_xmin(OXid newXid)
 
 	if (doCleanup)
 	{
-		unlink_unretained_o_buffers(&buffersDesc, OXID_BUFFERS_TAG,
+		/*
+		 * Drop every xidmap file that holds nothing still retained; see
+		 * o_buffers_unlink_dead_files().
+		 */
+		o_buffers_unlink_dead_files(&buffersDesc, OXID_BUFFERS_TAG,
 									ORIOLEDB_BLCKSZ / sizeof(OXidMapItem),
-									oldCheckpointXmin, oldCheckpointXmax,
-									newCheckpointXmin, newCheckpointXmax,
-									globalXmin);
-		unlink_unretained_o_buffers(&buffersDesc, OXID_BUFFERS_TAG,
-									ORIOLEDB_BLCKSZ / sizeof(OXidMapItem),
-									oldCleanedXmin, globalXmin,
+									&xid_meta->cleanedFileCursor,
+									&xid_meta->cleanedGapFileCursor,
 									newCheckpointXmin, newCheckpointXmax,
 									globalXmin);
 	}

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -735,21 +735,14 @@ update_min_undo_locations(UndoLogType undoType,
 			   minRetainLocation / UNDO_FILE_SIZE >= oldCheckpointStartLocation / UNDO_FILE_SIZE);
 
 		/*
-		 * Old active retain that's no longer retained. Capped at the new
-		 * active retain start, since [minRetainLocation, +inf) is still kept.
+		 * Drop every undo file that holds nothing still retained.  The retain
+		 * set alone decides, so it does not matter how the cleaned boundary
+		 * happens to fall inside a file.
 		 */
-		unlink_unretained_o_buffers(&undoBuffersDesc, (uint32) undoType,
+		o_buffers_unlink_dead_files(&undoBuffersDesc, (uint32) undoType,
 									ORIOLEDB_BLCKSZ,
-									oldCleanedLocation, minRetainLocation,
-									newCheckpointStartLocation,
-									newCheckpointEndLocation,
-									minRetainLocation);
-
-		/* Old checkpoint retain range that's no longer retained. */
-		unlink_unretained_o_buffers(&undoBuffersDesc, (uint32) undoType,
-									ORIOLEDB_BLCKSZ,
-									oldCheckpointStartLocation,
-									oldCheckpointEndLocation,
+									&meta->cleanedFileCursor,
+									&meta->cleanedGapFileCursor,
 									newCheckpointStartLocation,
 									newCheckpointEndLocation,
 									minRetainLocation);

--- a/src/utils/o_buffers.c
+++ b/src/utils/o_buffers.c
@@ -618,99 +618,97 @@ o_buffers_unlink_blocks_range(OBuffersDesc *desc, uint32 tag,
 }
 
 /*
- * Discard items in [cleanupStart, cleanupEnd) that are no longer kept by the
- * retain set [chkpRetainStart, chkpRetainEnd) U [transactionRetainStart, +inf).
- * Fully covered files are unlinked.  The leading file is also unlinked when
- * it lies entirely outside the retain set, so successive concurrent calls
- * with non-file-aligned boundaries don't leave orphan partial-coverage files.
+ * Move a reclaim cursor forward, never back.
+ *
+ * The cursors are only a hint that saves a call from redoing the previous
+ * one's work, so a concurrent caller that computed a lower value may lose the
+ * race harmlessly -- the worst outcome is one repeated sweep over files that
+ * are already gone.
+ */
+static void
+advance_cursor(pg_atomic_uint64 *cursor, int64 fileNumber)
+{
+	uint64		old = pg_atomic_read_u64(cursor);
+
+	while (old < (uint64) fileNumber)
+	{
+		if (pg_atomic_compare_exchange_u64(cursor, &old, (uint64) fileNumber))
+			break;
+	}
+}
+
+/*
+ * Unlink every file that holds nothing the retain set still needs.
+ *
+ * The retain set is [chkpRetainStart, chkpRetainEnd) U [transactionRetainStart,
+ * +inf), so the dead items form two intervals; a file is reclaimable exactly
+ * when it lies wholly inside one of them.  Rounding each interval inwards to
+ * whole files gives those files directly, without walking the range.
+ *
+ * The point of deciding per file against the *current* retain set, rather than
+ * per byte range against one caller-supplied range, is that a file straddling
+ * an interval edge is simply retried on every later call, until the edge has
+ * moved past its end.  The previous scheme unlinked only what a single range
+ * covered wholly and never revisited an older range, so the file holding the
+ * upper edge of a retired checkpoint retain range stayed on disk for good --
+ * one leaked file per checkpoint.
+ *
+ * Both cursors are low-water marks of "already reclaimed up to here", kept so
+ * that a call does not redo the work of the previous one; leaving them at 0
+ * only costs one extra sweep, which is how a cluster carrying files leaked by
+ * an earlier version reclaims them.
+ *
  * itemsPerBlock is the count of caller-defined items in one ORIOLEDB_BLCKSZ
  * block.
- *
- * Partition of items in [cleanupStart, cleanupEnd) against the new retain set:
- *
- *   1. item < retainStart                                  -- unlink
- *   2. item in [retainStart, chkpRetainEnd)                -- chkp, keep
- *   3. item in [chkpRetainEnd, transactionRetainStart)      -- gap, unlink
- *      (only reachable when chkpRetainEnd < transactionRetainStart)
- *   4. item >= transactionRetainStart                       -- active, keep
- *
- * When the chkp range is empty, retainStart = transactionRetainStart, the gap
- * branch is skipped, and everything below transactionRetainStart falls into
- * case 1.
  */
 void
-unlink_unretained_o_buffers(OBuffersDesc *desc, uint32 tag, int64 itemsPerBlock,
-							int64 cleanupStart, int64 cleanupEnd,
+o_buffers_unlink_dead_files(OBuffersDesc *desc, uint32 tag,
+							int64 itemsPerBlock,
+							pg_atomic_uint64 *belowCursor,
+							pg_atomic_uint64 *gapCursor,
 							int64 chkpRetainStart, int64 chkpRetainEnd,
 							int64 transactionRetainStart)
 {
 	int64		blocksPerFile = desc->singleFileSize / ORIOLEDB_BLCKSZ;
-	int64		retainStart;
-	int64		finish;
+	int64		itemsPerFile = blocksPerFile * itemsPerBlock;
+	bool		haveChkp = chkpRetainStart < chkpRetainEnd;
+	int64		firstFile,
+				lastFile;
 
 	/*
 	 * Block arithmetic below uses index / itemsPerBlock, which is only
 	 * correct when items align to block boundaries.  For straddling items
 	 * (e.g. RewindItem) the caller must compute block ranges itself and call
-	 * o_buffers_unlink_blocks_range directly.
+	 * o_buffers_unlink_blocks_range() directly.
 	 */
 	Assert(ORIOLEDB_BLCKSZ % itemsPerBlock == 0);
 
-	if (cleanupStart >= cleanupEnd)
-		return;
-
-	if (chkpRetainStart < chkpRetainEnd)
-		retainStart = Min(chkpRetainStart, transactionRetainStart);
-	else
-		retainStart = transactionRetainStart;
-
-	/* Case 1: items below the new persist start. */
-	finish = Min(cleanupEnd, retainStart);
-	if (cleanupStart < finish)
+	/*
+	 * Below the retain set entirely.  The checkpoint range can start above
+	 * the live tail, so the lower edge of the retain set is the smaller of
+	 * the two -- taking chkpRetainStart alone would reclaim live undo.
+	 */
+	firstFile = pg_atomic_read_u64(belowCursor);
+	lastFile = (haveChkp ? Min(chkpRetainStart, transactionRetainStart)
+				: transactionRetainStart) / itemsPerFile;
+	if (firstFile < lastFile)
 	{
-		int64		firstBlock = (cleanupStart + itemsPerBlock - 1) / itemsPerBlock;
-		int64		lastBlock = finish / itemsPerBlock - 1;
-		int64		retainBlock = retainStart / itemsPerBlock;
-		int64		leadFile = firstBlock / blocksPerFile;
-
-		/*
-		 * If the file containing the leading edge is entirely below retain,
-		 * extend the range down to its first block so the file is unlinked
-		 * rather than left as a stale partial-coverage shell.  The bytes
-		 * below cleanupStart in that file are below the previous cleaned
-		 * boundary and therefore already dead.
-		 */
-		if ((leadFile + 1) * blocksPerFile <= retainBlock)
-			firstBlock = leadFile * blocksPerFile;
-
-		o_buffers_unlink_blocks_range(desc, tag, firstBlock, lastBlock);
+		o_buffers_unlink_blocks_range(desc, tag, firstFile * blocksPerFile,
+									  lastFile * blocksPerFile - 1);
+		advance_cursor(belowCursor, lastFile);
 	}
 
-	/* Case 3: gap above chkpRetainEnd and below current retain. */
-	if (chkpRetainStart < chkpRetainEnd && chkpRetainEnd < transactionRetainStart)
+	/* The gap between the checkpoint range and the live tail. */
+	if (haveChkp)
 	{
-		int64		gapStart = Max(cleanupStart, chkpRetainEnd);
-		int64		gapEnd = Min(cleanupEnd, transactionRetainStart);
-
-		if (gapStart < gapEnd)
+		firstFile = (chkpRetainEnd + itemsPerFile - 1) / itemsPerFile;
+		firstFile = Max(firstFile, (int64) pg_atomic_read_u64(gapCursor));
+		lastFile = transactionRetainStart / itemsPerFile;
+		if (firstFile < lastFile)
 		{
-			int64		firstBlock = (gapStart + itemsPerBlock - 1) / itemsPerBlock;
-			int64		lastBlock = gapEnd / itemsPerBlock - 1;
-			int64		retainBlock = transactionRetainStart / itemsPerBlock;
-			int64		chkpEndBlock = (chkpRetainEnd + itemsPerBlock - 1) / itemsPerBlock;
-			int64		leadFile = firstBlock / blocksPerFile;
-			int64		leadFileFirst = leadFile * blocksPerFile;
-
-			/*
-			 * Extend only when the leading file sits entirely inside the gap
-			 * (above chkpRetainEnd and below transactionRetainStart): then
-			 * every item in it is dead.
-			 */
-			if (leadFileFirst >= chkpEndBlock &&
-				leadFileFirst + blocksPerFile <= retainBlock)
-				firstBlock = leadFileFirst;
-
-			o_buffers_unlink_blocks_range(desc, tag, firstBlock, lastBlock);
+			o_buffers_unlink_blocks_range(desc, tag, firstFile * blocksPerFile,
+										  lastFile * blocksPerFile - 1);
+			advance_cursor(gapCursor, lastFile);
 		}
 	}
 }

--- a/test/t/undo_cleanup_test.py
+++ b/test/t/undo_cleanup_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import os
+import re
+import threading
+import time
+import unittest
+
+from .base_test import BaseTest
+
+UNDO_FILE_SIZE = 0x4000000
+WORKERS = 4
+ROUNDS = 8
+ROWS = 40000
+
+
+class UndoCleanupTest(BaseTest):
+
+	def undo_files(self, node):
+		"""Numbers of the row-undo files currently on disk."""
+		undo_dir = os.path.join(node.data_dir, 'orioledb_undo')
+		result = []
+		for name in os.listdir(undo_dir):
+			match = re.match(r'^([0-9A-F]{10})row$', name)
+			if match:
+				result.append(int(match.group(1), 16))
+		return sorted(result)
+
+	def unretained_undo_files(self, node):
+		"""Undo files holding nothing that any retain position still keeps.
+
+		The retain set is the checkpoint range plus everything from the
+		current retain location on; a file outside both is garbage that
+		cleanup was supposed to have unlinked.
+		"""
+		(chkp_start, chkp_end, retain) = node.execute("""
+			SELECT checkpointRetainStartLocation, checkpointRetainEndLocation,
+			       minProcRetainLocation
+			FROM orioledb_get_undo_meta() WHERE undo_type = 'row';
+		""")[0]
+
+		result = []
+		for file_num in self.undo_files(node):
+			low = file_num * UNDO_FILE_SIZE
+			high = low + UNDO_FILE_SIZE
+			live = high > retain
+			in_chkp = chkp_start < chkp_end and low < chkp_end and chkp_start < high
+			if not live and not in_chkp:
+				result.append(file_num)
+		return result
+
+	def test_no_undo_file_outlives_its_retain(self):
+		"""Cleanup must not leave an undo file no retain position keeps.
+
+		Cleanup used to unlink only what a single caller-supplied range
+		covered wholly.  The file holding the upper edge of a retired
+		checkpoint retain range is covered only partially, and no later call
+		revisits that range -- so it stayed on disk for good, one 64 MB file
+		per checkpoint.
+
+		Three things are needed to reach that state, and dropping any of them
+		hides the bug: the retain position has to keep moving (a single
+		unmoving snapshot blocks cleanup outright), several sessions have to
+		churn concurrently, and a checkpoint has to retire a range whose edge
+		falls inside a file rather than on its boundary.
+		"""
+		node = self.node
+		node.append_conf('orioledb.undo_buffers = 256\n')
+		node.append_conf('orioledb.main_buffers = 8MB\n')
+		node.append_conf('checkpoint_timeout = 1h\n')
+		node.append_conf('max_connections = 30\n')
+		node.start()
+		node.safe_psql("""
+			CREATE EXTENSION IF NOT EXISTS orioledb;
+			CREATE TABLE o_churn (id int PRIMARY KEY, pad text) USING orioledb;
+			INSERT INTO o_churn SELECT g, repeat('x', 2000)
+				FROM generate_series(1, %d) g;
+		""" % ROWS)
+
+		stop = threading.Event()
+		failures = []
+
+		def churn(worker):
+			# Each round runs under a fresh snapshot, so the retain position
+			# advances instead of standing still.  Keep '%' out of the SQL:
+			# psycopg2 reads it as a parameter placeholder.
+			low = 1 + worker * (ROWS // WORKERS)
+			high = low + (ROWS // WORKERS) - 1
+			con = node.connect()
+			try:
+				while not stop.is_set():
+					con.begin('repeatable read')
+					con.execute("SELECT count(*) FROM o_churn "
+					            "WHERE id BETWEEN %d AND %d;" % (low, high))
+					con.execute("UPDATE o_churn SET pad = repeat('y', 2000) "
+					            "WHERE id BETWEEN %d AND %d;" % (low, high))
+					con.commit()
+			except Exception as e:
+				failures.append("worker %d: %s" % (worker, e))
+			finally:
+				con.close()
+
+		threads = [
+		    threading.Thread(target=churn, args=(worker, ), daemon=True)
+		    for worker in range(WORKERS)
+		]
+		for thread in threads:
+			thread.start()
+		try:
+			for _ in range(ROUNDS):
+				time.sleep(1.5)
+				node.safe_psql("CHECKPOINT;")
+		finally:
+			stop.set()
+			for thread in threads:
+				thread.join(timeout=60)
+		self.assertEqual(failures, [])
+
+		# Nothing is retained any more, so a last cleanup round has to leave
+		# only the checkpoint range and the live tail behind.
+		for _ in range(2):
+			node.safe_psql("UPDATE o_churn SET pad = repeat('z', 2000);")
+			node.safe_psql("CHECKPOINT;")
+
+		unretained = self.unretained_undo_files(node)
+		self.assertEqual(
+		    unretained, [], "undo files kept by nothing: %r (of %r)" %
+		    (unretained, self.undo_files(node)))

--- a/test/t/undo_cleanup_test.py
+++ b/test/t/undo_cleanup_test.py
@@ -67,7 +67,10 @@ class UndoCleanupTest(BaseTest):
 		"""
 		node = self.node
 		node.append_conf('orioledb.undo_buffers = 256\n')
-		node.append_conf('orioledb.main_buffers = 8MB\n')
+		# The page pool only has to hold the concurrent updates; it plays no
+		# part in the bug.  8MB was enough locally but exhausted the pool on
+		# CI, where four 20 MB statements overlap.
+		node.append_conf('orioledb.main_buffers = 256MB\n')
 		node.append_conf('checkpoint_timeout = 1h\n')
 		node.append_conf('max_connections = 30\n')
 		node.start()


### PR DESCRIPTION
## The leak

An OrioleDB cluster loses one 64 MB undo file per checkpoint, permanently,
under any workload — no crash or backend kill required.

Root-caused from a 96 GB `orioledb_undo` directory left by a churning
cluster, by parsing `orioledb_data/control` offline and classifying every file
against the persisted retain positions (starting the cluster would have let
startup cleanup destroy the evidence):

```
lastCheckpointNumber        1549
undoInfo[0] UndoLogRegular  last = file 30578 (1911 GB written)
                            retain 30571..30577
justified                      8 files
written after the checkpoint  12 files
ORPHANED                    1529 files = 95.6 GB
```

- **0.987 orphans per checkpoint**
- gap between consecutive orphans: `20 -> 1372 times`, `19 -> 102`, `21 -> 35`, mean 19.99
- undo produced per checkpoint: 30578/1549 = **19.74 files**

So the leak is exactly one file per checkpoint and strictly periodic. A
prediction from that reading held: the orphans end `… 30517, 30537, 30557`,
so the next one should be file 30577 — and `undoInfo[0].retainEnd` is file
30577.

## Why

`o_buffers_unlink_blocks_range()` unlinks a file only when a **single** call
covers it wholly:

```c
if (from == fileFirstBlock && to == fileLastBlock) unlink_file(...);
else if (orioledb_use_sparse_files)   /* off by default -> nothing happens */
```

A retired checkpoint retain range is visited by exactly one call
(`undo.c`, "Old checkpoint retain range that's no longer retained"), its upper
edge falls inside a file, and `cleanedLocation` has already moved above it, so
nothing revisits that range. A leading-file extension exists; there is no
symmetric trailing one.

## The change

Decide per file against the current retain set instead of per byte range
against one caller-supplied range. The dead items form two intervals, and
rounding each inwards to whole files names the reclaimable files directly —
no walking, O(1). A file straddling an edge is retried on every later call
until the edge moves past its end, which is precisely what the old scheme
never did.

Two low-water cursors keep a call from redoing the previous one's work. They
start at zero, so an existing cluster reclaims what earlier versions leaked on
its first cleanup.

The xidmap files share the helper and had the same defect.

## Test

`test/t/undo_cleanup_test.py` asserts the general invariant: no undo file lies
entirely outside the retain set. **Fails 3/3 on `main`** (7 orphans each run,
8 checkpoints → 7 retired ranges), **passes 3/3 with this change**, ~25 s.

Three ingredients are needed and each is documented in the test, because
dropping any one of them hides the bug: a snapshot pin that keeps moving (a
single unmoving pin blocks cleanup outright), several concurrent churn
sessions, and more than one file of undo per checkpoint.

## Checks

regress 50/50, isolation 38/38, testgres green.
