### PR TITLE
Size an index build's parallelism in pages, not bytes

### DIFF
--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -1935,7 +1935,7 @@ static int
 o_calculate_index_workers(BTreeDescr *primary, bool shmem_loaded, int nindices)
 {
 	int			parallel_workers;
-	BlockNumber table_blocks;
+	BlockNumber table_pages;
 
 	if (IsTransactionState())
 	{
@@ -1946,8 +1946,8 @@ o_calculate_index_workers(BTreeDescr *primary, bool shmem_loaded, int nindices)
 			if (!shmem_loaded)
 				o_btree_load_shmem(primary);
 
-			table_blocks = (uint64) TREE_NUM_LEAF_PAGES(primary) * ORIOLEDB_BLCKSZ;
-			parallel_workers = o_estimate_parallel_workers(table_blocks, -1, max_parallel_maintenance_workers);
+			table_pages = TREE_NUM_LEAF_PAGES(primary);
+			parallel_workers = o_estimate_parallel_workers(table_pages, -1, max_parallel_maintenance_workers);
 			elog(DEBUG4, "o_calculate_index_workers: %d workers", parallel_workers);
 		}
 		else


### PR DESCRIPTION
## The bug

`o_calculate_index_workers()` converts the tree's leaf page count to **bytes**
before handing it to an estimator that wants **pages**:

```c
table_blocks = (uint64) TREE_NUM_LEAF_PAGES(primary) * ORIOLEDB_BLCKSZ;
parallel_workers = o_estimate_parallel_workers(table_blocks, -1,
                                               max_parallel_maintenance_workers);
```

`o_estimate_parallel_workers()` names that parameter `table_pages` and compares
it against `min_parallel_table_scan_size`, a GUC measured in blocks — and
`TREE_NUM_LEAF_PAGES` is a page count everywhere else (`info->pages`,
`stats->num_pages`). The value arrives 8192x too large, so:

- the `table_pages < min_parallel_table_scan_size` early return never fires;
- the log-scale worker count always saturates `max_parallel_maintenance_workers`.

Every non-empty table builds its indexes in parallel, no matter how small.

## Measured

With `min_parallel_table_scan_size = 8MB`, `max_parallel_maintenance_workers = 2`:

| table | before | after |
|---|---|---|
| 100 rows (one leaf page) | `o_calculate_index_workers: 2 workers`, parallel build | `0 workers`, serial build |
| 92 MB | — | `2 workers`, parallel build |

So parallelism is kept where it pays and dropped where a DSM segment, shared
tuplesort coordination and a launched worker were pure overhead for a one-page
tree.

## Note

This applies during recovery too: a replica rebuilding a small index no longer
engages the dedicated index-build pool, so that path sees less exercise in
CI than it used to.

There is no user-visible output for the chosen worker count, so the numbers
above come from the existing `DEBUG4` line in `o_calculate_index_workers()`
plus the `parallel/serial index build` `DEBUG1` line; I did not find a natural
hook to assert on in a regression test.

regress 50/50.
