### PR TITLE
Handle refind_page failure in the merge retry loop

### DIFF
--- a/src/btree/merge.c
+++ b/src/btree/merge.c
@@ -411,7 +411,7 @@ btree_try_merge_and_unlock(BTreeDescr *desc, OInMemoryBlkno blkno,
 
 		if (!page_is_locked(parent_blkno))
 		{
-			OFindPageResult result PG_USED_FOR_ASSERTS_ONLY;
+			OFindPageResult result;
 
 			/* refind parent page if needed */
 			if (!O_TUPLE_IS_NULL(key.tuple))
@@ -422,7 +422,8 @@ btree_try_merge_and_unlock(BTreeDescr *desc, OInMemoryBlkno blkno,
 				result = refind_page(&find_context, NULL, BTreeKeyRightmost,
 									 level + 1,
 									 parent_blkno, parent_change_count);
-			Assert(result == OFindPageResultSuccess);
+			if (result != OFindPageResultSuccess)
+				break;
 		}
 
 		/* Step 3: do all the checks with parent and target */


### PR DESCRIPTION
cfd7c804 added TRY_LOCK and handled find_page failure for the initial parent descent, but the refind_page inside the while(true) loop still used Assert(result == OFindPageResultSuccess). The loop's continue paths (IO waits) unlock all pages, so the tree can be dropped before the refind, making the Assert fire during recovery undo.