### PR TITLE
Route a bridged index insert through the legacy aminsert entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ REGRESSCHECKS = btree_sys_check \
 				parallel_scan \
 				partial \
 				partition \
+				pgvector \
 				primary_key \
 				row_level_locks \
 				row_security \

--- a/ci/post_build_prerequisites.sh
+++ b/ci/post_build_prerequisites.sh
@@ -23,12 +23,24 @@ if [ $GITHUB_JOB != "run-benchmark" ] && [ $GITHUB_JOB != "pgindent" ] && [ $GIT
     # insert callback on aminsert rather than on the aminsertextended entry
     # point this fork added.  Every access method shipped with the fork has been
     # converted, so pgvector is the only thing that covers index bridging for
-    # the legacy signature; the test/sql/pgvector.sql regression test is added
-    # to the suite only when this install has happened.
+    # the legacy signature; test/sql/pgvector.sql runs its body only when this
+    # install has happened, and matches its pgvector_1 expected output when it
+    # has not.
+    #
+    # Its default build is -march=native and dispatches to hand-written AVX-512
+    # kernels, neither of which valgrind can execute: the first INSERT of a
+    # vector value dies with SIGILL.  Build it for the baseline architecture
+    # there instead, which costs nothing but the speed of an access method we
+    # only test for correctness.
+    if [ "${CHECK_TYPE:-}" = "valgrind_1" ] || [ "${CHECK_TYPE:-}" = "valgrind_2" ]; then
+        pgvector_make_args="OPTFLAGS= PG_CPPFLAGS=-DDISABLE_DISPATCH"
+    else
+        pgvector_make_args=""
+    fi
     wget https://codeload.github.com/pgvector/pgvector/tar.gz/refs/tags/v0.8.1
     tar -zxf v0.8.1
     rm v0.8.1
-    (cd pgvector-0.8.1 && make && make install)
+    (cd pgvector-0.8.1 && make $pgvector_make_args && make install)
 
     wget https://codeload.github.com/eulerto/wal2json/tar.gz/refs/tags/wal2json_2_6
     tar -zxf wal2json_2_6

--- a/ci/post_build_prerequisites.sh
+++ b/ci/post_build_prerequisites.sh
@@ -19,6 +19,17 @@ else
 fi
 
 if [ $GITHUB_JOB != "run-benchmark" ] && [ $GITHUB_JOB != "pgindent" ] && [ $GITHUB_JOB != "pg_upgrade" ]; then
+    # pgvector is built against stock PostgreSQL upstream, so it leaves its
+    # insert callback on aminsert rather than on the aminsertextended entry
+    # point this fork added.  Every access method shipped with the fork has been
+    # converted, so pgvector is the only thing that covers index bridging for
+    # the legacy signature; the test/sql/pgvector.sql regression test is added
+    # to the suite only when this install has happened.
+    wget https://codeload.github.com/pgvector/pgvector/tar.gz/refs/tags/v0.8.1
+    tar -zxf v0.8.1
+    rm v0.8.1
+    (cd pgvector-0.8.1 && make && make install)
+
     wget https://codeload.github.com/eulerto/wal2json/tar.gz/refs/tags/wal2json_2_6
     tar -zxf wal2json_2_6
     rm wal2json_2_6

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -241,6 +241,7 @@ orioledb_indexam_routine_hook(Oid tamoid, Oid amhandler)
 				bridged->original_routine = (IndexAmRoutine *) DatumGetPointer(datum);
 				bridged->routine = *bridged->original_routine;
 				bridged->routine.ambuild = bridged_ambuild;
+				bridged->routine.aminsert = NULL;
 				bridged->routine.aminsertextended = bridged_aminsert;
 				bridged->routine.ambeginscan = bridged_ambeginscan;
 				bridged->routine.amcanreturn = NULL;
@@ -2352,8 +2353,14 @@ bridged_aminsert(Relation rel, Datum *values, bool *isnull,
 
 	Assert(amroutine != NULL);
 
-	return amroutine->aminsertextended(rel, values, isnull, tupleid, heapRel,
-									   checkUnique, indexUnchanged, indexInfo);
+	if (amroutine->aminsertextended)
+		return amroutine->aminsertextended(rel, values, isnull, tupleid,
+										   heapRel, checkUnique,
+										   indexUnchanged, indexInfo);
+
+	return amroutine->aminsert(rel, values, isnull,
+							   DatumGetItemPointer(tupleid), heapRel,
+							   checkUnique, indexUnchanged, indexInfo);
 }
 
 static IndexScanDesc

--- a/test/expected/pgvector.out
+++ b/test/expected/pgvector.out
@@ -1,0 +1,121 @@
+CREATE SCHEMA pgvector;
+SET SESSION search_path = 'pgvector';
+CREATE EXTENSION orioledb;
+-- pgvector is not part of the fork, so it is not installed everywhere; CI
+-- installs it in ci/post_build_prerequisites.sh.  Where it is missing the test
+-- skips its body and matches the pgvector_1 alternative output instead -- the
+-- error from CREATE EXTENSION cannot be used for that, as it names an absolute
+-- path.
+SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector')
+	AS have_pgvector \gset
+\if :have_pgvector
+CREATE EXTENSION vector;
+-- pgvector is built against stock PostgreSQL, so it leaves its insert callback
+-- on aminsert, which takes a plain ItemPointer, rather than on the
+-- aminsertextended entry point this fork added, which takes the tuple
+-- identifier as a Datum and so can carry an OrioleDB rowid.  Every access
+-- method shipped with the fork has been converted to aminsertextended, so
+-- pgvector is the only thing available to the tests that covers index bridging
+-- for the legacy signature.  See orioledb/orioledb#1118.
+CREATE TABLE o_vec (
+	id int NOT NULL,
+	v vector(3),
+	PRIMARY KEY (id)
+) USING orioledb;
+-- Rows already present reach the index through ambuild ...
+INSERT INTO o_vec SELECT id, ARRAY[id, id, id]::vector FROM generate_series(1, 10) id;
+CREATE INDEX o_vec_hnsw_idx ON o_vec USING hnsw (v vector_l2_ops);
+NOTICE:  index bridging is enabled for orioledb table 'o_vec'
+DETAIL:  index access method 'hnsw' is supported only via index bridging for OrioleDB table
+-- ... and these have to reach it through aminsert.
+INSERT INTO o_vec SELECT id, ARRAY[id, id, id]::vector FROM generate_series(11, 20) id;
+UPDATE o_vec SET v = '[100,100,100]' WHERE id = 5;
+DELETE FROM o_vec WHERE id = 6;
+SET enable_seqscan = off;
+EXPLAIN (COSTS OFF) SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 5;
+                   QUERY PLAN                   
+------------------------------------------------
+ Limit
+   ->  Index Scan using o_vec_hnsw_idx on o_vec
+         Order By: (v <-> '[1,1,1]'::vector)
+(3 rows)
+
+SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 5;
+ id 
+----
+  1
+  2
+  3
+  4
+  7
+(5 rows)
+
+-- The index has to hold every live row, not just the ones the build saw.
+SELECT count(*) FROM (SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+ count 
+-------
+    19
+(1 row)
+
+SELECT id FROM o_vec ORDER BY v <-> '[100,100,100]' LIMIT 3;
+ id 
+----
+  5
+ 20
+ 19
+(3 rows)
+
+RESET enable_seqscan;
+SELECT count(*) FROM o_vec;
+ count 
+-------
+    19
+(1 row)
+
+-- Same for ivfflat, which resolves the tuple identifier on its own scan path.
+CREATE TABLE o_vec_ivf (
+	id int NOT NULL,
+	v vector(3),
+	PRIMARY KEY (id)
+) USING orioledb;
+INSERT INTO o_vec_ivf SELECT id, ARRAY[id, id, id]::vector FROM generate_series(1, 10) id;
+CREATE INDEX o_vec_ivf_idx ON o_vec_ivf USING ivfflat (v vector_l2_ops)
+	WITH (lists = 1);
+NOTICE:  index bridging is enabled for orioledb table 'o_vec_ivf'
+DETAIL:  index access method 'ivfflat' is supported only via index bridging for OrioleDB table
+INSERT INTO o_vec_ivf SELECT id, ARRAY[id, id, id]::vector FROM generate_series(11, 20) id;
+SET enable_seqscan = off;
+SELECT id FROM o_vec_ivf ORDER BY v <-> '[20,20,20]' LIMIT 5;
+ id 
+----
+ 20
+ 19
+ 18
+ 17
+ 16
+(5 rows)
+
+SELECT count(*) FROM (SELECT id FROM o_vec_ivf ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+ count 
+-------
+    20
+(1 row)
+
+RESET enable_seqscan;
+-- A rebuild over the whole table has to agree with what the inserts left.
+REINDEX INDEX o_vec_hnsw_idx;
+SET enable_seqscan = off;
+SELECT count(*) FROM (SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+ count 
+-------
+    19
+(1 row)
+
+RESET enable_seqscan;
+DROP TABLE o_vec;
+DROP TABLE o_vec_ivf;
+DROP EXTENSION vector;
+\endif
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA pgvector CASCADE;
+RESET search_path;

--- a/test/expected/pgvector_1.out
+++ b/test/expected/pgvector_1.out
@@ -1,0 +1,65 @@
+CREATE SCHEMA pgvector;
+SET SESSION search_path = 'pgvector';
+CREATE EXTENSION orioledb;
+-- pgvector is not part of the fork, so it is not installed everywhere; CI
+-- installs it in ci/post_build_prerequisites.sh.  Where it is missing the test
+-- skips its body and matches the pgvector_1 alternative output instead -- the
+-- error from CREATE EXTENSION cannot be used for that, as it names an absolute
+-- path.
+SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector')
+	AS have_pgvector \gset
+\if :have_pgvector
+CREATE EXTENSION vector;
+-- pgvector is built against stock PostgreSQL, so it leaves its insert callback
+-- on aminsert, which takes a plain ItemPointer, rather than on the
+-- aminsertextended entry point this fork added, which takes the tuple
+-- identifier as a Datum and so can carry an OrioleDB rowid.  Every access
+-- method shipped with the fork has been converted to aminsertextended, so
+-- pgvector is the only thing available to the tests that covers index bridging
+-- for the legacy signature.  See orioledb/orioledb#1118.
+CREATE TABLE o_vec (
+	id int NOT NULL,
+	v vector(3),
+	PRIMARY KEY (id)
+) USING orioledb;
+-- Rows already present reach the index through ambuild ...
+INSERT INTO o_vec SELECT id, ARRAY[id, id, id]::vector FROM generate_series(1, 10) id;
+CREATE INDEX o_vec_hnsw_idx ON o_vec USING hnsw (v vector_l2_ops);
+-- ... and these have to reach it through aminsert.
+INSERT INTO o_vec SELECT id, ARRAY[id, id, id]::vector FROM generate_series(11, 20) id;
+UPDATE o_vec SET v = '[100,100,100]' WHERE id = 5;
+DELETE FROM o_vec WHERE id = 6;
+SET enable_seqscan = off;
+EXPLAIN (COSTS OFF) SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 5;
+SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 5;
+-- The index has to hold every live row, not just the ones the build saw.
+SELECT count(*) FROM (SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+SELECT id FROM o_vec ORDER BY v <-> '[100,100,100]' LIMIT 3;
+RESET enable_seqscan;
+SELECT count(*) FROM o_vec;
+-- Same for ivfflat, which resolves the tuple identifier on its own scan path.
+CREATE TABLE o_vec_ivf (
+	id int NOT NULL,
+	v vector(3),
+	PRIMARY KEY (id)
+) USING orioledb;
+INSERT INTO o_vec_ivf SELECT id, ARRAY[id, id, id]::vector FROM generate_series(1, 10) id;
+CREATE INDEX o_vec_ivf_idx ON o_vec_ivf USING ivfflat (v vector_l2_ops)
+	WITH (lists = 1);
+INSERT INTO o_vec_ivf SELECT id, ARRAY[id, id, id]::vector FROM generate_series(11, 20) id;
+SET enable_seqscan = off;
+SELECT id FROM o_vec_ivf ORDER BY v <-> '[20,20,20]' LIMIT 5;
+SELECT count(*) FROM (SELECT id FROM o_vec_ivf ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+RESET enable_seqscan;
+-- A rebuild over the whole table has to agree with what the inserts left.
+REINDEX INDEX o_vec_hnsw_idx;
+SET enable_seqscan = off;
+SELECT count(*) FROM (SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+RESET enable_seqscan;
+DROP TABLE o_vec;
+DROP TABLE o_vec_ivf;
+DROP EXTENSION vector;
+\endif
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA pgvector CASCADE;
+RESET search_path;

--- a/test/sql/pgvector.sql
+++ b/test/sql/pgvector.sql
@@ -1,0 +1,75 @@
+CREATE SCHEMA pgvector;
+SET SESSION search_path = 'pgvector';
+CREATE EXTENSION orioledb;
+-- pgvector is not part of the fork, so it is not installed everywhere; CI
+-- installs it in ci/post_build_prerequisites.sh.  Where it is missing the test
+-- skips its body and matches the pgvector_1 alternative output instead -- the
+-- error from CREATE EXTENSION cannot be used for that, as it names an absolute
+-- path.
+SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector')
+	AS have_pgvector \gset
+\if :have_pgvector
+CREATE EXTENSION vector;
+
+-- pgvector is built against stock PostgreSQL, so it leaves its insert callback
+-- on aminsert, which takes a plain ItemPointer, rather than on the
+-- aminsertextended entry point this fork added, which takes the tuple
+-- identifier as a Datum and so can carry an OrioleDB rowid.  Every access
+-- method shipped with the fork has been converted to aminsertextended, so
+-- pgvector is the only thing available to the tests that covers index bridging
+-- for the legacy signature.  See orioledb/orioledb#1118.
+
+CREATE TABLE o_vec (
+	id int NOT NULL,
+	v vector(3),
+	PRIMARY KEY (id)
+) USING orioledb;
+
+-- Rows already present reach the index through ambuild ...
+INSERT INTO o_vec SELECT id, ARRAY[id, id, id]::vector FROM generate_series(1, 10) id;
+CREATE INDEX o_vec_hnsw_idx ON o_vec USING hnsw (v vector_l2_ops);
+
+-- ... and these have to reach it through aminsert.
+INSERT INTO o_vec SELECT id, ARRAY[id, id, id]::vector FROM generate_series(11, 20) id;
+UPDATE o_vec SET v = '[100,100,100]' WHERE id = 5;
+DELETE FROM o_vec WHERE id = 6;
+
+SET enable_seqscan = off;
+EXPLAIN (COSTS OFF) SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 5;
+SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 5;
+-- The index has to hold every live row, not just the ones the build saw.
+SELECT count(*) FROM (SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+SELECT id FROM o_vec ORDER BY v <-> '[100,100,100]' LIMIT 3;
+RESET enable_seqscan;
+
+SELECT count(*) FROM o_vec;
+
+-- Same for ivfflat, which resolves the tuple identifier on its own scan path.
+CREATE TABLE o_vec_ivf (
+	id int NOT NULL,
+	v vector(3),
+	PRIMARY KEY (id)
+) USING orioledb;
+INSERT INTO o_vec_ivf SELECT id, ARRAY[id, id, id]::vector FROM generate_series(1, 10) id;
+CREATE INDEX o_vec_ivf_idx ON o_vec_ivf USING ivfflat (v vector_l2_ops)
+	WITH (lists = 1);
+INSERT INTO o_vec_ivf SELECT id, ARRAY[id, id, id]::vector FROM generate_series(11, 20) id;
+
+SET enable_seqscan = off;
+SELECT id FROM o_vec_ivf ORDER BY v <-> '[20,20,20]' LIMIT 5;
+SELECT count(*) FROM (SELECT id FROM o_vec_ivf ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+RESET enable_seqscan;
+
+-- A rebuild over the whole table has to agree with what the inserts left.
+REINDEX INDEX o_vec_hnsw_idx;
+SET enable_seqscan = off;
+SELECT count(*) FROM (SELECT id FROM o_vec ORDER BY v <-> '[1,1,1]' LIMIT 100) s;
+RESET enable_seqscan;
+
+DROP TABLE o_vec;
+DROP TABLE o_vec_ivf;
+DROP EXTENSION vector;
+\endif
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA pgvector CASCADE;
+RESET search_path;


### PR DESCRIPTION
Fixes #1118.

### The bug

An HNSW index on an OrioleDB table can be created, is picked by the planner, and returns nothing for any row inserted after the build. IVFFlat is the same defect with a louder symptom: `TRAP: failed Assert("ItemPointerIsValid(&scan->xs_heaptid)"), File: "indexam.c", Line: 729`.

The index is not empty. After 5001 inserts it grows from 16 kB to 1.5 MB and still answers only with the 10 rows the build saw — every insert lands in it under an identifier the bridge cannot resolve.

### Why

The fork added `aminsertextended`, which takes the tuple identifier as a `Datum` and so can carry an OrioleDB rowid. `index_insert()` prefers `aminsert` whenever it is set:

```c
if (indexRelation->rd_indam->aminsert)
    return ...->aminsert(..., DatumGetItemPointer(tupleidDatum), ...);
else
    return ...->aminsertextended(...);
```

`orioledb_indexam_routine_hook()` overrides `ambuild`, `aminsertextended`, `ambeginscan` and `amcanreturn` on the bridged routine, but leaves the original `aminsert` in place. Every access method shipped with the fork — nbtree, gin, gist, hash, brin, spgist, contrib/bloom — has been converted to `aminsert = NULL`, so the wrapper wins for all of them. A third-party access method still has its `aminsert`, so `index_insert()` calls it directly, bypassing `bridged_aminsert()` and passing `DatumGetItemPointer()` of the rowid bytea, which points at the varlena header.

That is why GIN on an OrioleDB table is fine and pgvector is not, and why nothing in the tree catches it.

### The fix

Clear `aminsert` on the bridged routine so `index_insert()` takes the extended path, and let `bridged_aminsert()` fall back to the access method's own `aminsert` — with the bridge ctid it has already resolved — when the access method has no `aminsertextended`. Both changes are needed: either one alone leaves a hole.

Users with existing HNSW/IVFFlat indexes need to `REINDEX` them; what is stored in them now is garbage.

### The test

Nothing in the tree uses the legacy signature, so the test uses pgvector itself. `ci/post_build_prerequisites.sh` now installs pgvector v0.8.1 the same way it installs wal2json. The test is unconditional in `REGRESSCHECKS`; where pgvector is missing it skips its body via `\if` and matches `pgvector_1.out`. The `CREATE EXTENSION` error could not be used for that — it names an absolute path.

Verified in both directions: with the fix all 51 regression tests pass; with the fix reverted `pgvector` fails (HNSW scan returns 8 rows of 19, IVFFlat crashes the backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)