### PR TITLE
Stabilize bitmap_test plan in index_bridging under Valgrind

### DIFF
--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -4008,6 +4008,7 @@ DETAIL:  index access method 'btree' is requested with index bridging for Oriole
 CREATE INDEX bitmap_test_ix4 ON bitmap_test (h);
 ANALYZE bitmap_test;
 SET enable_seqscan = off;
+SET cpu_tuple_cost = 0.05;
 CREATE VIEW bitmap_test_mv AS (SELECT * FROM bitmap_test WHERE i < 100 AND h < 100 OR j < 100 LIMIT 20);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bitmap_test_mv;
                                  QUERY PLAN                                 
@@ -4167,6 +4168,7 @@ SELECT * FROM bitmap_test_mv;
 
 DROP VIEW bitmap_test_mv;
 RESET enable_seqscan;
+RESET cpu_tuple_cost;
 CREATE TABLE test_no_bmscan_on_text_pkey (data1 text PRIMARY KEY, data2 text, data3 text, i int) USING orioledb;
 CREATE INDEX ON test_no_bmscan_on_text_pkey USING spgist (data2);
 NOTICE:  index bridging is enabled for orioledb table 'test_no_bmscan_on_text_pkey'

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -4085,6 +4085,7 @@ DETAIL:  index access method 'btree' is requested with index bridging for Oriole
 CREATE INDEX bitmap_test_ix4 ON bitmap_test (h);
 ANALYZE bitmap_test;
 SET enable_seqscan = off;
+SET cpu_tuple_cost = 0.05;
 CREATE VIEW bitmap_test_mv AS (SELECT * FROM bitmap_test WHERE i < 100 AND h < 100 OR j < 100 LIMIT 20);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bitmap_test_mv;
                                  QUERY PLAN                                 
@@ -4244,6 +4245,7 @@ SELECT * FROM bitmap_test_mv;
 
 DROP VIEW bitmap_test_mv;
 RESET enable_seqscan;
+RESET cpu_tuple_cost;
 CREATE TABLE test_no_bmscan_on_text_pkey (data1 text PRIMARY KEY, data2 text, data3 text, i int) USING orioledb;
 CREATE INDEX ON test_no_bmscan_on_text_pkey USING spgist (data2);
 NOTICE:  index bridging is enabled for orioledb table 'test_no_bmscan_on_text_pkey'

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -777,6 +777,7 @@ CREATE INDEX bitmap_test_ix4 ON bitmap_test (h);
 ANALYZE bitmap_test;
 
 SET enable_seqscan = off;
+SET cpu_tuple_cost = 0.05;
 
 CREATE VIEW bitmap_test_mv AS (SELECT * FROM bitmap_test WHERE i < 100 AND h < 100 OR j < 100 LIMIT 20);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bitmap_test_mv;
@@ -797,6 +798,7 @@ SELECT * FROM bitmap_test_mv;
 DROP VIEW bitmap_test_mv;
 
 RESET enable_seqscan;
+RESET cpu_tuple_cost;
 
 CREATE TABLE test_no_bmscan_on_text_pkey (data1 text PRIMARY KEY, data2 text, data3 text, i int) USING orioledb;
 CREATE INDEX ON test_no_bmscan_on_text_pkey USING spgist (data2);


### PR DESCRIPTION
Fix flaky valid plan change in test seen on CI:

```
--- /home/runner/_work/orioledb/orioledb/orioledb/test/expected/index_bridging_1.out	2026-09-03 13:45:17.769922872 +0000
+++ /home/runner/_work/orioledb/orioledb/orioledb/test/results/index_bridging.out	2026-09-03 14:02:49.505263796 +0000
@@ -4191,25 +4191,21 @@
 DROP VIEW bitmap_test_mv;
 CREATE VIEW bitmap_test_mv AS (SELECT * FROM bitmap_test WHERE i < 100 AND j < 100 AND k < 200 OR h < 100 LIMIT 20);
 EXPLAIN (COSTS OFF) SELECT count(*) FROM bitmap_test_mv;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Aggregate
    ->  Limit
          ->  Result
                ->  Custom Scan (o_scan) on bitmap_test
+                     Filter: (((i < 100) AND (j < 100) AND (k < 200)) OR (h < 100))
                      Bitmap heap scan
-                     Recheck Cond: (((i < 100) AND (j < 100) AND (k < 200)) OR (h < 100))
+                     Recheck Cond: ((k < 200) OR (h < 100))
                      ->  BitmapOr
-                           ->  BitmapAnd
-                                 ->  Bitmap Index Scan on bitmap_test_ix1
-                                       Index Cond: (i < 100)
-                                 ->  Bitmap Index Scan on bitmap_test_ix2
-                                       Index Cond: (j < 100)
-                                 ->  Bitmap Index Scan on bitmap_test_ix3
-                                       Index Cond: (k < 200)
+                           ->  Bitmap Index Scan on bitmap_test_ix3
+                                 Index Cond: (k < 200)
                            ->  Bitmap Index Scan on bitmap_test_ix4
                                  Index Cond: (h < 100)
-(16 rows)
+(12 rows)
```