### PR TITLE
 Detect stale seq_buf pointers after concurrent tree eviction 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ sql/orioledb--1.5--1.6.sql
 sql/orioledb--1.6--1.7.sql
 sql/orioledb--1.7--1.8.sql
 sql/orioledb--1.8--1.9.sql
+sql/orioledb--1.9--1.10.sql
 
 # Exclude the PostGIS Docker build directory
 /docker-postgis

--- a/sql/orioledb--1.8--1.9_dev.sql
+++ b/sql/orioledb--1.8--1.9_dev.sql
@@ -22,3 +22,8 @@ CREATE FUNCTION orioledb_check_pending_truncates()
 RETURNS VOID
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_test_free_meta_page(relid oid)
+RETURNS VOID
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.8--1.9_dev.sql
+++ b/sql/orioledb--1.8--1.9_dev.sql
@@ -22,8 +22,3 @@ CREATE FUNCTION orioledb_check_pending_truncates()
 RETURNS VOID
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
-
-CREATE FUNCTION orioledb_test_free_meta_page(relid oid)
-RETURNS VOID
-AS 'MODULE_PATHNAME'
-VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.9--1.10_dev.sql
+++ b/sql/orioledb--1.9--1.10_dev.sql
@@ -7,3 +7,8 @@ CREATE FUNCTION orioledb_test_corrupt_row_undo(relid oid)
 RETURNS text
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_test_free_meta_page(relid oid)
+RETURNS VOID
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -113,10 +113,11 @@ static bool get_free_disk_extent_copy_blkno(BTreeDescr *desc, off_t page_size,
 static bool write_page_to_disk(BTreeDescr *desc, FileExtent *extent,
 							   uint32 curChkpNum,
 							   Pointer page, off_t page_size);
-static void write_page(OBTreeFindPageContext *context,
+static bool write_page(OBTreeFindPageContext *context,
 					   OInMemoryBlkno blkno, Page img,
 					   uint32 checkpoint_number,
-					   bool evict, bool copy_blkno);
+					   bool evict, bool copy_blkno,
+					   uint32 meta_change_count);
 static int	tree_offsets_cmp(const void *a, const void *b);
 static void writeback_put_extent(IOWriteBack *writeback, BTreeDescr *desc,
 								 uint64 downlink);
@@ -2364,10 +2365,10 @@ prepare_non_leaf_page(Page p)
 /*
  * Evict the page, assuming target page and its parent are locked.
  */
-static void
+static bool
 write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 		   uint32 checkpoint_number,
-		   bool evict, bool copy_blkno)
+		   bool evict, bool copy_blkno, uint32 meta_change_count)
 {
 	BTreeDescr *desc = context->desc;
 	OInMemoryBlkno parent_blkno = OInvalidInMemoryBlkno;
@@ -2434,6 +2435,24 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 					old_downlink = 0;
 		bool		dirty_parent;
 
+		/*
+		 * Concurrent tree eviction (evict_btree) frees the meta page while we
+		 * still hold a cached desc whose nextChkp[].shared points into it.
+		 * Detect this via the meta page's change count, which ppool_free_page
+		 * increments.  Must check before modifying any shared state (parent
+		 * downlink, ionum).
+		 */
+		if (OMetaPageIsValid(desc) &&
+			O_GET_IN_MEMORY_PAGE_CHANGE_COUNT(desc->rootInfo.metaPageBlkno)
+			!= meta_change_count)
+		{
+			unlock_io(ionum);
+			unlock_page(blkno);
+			if (!is_root)
+				unlock_page(parent_blkno);
+			return false;
+		}
+
 		/* Mark parent downlink as IO in-progress. */
 		if (evict)
 		{
@@ -2469,6 +2488,17 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 			CLEAN_DIRTY_CONCURRENT(blkno);
 			unlock_page(blkno);
 
+			/* Re-check after unlock: narrower window than the pre-lock check */
+			if (OMetaPageIsValid(desc) &&
+				O_GET_IN_MEMORY_PAGE_CHANGE_COUNT(desc->rootInfo.metaPageBlkno)
+				!= meta_change_count)
+			{
+				page_desc->ionum = -1;
+				unlock_io(ionum);
+				perform_writeback(&io_writeback);
+				return false;
+			}
+
 			if (STOPEVENTS_ENABLED())
 			{
 				Jsonb	   *params;
@@ -2500,7 +2530,7 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 				page_desc->ionum = -1;
 				unlock_io(ionum);
 				perform_writeback(&io_writeback);
-				return;
+				return true;
 			}
 		}
 
@@ -2573,6 +2603,7 @@ write_page(OBTreeFindPageContext *context, OInMemoryBlkno blkno, Page img,
 		ppool_free_page(desc->ppool, blkno, false);
 
 	perform_writeback(&io_writeback);
+	return true;
 }
 
 static void
@@ -3197,7 +3228,8 @@ walk_page(OInMemoryBlkno blkno, bool evict)
 				parent_page;
 	ORelOids	oids;
 	BTreeNonLeafTuphdr *int_hdr;
-	uint32		checkpoint_number;
+	uint32		checkpoint_number,
+				meta_change_count = 0;
 	bool		copy_blkno,
 				merge_tried = false;
 	OFindPageResult findResult;
@@ -3212,6 +3244,10 @@ retry:
 	desc = walk_page_prelock_check(blkno, evict, page_desc, p, &oids);
 	if (!desc)
 		return OWalkPageSkipped;
+
+	if (OMetaPageIsValid(desc))
+		meta_change_count = O_GET_IN_MEMORY_PAGE_CHANGE_COUNT(
+															  desc->rootInfo.metaPageBlkno);
 
 	if (!try_lock_page(blkno))
 		return OWalkPageSkipped;
@@ -3320,7 +3356,9 @@ retry:
 
 	STOPEVENT(STOPEVENT_BEFORE_WRITE_PAGE, NULL);
 
-	write_page(&context, blkno, img, checkpoint_number, evict, copy_blkno);
+	if (!write_page(&context, blkno, img, checkpoint_number, evict, copy_blkno,
+					meta_change_count))
+		return OWalkPageSkipped;
 
 	STOPEVENT(STOPEVENT_AFTER_WRITE_PAGE, NULL);
 

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1275,6 +1275,60 @@ store_read_page_checkpoint_stats(uint32 checkpointNum)
 	elog(DEBUG1, "Remember read_page_checkpoin: min %u max %u", min_read_page_checkpoint, max_read_page_checkpoint);
 }
 
+/*
+ * Simulate the effect of evict_btree on the meta page: free it via
+ * ppool_free_page (which increments its change count) and wipe the body
+ * to model page reuse.  Uses the checkpoint-namespace exclusive lock that
+ * the real eviction path (get_evict_btree_locks) acquires; the concurrent
+ * writer (bgwriter / page-pool clock) does NOT hold this lock, so no
+ * conflict -- exactly the gap that meta_change_count detection covers.
+ *
+ * We cannot call evict_btree directly because it requires all children
+ * to be evicted first (N_ONDISK == items_count), which would destroy the
+ * leaf page the concurrent writer is about to process.
+ */
+PG_FUNCTION_INFO_V1(orioledb_test_free_meta_page);
+
+Datum
+orioledb_test_free_meta_page(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	OTableDescr *descr;
+	BTreeDescr *td;
+	Relation	rel;
+	OInMemoryBlkno metaBlkno;
+
+	orioledb_check_shmem();
+
+	rel = relation_open(relid, AccessShareLock);
+	descr = relation_get_descr(rel);
+	td = &descr->indices[0]->desc;
+	o_btree_load_shmem(td);
+	metaBlkno = td->rootInfo.metaPageBlkno;
+	relation_close(rel, AccessShareLock);
+
+	if (OInMemoryBlknoIsValid(metaBlkno))
+	{
+		o_tables_rel_lock_extended(&td->oids, AccessExclusiveLock, true);
+
+		CLEAN_DIRTY(td->ppool, metaBlkno);
+		ppool_free_page(td->ppool, metaBlkno, false);
+
+		/*
+		 * Wipe everything after the page header to simulate page reuse.
+		 * The header (incl. change count) must survive so that the
+		 * meta_change_count check in write_page sees the ppool_free_page
+		 * increment; the seq_buf fields that perform_page_io dereferences
+		 * become garbage.
+		 */
+		memset(O_GET_IN_MEMORY_PAGE(metaBlkno) + O_PAGE_HEADER_SIZE,
+			   0, ORIOLEDB_BLCKSZ - O_PAGE_HEADER_SIZE);
+
+		o_tables_rel_unlock_extended(&td->oids, AccessExclusiveLock, true);
+	}
+	PG_RETURN_VOID();
+}
+
 #endif
 
 /*
@@ -3248,6 +3302,8 @@ retry:
 	if (OMetaPageIsValid(desc))
 		meta_change_count = O_GET_IN_MEMORY_PAGE_CHANGE_COUNT(
 															  desc->rootInfo.metaPageBlkno);
+
+	STOPEVENT(STOPEVENT_WALK_PAGE_BEFORE_LOCK, NULL);
 
 	if (!try_lock_page(blkno))
 		return OWalkPageSkipped;

--- a/src/utils/seq_buf.c
+++ b/src/utils/seq_buf.c
@@ -521,15 +521,25 @@ seq_buf_finalize(SeqBufDescPrivate *seqBufPrivate)
 		if (shared->location > 0)
 		{
 			off_t		offset = SEQBUF_FILE_OFFSET(shared, (off_t) shared->filePageNum);
+			size_t		data_size = shared->location - SEQBUF_DATA_OFF;
+			char		buf[SEQBUF_CHUNK_SIZE];
 
-			if (OFileWrite(seqBufPrivate->file, SEQBUF_DATA_POS(O_GET_IN_MEMORY_PAGE(shared->pages[shared->curPageNum])),
-						   shared->location - SEQBUF_DATA_OFF, offset, WAIT_EVENT_SLRU_WRITE) != shared->location - SEQBUF_DATA_OFF)
+			memcpy(buf,
+				   SEQBUF_DATA_POS(O_GET_IN_MEMORY_PAGE(shared->pages[shared->curPageNum])),
+				   data_size);
+
+			result = offset + data_size;
+			SpinLockRelease(&shared->lock);
+
+			if (OFileWrite(seqBufPrivate->file, buf, data_size,
+						   offset, WAIT_EVENT_SLRU_WRITE) != data_size)
 			{
-				SpinLockRelease(&shared->lock);
 				ereport(PANIC, (errcode_for_file_access(),
 								errmsg("could not finalize sequence buffer into file %s: %m",
 									   FilePathName(seqBufPrivate->file))));
 			}
+
+			goto done;
 		}
 	}
 
@@ -537,6 +547,7 @@ seq_buf_finalize(SeqBufDescPrivate *seqBufPrivate)
 		+ (shared->location - SEQBUF_DATA_OFF);
 	SpinLockRelease(&shared->lock);
 
+done:
 	seq_buf_close_file(seqBufPrivate);
 
 	if (result == 0)

--- a/stopevents.txt
+++ b/stopevents.txt
@@ -45,3 +45,4 @@ cic_before_flip
 merge_after_target_unlock
 undo_write_before_reserve
 undo_write_after_reserve
+walk_page_before_lock

--- a/test/t/eviction_test.py
+++ b/test/t/eviction_test.py
@@ -947,3 +947,90 @@ class EvictionTest(BaseTest):
 			        ('o_evicted', 'o_evicted_empty')))
 		finally:
 			con1.close()
+
+	def test_write_page_stale_seqbuf_after_concurrent_drop(self):
+		"""write_page must detect a freed meta page via change-count check.
+
+		walk_page resolves a BTreeDescr whose nextChkp[].shared points into
+		the meta page.  A concurrent evict_btree can free the meta page
+		while non-root pages are still alive.  The sweeping backend then
+		enters write_page with a stale desc.
+
+		The walk_page_before_lock stopevent parks the sweeping backend after
+		desc resolution but before the page lock.  While parked,
+		orioledb_test_free_meta_page frees only the meta page (simulating
+		evict_btree) leaving data pages alive so walk_page_check_locked
+		passes and write_page is reached.  The meta_change_count check in
+		write_page detects the stale pointer and bails out.
+
+		Without the fix, write_page proceeds to perform_page_io, accesses
+		desc->nextChkp[].shared in freed memory, and crashes.
+		"""
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "orioledb.main_buffers = 8MB\n"
+		    "orioledb.bgwriter_num_workers = 0\n"
+		    "orioledb.enable_stopevents = true\n")
+		node.start()
+
+		node.safe_psql(
+		    'postgres', "CREATE EXTENSION IF NOT EXISTS orioledb;\n"
+		    "CREATE TABLE o_wp (id int PRIMARY KEY, pad text)"
+		    " USING orioledb;\n"
+		    "INSERT INTO o_wp"
+		    " SELECT g, repeat('x', 400)"
+		    " FROM generate_series(1, 25000) g;")
+
+		node.safe_psql('postgres', "CHECKPOINT;")
+		node.safe_psql(
+		    'postgres', "UPDATE o_wp SET pad = repeat('y', 400)"
+		    " WHERE id = 1;")
+
+		ctrl = node.connect()
+		presser = node.connect()
+		presser_pid = presser.execute("SELECT pg_backend_pid();")[0][0]
+
+		ctrl.execute("SELECT pg_stopevent_set('walk_page_before_lock',"
+		             " '$pid == %d');" % presser_pid)
+
+		t = ThreadQueryExecutor(
+		    presser, "SELECT orioledb_write_pages('o_wp'::regclass::oid);")
+		t.start()
+
+		try:
+			wait_stopevent(node, presser_pid)
+
+			ctrl.execute("SELECT orioledb_test_free_meta_page("
+			             "'o_wp'::regclass::oid);")
+			ctrl.execute("SELECT pg_stopevent_reset('walk_page_before_lock');")
+		finally:
+			try:
+				ctrl.execute(
+				    "SELECT pg_stopevent_reset('walk_page_before_lock');")
+			except Exception:
+				pass
+			try:
+				t.join(timeout=30)
+			except Exception:
+				pass
+			try:
+				ctrl.close()
+			except Exception:
+				pass
+			try:
+				presser.close()
+			except Exception:
+				pass
+
+		with open(node.pg_log_file, errors='replace') as f:
+			log = f.read()
+		crashed = [
+		    line for line in log.splitlines()
+		    if 'TRAP' in line or 'terminated by signal' in line
+		]
+		self.assertEqual(
+		    crashed, [],
+		    "stale seq_buf pointer in write_page: %s" % (crashed[:3], ))
+
+		# The meta page body is wiped; skip the shutdown checkpoint.
+		node.stop(['-m', 'immediate'])


### PR DESCRIPTION
 Detect stale seq_buf pointers after concurrent tree eviction
Release seq_buf spinlock before file I/O in seq_buf_finalize

Fix for #1113 

Needs thorough review