### PR TITLE
Stop a promote from consuming an oxid nothing will resolve

### DIFF
--- a/src/catalog/o_tables.c
+++ b/src/catalog/o_tables.c
@@ -1575,15 +1575,24 @@ o_tables_evict(Oid datoid, List **evicted)
 void
 o_tables_truncate_all_unlogged()
 {
-	OTablesDropAllArg arg;
-	OXid		oxid;
-	OSnapshot	oSnapshot;
+	OTablesDropAllArg arg = {0};
 
-	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
-
-	arg.oxid = oxid;
-	arg.csn = oSnapshot.csn;
-
+	/*
+	 * Assign no oxid here.  The callback truncates through
+	 * o_truncate_table(), which takes its own, and it never reads
+	 * arg.oxid/arg.csn -- so an oxid taken here is consumed by nothing.
+	 * Taking one anyway is actively harmful: this runs from the snapshot hook
+	 * on the first snapshot after recovery, which on a promote is concurrent
+	 * with the end-of-recovery checkpoint.  The checkpoint asks every backend
+	 * to flush its undo locations, so the very act of committing this
+	 * transaction files it in the checkpoint's xids file as in-flight, while
+	 * checkpoint_xmin -- read before the commit advanced runXmin -- is
+	 * published below it.  Since a cluster with no unlogged tables writes no
+	 * WAL under that oxid, nothing in the WAL stream can ever resolve it:
+	 * every later start resurrects it from the xids file, and the next
+	 * promote announces it to the peer with a WAL_REC_ROLLBACK whose xmin
+	 * sits below the peer's own globalXmin.
+	 */
 	o_tables_foreach(o_tables_truncate_unlogged_callback,
 					 &o_non_deleted_snapshot, &arg);
 }

--- a/test/t/replication_test.py
+++ b/test/t/replication_test.py
@@ -3000,6 +3000,93 @@ class ReplicationTest(BaseTest):
 				except ProcessLookupError:
 					pass
 
+	def test_promotion_xid_horizon_switchover(self):
+		"""
+		Repeated promotions must not make a finish record from the new primary
+		carry an xmin below the standby's local globalXmin.
+		"""
+		master = self.node
+		master.start()
+		replica = None
+
+		def xid_meta(node):
+			return node.execute("SELECT nextxid, globalxmin "
+			                    "FROM orioledb_get_xid_meta();")[0]
+
+		def switchover(primary, standby, checkpoint_promoted):
+			standby.catchup()
+			standby.poll_query_until(
+			    "SELECT orioledb_recovery_synchronized();", expected=True)
+			before = xid_meta(standby)
+
+			# Stop without generating shutdown-checkpoint WAL on the old
+			# timeline, then promote the fully caught-up standby.
+			primary.stop(['-m', 'immediate'])
+			standby.promote()
+			standby.poll_query_until("SELECT NOT pg_is_in_recovery();",
+			                         expected=True)
+			after = xid_meta(standby)
+
+			# A promote must not consume an oxid: nextXid comes from the WAL
+			# both nodes read, and an oxid taken locally here would not be in
+			# the stream the peer replays.
+			self.assertEqual(before[0], after[0])
+			if checkpoint_promoted:
+				# Preserve this node's promotion advance in its control file.
+				# The other node is stopped before its automatic end-of-recovery
+				# checkpoint completes, reproducing the asymmetric horizons.
+				standby.safe_psql("CHECKPOINT;")
+
+			primary._assign_master(standby)
+			primary._create_recovery_conf(username=primary.os_ops.get_user())
+			primary.start()
+			primary.catchup()
+			primary.poll_query_until(
+			    "SELECT orioledb_recovery_synchronized();", expected=True)
+			return standby, primary
+
+		try:
+			master.safe_psql("""
+				CREATE EXTENSION orioledb;
+				CREATE TABLE o_promotion_xmin (
+					id integer PRIMARY KEY,
+					value integer NOT NULL
+				) USING orioledb;
+				INSERT INTO o_promotion_xmin VALUES (1, 0);
+				CHECKPOINT;
+			""")
+			replica = self.getReplica()
+			replica.start()
+			replica.catchup()
+
+			primary, standby = master, replica
+			for _ in range(4):
+				primary, standby = switchover(primary, standby, standby
+				                              is replica)
+
+			self.assertIs(primary, master)
+			# The horizons must not have drifted apart: an xmin the primary
+			# can still stamp on a WAL record has to be at or above what the
+			# standby seeded its globalXmin from.
+			self.assertGreaterEqual(xid_meta(primary)[0], xid_meta(standby)[1])
+			primary.safe_psql(
+			    "UPDATE o_promotion_xmin SET value = value + 1 WHERE id = 1;")
+			standby.catchup()
+			standby.poll_query_until(
+			    "SELECT orioledb_recovery_synchronized();", expected=True)
+			self.assertEqual(
+			    1,
+			    standby.execute(
+			        "SELECT value FROM o_promotion_xmin WHERE id = 1;")[0][0])
+		finally:
+			for node in (master, replica):
+				if node is None:
+					continue
+				try:
+					node.stop(['-m', 'immediate'])
+				except Exception:
+					pass
+
 	def test_replication_partition_index(self):
 		with self.node as master:
 			self.node.append_conf("default_table_access_method = 'orioledb'")


### PR DESCRIPTION
Fixes the `Assert(xmin >= globalXmin)` Elizaveta hit on physical replication after several switchovers back and forth:

```
TRAP: failed Assert("xmin >= pg_atomic_read_u64(&xid_meta->globalXmin)"),
      File: "src/recovery/recovery.c", Line: 3032
1  update_run_xmin
2  replay_on_record
...
5  orioledb_redo
```

### The bug

`o_tables_truncate_all_unlogged()` took an oxid that **nothing consumes** — `o_tables_truncate_unlogged_callback()` never reads `arg.oxid`/`arg.csn`, and `o_truncate_table()` assigns its own. That stray oxid is the deterministic `nextXid += 1` per promote, and it is where the whole failure comes from.

Measured chain, one link per log line from the repro:

```
[tgsn] free_run_xmin runXmin 52 -> 52
[tgsn] alloc oxid 52 by autovacuum launcher      <- snapshot hook, promote
[tgsn] commit oxid 52 by autovacuum launcher
[tgsn] write-control chkp=3 retainXmin=52 retainXmax=53 nextXid=53 runXmin=53
   ... restarted as a standby, seeds from its own chkp=3 ...
[tgsn] read_xids in-flight oxid 52 chkp=3
[tgsn] emitting WAL_REC_ROLLBACK for in-flight oxid 52 aborted by recovery_finish
[tgsb] update_run_xmin BELOW xmin=52 globalXmin=54 recovery_xmin=54
```

1. The function runs from the snapshot hook on the first snapshot after recovery ends, so on a promote it is concurrent with the end-of-recovery checkpoint. Usually the autovacuum launcher gets there first — hence "with no launchers the switchovers are clean".
2. The checkpoint sets `flushUndoLocations`, so **committing** this transaction is itself what files its oxid in the checkpoint's xids file as in-flight (`write_to_xids_queue()` from the undo path, not `finish_write_xids()`), while `checkpoint_xmin` — read before that commit advanced `runXmin` — is published one below it.
3. With no unlogged tables the transaction writes no WAL, so nothing in the stream can ever resolve the oxid. Every later start resurrects it: `read_xids()` forces `COMMITSEQNO_INPROGRESS`, the xids file outranking the xidmap.
4. The next promote aborts it and emits `WAL_REC_ROLLBACK` for it onto the new timeline — and by then the peer's floor has moved past it, because `globalXmin` is purely local (control file + own replay) and each promote lifts `runXmin` to `nextXid` and persists it at the following checkpoint. Neither advance reaches the other node.

Without asserts the standby keeps `globalXmin` ahead of `runXmin`, and `oxid_get_csn()` then reads still-unresolved oxids below it as finished — so this is an MVCC hazard, not only a diagnostic.

### The fix

Take no oxid in `o_tables_truncate_all_unlogged()`. `nextXid` then moves only for transactions that appear in the WAL both nodes read, and the horizons stay together.

Confirmed causal before fixing: with the `o_tables_truncate_all_unlogged()` call stubbed out entirely the assert disappears and the repro instead fails its own `before.nextxid + 1 == after.nextxid` expectation — i.e. that `+1` is exactly this call.

### The test

`test_promotion_xid_horizon_switchover`, from @kobets-i's `test-promotion-xmin-switchover` branch: four switchovers where only one of the two nodes checkpoints after its promote, which is what makes the two control files disagree. Two of its assertions encoded the buggy behaviour (`before.nextxid + 1 == after.nextxid`, and `assertLess(primary.nextxid, standby.globalxmin)` asserting that the drift exists); both are inverted into the real invariants here.

Validation: repro test OK, `unlogged_test` 3/3, `replication_test` 45/45, `recovery_test` 57/57, regress 50/50, pgindent and yapf clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)