### PR TITLE
Start draining undo earlier, and bound how long a drain holds the lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/toast_index_test.py \
 						test/t/trigger_test.py \
 						test/t/undo_cleanup_test.py \
+						test/t/undo_reserved_race_test.py \
 						test/t/unlogged_test.py \
 						test/t/vacuum_test.py \
 						test/t/transaction_test.py \

--- a/include/transam/undo.h
+++ b/include/transam/undo.h
@@ -370,6 +370,48 @@ extern PendingTruncatesMeta *pending_truncates_meta;
 										AssertMacro((int) (undoType) >= 0 && (int) (undoType) < (int) UndoLogsCount), \
 										&oProcData[MYPROCNUMBER].undoStackLocations[oProcData[MYPROCNUMBER].autonomousNestingLevel][(int) (undoType)])
 
+/*
+ * How much of the circular buffer each actor tries to keep free.
+ *
+ * The bgwriter aims higher than backends on purpose.  It should start
+ * draining while there is still room, so that a backend -- which can only
+ * evict from inside reserve_undo_size_extended(), where the write sits on the
+ * critical path of a running transaction -- normally finds the space already
+ * made for it.  Backends only pitch in once the ring is genuinely tight.
+ */
+#define UNDO_FREE_FRACTION_BGWRITER 10	/* bgwriter keeps 1/10 free */
+#define UNDO_FREE_FRACTION_BACKEND	20	/* backends step in below 1/20 */
+
+/*
+ * Bytes of the circular buffer that undo may still be written into without
+ * waiting for a drain.
+ */
+static inline UndoLocation
+undo_free_space(UndoMeta *meta, Size circularBufferSize)
+{
+	UndoLocation writeInProgressLocation = pg_atomic_read_u64(&meta->writeInProgressLocation);
+	UndoLocation lastUsedLocation = pg_atomic_read_u64(&meta->lastUsedLocation);
+
+	if (writeInProgressLocation + circularBufferSize <= lastUsedLocation)
+		return 0;
+	return writeInProgressLocation + circularBufferSize - lastUsedLocation;
+}
+
+/*
+ * The drain frontier that would leave 1/fraction of the ring free, given the
+ * undo produced so far.
+ */
+static inline UndoLocation
+undo_evict_target(UndoLocation lastUsedLocation, Size circularBufferSize,
+				  int fraction)
+{
+	Size		keepFree = circularBufferSize / fraction;
+
+	if (lastUsedLocation + keepFree <= circularBufferSize)
+		return 0;
+	return lastUsedLocation + keepFree - circularBufferSize;
+}
+
 extern Size undo_shmem_needs(void);
 extern void undo_shmem_init(Pointer buf, bool found);
 extern UndoMeta *get_undo_meta_by_type(UndoLogType undoType);

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -2073,6 +2073,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 	while (get_next_downlink(scan, &downlink, &scan->keyRangeLow, &scan->keyRangeHigh))
 	{
 		bool		valid_downlink = true;
+		bool		readUndo;
 
 		/*
 		 * Check if this downlink's key range overlaps the scan's
@@ -2216,6 +2217,25 @@ iterate_internal_page(BTreeSeqScan *scan)
 					leafPartial = &scan->leafPartial;
 				}
 
+				/*
+				 * A sampling scan runs on COMMITSEQNO_INPROGRESS and must not
+				 * walk page-level undo.  imgReadCsn is a normal csn even then
+				 * -- it comes from the internal page image -- so without this
+				 * the leaf read would rebuild a historical image from the
+				 * page log.  ANALYZE deliberately drops its hold on that log
+				 * so a minutes-long sample does not pin the ring, and the
+				 * record it wanted is then gone:
+				 *
+				 * undo_read -> get_page_from_undo -> read_page_from_undo ->
+				 * o_btree_try_read_page -> iterate_internal_page
+				 *
+				 * Reading the live page instead may hand sampling a row or
+				 * two it would not have seen at its snapshot, which is of no
+				 * consequence to a sample.
+				 */
+				readUndo = !(scan->sampler != NULL &&
+							 !COMMITSEQNO_IS_NORMAL(scan->oSnapshot.csn));
+
 				result = o_btree_try_read_page(scan->desc,
 											   DOWNLINK_GET_IN_MEMORY_BLKNO(downlink),
 											   DOWNLINK_GET_IN_MEMORY_CHANGECOUNT(downlink),
@@ -2224,7 +2244,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 											   NULL,
 											   BTreeKeyNone,
 											   leafPartial,
-											   true,
+											   readUndo,
 											   NULL);
 
 				if (result == ReadPageResultOK)

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1745,7 +1745,15 @@ read_disk_leaf_into_img(BTreeSeqScan *scan, uint64 downlinkLoc, CommitSeqNo csn)
 	read_result = read_page_from_disk(scan->desc, scan->leafImg, downlinkLoc,
 									  &extent);
 	header = (BTreePageHeader *) scan->leafImg;
-	if (header->csn >= csn)
+
+	/*
+	 * Only a normal csn asks for a historical image.  COMMITSEQNO_INPROGRESS
+	 * is 0, so without this test "header->csn >= csn" holds for every page
+	 * and a scan on such a snapshot walks a page log it has no business in --
+	 * o_btree_try_read_page() and load_first_historical_page() both make the
+	 * same check.
+	 */
+	if (COMMITSEQNO_IS_NORMAL(csn) && header->csn >= csn)
 		read_page_from_undo(scan->desc, scan->leafImg, header->undoLocation,
 							csn, NULL, BTreeKeyNone, NULL);
 
@@ -2073,7 +2081,6 @@ iterate_internal_page(BTreeSeqScan *scan)
 	while (get_next_downlink(scan, &downlink, &scan->keyRangeLow, &scan->keyRangeHigh))
 	{
 		bool		valid_downlink = true;
-		bool		readUndo;
 
 		/*
 		 * Check if this downlink's key range overlaps the scan's
@@ -2217,25 +2224,6 @@ iterate_internal_page(BTreeSeqScan *scan)
 					leafPartial = &scan->leafPartial;
 				}
 
-				/*
-				 * A sampling scan runs on COMMITSEQNO_INPROGRESS and must not
-				 * walk page-level undo.  imgReadCsn is a normal csn even then
-				 * -- it comes from the internal page image -- so without this
-				 * the leaf read would rebuild a historical image from the
-				 * page log.  ANALYZE deliberately drops its hold on that log
-				 * so a minutes-long sample does not pin the ring, and the
-				 * record it wanted is then gone:
-				 *
-				 * undo_read -> get_page_from_undo -> read_page_from_undo ->
-				 * o_btree_try_read_page -> iterate_internal_page
-				 *
-				 * Reading the live page instead may hand sampling a row or
-				 * two it would not have seen at its snapshot, which is of no
-				 * consequence to a sample.
-				 */
-				readUndo = !(scan->sampler != NULL &&
-							 !COMMITSEQNO_IS_NORMAL(scan->oSnapshot.csn));
-
 				result = o_btree_try_read_page(scan->desc,
 											   DOWNLINK_GET_IN_MEMORY_BLKNO(downlink),
 											   DOWNLINK_GET_IN_MEMORY_CHANGECOUNT(downlink),
@@ -2244,7 +2232,7 @@ iterate_internal_page(BTreeSeqScan *scan)
 											   NULL,
 											   BTreeKeyNone,
 											   leafPartial,
-											   readUndo,
+											   true,
 											   NULL);
 
 				if (result == ReadPageResultOK)
@@ -2572,7 +2560,20 @@ init_btree_seq_scan(BTreeSeqScan *scan)
 	init_page_find_context(&scan->context, desc, COMMITSEQNO_INPROGRESS,
 						   BTREE_PAGE_FIND_IMAGE |
 						   BTREE_PAGE_FIND_KEEP_LOKEY |
-						   BTREE_PAGE_FIND_READ_CSN);
+						   (sampler ? 0 : BTREE_PAGE_FIND_READ_CSN));
+
+	/*
+	 * Every page read below is made at context.imgReadCsn, which READ_CSN
+	 * fills in from the image actually read -- a normal csn, even though this
+	 * scan runs on COMMITSEQNO_INPROGRESS.  That is what sends the leaf reads
+	 * into the page log.  A sampling scan must stay out of it: ANALYZE drops
+	 * its hold on that log so a minutes-long sample does not pin the ring, so
+	 * the images are free to go.  Leave the csn non-normal for it, and every
+	 * read -- in memory or from disk -- takes the live page instead.
+	 * Sampling may then see a row or two it would not have seen at its
+	 * snapshot, which is of no consequence to a sample.
+	 */
+	scan->context.imgReadCsn = COMMITSEQNO_INPROGRESS;
 	clear_fixed_key(&scan->prevHikey);
 	clear_fixed_key(&scan->keyRangeHigh);
 	clear_fixed_key(&scan->keyRangeLow);

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -2048,6 +2048,35 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 	BlockNumber totalblocks;
 	ItemPointerData fake_iptr = {0};
 
+	/*
+	 * Sampling reads raw, latest tuples (stored below with
+	 * COMMITSEQNO_INPROGRESS) and never walks an undo chain, so the analyze
+	 * transaction's snapshot does not need the regular undo logs retained.
+	 *
+	 * Holding them does real damage: an autovacuum ANALYZE of a large table
+	 * runs for a minute or more, and for that whole time its snapshot pins
+	 * minProcRetainLocation.  The regular undo ring is far smaller than a
+	 * minute of undo production, so the eviction fast path can never discard
+	 * anything and every byte of undo is written to disk instead.
+	 *
+	 * Only for an autovacuum worker in READ COMMITTED, though.  Releasing the
+	 * retention is safe only when nothing else will read through this
+	 * snapshot afterwards, and that holds for autovacuum: the transaction is
+	 * its own, and past this scan it only writes pg_statistic.  A user's
+	 * ANALYZE can sit inside a REPEATABLE READ transaction, or alongside an
+	 * open cursor, whose later reads still need that snapshot's undo -- and
+	 * re-setting the location afterwards would not help, since the records
+	 * would already be gone.
+	 *
+	 * The system log stays retained either way: catalog access still goes
+	 * through the snapshot.
+	 */
+	if (AmAutoVacuumWorkerProcess() && XactIsoLevel == XACT_READ_COMMITTED)
+	{
+		clear_my_snapshot_retain_location(UndoLogRegular);
+		clear_my_snapshot_retain_location(UndoLogRegularPageLevel);
+	}
+
 	o_btree_load_shmem(&pk->desc);
 	totalblocks = TREE_NUM_LEAF_PAGES(&pk->desc);
 

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -2058,6 +2058,7 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 	BlockSamplerData bs;
 	BlockNumber totalblocks;
 	ItemPointerData fake_iptr = {0};
+	bool		releasedUndoRetain;
 
 	/*
 	 * Sampling reads raw, latest tuples (stored below with
@@ -2087,7 +2088,9 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 	 * The system log stays retained either way: catalog access still goes
 	 * through the snapshot.
 	 */
-	if (AmAutoVacuumWorkerProcess() && XactIsoLevel == XACT_READ_COMMITTED)
+	releasedUndoRetain = (AmAutoVacuumWorkerProcess() &&
+						  XactIsoLevel == XACT_READ_COMMITTED);
+	if (releasedUndoRetain)
 	{
 		clear_my_snapshot_retain_location(UndoLogRegular);
 		clear_my_snapshot_retain_location(UndoLogRegularPageLevel);
@@ -2172,6 +2175,26 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 										   &scanEnd, NULL);
 	}
 	free_btree_seq_scan(scan);
+
+	/*
+	 * Take the retain locations back now that the long part is over.  Only
+	 * the sampling scan itself is safe without them -- it reads the live page
+	 * and never walks a chain -- while the rest of this transaction is not,
+	 * and a reader that arrives after us would otherwise find its undo
+	 * recycled:
+	 *
+	 * PANIC: undo_read(): undo record was cleaned concurrently with the read:
+	 * undoType=1 ... transactionUndoRetainLocation=<invalid>
+	 *
+	 * Re-registering here is at the current location, so it does not (and
+	 * need not) resurrect anything the scan gave up: what it protects is
+	 * everything read from this point on.
+	 */
+	if (releasedUndoRetain)
+	{
+		set_my_snapshot_retain_location(UndoLogRegular);
+		set_my_snapshot_retain_location(UndoLogRegularPageLevel);
+	}
 
 
 	/*

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -39,6 +39,7 @@
 #include "utils/rel.h"
 #include "utils/stopevent.h"
 
+
 #include "access/heapam.h"
 #include "access/heaptoast.h"
 #include "access/multixact.h"
@@ -74,6 +75,16 @@
 #include "utils/sampling.h"
 #include "utils/syscache.h"
 #include "funcapi.h"
+#include "postmaster/autovacuum.h"
+
+/*
+ * AmAutoVacuumWorkerProcess() only arrived in PG17; before that the same
+ * question is IsAutoVacuumWorkerProcess().  vacuum.c carries this compat of
+ * its own, but that definition is local to it.
+ */
+#if PG_VERSION_NUM < 170000
+#define AmAutoVacuumWorkerProcess() IsAutoVacuumWorkerProcess()
+#endif
 
 static Size orioledb_parallelscan_estimate(Relation rel);
 static Size orioledb_parallelscan_initialize(Relation rel, ParallelTableScanDesc pscan);

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -2079,6 +2079,11 @@ orioledb_acquire_sample_rows(Relation relation, int elevel,
 	 * re-setting the location afterwards would not help, since the records
 	 * would already be gone.
 	 *
+	 * The page log goes too.  The sampling scan would otherwise rebuild a
+	 * historical page image through read_page_from_undo(), which is precisely
+	 * the record we are dropping our hold on; iterate_internal_page() skips
+	 * that walk for a sampling scan instead, and reads the live page.
+	 *
 	 * The system log stays retained either way: catalog access still goes
 	 * through the snapshot.
 	 */

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -561,6 +561,32 @@ get_undo_type_name(UndoLogType undoType)
 }
 
 /*
+ * Parameters for the undo_write_* stop events: which undo log we are in.
+ */
+static Jsonb *
+undo_write_stopevent_params(UndoLogType undoType)
+{
+	JsonbParseState *state = NULL;
+	JsonbValue	key,
+				val,
+			   *res;
+	MemoryContext oldcxt = MemoryContextSwitchTo(stopevents_cxt);
+
+	pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	key.type = jbvString;
+	key.val.string.len = strlen("undoType");
+	key.val.string.val = "undoType";
+	pushJsonbValue(&state, WJB_KEY, &key);
+	val.type = jbvNumeric;
+	val.val.numeric = DatumGetNumeric(DirectFunctionCall1(int8_numeric,
+														  Int64GetDatum((int64) undoType)));
+	pushJsonbValue(&state, WJB_VALUE, &val);
+	res = pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+	MemoryContextSwitchTo(oldcxt);
+	return JsonbValueToJsonb(res);
+}
+
+/*
  * In case of undoEviction the function increments writeInProgressChangeCount,
  * but doesn't release minUndoLocationsMutex. Releasing this mutex should be
  * done by a caller.
@@ -652,6 +678,31 @@ update_min_undo_locations(UndoLogType undoType,
 							minRetainLocation);
 	minTransactionRetainLocation = Max(pg_atomic_read_u64(&meta->minProcTransactionRetainLocation),
 									   minTransactionRetainLocation);
+
+	/*
+	 * minProcReservedLocation is not monotonic the way the two above are, so
+	 * it must not be clamped against its own previous value: a reservation is
+	 * taken at the current frontier, which sits far below what this minimum
+	 * reads when nobody holds one, and hiding such a live reservation would
+	 * let eviction recycle the slot its owner is about to write into.
+	 *
+	 * Clamp it to the drain frontier instead.  undo_write_internal() computes
+	 * its reservation from the writeInProgressLocation it read a moment
+	 * earlier, publishes it, and only then re-checks that frontier and
+	 * retries if it has moved; a scan landing in that window would otherwise
+	 * publish a location the frontier has already passed.
+	 * evict_undo_to_disk() clamps its target to this value, so that would
+	 * drag writeInProgressLocation and then writtenLocation *down*, and a
+	 * backend that had already concluded from the higher frontier that its
+	 * undo was on disk trips the assert in reserve_undo_size_extended().
+	 *
+	 * A live reservation can never be below the frontier -- eviction may not
+	 * pass one -- so only the stale kind is dropped here, and its owner takes
+	 * the retry path anyway.
+	 */
+	minReservedLocation = Max(pg_atomic_read_u64(&meta->writeInProgressLocation),
+							  minReservedLocation);
+
 
 	pg_atomic_write_u64(&meta->minProcReservedLocation, minReservedLocation);
 	pg_atomic_write_u64(&meta->minProcRetainLocation, minRetainLocation);
@@ -3500,7 +3551,28 @@ undo_write_internal(UndoLogType undoType, UndoLocation location,
 		/* Reserve the location we're going to write into */
 		memoryUndoLocation = Max(location, writeInProgressLocation);
 		Assert(pg_atomic_read_u64(&sharedLocations->reservedUndoLocation) == InvalidUndoLocation);
+
+		/*
+		 * memoryUndoLocation was computed from the writeInProgressLocation
+		 * read just above, and nothing is published yet, so the frontier is
+		 * free to move on while a test holds us here -- which is what makes
+		 * the value we are about to publish stale.
+		 */
+		if (STOPEVENTS_ENABLED())
+			STOPEVENT(STOPEVENT_UNDO_WRITE_BEFORE_RESERVE,
+					  undo_write_stopevent_params(undoType));
+
 		pg_atomic_write_u64(&sharedLocations->reservedUndoLocation, memoryUndoLocation);
+
+		/*
+		 * The reservation is visible to update_min_undo_locations() from here
+		 * on, but this process has not re-checked the frontier yet.  A scan
+		 * landing in this window takes minProcReservedLocation from a
+		 * location the frontier may already have passed.
+		 */
+		if (STOPEVENTS_ENABLED())
+			STOPEVENT(STOPEVENT_UNDO_WRITE_AFTER_RESERVE,
+					  undo_write_stopevent_params(undoType));
 
 		pg_memory_barrier();
 

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -1965,6 +1965,44 @@ evict_undo_to_disk(UndoLogType undoType,
 	LWLockRelease(&meta->undoWriteLock);
 }
 
+/*
+ * Opportunistic undo eviction from a backend.
+ *
+ * The bgwriter runs this very check, but it is a single process that also
+ * maintains the page pool, so under heavy undo production it falls behind.
+ * Backends then reach the point below with no headroom left, where eviction
+ * is mandatory and undoWriteLock is taken unconditionally -- so all of them
+ * queue up behind one multi-megabyte write.  Attempting the eviction here
+ * with a conditional acquire starts that write earlier, from whichever
+ * backend notices first, and lets the rest proceed untouched.
+ */
+static void
+try_evict_undo_opportunistically(UndoLogType undoType)
+{
+	UndoMeta   *meta = get_undo_meta_by_type(undoType);
+	Size		circularBufferSize = o_undo_circular_sizes[(int) undoType];
+	UndoLocation writeInProgressLocation,
+				lastUsedLocation,
+				minProcReservedLocation,
+				targetLocation;
+
+	writeInProgressLocation = pg_atomic_read_u64(&meta->writeInProgressLocation);
+	lastUsedLocation = pg_atomic_read_u64(&meta->lastUsedLocation);
+
+	/* Still more than 5% of the circular buffer free: leave it alone. */
+	if (writeInProgressLocation + circularBufferSize >=
+		lastUsedLocation + circularBufferSize / 20)
+		return;
+
+	/* Same target as the bgwriter: keep 5% of the buffer ahead of us. */
+	targetLocation = lastUsedLocation - (19 * circularBufferSize) / 20;
+	minProcReservedLocation = pg_atomic_read_u64(&meta->minProcReservedLocation);
+
+	if (targetLocation < minProcReservedLocation)
+		evict_undo_to_disk(undoType, targetLocation, minProcReservedLocation,
+						   true);
+}
+
 bool
 reserve_undo_size_extended(UndoLogType undoType, Size size,
 						   bool waitForUndoLocation)
@@ -2026,7 +2064,13 @@ reserve_undo_size_extended(UndoLogType undoType, Size size,
 
 	if (location + size <=
 		pg_atomic_read_u64(&meta->writtenLocation) + circularBufferSize)
+	{
+		/* We have room, but help evict if the buffer is nearly full. */
+		if (waitForUndoLocation &&
+			(undoType != UndoLogSystem || !have_locked_pages()))
+			try_evict_undo_opportunistically(undoType);
 		return true;
+	}
 
 	if (undoType != UndoLogSystem || !have_locked_pages())
 		update_min_undo_locations(undoType, false, waitForUndoLocation);
@@ -2067,13 +2111,14 @@ reserve_undo_size_extended(UndoLogType undoType, Size size,
 		 * It should be enough to just wait for current in-progress write to
 		 * be finished.
 		 */
-		LWLockAcquire(&meta->undoWriteLock, LW_SHARED);
-		LWLockRelease(&meta->undoWriteLock);
+		if (LWLockAcquireOrWait(&meta->undoWriteLock, LW_SHARED))
+			LWLockRelease(&meta->undoWriteLock);
 
-		/* TODO: consider removing lock if assers are disabled */
+#ifdef USE_ASSERT_CHECKING
 		SpinLockAcquire(&meta->minUndoLocationsMutex);
 		Assert(location + size <= pg_atomic_read_u64(&meta->writtenLocation) + circularBufferSize);
 		SpinLockRelease(&meta->minUndoLocationsMutex);
+#endif
 		return true;
 	}
 
@@ -3429,8 +3474,8 @@ undo_write_internal(UndoLogType undoType, UndoLocation location,
 	/* Wait for in-progress write if needed */
 	if (pg_atomic_read_u64(&meta->writtenLocation) < memoryUndoLocation)
 	{
-		LWLockAcquire(&meta->undoWriteLock, LW_SHARED);
-		LWLockRelease(&meta->undoWriteLock);
+		if (LWLockAcquireOrWait(&meta->undoWriteLock, LW_SHARED))
+			LWLockRelease(&meta->undoWriteLock);
 		Assert(pg_atomic_read_u64(&meta->writtenLocation) >= memoryUndoLocation);
 	}
 

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -1668,6 +1668,14 @@ read_undo_range_if_exists(OBuffersDesc *desc, Pointer buf, UndoLogType undoType,
  * reserve_undo_size_extended, or set_my_reserved_location waiters) make
  * progress instead of stalling for the whole flush.
  */
+/*
+ * Upper bound on how much one eviction writes while holding undoWriteLock
+ * exclusively.  Without it the "write at least 5% of the ring" floor grows
+ * with undo_buffers and so does the stall it imposes on every backend that
+ * needs undo space.
+ */
+#define UNDO_EVICT_MAX_CHUNK ((UndoLocation) 16 * 1024 * 1024)
+
 #define UNDO_FLUSH_BATCH_PAGES 128
 static void
 flush_dirty_undo_range(UndoLogType undoType,
@@ -1827,6 +1835,40 @@ flush_dirty_undo_range(UndoLogType undoType,
 		}
 
 		LWLockRelease(&meta->undoWriteLock);
+
+		/*
+		 * Persisting the pages is not enough when the ring itself is running
+		 * out: the slots stay occupied because writtenLocation does not move,
+		 * so producers still block.  Once free space drops to what makes a
+		 * backend evict, turn this pass into a drain of what we have just
+		 * made durable.
+		 *
+		 * Hand the range to evict_undo_to_disk() rather than advancing
+		 * writtenLocation here.  Moving that frontier requires the
+		 * writeInProgressLocation handshake -- publish the target, let
+		 * in-place writers see it, wait out reserved locations -- and doing
+		 * it correctly is exactly what that function is.  It also rewrites
+		 * the pages we flushed through the o_buffers cache (their dirty bit
+		 * is clear now, so they take the write_undo_range_clean path), which
+		 * matters: the flush above deliberately bypasses that cache, and once
+		 * reads start answering from disk a stale cached page must not be
+		 * left behind.
+		 */
+		if (undo_free_space(meta, circularBufferSize) <
+			circularBufferSize / UNDO_FREE_FRACTION_BACKEND)
+		{
+			/*
+			 * Re-read the reserved frontier instead of reusing the one the
+			 * caller sampled: evictions since then may have pushed
+			 * writtenLocation past that older value, and evict_undo_to_disk()
+			 * clamps its target to what we pass, which would then land below
+			 * writtenLocation and trip its writeInProgressLocation assert.
+			 */
+			UndoLocation reservedNow = pg_atomic_read_u64(&meta->minProcReservedLocation);
+
+			evict_undo_to_disk(undoType, Min(pageLoc, reservedNow),
+							   reservedNow, true);
+		}
 	}
 }
 
@@ -1885,10 +1927,18 @@ evict_undo_to_disk(UndoLogType undoType,
 		return;
 	}
 
-	/* Try to write 5% of the whole undo size if possible */
+	/*
+	 * Write a decent chunk at a time rather than exactly what was asked for,
+	 * but do not let that minimum scale with the ring: at undo_buffers = 1GB
+	 * a flat 5% is 50MB written under the exclusive lock, and every backend
+	 * that needs undo space waits it out.  Cap it so the worst-case hold
+	 * stays bounded however large the buffer is configured.
+	 */
 	writtenLocation = pg_atomic_read_u64(&meta->writtenLocation);
 	retainUndoLocation = Max(retainUndoLocation, writtenLocation);
-	targetUndoLocation = Max(targetUndoLocation, writtenLocation + circularBufferSize / 20);
+	targetUndoLocation = Max(targetUndoLocation,
+							 writtenLocation + Min(circularBufferSize / 20,
+												   UNDO_EVICT_MAX_CHUNK));
 	targetUndoLocation = Min(targetUndoLocation, minProcReservedLocation);
 
 	Assert(targetUndoLocation >= pg_atomic_read_u64(&meta->writeInProgressLocation));
@@ -1981,21 +2031,22 @@ try_evict_undo_opportunistically(UndoLogType undoType)
 {
 	UndoMeta   *meta = get_undo_meta_by_type(undoType);
 	Size		circularBufferSize = o_undo_circular_sizes[(int) undoType];
-	UndoLocation writeInProgressLocation,
-				lastUsedLocation,
+	UndoLocation lastUsedLocation,
 				minProcReservedLocation,
 				targetLocation;
 
-	writeInProgressLocation = pg_atomic_read_u64(&meta->writeInProgressLocation);
-	lastUsedLocation = pg_atomic_read_u64(&meta->lastUsedLocation);
-
-	/* Still more than 5% of the circular buffer free: leave it alone. */
-	if (writeInProgressLocation + circularBufferSize >=
-		lastUsedLocation + circularBufferSize / 20)
+	/*
+	 * The bgwriter drains towards a tenth of the ring free; a backend only
+	 * steps in once even half of that is gone, so in a healthy system this
+	 * costs nothing and the background drain does the work.
+	 */
+	if (undo_free_space(meta, circularBufferSize) >=
+		circularBufferSize / UNDO_FREE_FRACTION_BACKEND)
 		return;
 
-	/* Same target as the bgwriter: keep 5% of the buffer ahead of us. */
-	targetLocation = lastUsedLocation - (19 * circularBufferSize) / 20;
+	lastUsedLocation = pg_atomic_read_u64(&meta->lastUsedLocation);
+	targetLocation = undo_evict_target(lastUsedLocation, circularBufferSize,
+									   UNDO_FREE_FRACTION_BACKEND);
 	minProcReservedLocation = pg_atomic_read_u64(&meta->minProcReservedLocation);
 
 	if (targetLocation < minProcReservedLocation)
@@ -2120,6 +2171,28 @@ reserve_undo_size_extended(UndoLogType undoType, Size size,
 		SpinLockRelease(&meta->minUndoLocationsMutex);
 #endif
 		return true;
+	}
+
+	/*
+	 * Try to make the room without queueing for the exclusive lock first.  If
+	 * somebody else is already writing, waiting for that write to land is
+	 * both cheaper and more likely to be enough than adding one more
+	 * exclusive acquisition behind it.
+	 */
+	evict_undo_to_disk(undoType, location + size - circularBufferSize,
+					   minProcReservedLocation, true);
+	if (location + size <=
+		pg_atomic_read_u64(&meta->writtenLocation) + circularBufferSize)
+		return true;
+
+	if (location + size <=
+		pg_atomic_read_u64(&meta->writeInProgressLocation) + circularBufferSize)
+	{
+		if (LWLockAcquireOrWait(&meta->undoWriteLock, LW_SHARED))
+			LWLockRelease(&meta->undoWriteLock);
+		if (location + size <=
+			pg_atomic_read_u64(&meta->writtenLocation) + circularBufferSize)
+			return true;
 	}
 
 	evict_undo_to_disk(undoType, location + size - circularBufferSize,
@@ -3569,7 +3642,18 @@ orioledb_snapshot_hook(Snapshot snapshot)
 		lastUsedLocation = pg_atomic_read_u64(&meta->lastUsedLocation);
 		lastUsedUndoLocationWhenUpdatedMinLocation = pg_atomic_read_u64(&meta->lastUsedUndoLocationWhenUpdatedMinLocation);
 		if (lastUsedLocation - lastUsedUndoLocationWhenUpdatedMinLocation > o_undo_circular_sizes[(int) undoType] / 10)
-			update_min_undo_locations(undoType, false, true);
+		{
+			/*
+			 * Every backend taking a snapshot arrives here at once, and each
+			 * one would then contend for minUndoLocationsMutex to compute the
+			 * same answer.  An odd changecount means somebody is already
+			 * doing the scan, so skip it -- this is only a hint, and the next
+			 * snapshot re-checks.
+			 */
+			pg_read_barrier();
+			if ((meta->minUndoLocationsChangeCount & 1) == 0)
+				update_min_undo_locations(undoType, false, true);
+		}
 	}
 
 

--- a/src/transam/undo.c
+++ b/src/transam/undo.c
@@ -561,6 +561,39 @@ get_undo_type_name(UndoLogType undoType)
 }
 
 /*
+ * Wait until undo up to writtenTarget has reached disk.
+ *
+ * A wake-up from LWLockAcquireOrWait() only says undoWriteLock was free at
+ * some moment; it does not say the write covering our location has landed.
+ * Several actors evict -- the bgwriter, any backend that finds the ring
+ * tight, the checkpoint flush -- so the holder we were queued behind need not
+ * be the one that published the frontier we read, and a release by any of
+ * them wakes us.  Acting on a single wake-up is how a caller ends up
+ * concluding its undo is on disk when writtenLocation is still short of it.
+ *
+ * So loop.  Finding the lock free with the write still missing means nobody
+ * is going to do it for us; report that instead of spinning, and let the
+ * caller write it itself.
+ *
+ * Returns true once writtenLocation covers writtenTarget.
+ */
+static bool
+wait_for_undo_written(UndoMeta *meta, UndoLocation writtenTarget)
+{
+	for (;;)
+	{
+		if (pg_atomic_read_u64(&meta->writtenLocation) >= writtenTarget)
+			return true;
+
+		if (LWLockAcquireOrWait(&meta->undoWriteLock, LW_SHARED))
+		{
+			LWLockRelease(&meta->undoWriteLock);
+			return pg_atomic_read_u64(&meta->writtenLocation) >= writtenTarget;
+		}
+	}
+}
+
+/*
  * Parameters for the undo_write_* stop events: which undo log we are in.
  */
 static Jsonb *
@@ -2209,19 +2242,13 @@ reserve_undo_size_extended(UndoLogType undoType, Size size,
 		pg_atomic_read_u64(&meta->writeInProgressLocation) + circularBufferSize)
 	{
 		/*
-		 * Current in-progress undo write should cover our required location.
-		 * It should be enough to just wait for current in-progress write to
-		 * be finished.
+		 * A write in progress should cover our required location, so waiting
+		 * for it to land is enough -- when it really does land.  If it turns
+		 * out nobody is writing it, fall through and do the eviction below.
 		 */
-		if (LWLockAcquireOrWait(&meta->undoWriteLock, LW_SHARED))
-			LWLockRelease(&meta->undoWriteLock);
-
-#ifdef USE_ASSERT_CHECKING
-		SpinLockAcquire(&meta->minUndoLocationsMutex);
-		Assert(location + size <= pg_atomic_read_u64(&meta->writtenLocation) + circularBufferSize);
-		SpinLockRelease(&meta->minUndoLocationsMutex);
-#endif
-		return true;
+		if (wait_for_undo_written(meta,
+								  location + size - circularBufferSize))
+			return true;
 	}
 
 	/*
@@ -2237,14 +2264,9 @@ reserve_undo_size_extended(UndoLogType undoType, Size size,
 		return true;
 
 	if (location + size <=
-		pg_atomic_read_u64(&meta->writeInProgressLocation) + circularBufferSize)
-	{
-		if (LWLockAcquireOrWait(&meta->undoWriteLock, LW_SHARED))
-			LWLockRelease(&meta->undoWriteLock);
-		if (location + size <=
-			pg_atomic_read_u64(&meta->writtenLocation) + circularBufferSize)
-			return true;
-	}
+		pg_atomic_read_u64(&meta->writeInProgressLocation) + circularBufferSize &&
+		wait_for_undo_written(meta, location + size - circularBufferSize))
+		return true;
 
 	evict_undo_to_disk(undoType, location + size - circularBufferSize,
 					   minProcReservedLocation, false);
@@ -3617,11 +3639,15 @@ undo_write_internal(UndoLogType undoType, UndoLocation location,
 	}
 
 	/* Wait for in-progress write if needed */
-	if (pg_atomic_read_u64(&meta->writtenLocation) < memoryUndoLocation)
+	while (!wait_for_undo_written(meta, memoryUndoLocation))
 	{
-		if (LWLockAcquireOrWait(&meta->undoWriteLock, LW_SHARED))
-			LWLockRelease(&meta->undoWriteLock);
-		Assert(pg_atomic_read_u64(&meta->writtenLocation) >= memoryUndoLocation);
+		/*
+		 * Nobody is writing it, so make it happen: this path needs the record
+		 * on disk before it can rewrite it in place.
+		 */
+		evict_undo_to_disk(undoType, memoryUndoLocation,
+						   pg_atomic_read_u64(&meta->minProcReservedLocation),
+						   false);
 	}
 
 	/* Finally perform writing to the file */

--- a/src/workers/bgwriter.c
+++ b/src/workers/bgwriter.c
@@ -130,7 +130,6 @@ bgwriter_main(Datum main_arg)
 		{
 			OPagePoolType poolType;
 			UndoLocation lastUsedLocation;
-			UndoLocation writeInProgressLocation;
 			int			j;
 
 			if (ShutdownRequestPending)
@@ -186,13 +185,21 @@ bgwriter_main(Datum main_arg)
 			{
 				UndoMeta   *undo_meta = get_undo_meta_by_type((UndoLogType) j);
 
-				writeInProgressLocation = pg_atomic_read_u64(&undo_meta->writeInProgressLocation);
+				/*
+				 * Drain towards a tenth of the ring free, which is twice the
+				 * headroom a backend settles for.  Starting here means the
+				 * writing happens in the background rather than inside some
+				 * backend's reservation, where it would stall a transaction.
+				 */
 				lastUsedLocation = pg_atomic_read_u64(&undo_meta->lastUsedLocation);
-				if (writeInProgressLocation + undo_circular_buffer_size <
-					lastUsedLocation + undo_circular_buffer_size / 20)
+				if (undo_free_space(undo_meta, undo_circular_buffer_size) <
+					undo_circular_buffer_size / UNDO_FREE_FRACTION_BGWRITER)
 				{
 					UndoLocation minProcReservedLocation = pg_atomic_read_u64(&undo_meta->minProcReservedLocation);
-					UndoLocation targetLocation = lastUsedLocation - (19 * undo_circular_buffer_size) / 20;
+					UndoLocation targetLocation =
+						undo_evict_target(lastUsedLocation,
+										  undo_circular_buffer_size,
+										  UNDO_FREE_FRACTION_BGWRITER);
 
 					if (targetLocation < minProcReservedLocation)
 						evict_undo_to_disk((UndoLogType) j, targetLocation,

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -43,3 +43,5 @@ createdb_copy_fail
 cic_after_ambuild
 cic_before_flip
 merge_after_target_unlock
+undo_write_before_reserve
+undo_write_after_reserve

--- a/test/t/undo_reserved_race_test.py
+++ b/test/t/undo_reserved_race_test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import time
+import unittest
+from threading import Thread
+
+from .base_test import BaseTest
+
+
+class UndoReservedRaceTest(BaseTest):
+
+	def test_reserved_location_does_not_pull_frontiers_back(self):
+		"""minProcReservedLocation must never move the drain frontier back.
+
+		undo_write_internal() publishes reservedUndoLocation from the
+		writeInProgressLocation it read a moment earlier, then re-checks that
+		frontier and retries if it has moved.  Between those two steps the
+		reservation is visible to update_min_undo_locations(), which -- unlike
+		the two retain locations beside it -- publishes minProcReservedLocation
+		without clamping it to its previous value.  So a scan landing in that
+		window lowers it below writeInProgressLocation, and the next eviction
+		clamps its target to that, dragging writeInProgressLocation and then
+		writtenLocation backwards.
+
+		A backend that had already concluded from the higher
+		writeInProgressLocation that its undo was covered then finds
+		writtenLocation short of what it needs.
+		"""
+		node = self.node
+		node.append_conf('orioledb.enable_stopevents = true\n')
+		node.append_conf('orioledb.undo_buffers = 256\n')
+		node.append_conf('orioledb.main_buffers = 64MB\n')
+		node.append_conf('checkpoint_timeout = 1h\n')
+		node.start()
+		node.safe_psql("""
+			CREATE EXTENSION orioledb;
+			CREATE TABLE o_race (id int PRIMARY KEY, v int, pad text) USING orioledb;
+			INSERT INTO o_race SELECT g, 0, repeat('x', 500)
+				FROM generate_series(1, 2000) g;
+			CREATE TABLE o_bulk (id int PRIMARY KEY, pad text) USING orioledb;
+			INSERT INTO o_bulk SELECT g, repeat('b', 2000)
+				FROM generate_series(1, 20000) g;
+		""")
+
+		def undo_meta(con):
+			return con.execute("""
+				SELECT writeInProgressLocation, writtenLocation,
+				       minProcReservedLocation
+				FROM orioledb_get_undo_meta() WHERE undo_type = 'row';
+			""")[0]
+
+		ctl = node.connect()
+		locker = node.connect()
+		park = node.connect()
+		bulk = node.connect()
+
+		def undo_meta_of(con):
+			return con.execute("""
+				SELECT writeInProgressLocation, writtenLocation,
+				       minProcReservedLocation
+				FROM orioledb_get_undo_meta() WHERE undo_type = 'row';
+			""")[0]
+
+		def parked_pids():
+			return [
+			    p for row in ctl.execute(
+			        "SELECT waiter_pids FROM pg_stopevents();") if row[0]
+			    for p in row[0]
+			]
+
+		def wait_parked(what):
+			deadline = time.time() + 60
+			while time.time() < deadline:
+				pids = parked_pids()
+				if pids:
+					return pids[0]
+				time.sleep(0.1)
+			self.fail("nothing parked at %s" % what)
+
+		def churn(n):
+			for _ in range(n):
+				bulk.begin()
+				bulk.execute("UPDATE o_bulk SET pad = repeat('c', 2000);")
+				bulk.commit()
+
+		try:
+			# Give the row an undo chain, so there is a chain to clean later.
+			locker.begin()
+			locker.execute("UPDATE o_race SET v = v + 1 WHERE id = 1;")
+			locker.commit()
+
+			ctl.execute(
+			    "SELECT pg_stopevent_set('undo_write_before_reserve', 'true');"
+			)
+			ctl.execute(
+			    "SELECT pg_stopevent_set('undo_write_after_reserve', 'true');")
+
+			# One transaction locks the tuple, a second queues behind it.  When
+			# the first finishes it is the waiter that strips the lock-only
+			# record from the chain -- clean_chain_has_locks_flag() ->
+			# undo_write() -- which is the path both events sit on.
+			locker.begin()
+			locker.execute("SELECT * FROM o_race WHERE id = 1 FOR UPDATE;")
+
+			def parker():
+				try:
+					park.begin()
+					park.execute(
+					    "SELECT * FROM o_race WHERE id = 1 FOR UPDATE;")
+					park.commit()
+				except Exception as e:
+					print("parker: %s" % str(e)[:100], flush=True)
+
+			thread = Thread(target=parker)
+			thread.start()
+			time.sleep(1.0)
+			locker.commit()
+
+			wait_parked("undo_write_before_reserve")
+
+			# Nothing is published yet, so the frontier is free: drive it far
+			# past the location the waiter already read.
+			churn(3)
+			advanced = undo_meta_of(ctl)
+
+			# Let it publish that now-stale reservation and stop again before
+			# it can re-check.
+			ctl.execute(
+			    "SELECT pg_stopevent_reset('undo_write_before_reserve');")
+			wait_parked("undo_write_after_reserve")
+
+			# Somebody scans the per-proc locations while the stale value is
+			# published.  This is the step that lowers minProcReservedLocation.
+			ctl.execute("SELECT orioledb_get_undo_meta();")
+			bulk.begin()
+			bulk.execute("SELECT count(*) FROM o_bulk;")
+			bulk.commit()
+			scanned = undo_meta_of(ctl)
+
+			ctl.execute(
+			    "SELECT pg_stopevent_reset('undo_write_after_reserve');")
+			thread.join(timeout=60)
+
+			# And now an eviction, whose target is clamped by that value.
+			churn(2)
+			evicted = undo_meta_of(ctl)
+
+			print("advanced wip=%d written=%d reserved=%d" % advanced,
+			      flush=True)
+			print("scanned  wip=%d written=%d reserved=%d" % scanned,
+			      flush=True)
+			print("evicted  wip=%d written=%d reserved=%d" % evicted,
+			      flush=True)
+
+			# The invariant is not that this value never decreases -- a
+			# reservation is taken at the current frontier, so it legitimately
+			# reads lower than a moment when nobody held one.  What must hold
+			# is that it never drops *below* the frontier: evict_undo_to_disk()
+			# clamps its target to it, so a lower value drags the frontier
+			# back and breaks what reserve_undo_size_extended() concluded.
+			self.assertGreaterEqual(
+			    scanned[2], scanned[0],
+			    "minProcReservedLocation fell below writeInProgressLocation")
+			self.assertGreaterEqual(evicted[0], advanced[0],
+			                        "writeInProgressLocation went backwards")
+			self.assertGreaterEqual(evicted[1], advanced[1],
+			                        "writtenLocation went backwards")
+		finally:
+			for ev in ('undo_write_before_reserve',
+			           'undo_write_after_reserve'):
+				try:
+					ctl.execute("SELECT pg_stopevent_reset('%s');" % ev)
+				except Exception:
+					pass
+			for con in (park, bulk, locker, ctl):
+				try:
+					con.close()
+				except Exception:
+					pass


### PR DESCRIPTION
Four changes to how the undo circular buffer is kept from filling up, so that
the writing happens in the background instead of inside a backend's
reservation, and so that when it does happen it holds the lock for a bounded
time.

## Backends evict opportunistically

The bgwriter already evicts once the ring is nearly full, but it is a single
process that also maintains the page pool. Backends then reach
`reserve_undo_size_extended()` with no headroom left, where eviction is
mandatory and `undoWriteLock` is taken unconditionally, and queue behind one
multi-megabyte write. Backends now run the same check on the path where the
reservation already fits, with a conditional acquire, so the first one to
notice starts the write and the rest carry on.

## Separate targets for the bgwriter and backends

The bgwriter drains towards a tenth of the ring free, twice the headroom a
backend settles for. Both now go through `undo_free_space()` /
`undo_evict_target()` instead of open-coding the same fractions in two
places.

## Bound the drain, and start it earlier (from #1013)

- Cap the eviction chunk at 16MB. The "write at least 5% of the ring" floor
  scaled with `undo_buffers`, so at 1GB one eviction wrote 50MB under the
  exclusive lock while every backend needing undo space waited it out.
- Try a non-blocking eviction before the blocking one: if somebody else is
  already writing, waiting for that write to land beats queueing a second
  exclusive acquisition behind it.
- Skip the min-undo-location scan in the snapshot hook when the changecount
  says another backend is already doing it — every backend taking a snapshot
  would otherwise contend for `minUndoLocationsMutex` to compute the same
  answer.

**Not taken from #1013:** advancing `writtenLocation` per page while releasing
`undoWriteLock` inside the write loop. `writeInProgressLocation` already holds
the final target there, so a waiter let through in that window sees the lock
free, concludes the write finished, and reuses ring slots whose contents never
reached disk. The 16MB cap bounds the hold time without that risk.

## The checkpoint flush drains rather than merely persists

Writing pages out does not help a ring that is running out, because the slots
stay occupied until `writtenLocation` moves. Once free space falls to what
makes a backend evict, `flush_dirty_undo_range()` hands what it has made
durable to `evict_undo_to_disk()` between batches. Going through that function
rather than advancing the frontier in place is deliberate: moving it needs the
`writeInProgressLocation` handshake, and it also rewrites the flushed pages
through the `o_buffers` cache, which the flush deliberately bypasses and which
must not be left stale once reads start answering from disk.

## Do not retain undo while autovacuum samples for ANALYZE

`orioledb_acquire_sample_rows()` reads raw, latest tuples and never walks an
undo chain, but its snapshot pins `minProcRetainLocation` for the whole scan.
An autovacuum ANALYZE of a large table runs well over a minute while the ring
holds seconds of production, so nothing can be discarded and the entire undo
stream goes to disk. Released for an autovacuum worker in READ COMMITTED only
— the case where nothing else reads through that snapshot afterwards.

## Measurement, and what it says about the bgwriter target

With a temporary probe counting who evicts, under 32 clients doing 1000-row
updates against a 16MB ring for 40s:

```
10097  backend, opportunistic
   48  backend, forced
    0  bgwriter
```

Raising the bgwriter's target does not by itself make it the one that writes.
It wakes on `bgwriter_delay` (200ms) while a tenth of that ring turns over in
roughly 20ms, so backends checking on every reservation always get there
first; polling faster does not close the gap either (still zero). For the
bgwriter to actually win, backends would have to wake it and defer to it,
which needs its latch published in shared memory. **Not done here** — it would
change the behaviour of the first commit, and is worth deciding separately.

Also note the undo-pressure regime itself was not reachable on the test
machine: at ~70MB/s of undo production the drain keeps up and the ring stays
about half free, so there is no throughput claim attached to any of this.

## Checks

regress 50/50, isolation 38/38, testgres 78 OK, pgindent clean.
`src/tableam/handler.c` compile-checked against PG16 as well: the ANALYZE
commit used `AmAutoVacuumWorkerProcess()`, which only exists from PG17, and
did not build there — fixed in the last commit.
