### PR TITLE
Protect bridged unique concurrent builds

### DIFF
--- a/doc/architecture/concurrent-index.mdx
+++ b/doc/architecture/concurrent-index.mdx
@@ -18,9 +18,11 @@ Two paths coexist:
 - **Bridged** (any non-btree AM, or btree with
   `WITH(orioledb_index=false)`, or btree on a table whose `index_bridging`
   is enabled): the index is a stock PG index keyed by `bridge_ctid`;
-  ambuild lands in `bridged_ambuild` / `btbuild` and PG's CIC machinery
-  handles it natively, UNIQUE included.  No orioledb-specific BUILDING
-  state, no spool.  `orioledb_index_validate_scan` is a no-op for these.
+  ambuild lands in `bridged_ambuild` / `btbuild`.  Non-unique CIC uses PG's
+  machinery with no orioledb-specific BUILDING state or spool.  UNIQUE CIC
+  is downgraded to a plain build (or rejected in strict mode) because
+  `orioledb_index_validate_scan` does not yet catch up rows committed during
+  the bridged phase-2 build.
 
 The rest of this page describes the native btree path.
 
@@ -287,7 +289,9 @@ existing recovery-finish work.
   writers insert different PKs with same secondary value; the
   post-drain unique-fields walk catches the duplicate.
 - `test_cic_bridged_gin`: bridged GIN CIC through PG's machinery.
-- `test_cic_bridged_unique_btree`: bridged UNIQUE btree CIC.
+- `test_cic_bridged_unique_btree`: bridged UNIQUE CIC is safely downgraded.
+- `test_cic_bridged_unique_concurrent_insert`: a writer paused inside the
+  build cannot leave a row absent from the finished unique index.
 - `test_cic_concurrent_writes`: writer thread runs during the build;
   spool drain produces a complete index.
 - `test_cic_writer_spans_all_phases`: writer commits tiny transactions
@@ -300,6 +304,10 @@ existing recovery-finish work.
 
 ## Limitations
 
+- Bridged UNIQUE CIC is downgraded to a plain `CREATE UNIQUE INDEX` by
+  default, or rejected when `orioledb.strict_mode` is enabled.  A concurrent
+  implementation needs a bridged phase-3 primary-tree walk equivalent to
+  PostgreSQL's heap validation scan.
 - **DEFERRABLE INITIALLY DEFERRED UNIQUE** within a *single*
   transaction that creates and resolves duplicates inside the build
   window is currently not supported: the spool replays every event

--- a/src/catalog/ddl.c
+++ b/src/catalog/ddl.c
@@ -935,8 +935,8 @@ ReindexPartitions(Oid relid, bool concurrently)
  * full orioledb-native build) or on the *bridged* path (the index is a
  * stock PG index keyed by bridge_ctid, built by btbuild / each AM's own
  * ambuild)?  The BUILDING/spool plumbing only applies to native
- * indexes; bridged indexes are handled by PG's standard CIC machinery
- * (and that includes UNIQUE).
+ * indexes.  Bridged indexes do not have the phase-3 catch-up scan needed
+ * for UNIQUE CIC, so those builds are rejected or downgraded below.
  *
  * Mirrors the resolution that orioledb_indexam_routine_hook +
  * orioledb_ambuild's `options->orioledb_index` branch perform later,
@@ -1698,12 +1698,23 @@ orioledb_utility_command(PlannedStmt *pstmt,
 				 * - *Bridged* (any non-btree AM, or btree with
 				 * WITH(orioledb_index=false), or btree on a table whose
 				 * index_bridging is enabled): the index is a stock-PG index
-				 * keyed by bridge_ctid; ambuild lands in bridged_ambuild /
-				 * btbuild and PG's CIC machinery handles it natively, UNIQUE
-				 * included.  Don't second-guess any of it -- just let it
-				 * through.
+				 * keyed by bridge_ctid.  Non-unique CIC can use that path, but
+				 * UNIQUE must be downgraded until validate_scan can catch rows
+				 * committed during the phase-2 build.
 				 */
-				(void) o_cic_is_native_index(rel, stmt);
+				if (stmt->unique && !o_cic_is_native_index(rel, stmt))
+				{
+					if (orioledb_strict_mode)
+					{
+						table_close(rel, lockmode);
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("CREATE UNIQUE INDEX CONCURRENTLY is not supported for bridged indexes on orioledb tables")));
+					}
+					stmt->concurrent = false;
+					ereport(WARNING,
+							(errmsg("CREATE UNIQUE INDEX CONCURRENTLY is not supported for bridged indexes on orioledb tables, using a plain CREATE UNIQUE INDEX instead")));
+				}
 			}
 			table_close(rel, lockmode);
 		}

--- a/src/tableam/handler.c
+++ b/src/tableam/handler.c
@@ -1318,7 +1318,8 @@ orioledb_index_validate_scan(Relation heapRelation,
 	bool		bridged;
 
 	/*
-	 * Bridged index (any non-btree AM, or btree with orioledb_index = false):
+	 * Bridged non-unique index (any non-btree AM, or btree with
+	 * orioledb_index = false):
 	 * it's a stock-PG index keyed by bridge_ctid.  The phase-2 build was done
 	 * by the AM's own ambuild via bridged_ambuild / btbuild, and PG has
 	 * already set indisready=true between phase 2 and this call, so
@@ -1326,11 +1327,10 @@ orioledb_index_validate_scan(Relation heapRelation,
 	 * nothing native to do here -- no OIndex sys-tree row, no orioledb tree,
 	 * no spool.  PG will mark the index valid on return.
 	 *
-	 * Catch-up of inserts that happened *during* the phase-2 build (after its
-	 * snapshot but before indisready=true) is a follow-up: PG's heap-AM
-	 * validate_index would catch them by re-walking the heap here, and
-	 * orioledb-bridged would need an equivalent walk of the primary tree.
-	 * Single-writer CIC and bulk-load scenarios are unaffected.
+	 * PG's heap-AM validate_index would catch inserts made after the phase-2
+	 * snapshot by re-walking the heap here.  Orioledb-bridged does not yet
+	 * have an equivalent walk of the primary tree, so bridged UNIQUE CIC is
+	 * downgraded or rejected by the utility hook.
 	 */
 	bridged = indexRelation->rd_rel->relam != BTREE_AM_OID ||
 		(options && !options->orioledb_index);
@@ -1350,8 +1350,8 @@ orioledb_index_validate_scan(Relation heapRelation,
 	 * the spool of captured concurrent DML, flip OIndex.state to VALID, emit
 	 * WAL_REC_CIC_INDEX_VALID, drop the spool dir.
 	 *
-	 * UNIQUE is rejected at the ddl.c gate so we never need to perform the
-	 * duplicate-detection validation PG does for unique indexes.
+	 * Native UNIQUE indexes are checked during build and by the post-drain
+	 * unique-fields walk before their state is flipped to VALID.
 	 */
 	o_define_index_concurrent_finish(heapRelation, indexRelation);
 }

--- a/test/t/concurrent_index_test.py
+++ b/test/t/concurrent_index_test.py
@@ -29,8 +29,9 @@ class ConcurrentIndexTest(BaseTest):
 	Bridged indexes (any non-btree AM, or btree with
 	WITH(orioledb_index=false), or btree on a table with
 	index_bridging enabled) are stock-PG indexes keyed by
-	bridge_ctid; CIC for those flows through PG's standard
-	machinery, no orioledb-specific BUILDING/spool plumbing.
+	bridge_ctid.  Non-unique CIC flows through PG's standard
+	machinery.  UNIQUE CIC is downgraded to a plain build because
+	OrioleDB does not yet provide the bridged phase-3 catch-up scan.
 	"""
 
 	def test_cic_basic(self):
@@ -228,10 +229,8 @@ class ConcurrentIndexTest(BaseTest):
 
 	def test_cic_bridged_unique_btree(self):
 		"""
-		CIC on a UNIQUE btree index over a bridged orioledb table
-		(WITH index_bridging) should also flow through PG's stock
-		CIC machinery — UNIQUE is fine when the underlying index
-		is a stock PG btree on bridge_ctid.
+		UNIQUE CIC on a bridged orioledb table is downgraded to a
+		plain build, which still enforces uniqueness.
 		"""
 		node = self.node
 		node.start()
@@ -246,13 +245,132 @@ class ConcurrentIndexTest(BaseTest):
 				INSERT INTO o_cic_b_uniq
 				SELECT g, 'v' || g FROM generate_series(1, 200) g;
 			""")
-			node.safe_psql(
+			_, _, err = node.psql(
 			    "CREATE UNIQUE INDEX CONCURRENTLY o_cic_b_uniq_val_uidx "
 			    "ON o_cic_b_uniq (val);")
+			self.assertIn(b"using a plain CREATE UNIQUE INDEX instead", err)
 			# Uniqueness enforced post-build.
 			with self.assertRaises(Exception):
 				node.safe_psql("INSERT INTO o_cic_b_uniq VALUES (201, 'v1');")
 		finally:
+			try:
+				node.stop()
+			except Exception:
+				pass
+
+	def test_cic_bridged_unique_concurrent_insert(self):
+		"""
+		A row committed after the bridged UNIQUE build takes its snapshot
+		must not be omitted from the finished index.  Pause expression
+		evaluation during the build so the writer lands in that window.
+		"""
+		node = self.node
+		node.start()
+		ctrl = None
+		cic_conn = None
+		writer_conn = None
+		cic = None
+		writer = None
+		try:
+			node.safe_psql("""
+				CREATE EXTENSION orioledb;
+				CREATE FUNCTION o_cic_pause(value text) RETURNS text
+				LANGUAGE plpgsql IMMUTABLE AS $$
+				BEGIN
+					IF value = 'v1' THEN
+						PERFORM pg_advisory_xact_lock(292);
+					END IF;
+					RETURN value;
+				END;
+				$$;
+				CREATE TABLE o_cic_b_race (
+					id int NOT NULL PRIMARY KEY,
+					val text NOT NULL
+				) USING orioledb;
+				INSERT INTO o_cic_b_race
+				SELECT g, 'v' || g FROM generate_series(1, 200) g;
+			""")
+
+			ctrl = node.connect()
+			ctrl.begin()
+			ctrl.execute("SELECT pg_advisory_xact_lock(292)")
+
+			cic_conn = node.connect(autocommit=True)
+			cic_pid = cic_conn.execute("SELECT pg_backend_pid()")[0][0]
+			cic = ThreadQueryExecutor(
+			    cic_conn,
+			    "CREATE UNIQUE INDEX CONCURRENTLY o_cic_b_race_val_uidx "
+			    "ON o_cic_b_race (o_cic_pause(val)) "
+			    "WITH (orioledb_index = off);")
+			cic.start()
+
+			deadline = time.time() + 10
+			while time.time() < deadline:
+				waiting = node.execute(
+				    "SELECT wait_event = 'advisory' FROM pg_stat_activity "
+				    "WHERE pid = %d" % cic_pid)
+				if waiting and waiting[0][0]:
+					break
+				time.sleep(0.1)
+			else:
+				self.fail("bridged index build did not reach advisory lock")
+
+			writer_conn = node.connect(autocommit=True)
+			writer_pid = writer_conn.execute("SELECT pg_backend_pid()")[0][0]
+			writer = ThreadQueryExecutor(
+			    writer_conn, "INSERT INTO o_cic_b_race "
+			    "SELECT g, 'late' || g FROM generate_series(201, 210) g;")
+			writer.start()
+
+			# CIC permits the insert immediately; the safe plain build blocks it
+			# on its table lock.  Wait for either outcome before resuming build.
+			deadline = time.time() + 10
+			while time.time() < deadline:
+				settled = node.execute(
+				    "SELECT EXISTS (SELECT 1 FROM o_cic_b_race "
+				    "WHERE id = 210) OR EXISTS (SELECT 1 "
+				    "FROM pg_stat_activity WHERE pid = %d "
+				    "AND wait_event_type = 'Lock')" % writer_pid)[0][0]
+				if settled:
+					break
+				time.sleep(0.1)
+			else:
+				self.fail("concurrent insert neither committed nor blocked")
+
+			ctrl.commit()
+			cic.join()
+			writer.join()
+
+			expected = [(i, ) for i in range(201, 211)]
+			heap_rows = node.execute(
+			    "SELECT id FROM o_cic_b_race "
+			    "WHERE id BETWEEN 201 AND 210 ORDER BY id")
+			self.assertEqual(heap_rows, expected)
+			with node.connect() as c:
+				c.execute("SET enable_seqscan = off")
+				index_rows = c.execute(
+				    "SELECT id FROM o_cic_b_race "
+				    "WHERE o_cic_pause(val) >= 'late' "
+				    "AND o_cic_pause(val) < 'latf' ORDER BY id")
+			self.assertEqual(index_rows, expected)
+			with self.assertRaises(Exception):
+				node.safe_psql(
+				    "INSERT INTO o_cic_b_race VALUES (211, 'late201');")
+		finally:
+			if ctrl is not None:
+				try:
+					ctrl.rollback()
+				except Exception:
+					pass
+			for thread in (cic, writer):
+				if thread is not None:
+					try:
+						thread.join(10)
+					except Exception:
+						pass
+			for conn in (cic_conn, writer_conn, ctrl):
+				if conn is not None:
+					conn.close()
 			try:
 				node.stop()
 			except Exception:


### PR DESCRIPTION
Bridged index validation does not catch rows committed during phase 2. Downgrade unique concurrent builds to a plain build, reject them in strict mode, and add deterministic concurrent-row coverage.