### PR TITLE
Validate undo tuple sizes during historical scans

### DIFF
--- a/include/btree/undo.h
+++ b/include/btree/undo.h
@@ -242,6 +242,27 @@ extern void btree_relnode_undo_callback(UndoLogType undoType,
 										UndoStackItem *baseItem, OXid oxid,
 										OUndoCallbackStage stage,
 										bool changeCountsValid);
+static inline LocationIndex
+validate_undo_item_size(LocationIndex itemSize)
+{
+	LocationIndex tupleSize;
+
+	if (unlikely(itemSize < sizeof(BTreeModifyUndoStackItem)))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("corrupted undo record: item size %u smaller than header %u",
+						(unsigned) itemSize,
+						(unsigned) sizeof(BTreeModifyUndoStackItem))));
+	tupleSize = itemSize - sizeof(BTreeModifyUndoStackItem);
+	if (unlikely(tupleSize > O_BTREE_MAX_TUPLE_SIZE))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("corrupted undo record: tuple size %u exceeds maximum %u",
+						(unsigned) tupleSize,
+						(unsigned) O_BTREE_MAX_TUPLE_SIZE)));
+	return tupleSize;
+}
+
 extern void get_prev_leaf_header_from_undo(UndoLogType undoType,
 										   BTreeLeafTuphdr *tuphdr,
 										   bool inPage);

--- a/orioledb.control
+++ b/orioledb.control
@@ -1,5 +1,5 @@
 # orioledb extension
 comment = 'OrioleDB -- the next generation transactional engine'
-default_version = '1.9'
+default_version = '1.10'
 module_pathname = '$libdir/orioledb'
 relocatable = true

--- a/sql/orioledb--1.9--1.10_dev.sql
+++ b/sql/orioledb--1.9--1.10_dev.sql
@@ -1,0 +1,9 @@
+/* contrib/orioledb/sql/orioledb--1.9--1.10_dev.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.10'" to load this file. \quit
+
+CREATE FUNCTION orioledb_test_corrupt_row_undo(relid oid)
+RETURNS text
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/sql/orioledb--1.9--1.10_prod.sql
+++ b/sql/orioledb--1.9--1.10_prod.sql
@@ -1,0 +1,4 @@
+/* contrib/orioledb/sql/orioledb--1.9--1.10_prod.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION orioledb UPDATE TO '1.10'" to load this file. \quit

--- a/src/btree/undo.c
+++ b/src/btree/undo.c
@@ -2288,10 +2288,14 @@ get_prev_leaf_header_and_tuple_from_undo(UndoLogType undoType,
 
 	*tuphdr = item.tuphdr;
 	tuple->formatFlags = tuphdr->formatFlags;
-	tupleSize = item.header.itemSize - sizeof(BTreeModifyUndoStackItem);
+	tupleSize = validate_undo_item_size(item.header.itemSize);
 	if (sizeAvailable == 0)
 		tuple->data = palloc(tupleSize);
-	Assert(sizeAvailable == 0 || sizeAvailable >= tupleSize);
+	else if (unlikely(tupleSize > sizeAvailable))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("corrupted undo record: tuple size %u exceeds available %u",
+						(unsigned) tupleSize, (unsigned) sizeAvailable)));
 	undo_read(undoType,
 			  undoLocation + BTreeLeafTuphdrSize,
 			  tupleSize,
@@ -2429,6 +2433,108 @@ orioledb_test_corrupt_page_undo(PG_FUNCTION_ARGS)
 
 	if (type_name)
 		PG_RETURN_TEXT_P(cstring_to_text(type_name));
+	PG_RETURN_NULL();
+}
+
+PG_FUNCTION_INFO_V1(orioledb_test_corrupt_row_undo);
+
+/*
+ * Walk the primary index btree, find the first leaf tuple with a valid
+ * tuple-level undoLocation, and corrupt the itemSize field in its
+ * BTreeModifyUndoStackItem header.  Returns "tuple" on success, NULL
+ * if no tuple-level undo record was found.
+ *
+ * Test-only; guarded by IS_DEV.
+ */
+Datum
+orioledb_test_corrupt_row_undo(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	Relation	rel;
+	OTableDescr *descr;
+	OIndexDescr *idx;
+	BTreeDescr *desc;
+	OInMemoryBlkno blkno;
+	UndoLogType undoType;
+	bool		found = false;
+
+	orioledb_check_shmem();
+
+	rel = relation_open(relid, AccessShareLock);
+	descr = relation_get_descr(rel);
+	if (!descr)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation oid %u is not orioledb", relid)));
+
+	idx = descr->indices[0];
+	desc = &idx->desc;
+	o_btree_load_shmem(desc);
+	undoType = desc->undoType;
+	blkno = desc->rootInfo.rootPageBlkno;
+
+	/* Walk from root to a leaf. */
+	lock_page(blkno);
+	while (true)
+	{
+		Page		p = O_GET_IN_MEMORY_PAGE(blkno);
+
+		if (O_PAGE_IS(p, LEAF))
+		{
+			BTreePageItemLocator loc;
+
+			BTREE_PAGE_FOREACH_ITEMS(p, &loc)
+			{
+				BTreeLeafTuphdr *tuphdr = (BTreeLeafTuphdr *)
+					BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
+
+				if (UndoLocationIsValid(tuphdr->undoLocation) &&
+					UNDO_REC_EXISTS(undoType, tuphdr->undoLocation))
+				{
+					BTreeModifyUndoStackItem item;
+					UndoLocation itemLoc;
+
+					itemLoc = tuphdr->undoLocation -
+						offsetof(BTreeModifyUndoStackItem, tuphdr);
+					undo_read(undoType, itemLoc,
+							  sizeof(item), (Pointer) &item);
+					item.header.itemSize = 0xFFFF;
+					undo_write(undoType, itemLoc,
+							   sizeof(item), (Pointer) &item);
+					found = true;
+					break;
+				}
+			}
+			unlock_page(blkno);
+			break;
+		}
+		else
+		{
+			BTreePageItemLocator loc;
+			BTreeNonLeafTuphdr *tuphdr;
+			OInMemoryBlkno child;
+
+			BTREE_PAGE_LOCATOR_FIRST(p, &loc);
+			tuphdr = (BTreeNonLeafTuphdr *)
+				BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
+
+			if (!DOWNLINK_IS_IN_MEMORY(tuphdr->downlink))
+			{
+				unlock_page(blkno);
+				ereport(ERROR,
+						(errmsg("leftmost child is not in memory")));
+			}
+			child = DOWNLINK_GET_IN_MEMORY_BLKNO(tuphdr->downlink);
+			lock_page(child);
+			unlock_page(blkno);
+			blkno = child;
+		}
+	}
+
+	relation_close(rel, AccessShareLock);
+
+	if (found)
+		PG_RETURN_TEXT_P(cstring_to_text("tuple"));
 	PG_RETURN_NULL();
 }
 

--- a/src/recovery/recovery.c
+++ b/src/recovery/recovery.c
@@ -508,7 +508,7 @@ apply_one_pending_sk_fixup(PendingSkFixup *entry)
 	primary = GET_PRIMARY(descr);
 
 	/* The undo entry stores the pre-image tuple right after the header. */
-	oldTupleSize = item.header.itemSize - sizeof(BTreeModifyUndoStackItem);
+	oldTupleSize = validate_undo_item_size(item.header.itemSize);
 	if (oldTupleSize == 0)
 		return;
 	oldTuple.formatFlags = item.tuphdr.formatFlags;

--- a/test/t/seq_scan_undo_test.py
+++ b/test/t/seq_scan_undo_test.py
@@ -154,3 +154,45 @@ class SeqScanUndoTest(BaseTest):
 
 		reader.close()
 		node.stop(['-m', 'immediate'])
+
+	def test_corrupt_undo_tuple_size(self):
+		"""
+		Corrupted itemSize in a tuple-level undo record must raise
+		ERRCODE_DATA_CORRUPTED instead of overrunning the caller's buffer.
+		"""
+		node = self.node
+		node.append_conf(
+		    'postgresql.conf', "shared_preload_libraries = orioledb\n"
+		    "orioledb.main_buffers = 8MB\n"
+		    "orioledb.debug_disable_pools_limit = true\n"
+		    "orioledb.debug_disable_bgwriter = true\n")
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		node.safe_psql("""
+			CREATE TABLE o_undo_corrupt_tuple (
+				id int PRIMARY KEY,
+				payload text
+			) USING orioledb;
+			INSERT INTO o_undo_corrupt_tuple
+				SELECT g, repeat('x', 200) FROM generate_series(1, 100) g;
+		""")
+
+		# Pin an old snapshot so tuple undo chains are preserved.
+		reader = node.connect()
+		reader.begin('REPEATABLE READ')
+		reader.execute("SELECT count(*) FROM o_undo_corrupt_tuple;")
+
+		# Update to create tuple-level undo, then corrupt the itemSize.
+		node.safe_psql("""
+			UPDATE o_undo_corrupt_tuple SET payload = repeat('y', 200);
+			SELECT orioledb_test_corrupt_row_undo(
+				'o_undo_corrupt_tuple'::regclass::oid);
+		""")
+
+		# The pinned reader must hit the corrupted undo and get a clean error.
+		with self.assertRaises(Exception) as cm:
+			reader.execute("SELECT * FROM o_undo_corrupt_tuple;")
+		self.assertIn("corrupted undo record", str(cm.exception))
+
+		reader.close()
+		node.stop(['-m', 'immediate'])


### PR DESCRIPTION
Tuple-level undo records (BTreeModifyUndoStackItem) store an itemSize that is trusted without bounds checks when reading previous tuple versions. A corrupted itemSize causes an out-of-bounds undo_read into the caller's buffer (e.g. a btree page slot in apply_btree_modify_undo), or a uint16 underflow when itemSize < sizeof(BTreeModifyUndoStackItem).

Add validate_undo_item_size() in btree/undo.h that raises ERRCODE_DATA_CORRUPTED when itemSize is too small (underflow) or the resulting tuple size exceeds O_BTREE_MAX_TUPLE_SIZE. Replace the Assert-only guard in get_prev_leaf_header_and_tuple_from_undo with always-on validation, and add the same check in recovery.c where the identical pattern computes oldTupleSize from undo.

Add orioledb_test_corrupt_row_undo() (IS_DEV) and a regression test that corrupts itemSize to 0xFFFF and verifies the clean error.

Ref: ori-271, ori-272