### PR TITLE
Disable flaky S3 tests under valgrind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,8 @@ endif
 override CFLAGS_SL += -DCOMMIT_HASH=$(COMMIT_HASH) -Wno-error=deprecated-declarations
 
 ifdef VALGRIND
-override with_temp_install += PGCTLTIMEOUT=3000 PG_TEST_TIMEOUT_DEFAULT=500 \
+override with_temp_install += USE_VALGRIND=1 \
+	PGCTLTIMEOUT=3000 PG_TEST_TIMEOUT_DEFAULT=500 \
 	valgrind --vgdb=yes --leak-check=no \
 	--num-callers=20 --suppressions=$(CURDIR)/valgrind.supp --time-stamp=yes \
 	--log-file=$(CURDIR)/pid-%p.log --trace-children=yes \

--- a/test/t/s3_base_test.py
+++ b/test/t/s3_base_test.py
@@ -9,6 +9,7 @@ import socket
 from socket import AddressFamily, SocketKind
 import sys
 import time
+import unittest
 from threading import Thread
 from typing import Optional, Any
 from urllib3.util import connection
@@ -80,6 +81,9 @@ def mock_moto_unkown_error(self) -> TYPE_RESPONSE:
 	raise InvalidRequest("mock_moto_unkown_error")
 
 
+# TODO: re-enable under valgrind once s3_header_mark_part_loaded race is fixed
+@unittest.skipIf(
+    os.environ.get('USE_VALGRIND') == '1', 'S3 tests flaky under valgrind')
 class S3BaseTest(BaseTest):
 	bucket_name = "test-bucket"
 	host = "localhost"


### PR DESCRIPTION
s3_header_mark_part_loaded assertion fires sometimes under valgrind timing. S3 feature is not stable and is disabled in prod builds, so we just disable flaky tests. This is to be reverted when s3 is stable enough to be turned on in prod.