### PR TITLE
Include indices reorder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ REGRESSCHECKS = btree_sys_check \
 				generated \
 				getsomeattrs \
 				index_bridging \
+				include_pk \
 				indices \
 				indices_build \
 				inherits \
@@ -157,8 +158,9 @@ ISOLATIONCHECKS = bitmap_hist_scan \
 				  btree_print_backend_id \
 				  btree_scan \
 				  concurrent_update_delete \
-				  fkeys \
-				  included \
+				fkeys \
+				include_pk_wait \
+				included \
 				  insert_fails \
 				  ioc_deadlock \
 				  ioc_lost_update \

--- a/include/catalog/o_indices.h
+++ b/include/catalog/o_indices.h
@@ -88,6 +88,13 @@ typedef struct
 	AttrNumber	primaryFieldsAttnums[INDEX_MAX_KEYS];
 
 	/*
+	 * PostgreSQL IndexAM field order to physical tuple attnums, counting from
+	 * 1
+	 */
+	uint16		nIndexAmFields;
+	AttrNumber	indexAmAttnums[2 * INDEX_MAX_KEYS];
+
+	/*
 	 * Fields above are stored in SYS_TREES_O_INDICES and
 	 * serialized/deserialized by serialize_o_index()/deserialize_o_index().
 	 * Fields below are also stored in SYS_TREES_O_INDICES, but they are

--- a/include/orioledb.h
+++ b/include/orioledb.h
@@ -99,7 +99,7 @@
  */
 #define ORIOLEDB_VERSION "OrioleDB beta 17"
 #define ORIOLEDB_BINARY_VERSION 10
-#define ORIOLEDB_SYS_TREE_VERSION	1	/* Version of system catalog */
+#define ORIOLEDB_SYS_TREE_VERSION	2	/* Version of system catalog */
 #define ORIOLEDB_PAGE_VERSION		1	/* Version of binary page format */
 #define ORIOLEDB_COMPRESS_VERSION	1	/* Version of page compression (only
 										 * for compressed pages) */

--- a/include/tableam/descr.h
+++ b/include/tableam/descr.h
@@ -195,13 +195,14 @@ struct OIndexDescr
 	OIndexField *fields;
 
 	/*
-	 * Attnums for primary key values in the secondary index tuples. We may
-	 * assume that secondary index tuple just contain primary key values in
-	 * the tail.  But we would like to save the space if secondary index
-	 * shares some attributes with primary key.
+	 * Attnums for primary key values in secondary index tuples.  A value may
+	 * be in the key, INCLUDE range, or appended primary-key tail because a
+	 * column shared with the secondary index is stored only once.
 	 */
 	int			nPrimaryFields;
 	AttrNumber	primaryFieldsAttnums[INDEX_MAX_KEYS];
+	int			nIndexAmFields;
+	AttrNumber	indexAmAttnums[2 * INDEX_MAX_KEYS];
 
 	/* Compression rate used in this index */
 	OCompress	compress;
@@ -264,8 +265,8 @@ OIndexKeyAttnumToTupleAttnum(BTreeKeyType keyType, OIndexDescr *idx, int attnum)
 
 #define OIgnoreColumn(descr, attnum) \
 	((descr->desc.type != oIndexToast && descr->desc.type != oIndexBridge) && \
-		(attnum >= descr->nKeyFields) && \
-	 (attnum < (descr->nKeyFields + descr->nIncludedFields)))
+	 (attnum >= (descr->nFields - descr->nIncludedFields)) && \
+	 (attnum < descr->nFields))
 
 struct OTableDescr
 {

--- a/src/catalog/o_indices.c
+++ b/src/catalog/o_indices.c
@@ -340,7 +340,8 @@ make_ctid_o_index(OTable *table, OIndexVersionMode ixVerMode)
 }
 
 static int
-find_existing_field(OIndex *index, int maxIndex, OTableIndexField *field)
+find_existing_field(OIndex *index, int maxIndex, OTableIndexField *field,
+					bool match_opclass)
 {
 	int			i;
 
@@ -348,7 +349,8 @@ find_existing_field(OIndex *index, int maxIndex, OTableIndexField *field)
 	{
 		if (field->attnum != EXPR_ATTNUM &&
 			field->attnum == index->leafFields[i].attnum &&
-			field->opclass == index->leafFields[i].opclass)
+			(!match_opclass ||
+			 field->opclass == index->leafFields[i].opclass))
 		{
 			return i;
 		}
@@ -435,7 +437,8 @@ make_primary_o_index(OTable *table, OIndexVersionMode ixVerMode)
 	{
 		int			found_attnum;
 
-		found_attnum = find_existing_field(result, nadded, &tableIndex->fields[i]);
+		found_attnum = find_existing_field(result, nadded,
+										   &tableIndex->fields[i], true);
 		if (found_attnum >= 0)
 		{
 			List	   *duplicate;
@@ -463,41 +466,42 @@ make_primary_o_index(OTable *table, OIndexVersionMode ixVerMode)
 }
 
 static void
-add_index_fields(OIndex *index, OTable *table, OTableIndex *tableIndex, int *nadded, bool fillPrimary)
+add_index_fields(OIndex *index, OTable *table, OTableIndex *tableIndex,
+				 int field_from, int field_to, int *nadded,
+				 bool fillPrimary, bool fillIndexAm)
 {
 	int			i;
 	int			expr_field = 0;
-	int			init_nKeyFields = index->nKeyFields;
 
 	if (tableIndex)
 	{
-		int			nFields = fillPrimary ? tableIndex->nkeyfields : tableIndex->nfields;
+		for (i = 0; i < field_from; i++)
+		{
+			if (tableIndex->fields[i].attnum == EXPR_ATTNUM)
+				expr_field++;
+		}
 
-		for (i = 0; i < nFields; i++)
+		for (i = field_from; i < field_to; i++)
 		{
 			int			attnum = tableIndex->fields[i].attnum;
 			int			found_attnum;
 
-			found_attnum = find_existing_field(index, *nadded, &tableIndex->fields[i]);
+			found_attnum = find_existing_field(index, *nadded,
+											   &tableIndex->fields[i],
+											   i < tableIndex->nkeyfields || fillPrimary);
 			if (found_attnum >= 0)
 			{
 				if (fillPrimary)
 					index->primaryFieldsAttnums[index->nPrimaryFields++] = found_attnum + 1;
 				else
 				{
-					List	   *duplicate;
-
-					if (i < init_nKeyFields)
+					if (i < tableIndex->nkeyfields)
 						index->nKeyFields--;
 					else
 						index->nIncludedFields--;
-
-					Assert(CurrentMemoryContext == index->index_mctx);
-					/* (fieldnum, original fieldnum) */
-					/* cppcheck-suppress unknownEvaluationOrder */
-					duplicate = list_make2_int(*nadded, found_attnum);
-					index->duplicates = lappend(index->duplicates, duplicate);
 				}
+				if (fillIndexAm)
+					index->indexAmAttnums[index->nIndexAmFields++] = found_attnum + 1;
 
 				continue;
 			}
@@ -510,6 +514,8 @@ add_index_fields(OIndex *index, OTable *table, OTableIndex *tableIndex, int *nad
 			index->leafFields[*nadded] = tableIndex->fields[i];
 			if (fillPrimary)
 				index->primaryFieldsAttnums[index->nPrimaryFields++] = *nadded + 1;
+			if (fillIndexAm)
+				index->indexAmAttnums[index->nIndexAmFields++] = *nadded + 1;
 			(*nadded)++;
 		}
 	}
@@ -587,12 +593,39 @@ make_secondary_o_index(OTable *table, OTableIndex *tableIndex, OIndexVersionMode
 		result->exclops = palloc0(tableIndex->nkeyfields * sizeof(Oid));
 		memcpy(result->exclops, tableIndex->exclops, tableIndex->nkeyfields * sizeof(Oid));
 	}
-	add_index_fields(result, table, tableIndex, &nadded, false);
-	if (tableIndex->nfields == tableIndex->nkeyfields)
-		result->nKeyFields = nadded;
+	add_index_fields(result, table, tableIndex, 0, tableIndex->nkeyfields,
+					 &nadded, false, true);
 	Assert(nadded <= tableIndex->nfields);
-	add_index_fields(result, table, primary, &nadded, true);
+	add_index_fields(result, table, primary, 0,
+					 primary ? primary->nkeyfields : 0,
+					 &nadded, true, false);
+	add_index_fields(result, table, tableIndex, tableIndex->nkeyfields,
+					 tableIndex->nfields, &nadded, false, true);
 	Assert(nadded <= result->nLeafFields);
+
+	if (primary)
+	{
+		int			i;
+
+		for (i = 0; i < primary->nkeyfields; i++)
+		{
+			int			j;
+			bool		member = false;
+
+			for (j = 0; j < tableIndex->nfields; j++)
+			{
+				if (primary->fields[i].attnum == tableIndex->fields[j].attnum)
+				{
+					member = true;
+					break;
+				}
+			}
+			if (!member)
+				result->indexAmAttnums[result->nIndexAmFields++] =
+					result->primaryFieldsAttnums[i];
+		}
+	}
+	Assert(result->nIndexAmFields <= lengthof(result->indexAmAttnums));
 	MemoryContextSwitchTo(old_mcxt);
 	result->nLeafFields = nadded;
 	result->nNonLeafFields = nadded;
@@ -660,7 +693,9 @@ make_toast_o_index(OTable *table, OIndexVersionMode ixVerMode)
 	result->leafFields = (OTableIndexField *) palloc0(sizeof(OTableIndexField) * result->nLeafFields);
 
 	nadded = 0;
-	add_index_fields(result, table, primary, &nadded, true);
+	add_index_fields(result, table, primary, 0,
+					 primary ? primary->nkeyfields : 0,
+					 &nadded, true, false);
 	make_builtin_field(&result->leafTableFields[nadded], &result->leafFields[nadded],
 					   INT2OID, "attnum", FirstLowInvalidHeapAttributeNumber,
 					   INT2_BTREE_OPS_OID,
@@ -733,7 +768,9 @@ make_bridge_o_index(OTable *table, OIndexVersionMode ixVerMode)
 					   table->tid_hash_fn_oid);
 	nadded++;
 
-	add_index_fields(result, table, primary, &nadded, true);
+	add_index_fields(result, table, primary, 0,
+					 primary ? primary->nkeyfields : 0,
+					 &nadded, true, false);
 	Assert(nadded == result->nLeafFields);
 	result->nLeafFields = nadded;
 
@@ -1214,6 +1251,24 @@ cache_scan_tupdesc_and_slot(OIndexDescr *index_descr, OIndex *oIndex)
 	int			nduplicates = list_length(oIndex->duplicates);
 	int			cur_attr;
 
+	if (oIndex->nIndexAmFields > 0)
+	{
+		nfields = oIndex->nIndexAmFields;
+		index_descr->itupdesc = CreateTemplateTupleDesc(nfields);
+		for (i = 0; i < nfields; i++)
+		{
+			AttrNumber	attnum = oIndex->indexAmAttnums[i];
+
+			Assert(attnum > 0 && attnum <= oIndex->nLeafFields);
+			TupleDescCopyEntry(index_descr->itupdesc, i + 1,
+							   index_descr->leafTupdesc, attnum);
+		}
+		index_descr->index_slot =
+			MakeSingleTupleTableSlot(index_descr->leafTupdesc,
+									 &TTSOpsOrioleDB);
+		return;
+	}
+
 	/*
 	 * TODO: Check why this called multiple times for ctid_primary during
 	 * single CREATE INDEX
@@ -1540,6 +1595,10 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, void *o_table_source, OTa
 
 	descr->nKeyFields = oIndex->nKeyFields;
 	descr->nIncludedFields = oIndex->nIncludedFields;
+	descr->nIndexAmFields = oIndex->nIndexAmFields;
+	memcpy(descr->indexAmAttnums, oIndex->indexAmAttnums,
+		   descr->nIndexAmFields * sizeof(descr->indexAmAttnums[0]));
+
 	for (i = 0; i < oIndex->nLeafFields; i++)
 	{
 		OTableIndexField *iField = &oIndex->leafFields[i];
@@ -1602,7 +1661,8 @@ o_index_fill_descr(OIndexDescr *descr, OIndex *oIndex, void *o_table_source, OTa
 		AttrNumber	attnum = oIndex->primaryFieldsAttnums[i] - 1;
 		OTableIndexField *iField = &oIndex->leafFields[attnum];
 
-		temp_field.collation = TupleDescAttr(descr->leafTupdesc, i)->attcollation;
+		temp_field.collation = TupleDescAttr(descr->leafTupdesc,
+											 attnum)->attcollation;
 		if (OidIsValid(iField->collation))
 			temp_field.collation = iField->collation;
 

--- a/src/indexam/handler.c
+++ b/src/indexam/handler.c
@@ -569,30 +569,20 @@ append_rowid_values(OIndexDescr *id,
 		tuple.formatFlags = add->flags;
 		*version = o_tuple_get_version(tuple);
 
-		if (id->nPrimaryFields <= id->nFields)
+		Assert(id->nPrimaryFields <= id->nFields);
+		for (int i = 0; i < id->nPrimaryFields; i++)
 		{
-			int			i;
-			int			pk_from;
+			AttrNumber	attnum = id->primaryFieldsAttnums[i] - 1;
 
-			pk_from = id->nFields - id->nPrimaryFields;
-
-			/* Amount of index fields checked in o_define_index_validate */
-			for (i = 0; i < id->nPrimaryFields; i++)
-			{
-				AttrNumber	attnum = id->primaryFieldsAttnums[i] - 1;
-
-				if (attnum >= pk_from)
-				{
-					values[attnum] = o_fastgetattr(tuple, i + 1, pk_tupdesc, pk_spec, &isnull[attnum]);
-				}
-			}
+			values[attnum] = o_fastgetattr(tuple, i + 1, pk_tupdesc,
+										   pk_spec, &isnull[attnum]);
 		}
 	}
 	else
 	{
 		ORowIdAddendumCtid *add;
 		ORowIdAddendumCtid addbuf;
-		AttrNumber	attnum = id->nFields - 1;
+		AttrNumber	attnum;
 
 		/* Decode through an aligned copy; see the non-ctid branch above. */
 		memcpy(&addbuf, p, sizeof(addbuf));
@@ -600,6 +590,8 @@ append_rowid_values(OIndexDescr *id,
 		*csn = add->csn;
 		*version = add->version;
 		p += MAXALIGN(sizeof(ORowIdAddendumCtid));
+		Assert(id->nPrimaryFields == 1);
+		attnum = id->primaryFieldsAttnums[0] - 1;
 		values[attnum] = PointerGetDatum(p);
 		isnull[attnum] = false;
 	}
@@ -609,11 +601,8 @@ static void
 detoast_passed_values(OIndexDescr *index_descr, Datum *values, bool *isnull, bool *vfree)
 {
 	int			i;
-	int			pk_from;
 
-	pk_from = index_descr->nFields - index_descr->nPrimaryFields;
-
-	for (i = 0; i < pk_from; i++)
+	for (i = 0; i < index_descr->nFields; i++)
 	{
 		Form_pg_attribute att = TupleDescAttr(index_descr->nonLeafTupdesc, i);
 		Datum		tmp;
@@ -626,6 +615,27 @@ detoast_passed_values(OIndexDescr *index_descr, Datum *values, bool *isnull, boo
 			values[i] = tmp;
 			vfree[i] = true;
 		}
+	}
+}
+
+static void
+map_indexam_values(OIndexDescr *index_descr, int nvalues,
+				   Datum *input_values, bool *input_isnull,
+				   Datum *values, bool *isnull)
+{
+	int			i;
+
+	Assert(nvalues <= index_descr->nIndexAmFields);
+	memset(values, 0, sizeof(*values) * index_descr->nFields);
+	memset(isnull, true, sizeof(*isnull) * index_descr->nFields);
+
+	for (i = 0; i < nvalues; i++)
+	{
+		AttrNumber	attnum = index_descr->indexAmAttnums[i] - 1;
+
+		Assert(attnum >= 0 && attnum < index_descr->nFields);
+		values[attnum] = input_values[i];
+		isnull[attnum] = input_isnull[i];
 	}
 }
 
@@ -656,6 +666,8 @@ orioledb_aminsert(Relation rel, Datum *values, bool *isnull,
 	uint32		version;
 	OTuple		tuple;
 	CommitSeqNo csn;
+	Datum		index_values[2 * INDEX_MAX_KEYS];
+	bool		index_isnull[2 * INDEX_MAX_KEYS];
 	OBTOptions *options = (OBTOptions *) rel->rd_options;
 
 	if (options && !options->orioledb_index)
@@ -719,45 +731,16 @@ orioledb_aminsert(Relation rel, Datum *values, bool *isnull,
 	}
 	Assert(ix_num < descr->nIndices);
 
-	if (index_descr->duplicates != NIL)
-	{
-		ListCell   *lc = NULL;
-		List	   *duplicate = NIL;
-		int			cur_attr;
-		int			i;
-
-		/* Remove duplicate column values to store in our index */
-
-		if (index_descr->duplicates != NIL)
-			lc = list_head(index_descr->duplicates);
-		if (lc != NULL)
-			duplicate = (List *) lfirst(lc);
-
-		cur_attr = 0;
-		for (i = 0; i < rel->rd_att->natts; i++)
-		{
-			if (duplicate != NIL && linitial_int(duplicate) == cur_attr)
-			{
-				lc = lnext(index_descr->duplicates, lc);
-				if (lc != NULL)
-					duplicate = (List *) lfirst(lc);
-				else
-					duplicate = NIL;
-			}
-			else
-			{
-				values[cur_attr] = values[i];
-				cur_attr++;
-			}
-		}
-	}
+	map_indexam_values(index_descr, rel->rd_att->natts,
+					   values, isnull, index_values, index_isnull);
 	append_rowid_values(index_descr,
 						GET_PRIMARY(descr)->nonLeafTupdesc,
 						&GET_PRIMARY(descr)->nonLeafSpec,
-						tupleid, values, isnull,
+						tupleid, index_values, index_isnull,
 						&csn, &version);
 
-	tuple = o_form_tuple(index_descr->leafTupdesc, &index_descr->leafSpec, version, values, isnull, NULL);
+	tuple = o_form_tuple(index_descr->leafTupdesc, &index_descr->leafSpec,
+						 version, index_values, index_isnull, NULL);
 	slot = index_descr->old_leaf_slot;
 	tts_orioledb_store_tuple(slot, tuple, descr, csn, ix_num, false, NULL);
 	callbackInfo.arg = slot;
@@ -810,6 +793,10 @@ orioledb_amupdate(Relation rel, bool new_valid, bool old_valid,
 	OTuple		old_tuple;
 	bool	   *vfree;
 	int			i;
+	Datum		index_values[2 * INDEX_MAX_KEYS];
+	bool		index_isnull[2 * INDEX_MAX_KEYS];
+	Datum		index_values_old[2 * INDEX_MAX_KEYS];
+	bool		index_isnull_old[2 * INDEX_MAX_KEYS];
 	OBTOptions *options = (OBTOptions *) rel->rd_options;
 
 	if (options && !options->orioledb_index)
@@ -857,25 +844,33 @@ orioledb_amupdate(Relation rel, bool new_valid, bool old_valid,
 	}
 	Assert(ix_num < descr->nIndices);
 
+	map_indexam_values(index_descr, rel->rd_att->natts,
+					   valuesOld, isnullOld,
+					   index_values_old, index_isnull_old);
 	append_rowid_values(index_descr,
 						GET_PRIMARY(descr)->nonLeafTupdesc,
 						&GET_PRIMARY(descr)->nonLeafSpec,
-						oldTupleid, valuesOld, isnullOld,
+						oldTupleid, index_values_old, index_isnull_old,
 						&csn, &version);
 	vfree = palloc0(sizeof(bool) * index_descr->leafTupdesc->natts);
 	/* TODO: Probably there is a better way than detoasting here */
-	detoast_passed_values(index_descr, valuesOld, isnullOld, vfree);
+	detoast_passed_values(index_descr, index_values_old, index_isnull_old,
+						  vfree);
 	old_tuple = o_form_tuple(index_descr->leafTupdesc, &index_descr->leafSpec,
-							 version, valuesOld, isnullOld, NULL);
+							 version, index_values_old, index_isnull_old,
+							 NULL);
 	old_slot = index_descr->old_leaf_slot;
 	tts_orioledb_store_non_leaf_tuple(old_slot, old_tuple, descr, csn, ix_num, false, NULL);
 
+	map_indexam_values(index_descr, rel->rd_att->natts,
+					   values, isnull, index_values, index_isnull);
 	append_rowid_values(index_descr,
 						GET_PRIMARY(descr)->nonLeafTupdesc,
 						&GET_PRIMARY(descr)->nonLeafSpec,
-						tupleid, values, isnull,
+						tupleid, index_values, index_isnull,
 						&csn, &version);
-	new_tuple = o_form_tuple(index_descr->leafTupdesc, &index_descr->leafSpec, version, values, isnull, NULL);
+	new_tuple = o_form_tuple(index_descr->leafTupdesc, &index_descr->leafSpec,
+							 version, index_values, index_isnull, NULL);
 	new_slot = index_descr->new_leaf_slot;
 	tts_orioledb_store_non_leaf_tuple(new_slot, new_tuple, descr, csn, ix_num, false, NULL);
 
@@ -889,7 +884,7 @@ orioledb_amupdate(Relation rel, bool new_valid, bool old_valid,
 	for (i = 0; i < index_descr->leafTupdesc->natts; i++)
 	{
 		if (vfree[i])
-			pfree(DatumGetPointer(valuesOld[i]));
+			pfree(DatumGetPointer(index_values_old[i]));
 	}
 	pfree(vfree);
 
@@ -909,7 +904,7 @@ orioledb_amupdate(Relation rel, bool new_valid, bool old_valid,
 					{
 						if (i != 0)
 							appendStringInfo(str, ", ");
-						if (isnull[i])
+						if (index_isnull_old[i])
 							appendStringInfo(str, "null");
 						else
 						{
@@ -919,7 +914,8 @@ orioledb_amupdate(Relation rel, bool new_valid, bool old_valid,
 
 							getTypeOutputInfo(TupleDescAttr(index_descr->leafTupdesc, i)->atttypid,
 											  &typoutput, &typisvarlena);
-							res = OidOutputFunctionCall(typoutput, valuesOld[i]);
+							res = OidOutputFunctionCall(typoutput,
+														index_values_old[i]);
 							appendStringInfo(str, "'%s'", res);
 						}
 					}
@@ -981,6 +977,8 @@ orioledb_amdelete(Relation rel, Datum *values, bool *isnull,
 	OTuple		tuple;
 	bool	   *vfree;
 	int			i;
+	Datum		index_values[2 * INDEX_MAX_KEYS];
+	bool		index_isnull[2 * INDEX_MAX_KEYS];
 	OBTOptions *options = (OBTOptions *) rel->rd_options;
 
 	if (options && !options->orioledb_index)
@@ -1009,15 +1007,17 @@ orioledb_amdelete(Relation rel, Datum *values, bool *isnull,
 	Assert(ix_num < descr->nIndices);
 
 	slot = index_descr->old_leaf_slot;
+	map_indexam_values(index_descr, rel->rd_att->natts,
+					   values, isnull, index_values, index_isnull);
 	append_rowid_values(index_descr,
 						GET_PRIMARY(descr)->nonLeafTupdesc,
 						&GET_PRIMARY(descr)->nonLeafSpec,
-						tupleid, values, isnull,
+						tupleid, index_values, index_isnull,
 						&csn, &version);
 	vfree = palloc0(sizeof(bool) * index_descr->nonLeafTupdesc->natts);
-	detoast_passed_values(index_descr, values, isnull, vfree);
+	detoast_passed_values(index_descr, index_values, index_isnull, vfree);
 	tuple = o_form_tuple(index_descr->leafTupdesc, &index_descr->leafSpec,
-						 version, values, isnull, NULL);
+						 version, index_values, index_isnull, NULL);
 	tts_orioledb_store_tuple(slot, tuple, descr, csn, ix_num, false, NULL);
 
 	fill_current_oxid_osnapshot(&oxid, &oSnapshot);
@@ -1026,7 +1026,7 @@ orioledb_amdelete(Relation rel, Datum *values, bool *isnull,
 	for (i = 0; i < index_descr->nonLeafTupdesc->natts; i++)
 	{
 		if (vfree[i])
-			pfree(DatumGetPointer(values[i]));
+			pfree(DatumGetPointer(index_values[i]));
 	}
 	pfree(vfree);
 
@@ -1046,7 +1046,7 @@ orioledb_amdelete(Relation rel, Datum *values, bool *isnull,
 					{
 						if (i != 0)
 							appendStringInfo(str, ", ");
-						if (isnull[i])
+						if (index_isnull[i])
 							appendStringInfo(str, "null");
 						else
 						{
@@ -1056,7 +1056,8 @@ orioledb_amdelete(Relation rel, Datum *values, bool *isnull,
 
 							getTypeOutputInfo(TupleDescAttr(index_descr->nonLeafTupdesc, i)->atttypid,
 											  &typoutput, &typisvarlena);
-							res = OidOutputFunctionCall(typoutput, values[i]);
+							res = OidOutputFunctionCall(typoutput,
+														index_values[i]);
 							appendStringInfo(str, "'%s'", res);
 						}
 					}
@@ -1939,6 +1940,10 @@ fill_itup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
 	bool	   *rowid_isnull = NULL;
 	Datum		temp_rowid_values[2 * INDEX_MAX_KEYS];
 	bool		temp_rowid_isnull[2 * INDEX_MAX_KEYS];
+	Datum		itup_values[2 * INDEX_MAX_KEYS];
+	bool		itup_isnull[2 * INDEX_MAX_KEYS];
+	Datum	   *output_values;
+	bool	   *output_isnull;
 
 	slot = index_descr->index_slot;
 	tts_orioledb_store_tuple(slot, tuple, descr, tupleCsn, o_scan->ixNum, true, hint);
@@ -1948,7 +1953,8 @@ fill_itup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
 	 * moving values from duplicate field places that will be filled during
 	 * index_form_tuple
 	 */
-	if (index_descr->duplicates != NIL)
+	if (index_descr->nIndexAmFields == 0 &&
+		index_descr->duplicates != NIL)
 	{
 		int			lc_id = 0;
 		ListCell   *lc = NULL;
@@ -2073,32 +2079,30 @@ fill_itup(IndexScanDesc scan, OTuple tuple, OTableDescr *descr,
 		scan->xs_itup = NULL;
 	}
 
-	/*--
-	 * OrioleDB's internal itupdesc already matches the planner-side
-	 * indextlist layout in both column count and column order:
-	 *
-	 *   itupdesc = [non-duplicate secondary key cols
-	 *               | non-duplicate INCLUDE cols
-	 *               | duplicate cols (refilled from their source columns)
-	 *               | extra PK key cols not already in the secondary],
-	 *
-	 *   planner indextlist = rd_att (all declared cols, including dups)
-	 *                       + (when has_primary, PK key cols not in
-	 *                          rd_att.indexkeys, added by
-	 *                          set_plain_rel_pathlist_hook()).
-	 *
-	 * Their natts agree because the duplicate slots in itupdesc account
-	 * for exactly the same columns as the duplicates inside rd_att, and
-	 * because scan.c's hook only adds PK *key* cols (matching the
-	 * !primaryIsCtid path that populates the PK tail of itupdesc).  The
-	 * duplicate-slot rearrangement done by the block right above this
-	 * comment leaves slot->tts_values in itupdesc order, so we hand the
-	 * pair directly to index_form_tuple.
-	 */
+	if (index_descr->nIndexAmFields > 0)
+	{
+		int			i;
+
+		for (i = 0; i < index_descr->nIndexAmFields; i++)
+		{
+			AttrNumber	attnum = index_descr->indexAmAttnums[i] - 1;
+
+			itup_values[i] = slot->tts_values[attnum];
+			itup_isnull[i] = slot->tts_isnull[attnum];
+		}
+		output_values = itup_values;
+		output_isnull = itup_isnull;
+	}
+	else
+	{
+		output_values = slot->tts_values;
+		output_isnull = slot->tts_isnull;
+	}
+
 	scan->xs_itupdesc = index_descr->itupdesc;
 	scan->xs_itup = index_form_tuple(index_descr->itupdesc,
-									 slot->tts_values,
-									 slot->tts_isnull);
+									 output_values,
+									 output_isnull);
 
 	ItemPointerCopy(&slot->tts_tid, &scan->xs_itup->t_tid);
 

--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -907,9 +907,6 @@ fill_pkey_bound(TupleTableSlot *slot, OIndexDescr *idx, OBTreeKeyBound *pkey)
 	else
 	{
 		int			i;
-		int			pk_from;
-
-		pk_from = idx->nFields - idx->nPrimaryFields;
 
 		pkey->nkeys = idx->nPrimaryFields;
 		for (i = 0; i < idx->nPrimaryFields; i++)
@@ -917,11 +914,11 @@ fill_pkey_bound(TupleTableSlot *slot, OIndexDescr *idx, OBTreeKeyBound *pkey)
 			AttrNumber	attnum = idx->primaryFieldsAttnums[i];
 
 			pkey->keys[i].value = slot->tts_values[attnum - 1];
-			pkey->keys[i].type = TupleDescAttr(idx->leafTupdesc, pk_from + i)->atttypid;
+			pkey->keys[i].type = TupleDescAttr(idx->leafTupdesc, attnum - 1)->atttypid;
 			pkey->keys[i].flags = O_VALUE_BOUND_PLAIN_VALUE;
 			if (slot->tts_isnull[attnum - 1])
 				pkey->keys[i].flags |= O_VALUE_BOUND_NULL;
-			pkey->keys[i].comparator = idx->fields[pk_from + i].comparator;
+			pkey->keys[i].comparator = idx->pk_comparators[i];
 			pkey->keys[i].exclusion_fn = NULL;
 		}
 	}

--- a/src/tableam/tree.c
+++ b/src/tableam/tree.c
@@ -286,10 +286,14 @@ hash_combine_mix_field(OIndexDescr *idx, TupleDesc tupdesc,
 	bool		isnull;
 	uint32		element_hash;
 
+	/* Hash exactly the fields that participate in tuple comparison. */
+	if (OIgnoreColumn(idx, field_num))
+		return hash;
 	val = o_fastgetattr(tup, attnum, tupdesc, spec, &isnull);
 	if (isnull)
 		return hash;
-	if (idx->fields[field_num].hash_fn == &o_default_hash_fn)
+	if (idx->fields[field_num].hash_fn == NULL ||
+		idx->fields[field_num].hash_fn == &o_default_hash_fn)
 		return hash;
 	element_hash = o_call_hash_fn(idx->fields[field_num].hash_fn,
 								  idx->fields[field_num].collation,
@@ -546,13 +550,7 @@ o_fill_pindex_tuple_key_bound(BTreeDescr *desc,
 {
 	OIndexDescr *id = o_get_tree_def(desc);
 	int			i;
-	int			pk_from;
 	bool		isnull;
-
-	if (desc->type == oIndexBridge)
-		pk_from = 1;
-	else
-		pk_from = id->nFields - id->nPrimaryFields;
 
 	bound->nkeys = id->nPrimaryFields;
 	for (i = 0; i < id->nPrimaryFields; i++)
@@ -560,7 +558,7 @@ o_fill_pindex_tuple_key_bound(BTreeDescr *desc,
 		AttrNumber	attnum = id->primaryFieldsAttnums[i];
 
 		bound->keys[i].value = o_fastgetattr(tup, attnum, id->leafTupdesc, &id->leafSpec, &isnull);
-		bound->keys[i].type = TupleDescAttr(id->leafTupdesc, pk_from + i)->atttypid;
+		bound->keys[i].type = TupleDescAttr(id->leafTupdesc, attnum - 1)->atttypid;
 		bound->keys[i].flags = O_VALUE_BOUND_PLAIN_VALUE;
 		if (isnull)
 			bound->keys[i].flags |= O_VALUE_BOUND_NULL;

--- a/src/tuple/slot.c
+++ b/src/tuple/slot.c
@@ -176,12 +176,24 @@ make_key_from_secondary_slot(TupleTableSlot *slot, OIndexDescr *idx, OTableDescr
 	{
 		int			pk_attnum = idx->primaryFieldsAttnums[i];
 		int			attindex = pk_attnum - 1;
+#ifdef USE_ASSERT_CHECKING
+		Form_pg_attribute att;
+#endif
+
+		if (idx->nIndexAmFields > 0 &&
+			slot->tts_tupleDescriptor != idx->leafTupdesc)
+		{
+			for (attindex = 0; attindex < idx->nIndexAmFields; attindex++)
+			{
+				if (idx->indexAmAttnums[attindex] == pk_attnum)
+					break;
+			}
+			Assert(attindex < idx->nIndexAmFields);
+		}
 
 #ifdef USE_ASSERT_CHECKING
 		/* PK attributes shouldn't be external or compressed */
-		Form_pg_attribute att;
-
-		att = TupleDescAttr(slot->tts_tupleDescriptor, pk_attnum - 1);
+		att = TupleDescAttr(slot->tts_tupleDescriptor, attindex);
 		if (!slot->tts_isnull[attindex] && att->attlen < 0)
 		{
 			Assert(!VARATT_IS_EXTERNAL(slot->tts_values[attindex]));
@@ -239,6 +251,7 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 									 * attributes. */
 	OIndexDescr *idx;
 	bool		index_order;
+	bool		mapped_index_order = false;
 	int			cur_tbl_attnum = 0;
 	bool	   *isfilled = NULL;
 
@@ -261,6 +274,9 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 	if (oslot->ixnum == PrimaryIndexNumber)
 		index_order = index_order &&
 			slot->tts_tupleDescriptor->natts == idx->nFields;
+	else if (index_order && idx->nIndexAmFields > 0 &&
+			 slot->tts_tupleDescriptor != idx->leafTupdesc)
+		mapped_index_order = true;
 
 	/*
 	 * Ensure that if there are valid attributes, the slot is for the primary
@@ -313,6 +329,9 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 	{
 		int			needed = Max(natts, __natts);
 
+		if (mapped_index_order)
+			needed = Max(needed, slot->tts_tupleDescriptor->natts);
+
 		if (oslot->isfilledLen < needed)
 		{
 			if (oslot->isfilled)
@@ -330,6 +349,8 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 	{
 		Form_pg_attribute thisatt;
 		int			res_attnum = 0;
+		Datum		value = (Datum) 0;
+		bool		value_isnull = true;
 
 		/*
 		 * Determine the result attribute number based on the index type and
@@ -365,7 +386,10 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 		}
 		else if (index_order)
 		{
-			if (GET_PRIMARY(descr)->primaryIsCtid && attnum == natts - 1)
+			if (mapped_index_order)
+				res_attnum = -3;
+			else if (GET_PRIMARY(descr)->primaryIsCtid &&
+					 attnum == idx->primaryFieldsAttnums[0] - 1)
 				res_attnum = -1;
 			else
 				res_attnum = attnum;
@@ -376,7 +400,25 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 		}
 
 		/* Ensure the result attribute number is valid. */
-		Assert(res_attnum >= -2);
+		Assert(res_attnum >= -3);
+		if (res_attnum == -3)
+		{
+			int			index_attnum;
+
+			value = o_tuple_read_next_field(&oslot->state, &value_isnull);
+			for (index_attnum = 0;
+				 index_attnum < idx->nIndexAmFields;
+				 index_attnum++)
+			{
+				if (idx->indexAmAttnums[index_attnum] == attnum + 1)
+				{
+					values[index_attnum] = value;
+					isnull[index_attnum] = value_isnull;
+					isfilled[index_attnum] = true;
+				}
+			}
+			thisatt = TupleDescAttr(idx->leafTupdesc, attnum);
+		}
 		if (res_attnum >= 0)
 		{
 			if (oslot->ixnum == BridgeIndexNumber && attnum == 0)
@@ -397,6 +439,8 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 			values[res_attnum] = o_tuple_read_next_field(&oslot->state,
 														 &isnull[res_attnum]);
 			isfilled[res_attnum] = true;
+			value = values[res_attnum];
+			value_isnull = isnull[res_attnum];
 
 			/* Determine the attribute metadata based on the index and order. */
 			if (oslot->ixnum == PrimaryIndexNumber && !index_order)
@@ -408,15 +452,20 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 			 * Check for TOASTed attributes and adjust the number of
 			 * attributes if necessary.
 			 */
-			if (!isnull[res_attnum] && !thisatt->attbyval && thisatt->attlen < 0)
+		}
+		if (res_attnum >= 0 || res_attnum == -3)
+		{
+			if (!value_isnull && !thisatt->attbyval && thisatt->attlen < 0)
 			{
-				Pointer		p = DatumGetPointer(values[res_attnum]);
+				Pointer		p = DatumGetPointer(value);
 
 				Assert(p);
 				if (IS_TOAST_POINTER(p) && !VARATT_IS_EXTERNAL_ORIOLEDB(p))
 				{
 					hastoast = true;
-					natts = Max(natts, idx->maxTableAttnum - ctid_off);
+					if (!mapped_index_order)
+						natts = Max(natts,
+									idx->maxTableAttnum - ctid_off);
 				}
 			}
 		}
@@ -449,6 +498,8 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 	if (hastoast)
 	{
 		OTuple		pkey;
+		int			toast_natts = mapped_index_order ?
+			slot->tts_tupleDescriptor->natts : natts;
 
 		/* Allocate memory for TOASTed attributes if not already done. */
 		if (!oslot->to_toast)
@@ -461,7 +512,7 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 			pkey = make_key_from_secondary_slot(slot, idx, descr);
 
 		/* Iterate over attributes to process TOASTed values. */
-		for (attnum = 0; attnum < natts; attnum++)
+		for (attnum = 0; attnum < toast_natts; attnum++)
 		{
 			Form_pg_attribute thisatt;
 
@@ -492,9 +543,14 @@ tts_orioledb_getsomeattrs(TupleTableSlot *slot, int __natts)
 			pfree(pkey.data);
 	}
 
-	/* Ensure the number of processed attributes matches the expected count. */
-	Assert(attnum == natts);
-
+	if (mapped_index_order)
+	{
+		for (attnum = slot->tts_nvalid;
+			 attnum < slot->tts_tupleDescriptor->natts; attnum++)
+			Assert(isfilled[attnum]);
+		slot->tts_nvalid = slot->tts_tupleDescriptor->natts;
+	}
+	else
 	{
 		int			first_unfilled = slot->tts_nvalid;
 
@@ -903,7 +959,20 @@ tts_orioledb_init_reader(TupleTableSlot *slot)
 			ItemPointer iptr;
 			bool		isnull;
 
-			if (oslot->leafTuple)
+			if (idx->nIndexAmFields > 0)
+			{
+				Datum		value;
+
+				value = o_fastgetattr(oslot->tuple,
+									  idx->primaryFieldsAttnums[0],
+									  oslot->leafTuple ? idx->leafTupdesc :
+									  idx->nonLeafTupdesc,
+									  oslot->leafTuple ? &idx->leafSpec :
+									  &idx->nonLeafSpec,
+									  &isnull);
+				iptr = (ItemPointer) DatumGetPointer(value);
+			}
+			else if (oslot->leafTuple)
 				iptr = o_tuple_get_last_iptr(idx->leafTupdesc, &idx->leafSpec,
 											 oslot->tuple, &isnull);
 			else

--- a/test/expected/btree_sys_check_1.out
+++ b/test/expected/btree_sys_check_1.out
@@ -122,18 +122,19 @@ SELECT regexp_replace(
 		'g');
                                            regexp_replace                                            
 -----------------------------------------------------------------------------------------------------
- Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 5104                                            +
+ Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 5872                                            +
  state = free, datoid equal, relnode equal, ix_type = primary, clean                                +
      Leftmost, Rightmost                                                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = (1, (NNN, NNN, NNN), 1663, 0)  +
-     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 703)                    +
-   Chunk 1: offset = 1, location = 1016, hikey location = 104, hikey = (3, (NNN, NNN, NNN), 1663, 0)+
-     Item 1: deleted, offset = 1024, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 1051)                  +
-     Item 2: deleted, offset = 2128, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 703)                   +
-   Chunk 2: offset = 3, location = 2880, hikey location = 136                                       +
-     Item 3: deleted, offset = 2888, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 819)                   +
-     Item 4: deleted, offset = 3760, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 703)                   +
-     Item 5: deleted, offset = 4512, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 819)                   +
+     Item 0: deleted, offset = 264, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 831)                    +
+   Chunk 1: offset = 1, location = 1144, hikey location = 104, hikey = (3, (NNN, NNN, NNN), 1663, 0)+
+     Item 1: deleted, offset = 1152, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 1179)                  +
+     Item 2: deleted, offset = 2384, tuple = ((1, (NNN, NNN, NNN), 1663, 0), 831)                   +
+   Chunk 2: offset = 3, location = 3264, hikey location = 136, hikey = (3, (NNN, NNN, NNN), 1663, 0)+
+     Item 3: deleted, offset = 3272, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 947)                   +
+   Chunk 3: offset = 4, location = 4272, hikey location = 168                                       +
+     Item 4: deleted, offset = 4280, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 831)                   +
+     Item 5: deleted, offset = 5160, tuple = ((3, (NNN, NNN, NNN), 1663, 0), 947)                   +
                                                                                                     +
  
 (1 row)

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -996,18 +996,18 @@ CREATE INDEX o_test_duplicate_key_fields_ix1
 	ON o_test_duplicate_key_fields (val_1, val_2, val_1) INCLUDE (val_1);
 INSERT INTO o_test_duplicate_key_fields SELECT v, v * 10 FROM generate_series(1, 5) v;
 SELECT orioledb_tbl_indices('o_test_duplicate_key_fields'::regclass);
-                 orioledb_tbl_indices                 
-------------------------------------------------------
- Index ctid_primary                                  +
-     Index type: primary, unique, ctid               +
-     Leaf tuple size: 3, non-leaf tuple size: 1      +
-     Non-leaf tuple fields: ctid                     +
-     Leaf tuple fields: ctid, val_2, val_1           +
- Index o_test_duplicate_key_fields_ix1               +
-     Index type: secondary                           +
-     Leaf tuple size: 4, non-leaf tuple size: 4      +
-     Non-leaf tuple fields: val_1, val_2, val_1, ctid+
-     Leaf tuple fields: val_1, val_2, val_1, ctid    +
+              orioledb_tbl_indices              
+------------------------------------------------
+ Index ctid_primary                            +
+     Index type: primary, unique, ctid         +
+     Leaf tuple size: 3, non-leaf tuple size: 1+
+     Non-leaf tuple fields: ctid               +
+     Leaf tuple fields: ctid, val_2, val_1     +
+ Index o_test_duplicate_key_fields_ix1         +
+     Index type: secondary                     +
+     Leaf tuple size: 3, non-leaf tuple size: 3+
+     Non-leaf tuple fields: val_1, val_2, ctid +
+     Leaf tuple fields: val_1, val_2, ctid     +
  
 (1 row)
 
@@ -1026,15 +1026,15 @@ SELECT orioledb_tbl_structure('o_test_duplicate_key_fields'::regclass, 'nue');
      Item 4: offset = 400, tuple = ('(0,5)', '5', '50')             +
                                                                     +
  Index o_test_duplicate_key_fields_ix1 contents                     +
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0               +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0               +
  state = free, datoid equal, relnode equal, ix_type = regular, dirty+
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
-     Item 0: offset = 272, tuple = ('10', '1', '10', '(0,1)')       +
-     Item 1: offset = 312, tuple = ('20', '2', '20', '(0,2)')       +
-     Item 2: offset = 352, tuple = ('30', '3', '30', '(0,3)')       +
-     Item 3: offset = 392, tuple = ('40', '4', '40', '(0,4)')       +
-     Item 4: offset = 432, tuple = ('50', '5', '50', '(0,5)')       +
+     Item 0: offset = 272, tuple = ('10', '1', '(0,1)')             +
+     Item 1: offset = 304, tuple = ('20', '2', '(0,2)')             +
+     Item 2: offset = 336, tuple = ('30', '3', '(0,3)')             +
+     Item 3: offset = 368, tuple = ('40', '4', '(0,4)')             +
+     Item 4: offset = 400, tuple = ('50', '5', '(0,5)')             +
                                                                     +
  Index toast: not loaded                                            +
  

--- a/test/expected/include_pk.out
+++ b/test/expected/include_pk.out
@@ -1,6 +1,5 @@
 -- A primary key column named in an INCLUDE list is stored once, in the
--- INCLUDE position, but it must still take part in the index key: two rows
--- that agree on the key columns are two distinct entries.
+-- deduplicated PK segment, and remains available to index-only scans.
 CREATE SCHEMA include_pk;
 SET SESSION search_path = 'include_pk';
 CREATE EXTENSION orioledb;
@@ -259,18 +258,93 @@ SELECT orioledb_tbl_structure('o_test_include_pk3'::regclass, 'ne');
      Leftmost, Rightmost                                            +
    Chunk 0: offset = 0, location = 256, hikey location = 64         +
      Item 0: offset = 264, tuple = ('7', '1', '1')                  +
-     Item 1: offset = 296, tuple = ('7', '1', '2')                  +
-     Item 2: deleted, offset = 328, tuple = ('7', '2', '1')         +
+     Item 1: deleted, offset = 296, tuple = ('7', '1', '2')         +
+     Item 2: offset = 328, tuple = ('7', '2', '1')                  +
      Item 3: offset = 360, tuple = ('8', '2', '2')                  +
                                                                     +
  Index toast: not loaded                                            +
  
 (1 row)
 
+-- composite PK delete correctness without any secondary index
+CREATE TABLE o_test_include_pk4
+(
+	a int,
+	b int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_include_pk4 VALUES (1, 1), (1, 2), (2, 1), (2, 2);
+SELECT a, b FROM o_test_include_pk4 ORDER BY a, b;
+ a | b 
+---+---
+ 1 | 1
+ 1 | 2
+ 2 | 1
+ 2 | 2
+(4 rows)
+
+DELETE FROM o_test_include_pk4 WHERE a = 1 AND b = 2;
+SELECT a, b FROM o_test_include_pk4 ORDER BY a, b;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 1
+ 2 | 2
+(3 rows)
+
+-- PK fields can be interleaved with INCLUDE fields of different types.
+-- Exercise both secondary-to-primary lookup and ON CONFLICT row locking.
+CREATE TABLE o_test_include_pk5
+(
+	a text,
+	b int,
+	v int,
+	token text,
+	note text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+CREATE INDEX o_test_include_pk5_v ON o_test_include_pk5 (v)
+	INCLUDE (b, note);
+CREATE UNIQUE INDEX o_test_include_pk5_token ON o_test_include_pk5 (token)
+	INCLUDE (b);
+INSERT INTO o_test_include_pk5 VALUES
+	('one', 1, 7, 'first', repeat('x', 10000)),
+	('two', 2, 7, 'second', repeat('y', 10000));
+SET enable_seqscan = off;
+SELECT a, b, token, length(note) FROM o_test_include_pk5
+	WHERE v = 7 ORDER BY a, b;
+  a  | b | token  | length 
+-----+---+--------+--------
+ one | 1 | first  |  10000
+ two | 2 | second |  10000
+(2 rows)
+
+RESET enable_seqscan;
+INSERT INTO o_test_include_pk5 VALUES
+	('unused', 9, 9, 'first', 'updated')
+	ON CONFLICT (token) DO UPDATE SET note = EXCLUDED.note
+	RETURNING a, b, token, note;
+  a  | b | token |  note   
+-----+---+-------+---------
+ one | 1 | first | updated
+(1 row)
+
+DELETE FROM o_test_include_pk5 WHERE a = 'two' AND b = 2;
+SET enable_seqscan = off;
+SELECT a, b, token, length(note) FROM o_test_include_pk5
+	WHERE v = 7 ORDER BY a, b;
+  a  | b | token | length 
+-----+---+-------+--------
+ one | 1 | first |      7
+(1 row)
+
+RESET enable_seqscan;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to table o_test_include_pk
 drop cascades to table o_test_include_pk2
 drop cascades to table o_test_include_pk3
+drop cascades to table o_test_include_pk4
+drop cascades to table o_test_include_pk5
 DROP SCHEMA include_pk CASCADE;
 RESET search_path;

--- a/test/expected/include_pk.out
+++ b/test/expected/include_pk.out
@@ -1,0 +1,276 @@
+-- A primary key column named in an INCLUDE list is stored once, in the
+-- INCLUDE position, but it must still take part in the index key: two rows
+-- that agree on the key columns are two distinct entries.
+CREATE SCHEMA include_pk;
+SET SESSION search_path = 'include_pk';
+CREATE EXTENSION orioledb;
+CREATE TABLE o_test_include_pk
+(
+	id text PRIMARY KEY,
+	grp text,
+	created_at timestamptz,
+	ttl bigint,
+	deleted bool NOT NULL DEFAULT false
+) USING orioledb;
+CREATE INDEX o_test_include_pk_ix ON o_test_include_pk (grp, created_at)
+	INCLUDE (id, ttl) WHERE NOT deleted AND ttl IS NOT NULL;
+INSERT INTO o_test_include_pk VALUES ('a', 'g-0', '2026-01-01 00:00:00+00', 3600);
+INSERT INTO o_test_include_pk VALUES ('b', 'g-0', '2026-01-01 00:00:00+00', 3600);
+INSERT INTO o_test_include_pk VALUES ('c', 'g-0', '2026-01-01 00:00:00+00', 3600)
+	ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_test_include_pk VALUES ('d', 'g-1', '2026-01-01 00:00:00+00', NULL);
+SET enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_include_pk
+		WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Incremental Sort
+   Sort Key: grp, created_at, id
+   Presorted Key: grp, created_at
+   ->  Custom Scan (o_scan) on o_test_include_pk
+         Forward index only scan of: o_test_include_pk_ix
+(5 rows)
+
+SELECT id, grp FROM o_test_include_pk
+	WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+ id | grp 
+----+-----
+ a  | g-0
+ b  | g-0
+ c  | g-0
+(3 rows)
+
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk'::regclass, 'ne');
+                                   orioledb_tbl_structure                                    
+---------------------------------------------------------------------------------------------
+ Index o_test_include_pk_pkey contents                                                      +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 0                                       +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty                        +
+     Leftmost, Rightmost                                                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                                 +
+     Item 0: offset = 264, tuple = ('a', 'g-0', 'Wed Dec 31 16:00:00 2025 PST', '3600', 'f')+
+     Item 1: offset = 320, tuple = ('b', 'g-0', 'Wed Dec 31 16:00:00 2025 PST', '3600', 'f')+
+     Item 2: offset = 376, tuple = ('c', 'g-0', 'Wed Dec 31 16:00:00 2025 PST', '3600', 'f')+
+     Item 3: offset = 432, tuple = ('d', 'g-1', 'Wed Dec 31 16:00:00 2025 PST', null, 'f')  +
+                                                                                            +
+ Index o_test_include_pk_ix contents                                                        +
+ Page 0: level = 0, maxKeyLen = 40, nVacatedBytes = 0                                       +
+ state = free, datoid equal, relnode equal, ix_type = regular, dirty                        +
+     Leftmost, Rightmost                                                                    +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                                 +
+     Item 0: offset = 264, tuple = ('g-0', 'Wed Dec 31 16:00:00 2025 PST', 'a', '3600')     +
+     Item 1: offset = 320, tuple = ('g-0', 'Wed Dec 31 16:00:00 2025 PST', 'b', '3600')     +
+     Item 2: offset = 376, tuple = ('g-0', 'Wed Dec 31 16:00:00 2025 PST', 'c', '3600')     +
+                                                                                            +
+ Index toast: not loaded                                                                    +
+ 
+(1 row)
+
+-- leaving the predicate must remove exactly this row's entry
+UPDATE o_test_include_pk SET deleted = true WHERE id = 'b';
+UPDATE o_test_include_pk SET deleted = true WHERE id = 'a';
+-- and coming back must add it again
+UPDATE o_test_include_pk SET deleted = false WHERE id = 'b';
+SET enable_seqscan = off;
+SELECT id, grp FROM o_test_include_pk
+	WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+ id | grp 
+----+-----
+ b  | g-0
+ c  | g-0
+(2 rows)
+
+RESET enable_seqscan;
+DELETE FROM o_test_include_pk WHERE id = 'c';
+SET enable_seqscan = off;
+SELECT id, grp FROM o_test_include_pk
+	WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+ id | grp 
+----+-----
+ b  | g-0
+(1 row)
+
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk'::regclass, 'ne');
+                                        orioledb_tbl_structure                                        
+------------------------------------------------------------------------------------------------------
+ Index o_test_include_pk_pkey contents                                                               +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 56                                               +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty                                 +
+     Leftmost, Rightmost                                                                             +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                                          +
+     Item 0: offset = 264, tuple = ('a', 'g-0', 'Wed Dec 31 16:00:00 2025 PST', '3600', 't')         +
+     Item 1: offset = 320, tuple = ('b', 'g-0', 'Wed Dec 31 16:00:00 2025 PST', '3600', 'f')         +
+     Item 2: deleted, offset = 376, tuple = ('c', 'g-0', 'Wed Dec 31 16:00:00 2025 PST', '3600', 'f')+
+     Item 3: offset = 432, tuple = ('d', 'g-1', 'Wed Dec 31 16:00:00 2025 PST', null, 'f')           +
+                                                                                                     +
+ Index o_test_include_pk_ix contents                                                                 +
+ Page 0: level = 0, maxKeyLen = 40, nVacatedBytes = 112                                              +
+ state = free, datoid equal, relnode equal, ix_type = regular, dirty                                 +
+     Leftmost, Rightmost                                                                             +
+   Chunk 0: offset = 0, location = 256, hikey location = 64                                          +
+     Item 0: deleted, offset = 264, tuple = ('g-0', 'Wed Dec 31 16:00:00 2025 PST', 'a', '3600')     +
+     Item 1: offset = 320, tuple = ('g-0', 'Wed Dec 31 16:00:00 2025 PST', 'b', '3600')              +
+     Item 2: deleted, offset = 376, tuple = ('g-0', 'Wed Dec 31 16:00:00 2025 PST', 'c', '3600')     +
+                                                                                                     +
+ Index toast: not loaded                                                                             +
+ 
+(1 row)
+
+-- non-partial variant, and a UNIQUE index whose INCLUDE list names the key
+CREATE TABLE o_test_include_pk2
+(
+	id int PRIMARY KEY,
+	grp int,
+	payload text
+) USING orioledb;
+CREATE INDEX o_test_include_pk2_grp ON o_test_include_pk2 (grp) INCLUDE (id, payload);
+CREATE UNIQUE INDEX o_test_include_pk2_payload ON o_test_include_pk2 (payload) INCLUDE (id);
+INSERT INTO o_test_include_pk2 SELECT i, i % 3, 'p' || i FROM generate_series(1, 9) i;
+SET enable_seqscan = off;
+SELECT grp, id FROM o_test_include_pk2 WHERE grp = 1 ORDER BY id;
+ grp | id 
+-----+----
+   1 |  1
+   1 |  4
+   1 |  7
+(3 rows)
+
+SELECT id FROM o_test_include_pk2 WHERE payload = 'p5';
+ id 
+----
+  5
+(1 row)
+
+RESET enable_seqscan;
+UPDATE o_test_include_pk2 SET grp = 1 WHERE id = 6;
+DELETE FROM o_test_include_pk2 WHERE id = 4;
+SET enable_seqscan = off;
+SELECT grp, id FROM o_test_include_pk2 WHERE grp = 1 ORDER BY id;
+ grp | id 
+-----+----
+   1 |  1
+   1 |  6
+   1 |  7
+(3 rows)
+
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk2'::regclass, 'ne');
+                       orioledb_tbl_structure                        
+---------------------------------------------------------------------
+ Index o_test_include_pk2_pkey contents                             +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 40               +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty+
+     Leftmost, Rightmost                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 64         +
+     Item 0: offset = 280, tuple = ('1', '1', 'p1')                 +
+     Item 1: offset = 320, tuple = ('2', '2', 'p2')                 +
+     Item 2: offset = 360, tuple = ('3', '0', 'p3')                 +
+     Item 3: deleted, offset = 400, tuple = ('4', '1', 'p4')        +
+     Item 4: offset = 440, tuple = ('5', '2', 'p5')                 +
+     Item 5: offset = 480, tuple = ('6', '1', 'p6')                 +
+     Item 6: offset = 520, tuple = ('7', '1', 'p7')                 +
+     Item 7: offset = 560, tuple = ('8', '2', 'p8')                 +
+     Item 8: offset = 600, tuple = ('9', '0', 'p9')                 +
+                                                                    +
+ Index o_test_include_pk2_grp contents                              +
+ Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 80              +
+ state = free, datoid equal, relnode equal, ix_type = regular, dirty+
+     Leftmost, Rightmost                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 64         +
+     Item 0: offset = 280, tuple = ('0', '3', 'p3')                 +
+     Item 1: deleted, offset = 320, tuple = ('0', '6', 'p6')        +
+     Item 2: offset = 360, tuple = ('0', '9', 'p9')                 +
+     Item 3: offset = 400, tuple = ('1', '1', 'p1')                 +
+     Item 4: deleted, offset = 440, tuple = ('1', '4', 'p4')        +
+     Item 5: offset = 480, tuple = ('1', '6', 'p6')                 +
+     Item 6: offset = 520, tuple = ('1', '7', 'p7')                 +
+     Item 7: offset = 560, tuple = ('2', '2', 'p2')                 +
+     Item 8: offset = 600, tuple = ('2', '5', 'p5')                 +
+     Item 9: offset = 640, tuple = ('2', '8', 'p8')                 +
+                                                                    +
+ Index o_test_include_pk2_payload contents                          +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 32              +
+ state = free, datoid equal, relnode equal, ix_type = unique, dirty +
+     Leftmost, Rightmost                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 64         +
+     Item 0: offset = 280, tuple = ('p1', '1')                      +
+     Item 1: offset = 312, tuple = ('p2', '2')                      +
+     Item 2: offset = 344, tuple = ('p3', '3')                      +
+     Item 3: deleted, offset = 376, tuple = ('p4', '4')             +
+     Item 4: offset = 408, tuple = ('p5', '5')                      +
+     Item 5: offset = 440, tuple = ('p6', '6')                      +
+     Item 6: offset = 472, tuple = ('p7', '7')                      +
+     Item 7: offset = 504, tuple = ('p8', '8')                      +
+     Item 8: offset = 536, tuple = ('p9', '9')                      +
+                                                                    +
+ Index toast: not loaded                                            +
+ 
+(1 row)
+
+-- composite primary key with only one of its columns included
+CREATE TABLE o_test_include_pk3
+(
+	a int,
+	b int,
+	v int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+CREATE INDEX o_test_include_pk3_v ON o_test_include_pk3 (v) INCLUDE (b);
+INSERT INTO o_test_include_pk3 VALUES (1, 1, 7), (1, 2, 7), (2, 1, 7), (2, 2, 8);
+SET enable_seqscan = off;
+SELECT a, b FROM o_test_include_pk3 WHERE v = 7 ORDER BY a, b;
+ a | b 
+---+---
+ 1 | 1
+ 1 | 2
+ 2 | 1
+(3 rows)
+
+RESET enable_seqscan;
+DELETE FROM o_test_include_pk3 WHERE a = 1 AND b = 2;
+SET enable_seqscan = off;
+SELECT a, b FROM o_test_include_pk3 WHERE v = 7 ORDER BY a, b;
+ a | b 
+---+---
+ 1 | 1
+ 2 | 1
+(2 rows)
+
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk3'::regclass, 'ne');
+                       orioledb_tbl_structure                        
+---------------------------------------------------------------------
+ Index o_test_include_pk3_pkey contents                             +
+ Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 32               +
+ state = free, datoid equal, relnode equal, ix_type = primary, dirty+
+     Leftmost, Rightmost                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 64         +
+     Item 0: offset = 264, tuple = ('1', '1', '7')                  +
+     Item 1: deleted, offset = 296, tuple = ('1', '2', '7')         +
+     Item 2: offset = 328, tuple = ('2', '1', '7')                  +
+     Item 3: offset = 360, tuple = ('2', '2', '8')                  +
+                                                                    +
+ Index o_test_include_pk3_v contents                                +
+ Page 0: level = 0, maxKeyLen = 16, nVacatedBytes = 32              +
+ state = free, datoid equal, relnode equal, ix_type = regular, dirty+
+     Leftmost, Rightmost                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 64         +
+     Item 0: offset = 264, tuple = ('7', '1', '1')                  +
+     Item 1: offset = 296, tuple = ('7', '1', '2')                  +
+     Item 2: deleted, offset = 328, tuple = ('7', '2', '1')         +
+     Item 3: offset = 360, tuple = ('8', '2', '2')                  +
+                                                                    +
+ Index toast: not loaded                                            +
+ 
+(1 row)
+
+DROP EXTENSION orioledb CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to table o_test_include_pk
+drop cascades to table o_test_include_pk2
+drop cascades to table o_test_include_pk3
+DROP SCHEMA include_pk CASCADE;
+RESET search_path;

--- a/test/expected/include_pk_wait.out
+++ b/test/expected/include_pk_wait.out
@@ -1,0 +1,27 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_begin s1_insert_a s2_insert_b s2_update_b s1_commit s2_select
+step s1_begin: BEGIN;
+step s1_insert_a: INSERT INTO o_include_pk VALUES ('a', 'g-0', '2026-01-01 00:00:00+00', 1);
+step s2_insert_b: INSERT INTO o_include_pk VALUES ('b', 'g-0', '2026-01-01 00:00:00+00', 1);
+step s2_update_b: UPDATE o_include_pk SET ttl = 2 WHERE id = 'b';
+step s1_commit: COMMIT;
+step s2_select: SET enable_seqscan = off; SELECT id, ttl FROM o_include_pk WHERE grp = 'g-0' ORDER BY id;
+id|ttl
+--+---
+a |  1
+b |  2
+(2 rows)
+
+
+starting permutation: s1_begin s1_insert_a s2_insert_b s1_rollback s2_select
+step s1_begin: BEGIN;
+step s1_insert_a: INSERT INTO o_include_pk VALUES ('a', 'g-0', '2026-01-01 00:00:00+00', 1);
+step s2_insert_b: INSERT INTO o_include_pk VALUES ('b', 'g-0', '2026-01-01 00:00:00+00', 1);
+step s1_rollback: ROLLBACK;
+step s2_select: SET enable_seqscan = off; SELECT id, ttl FROM o_include_pk WHERE grp = 'g-0' ORDER BY id;
+id|ttl
+--+---
+b |  1
+(1 row)
+

--- a/test/expected/indices_2.out
+++ b/test/expected/indices_2.out
@@ -6199,8 +6199,8 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  Index o_test_reuse_multiple_indices_ix3                 +
      Index type: secondary                               +
      Leaf tuple size: 3, non-leaf tuple size: 3          +
-     Non-leaf tuple fields: val_4, val_2, val_1          +
-     Leaf tuple fields: val_4, val_2, val_1              +
+     Non-leaf tuple fields: val_4, val_1, val_2          +
+     Leaf tuple fields: val_4, val_1, val_2              +
  Index o_test_reuse_multiple_indices_ix4                 +
      Index type: secondary                               +
      Leaf tuple size: 3, non-leaf tuple size: 3          +
@@ -6302,11 +6302,11 @@ SELECT orioledb_tbl_structure('o_test_reuse_multiple_indices'::regclass,
  state = free, datoid equal, relnode equal, ix_type = regular, dirty +
      Leftmost, Rightmost                                             +
    Chunk 0: offset = 0, location = 256, hikey location = 64          +
-     Item 0: offset = 272, tuple = ('100', 'XXX1', '1')              +
-     Item 1: offset = 312, tuple = ('200', 'XXX2', '2')              +
-     Item 2: offset = 352, tuple = ('300', 'XXX3', '3')              +
-     Item 3: offset = 392, tuple = ('400', 'XXX4', '4')              +
-     Item 4: offset = 432, tuple = ('500', 'XXX5', '5')              +
+     Item 0: offset = 272, tuple = ('100', '1', 'XXX1')              +
+     Item 1: offset = 312, tuple = ('200', '2', 'XXX2')              +
+     Item 2: offset = 352, tuple = ('300', '3', 'XXX3')              +
+     Item 3: offset = 392, tuple = ('400', '4', 'XXX4')              +
+     Item 4: offset = 432, tuple = ('500', '5', 'XXX5')              +
                                                                      +
  Index o_test_reuse_multiple_indices_ix4 contents                    +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                +
@@ -6427,8 +6427,8 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  Index o_test_reuse_multiple_indices_ix3                 +
      Index type: secondary                               +
      Leaf tuple size: 3, non-leaf tuple size: 3          +
-     Non-leaf tuple fields: val_4, val_2, val_1          +
-     Leaf tuple fields: val_4, val_2, val_1              +
+     Non-leaf tuple fields: val_4, val_1, val_2          +
+     Leaf tuple fields: val_4, val_1, val_2              +
  Index o_test_reuse_multiple_indices_ix4                 +
      Index type: secondary                               +
      Leaf tuple size: 3, non-leaf tuple size: 3          +
@@ -6467,11 +6467,11 @@ SELECT orioledb_tbl_structure('o_test_reuse_multiple_indices'::regclass,
  state = free, datoid equal, relnode equal, ix_type = regular, dirty +
      Leftmost, Rightmost                                             +
    Chunk 0: offset = 0, location = 256, hikey location = 64          +
-     Item 0: offset = 272, tuple = ('100', 'XXX1', '1')              +
-     Item 1: offset = 312, tuple = ('200', 'XXX2', '2')              +
-     Item 2: offset = 352, tuple = ('300', 'XXX3', '3')              +
-     Item 3: offset = 392, tuple = ('400', 'XXX4', '4')              +
-     Item 4: offset = 432, tuple = ('500', 'XXX5', '5')              +
+     Item 0: offset = 272, tuple = ('100', '1', 'XXX1')              +
+     Item 1: offset = 312, tuple = ('200', '2', 'XXX2')              +
+     Item 2: offset = 352, tuple = ('300', '3', 'XXX3')              +
+     Item 3: offset = 392, tuple = ('400', '4', 'XXX4')              +
+     Item 4: offset = 432, tuple = ('500', '5', 'XXX5')              +
                                                                      +
  Index o_test_reuse_multiple_indices_ix4 contents                    +
  Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                +
@@ -6578,8 +6578,8 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  Index o_test_reuse_multiple_indices_ix3                 +
      Index type: secondary                               +
      Leaf tuple size: 3, non-leaf tuple size: 3          +
-     Non-leaf tuple fields: val_4, val_2, val_1          +
-     Leaf tuple fields: val_4, val_2, val_1              +
+     Non-leaf tuple fields: val_4, val_1, val_2          +
+     Leaf tuple fields: val_4, val_1, val_2              +
  Index o_test_reuse_multiple_indices_ix4                 +
      Index type: secondary                               +
      Leaf tuple size: 3, non-leaf tuple size: 3          +
@@ -6775,19 +6775,19 @@ SELECT orioledb_tbl_structure('o_test_reuse_multiple_indices'::regclass, 'nue');
      Item 4: offset = 456, tuple = ('10', 'XXX1', '1')                                    +
                                                                                           +
  Index o_test_reuse_multiple_indices_ix3 contents                                         +
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                     +
+ Page 0: level = 0, maxKeyLen = 21, nVacatedBytes = 0                                     +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                      +
      Leftmost, Rightmost                                                                  +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', 'XXX2', '2') +
-     Item 0: offset = 264, tuple = ('100', 'XXX1', '1')                                   +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', 'XXX3', '3')+
-     Item 1: offset = 312, tuple = ('200', 'XXX2', '2')                                   +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', 'XXX4', '4')+
-     Item 2: offset = 360, tuple = ('300', 'XXX3', '3')                                   +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', 'XXX5', '5')+
-     Item 3: offset = 408, tuple = ('400', 'XXX4', '4')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', '2', 'XXX2') +
+     Item 0: offset = 264, tuple = ('100', '1', 'XXX1')                                   +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', '3', 'XXX3')+
+     Item 1: offset = 312, tuple = ('200', '2', 'XXX2')                                   +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', '4', 'XXX4')+
+     Item 2: offset = 360, tuple = ('300', '3', 'XXX3')                                   +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', '5', 'XXX5')+
+     Item 3: offset = 408, tuple = ('400', '4', 'XXX4')                                   +
    Chunk 4: offset = 4, location = 448, hikey location = 176                              +
-     Item 4: offset = 456, tuple = ('500', 'XXX5', '5')                                   +
+     Item 4: offset = 456, tuple = ('500', '5', 'XXX5')                                   +
                                                                                           +
  Index o_test_reuse_multiple_indices_ix4 contents                                         +
  Page 0: level = 0, maxKeyLen = 21, nVacatedBytes = 0                                     +
@@ -6844,13 +6844,13 @@ SELECT orioledb_tbl_indices('o_test_reuse_multiple_indices'::regclass);
  Index o_test_reuse_multiple_indices_ix3                       +
      Index type: secondary                                     +
      Leaf tuple size: 3, non-leaf tuple size: 3                +
-     Non-leaf tuple fields: val_4, val_2, ctid                 +
-     Leaf tuple fields: val_4, val_2, ctid                     +
+     Non-leaf tuple fields: val_4, ctid, val_2                 +
+     Leaf tuple fields: val_4, ctid, val_2                     +
  Index o_test_reuse_multiple_indices_ix4                       +
      Index type: secondary                                     +
      Leaf tuple size: 4, non-leaf tuple size: 4                +
-     Non-leaf tuple fields: val_5, val_1, val_2, ctid          +
-     Leaf tuple fields: val_5, val_1, val_2, ctid              +
+     Non-leaf tuple fields: val_5, ctid, val_1, val_2          +
+     Leaf tuple fields: val_5, ctid, val_1, val_2              +
  
 (1 row)
 
@@ -6979,34 +6979,34 @@ SELECT orioledb_tbl_structure('o_test_reuse_multiple_indices'::regclass, 'nue');
      Item 4: offset = 456, tuple = ('10', 'XXX1', '(0,1)')                                       +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix3 contents                                                +
- Page 0: level = 0, maxKeyLen = 24, nVacatedBytes = 0                                            +
+ Page 0: level = 0, maxKeyLen = 23, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', 'XXX2', '(0,2)')    +
-     Item 0: offset = 264, tuple = ('100', 'XXX1', '(0,1)')                                      +
-   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', 'XXX3', '(0,3)')   +
-     Item 1: offset = 312, tuple = ('200', 'XXX2', '(0,2)')                                      +
-   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', 'XXX4', '(0,4)')   +
-     Item 2: offset = 360, tuple = ('300', 'XXX3', '(0,3)')                                      +
-   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', 'XXX5', '(0,5)')   +
-     Item 3: offset = 408, tuple = ('400', 'XXX4', '(0,4)')                                      +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('200', '(0,2)', 'XXX2')    +
+     Item 0: offset = 264, tuple = ('100', '(0,1)', 'XXX1')                                      +
+   Chunk 1: offset = 1, location = 304, hikey location = 104, hikey = ('300', '(0,3)', 'XXX3')   +
+     Item 1: offset = 312, tuple = ('200', '(0,2)', 'XXX2')                                      +
+   Chunk 2: offset = 2, location = 352, hikey location = 128, hikey = ('400', '(0,4)', 'XXX4')   +
+     Item 2: offset = 360, tuple = ('300', '(0,3)', 'XXX3')                                      +
+   Chunk 3: offset = 3, location = 400, hikey location = 152, hikey = ('500', '(0,5)', 'XXX5')   +
+     Item 3: offset = 408, tuple = ('400', '(0,4)', 'XXX4')                                      +
    Chunk 4: offset = 4, location = 448, hikey location = 176                                     +
-     Item 4: offset = 456, tuple = ('500', 'XXX5', '(0,5)')                                      +
+     Item 4: offset = 456, tuple = ('500', '(0,5)', 'XXX5')                                      +
                                                                                                  +
  Index o_test_reuse_multiple_indices_ix4 contents                                                +
- Page 0: level = 0, maxKeyLen = 28, nVacatedBytes = 0                                            +
+ Page 0: level = 0, maxKeyLen = 25, nVacatedBytes = 0                                            +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                             +
      Leftmost, Rightmost                                                                         +
-   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('c', '2', 'XXX2', '(0,2)') +
-     Item 0: offset = 264, tuple = ('b', '1', 'XXX1', '(0,1)')                                   +
-   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('d', '3', 'XXX3', '(0,3)')+
-     Item 1: offset = 320, tuple = ('c', '2', 'XXX2', '(0,2)')                                   +
-   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e', '4', 'XXX4', '(0,4)')+
-     Item 2: offset = 376, tuple = ('d', '3', 'XXX3', '(0,3)')                                   +
-   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('f', '5', 'XXX5', '(0,5)')+
-     Item 3: offset = 432, tuple = ('e', '4', 'XXX4', '(0,4)')                                   +
+   Chunk 0: offset = 0, location = 256, hikey location = 80, hikey = ('c', '(0,2)', '2', 'XXX2') +
+     Item 0: offset = 264, tuple = ('b', '(0,1)', '1', 'XXX1')                                   +
+   Chunk 1: offset = 1, location = 312, hikey location = 112, hikey = ('d', '(0,3)', '3', 'XXX3')+
+     Item 1: offset = 320, tuple = ('c', '(0,2)', '2', 'XXX2')                                   +
+   Chunk 2: offset = 2, location = 368, hikey location = 144, hikey = ('e', '(0,4)', '4', 'XXX4')+
+     Item 2: offset = 376, tuple = ('d', '(0,3)', '3', 'XXX3')                                   +
+   Chunk 3: offset = 3, location = 424, hikey location = 176, hikey = ('f', '(0,5)', '5', 'XXX5')+
+     Item 3: offset = 432, tuple = ('e', '(0,4)', '4', 'XXX4')                                   +
    Chunk 4: offset = 4, location = 480, hikey location = 208                                     +
-     Item 4: offset = 488, tuple = ('f', '5', 'XXX5', '(0,5)')                                   +
+     Item 4: offset = 488, tuple = ('f', '(0,5)', '5', 'XXX5')                                   +
                                                                                                  +
  Index toast: not loaded                                                                         +
  
@@ -7092,8 +7092,8 @@ SELECT orioledb_tbl_indices('o_test_include_like'::regclass);
  Index o_test_include_like_ix_include          +
      Index type: secondary, unique             +
      Leaf tuple size: 3, non-leaf tuple size: 3+
-     Non-leaf tuple fields: val2, value, key   +
-     Leaf tuple fields: val2, value, key       +
+     Non-leaf tuple fields: val2, key, value   +
+     Leaf tuple fields: val2, key, value       +
  
 (1 row)
 
@@ -7134,8 +7134,8 @@ SELECT orioledb_tbl_indices('o_test_include_like_like'::regclass);
  Index o_test_include_like_like_val2_value_idx +
      Index type: secondary, unique             +
      Leaf tuple size: 3, non-leaf tuple size: 3+
-     Non-leaf tuple fields: val2, value, key   +
-     Leaf tuple fields: val2, value, key       +
+     Non-leaf tuple fields: val2, key, value   +
+     Leaf tuple fields: val2, key, value       +
  
 (1 row)
 
@@ -7175,8 +7175,8 @@ SELECT orioledb_tbl_indices('o_test_include_like'::regclass);
  Index o_test_include_like_ix_include          +
      Index type: secondary, unique             +
      Leaf tuple size: 3, non-leaf tuple size: 3+
-     Non-leaf tuple fields: val2, value, ctid  +
-     Leaf tuple fields: val2, value, ctid      +
+     Non-leaf tuple fields: val2, ctid, value  +
+     Leaf tuple fields: val2, ctid, value      +
  
 (1 row)
 
@@ -7216,8 +7216,8 @@ SELECT orioledb_tbl_indices('o_test_include_like_like'::regclass);
  Index o_test_include_like_like_val2_value_idx +
      Index type: secondary, unique             +
      Leaf tuple size: 3, non-leaf tuple size: 3+
-     Non-leaf tuple fields: val2, value, ctid  +
-     Leaf tuple fields: val2, value, ctid      +
+     Non-leaf tuple fields: val2, ctid, value  +
+     Leaf tuple fields: val2, ctid, value      +
  
 (1 row)
 
@@ -7282,8 +7282,8 @@ SELECT orioledb_tbl_indices('o_test_include_like_like'::regclass);
  Index o_test_include_like_like_val2_value_idx +
      Index type: secondary, unique             +
      Leaf tuple size: 3, non-leaf tuple size: 3+
-     Non-leaf tuple fields: val2, value, key   +
-     Leaf tuple fields: val2, value, key       +
+     Non-leaf tuple fields: val2, key, value   +
+     Leaf tuple fields: val2, key, value       +
  
 (1 row)
 
@@ -7511,8 +7511,8 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed'::regclass);
  Index o_test_pkey_mixed_ix1                                      +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  
 (1 row)
 
@@ -7549,13 +7549,13 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed'::regclass);
  Index o_test_pkey_mixed_ix1                                      +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_uniq1                                    +
      Index type: secondary, unique                                +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2    +
  
 (1 row)
 
@@ -7594,18 +7594,18 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed'::regclass);
  Index o_test_pkey_mixed_ix1                                      +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_uniq1                                    +
      Index type: secondary, unique                                +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_ix3                                      +
      Index type: secondary                                        +
      Leaf tuple size: 7, non-leaf tuple size: 7                   +
-     Non-leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2        +
-     Leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2            +
+     Non-leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3        +
+     Leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3            +
  
 (1 row)
 
@@ -7646,23 +7646,23 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed'::regclass);
  Index o_test_pkey_mixed_ix1                                      +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_uniq1                                    +
      Index type: secondary, unique                                +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_ix3                                      +
      Index type: secondary                                        +
      Leaf tuple size: 7, non-leaf tuple size: 7                   +
-     Non-leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2        +
-     Leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2            +
+     Non-leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3        +
+     Leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3            +
  Index o_test_pkey_mixed_ix4                                      +
      Index type: secondary                                        +
      Leaf tuple size: 8, non-leaf tuple size: 8                   +
-     Non-leaf tuple fields: i1, f1, pk4, f2, pk3, i2, pk1, pk2    +
-     Leaf tuple fields: i1, f1, pk4, f2, pk3, i2, pk1, pk2        +
+     Non-leaf tuple fields: i1, f1, pk4, f2, pk1, pk2, pk3, i2    +
+     Leaf tuple fields: i1, f1, pk4, f2, pk1, pk2, pk3, i2        +
  
 (1 row)
 
@@ -7687,36 +7687,36 @@ SELECT orioledb_tbl_structure('o_test_pkey_mixed'::regclass, 'nue');
  state = free, datoid equal, relnode equal, ix_type = regular, dirty                              +
      Leftmost, Rightmost                                                                          +
    Chunk 0: offset = 0, location = 256, hikey location = 64                                       +
-     Item 0: offset = 264, tuple = ('1', '2', '6', '3', '4', '9', '5', '7', '8')                  +
-     Item 1: offset = 320, tuple = ('10', '20', '60', '30', '40', '90', '50', '70', '80')         +
-     Item 2: offset = 376, tuple = ('100', '200', '600', '300', '400', '900', '500', '700', '800')+
+     Item 0: offset = 264, tuple = ('1', '2', '6', '3', '7', '8', '9', '4', '5')                  +
+     Item 1: offset = 320, tuple = ('10', '20', '60', '30', '70', '80', '90', '40', '50')         +
+     Item 2: offset = 376, tuple = ('100', '200', '600', '300', '700', '800', '900', '400', '500')+
                                                                                                   +
  Index o_test_pkey_mixed_uniq1 contents                                                           +
  Page 0: level = 0, maxKeyLen = 40, nVacatedBytes = 0                                             +
  state = free, datoid equal, relnode equal, ix_type = unique, dirty                               +
      Leftmost, Rightmost                                                                          +
    Chunk 0: offset = 0, location = 256, hikey location = 64                                       +
-     Item 0: offset = 264, tuple = ('2', '1', '6', '3', '4', '9', '5', '7', '8')                  +
-     Item 1: offset = 320, tuple = ('20', '10', '60', '30', '40', '90', '50', '70', '80')         +
-     Item 2: offset = 376, tuple = ('200', '100', '600', '300', '400', '900', '500', '700', '800')+
+     Item 0: offset = 264, tuple = ('2', '1', '6', '3', '7', '8', '9', '4', '5')                  +
+     Item 1: offset = 320, tuple = ('20', '10', '60', '30', '70', '80', '90', '40', '50')         +
+     Item 2: offset = 376, tuple = ('200', '100', '600', '300', '700', '800', '900', '400', '500')+
                                                                                                   +
  Index o_test_pkey_mixed_ix3 contents                                                             +
  Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                             +
  state = free, datoid equal, relnode equal, ix_type = regular, dirty                              +
      Leftmost, Rightmost                                                                          +
    Chunk 0: offset = 0, location = 256, hikey location = 64                                       +
-     Item 0: offset = 264, tuple = ('3', '2', '9', '1', '8', '6', '7')                            +
-     Item 1: offset = 312, tuple = ('30', '20', '90', '10', '80', '60', '70')                     +
-     Item 2: offset = 360, tuple = ('300', '200', '900', '100', '800', '600', '700')              +
+     Item 0: offset = 264, tuple = ('3', '2', '9', '1', '6', '7', '8')                            +
+     Item 1: offset = 312, tuple = ('30', '20', '90', '10', '60', '70', '80')                     +
+     Item 2: offset = 360, tuple = ('300', '200', '900', '100', '600', '700', '800')              +
                                                                                                   +
  Index o_test_pkey_mixed_ix4 contents                                                             +
  Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                             +
  state = free, datoid equal, relnode equal, ix_type = regular, dirty                              +
      Leftmost, Rightmost                                                                          +
    Chunk 0: offset = 0, location = 256, hikey location = 64                                       +
-     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '8', '5', '6', '7')                       +
-     Item 1: offset = 312, tuple = ('40', '10', '90', '20', '80', '50', '60', '70')               +
-     Item 2: offset = 360, tuple = ('400', '100', '900', '200', '800', '500', '600', '700')       +
+     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '6', '7', '8', '5')                       +
+     Item 1: offset = 312, tuple = ('40', '10', '90', '20', '60', '70', '80', '50')               +
+     Item 2: offset = 360, tuple = ('400', '100', '900', '200', '600', '700', '800', '500')       +
                                                                                                   +
  Index toast: not loaded                                                                          +
  
@@ -7779,9 +7779,9 @@ EXPLAIN (COSTS OFF) SELECT f3, f2, pk4, f1, pk4, pk3, pk1, pk2 FROM o_test_pkey_
 SELECT f3, f2, pk4, f1, pk4, pk3, pk1, pk2 FROM o_test_pkey_mixed ORDER BY f3;
  f3  | f2  | pk4 | f1  | pk4 | pk3 | pk1 | pk2 
 -----+-----+-----+-----+-----+-----+-----+-----
-   3 |   2 |   9 |   1 |   9 |   6 |   7 |    
-  30 |  20 |  90 |  10 |  90 |  60 |  70 |    
- 300 | 200 | 900 | 100 | 900 | 600 | 700 |    
+   3 |   2 |   9 |   1 |   9 |   8 |   6 |   7
+  30 |  20 |  90 |  10 |  90 |  80 |  60 |  70
+ 300 | 200 | 900 | 100 | 900 | 800 | 600 | 700
 (3 rows)
 
 EXPLAIN (COSTS OFF) SELECT i1, f1, pk4, f2, pk4, pk3, i2, pk1, pk2 FROM o_test_pkey_mixed ORDER BY i1;
@@ -7795,9 +7795,9 @@ EXPLAIN (COSTS OFF) SELECT i1, f1, pk4, f2, pk4, pk3, i2, pk1, pk2 FROM o_test_p
 SELECT i1, f1, pk4, f2, pk4, pk3, i2, pk1, pk2 FROM o_test_pkey_mixed ORDER BY i1;
  i1  | f1  | pk4 | f2  | pk4 | pk3 | i2  | pk1 | pk2 
 -----+-----+-----+-----+-----+-----+-----+-----+-----
-   4 |   1 |   9 |   2 |   9 |   5 |   6 |   7 |    
-  40 |  10 |  90 |  20 |  90 |  50 |  60 |  70 |    
- 400 | 100 | 900 | 200 | 900 | 500 | 600 | 700 |    
+   4 |   1 |   9 |   2 |   9 |   8 |   5 |   6 |   7
+  40 |  10 |  90 |  20 |  90 |  80 |  50 |  60 |  70
+ 400 | 100 | 900 | 200 | 900 | 800 | 500 | 600 | 700
 (3 rows)
 
 RESET enable_seqscan;
@@ -7892,8 +7892,8 @@ SELECT orioledb_tbl_indices('o_test_include_box'::regclass);
  Index o_test_include_box_ix1                  +
      Index type: secondary, unique             +
      Leaf tuple size: 3, non-leaf tuple size: 3+
-     Non-leaf tuple fields: val_1, val_4, ctid +
-     Leaf tuple fields: val_1, val_4, ctid     +
+     Non-leaf tuple fields: val_1, ctid, val_4 +
+     Leaf tuple fields: val_1, ctid, val_4     +
  
 (1 row)
 
@@ -7918,9 +7918,9 @@ SELECT orioledb_tbl_structure('o_test_include_box'::regclass, 'nue');
  state = free, datoid equal, relnode equal, ix_type = unique, dirty       +
      Leftmost, Rightmost                                                  +
    Chunk 0: offset = 0, location = 256, hikey location = 64               +
-     Item 0: offset = 264, tuple = ('1', '(4,5),(2,3)', '(0,1)')          +
-     Item 1: offset = 328, tuple = ('10', '(40,50),(20,30)', '(0,2)')     +
-     Item 2: offset = 392, tuple = ('100', '(400,500),(200,300)', '(0,3)')+
+     Item 0: offset = 264, tuple = ('1', '(0,1)', '(4,5),(2,3)')          +
+     Item 1: offset = 328, tuple = ('10', '(0,2)', '(40,50),(20,30)')     +
+     Item 2: offset = 392, tuple = ('100', '(0,3)', '(400,500),(200,300)')+
                                                                           +
  Index toast: not loaded                                                  +
  
@@ -7977,8 +7977,8 @@ SELECT orioledb_tbl_indices('o_test_include_box_with_pkey'::regclass);
  Index o_test_include_box_with_pkey_ix1           +
      Index type: secondary, unique                +
      Leaf tuple size: 3, non-leaf tuple size: 3   +
-     Non-leaf tuple fields: val_2, val_4, val_1   +
-     Leaf tuple fields: val_2, val_4, val_1       +
+     Non-leaf tuple fields: val_2, val_1, val_4   +
+     Leaf tuple fields: val_2, val_1, val_4       +
  Index o_test_include_box_with_pkey_ix2           +
      Index type: secondary, unique                +
      Leaf tuple size: 2, non-leaf tuple size: 2   +
@@ -8004,13 +8004,13 @@ SELECT orioledb_tbl_structure('o_test_include_box_with_pkey'::regclass, 'nue');
      Item 2: offset = 392, tuple = ('100', '200', '300', '(600,700),(400,500)')+
                                                                                +
  Index o_test_include_box_with_pkey_ix1 contents                               +
- Page 0: level = 0, maxKeyLen = 48, nVacatedBytes = 0                          +
+ Page 0: level = 0, maxKeyLen = 40, nVacatedBytes = 0                          +
  state = free, datoid equal, relnode equal, ix_type = unique, dirty            +
      Leftmost, Rightmost                                                       +
    Chunk 0: offset = 0, location = 256, hikey location = 64                    +
-     Item 0: offset = 264, tuple = ('2', '(6,7),(4,5)', '1')                   +
-     Item 1: offset = 328, tuple = ('20', '(60,70),(40,50)', '10')             +
-     Item 2: offset = 392, tuple = ('200', '(600,700),(400,500)', '100')       +
+     Item 0: offset = 264, tuple = ('2', '1', '(6,7),(4,5)')                   +
+     Item 1: offset = 320, tuple = ('20', '10', '(60,70),(40,50)')             +
+     Item 2: offset = 376, tuple = ('200', '100', '(600,700),(400,500)')       +
                                                                                +
  Index o_test_include_box_with_pkey_ix2 contents                               +
  Page 0: level = 0, maxKeyLen = 8, nVacatedBytes = 0                           +

--- a/test/expected/indices_build.out
+++ b/test/expected/indices_build.out
@@ -23933,8 +23933,8 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed_build'::regclass);
  Index o_test_pkey_mixed_build_ix1                                +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  
 (1 row)
 
@@ -23971,13 +23971,13 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed_build'::regclass);
  Index o_test_pkey_mixed_build_ix1                                +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_build_uniq1                              +
      Index type: secondary, unique                                +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2    +
  
 (1 row)
 
@@ -24016,18 +24016,18 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed_build'::regclass);
  Index o_test_pkey_mixed_build_ix1                                +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_build_uniq1                              +
      Index type: secondary, unique                                +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_build_ix3                                +
      Index type: secondary                                        +
      Leaf tuple size: 7, non-leaf tuple size: 7                   +
-     Non-leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2        +
-     Leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2            +
+     Non-leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3        +
+     Leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3            +
  
 (1 row)
 
@@ -24068,23 +24068,23 @@ SELECT orioledb_tbl_indices('o_test_pkey_mixed_build'::regclass);
  Index o_test_pkey_mixed_build_ix1                                +
      Index type: secondary                                        +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f1, f2, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f1, f2, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_build_uniq1                              +
      Index type: secondary, unique                                +
      Leaf tuple size: 9, non-leaf tuple size: 9                   +
-     Non-leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3+
-     Leaf tuple fields: f2, f1, pk1, f3, i1, pk4, i2, pk2, pk3    +
+     Non-leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2+
+     Leaf tuple fields: f2, f1, pk1, f3, pk2, pk3, pk4, i1, i2    +
  Index o_test_pkey_mixed_build_ix3                                +
      Index type: secondary                                        +
      Leaf tuple size: 7, non-leaf tuple size: 7                   +
-     Non-leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2        +
-     Leaf tuple fields: f3, f2, pk4, f1, pk3, pk1, pk2            +
+     Non-leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3        +
+     Leaf tuple fields: f3, f2, pk4, f1, pk1, pk2, pk3            +
  Index o_test_pkey_mixed_build_ix4                                +
      Index type: secondary                                        +
      Leaf tuple size: 8, non-leaf tuple size: 8                   +
-     Non-leaf tuple fields: i1, f1, pk4, f2, pk3, i2, pk1, pk2    +
-     Leaf tuple fields: i1, f1, pk4, f2, pk3, i2, pk1, pk2        +
+     Non-leaf tuple fields: i1, f1, pk4, f2, pk1, pk2, pk3, i2    +
+     Leaf tuple fields: i1, f1, pk4, f2, pk1, pk2, pk3, i2        +
  
 (1 row)
 
@@ -24186,45 +24186,45 @@ SELECT orioledb_tbl_structure('o_test_pkey_mixed_build'::regclass, 'nue');
  Page 0: level = 0, maxKeyLen = 36, nVacatedBytes = 0                                                                                +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                                 +
      Leftmost, Rightmost                                                                                                             +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('10', '20', '60', '30', '40', '90', '50', '70', '80')          +
-     Item 0: offset = 264, tuple = ('1', '2', '6', '3', '4', '9', '5', '7', '8')                                                     +
-   Chunk 1: offset = 1, location = 320, hikey location = 112, hikey = ('100', '200', '600', '300', '400', '900', '500', '700', '800')+
-     Item 1: offset = 328, tuple = ('10', '20', '60', '30', '40', '90', '50', '70', '80')                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('10', '20', '60', '30', '70', '80', '90', '40', '50')          +
+     Item 0: offset = 264, tuple = ('1', '2', '6', '3', '7', '8', '9', '4', '5')                                                     +
+   Chunk 1: offset = 1, location = 320, hikey location = 112, hikey = ('100', '200', '600', '300', '700', '800', '900', '400', '500')+
+     Item 1: offset = 328, tuple = ('10', '20', '60', '30', '70', '80', '90', '40', '50')                                            +
    Chunk 2: offset = 2, location = 384, hikey location = 152                                                                         +
-     Item 2: offset = 392, tuple = ('100', '200', '600', '300', '400', '900', '500', '700', '800')                                   +
+     Item 2: offset = 392, tuple = ('100', '200', '600', '300', '700', '800', '900', '400', '500')                                   +
                                                                                                                                      +
  Index o_test_pkey_mixed_build_uniq1 contents                                                                                        +
  Page 0: level = 0, maxKeyLen = 36, nVacatedBytes = 0                                                                                +
  state = free, datoid equal, relnode equal, ix_type = unique, clean                                                                  +
      Leftmost, Rightmost                                                                                                             +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('20', '10', '60', '30', '40', '90', '50', '70', '80')          +
-     Item 0: offset = 264, tuple = ('2', '1', '6', '3', '4', '9', '5', '7', '8')                                                     +
-   Chunk 1: offset = 1, location = 320, hikey location = 112, hikey = ('200', '100', '600', '300', '400', '900', '500', '700', '800')+
-     Item 1: offset = 328, tuple = ('20', '10', '60', '30', '40', '90', '50', '70', '80')                                            +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('20', '10', '60', '30', '70', '80', '90', '40', '50')          +
+     Item 0: offset = 264, tuple = ('2', '1', '6', '3', '7', '8', '9', '4', '5')                                                     +
+   Chunk 1: offset = 1, location = 320, hikey location = 112, hikey = ('200', '100', '600', '300', '700', '800', '900', '400', '500')+
+     Item 1: offset = 328, tuple = ('20', '10', '60', '30', '70', '80', '90', '40', '50')                                            +
    Chunk 2: offset = 2, location = 384, hikey location = 152                                                                         +
-     Item 2: offset = 392, tuple = ('200', '100', '600', '300', '400', '900', '500', '700', '800')                                   +
+     Item 2: offset = 392, tuple = ('200', '100', '600', '300', '700', '800', '900', '400', '500')                                   +
                                                                                                                                      +
  Index o_test_pkey_mixed_build_ix3 contents                                                                                          +
  Page 0: level = 0, maxKeyLen = 28, nVacatedBytes = 0                                                                                +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                                 +
      Leftmost, Rightmost                                                                                                             +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('30', '20', '90', '10', '80', '60', '70')                      +
-     Item 0: offset = 264, tuple = ('3', '2', '9', '1', '8', '6', '7')                                                               +
-   Chunk 1: offset = 1, location = 312, hikey location = 104, hikey = ('300', '200', '900', '100', '800', '600', '700')              +
-     Item 1: offset = 320, tuple = ('30', '20', '90', '10', '80', '60', '70')                                                        +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('30', '20', '90', '10', '60', '70', '80')                      +
+     Item 0: offset = 264, tuple = ('3', '2', '9', '1', '6', '7', '8')                                                               +
+   Chunk 1: offset = 1, location = 312, hikey location = 104, hikey = ('300', '200', '900', '100', '600', '700', '800')              +
+     Item 1: offset = 320, tuple = ('30', '20', '90', '10', '60', '70', '80')                                                        +
    Chunk 2: offset = 2, location = 368, hikey location = 136                                                                         +
-     Item 2: offset = 376, tuple = ('300', '200', '900', '100', '800', '600', '700')                                                 +
+     Item 2: offset = 376, tuple = ('300', '200', '900', '100', '600', '700', '800')                                                 +
                                                                                                                                      +
  Index o_test_pkey_mixed_build_ix4 contents                                                                                          +
  Page 0: level = 0, maxKeyLen = 32, nVacatedBytes = 0                                                                                +
  state = free, datoid equal, relnode equal, ix_type = regular, clean                                                                 +
      Leftmost, Rightmost                                                                                                             +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('40', '10', '90', '20', '80', '50', '60', '70')                +
-     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '8', '5', '6', '7')                                                          +
-   Chunk 1: offset = 1, location = 312, hikey location = 104, hikey = ('400', '100', '900', '200', '800', '500', '600', '700')       +
-     Item 1: offset = 320, tuple = ('40', '10', '90', '20', '80', '50', '60', '70')                                                  +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('40', '10', '90', '20', '60', '70', '80', '50')                +
+     Item 0: offset = 264, tuple = ('4', '1', '9', '2', '6', '7', '8', '5')                                                          +
+   Chunk 1: offset = 1, location = 312, hikey location = 104, hikey = ('400', '100', '900', '200', '600', '700', '800', '500')       +
+     Item 1: offset = 320, tuple = ('40', '10', '90', '20', '60', '70', '80', '50')                                                  +
    Chunk 2: offset = 2, location = 368, hikey location = 136                                                                         +
-     Item 2: offset = 376, tuple = ('400', '100', '900', '200', '800', '500', '600', '700')                                          +
+     Item 2: offset = 376, tuple = ('400', '100', '900', '200', '600', '700', '800', '500')                                          +
                                                                                                                                      +
  Index toast: not loaded                                                                                                             +
  
@@ -24357,8 +24357,8 @@ SELECT orioledb_tbl_indices('o_test_include_box_build'::regclass);
  Index o_test_include_box_build_ix1            +
      Index type: secondary, unique             +
      Leaf tuple size: 3, non-leaf tuple size: 3+
-     Non-leaf tuple fields: val_1, val_4, ctid +
-     Leaf tuple fields: val_1, val_4, ctid     +
+     Non-leaf tuple fields: val_1, ctid, val_4 +
+     Leaf tuple fields: val_1, ctid, val_4     +
  
 (1 row)
 
@@ -24392,15 +24392,15 @@ SELECT orioledb_tbl_structure('o_test_include_box_build'::regclass, 'nue');
      Item 2: offset = 392, tuple = ('(0,3)', '100', '(400,500),(200,300)')                                   +
                                                                                                              +
  Index o_test_include_box_build_ix1 contents                                                                 +
- Page 0: level = 0, maxKeyLen = 46, nVacatedBytes = 0                                                        +
+ Page 0: level = 0, maxKeyLen = 48, nVacatedBytes = 0                                                        +
  state = free, datoid equal, relnode equal, ix_type = unique, clean                                          +
      Leftmost, Rightmost                                                                                     +
-   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('10', '(40,50),(20,30)', '(0,2)')      +
-     Item 0: offset = 264, tuple = ('1', '(4,5),(2,3)', '(0,1)')                                             +
-   Chunk 1: offset = 1, location = 328, hikey location = 120, hikey = ('100', '(400,500),(200,300)', '(0,3)')+
-     Item 1: offset = 336, tuple = ('10', '(40,50),(20,30)', '(0,2)')                                        +
+   Chunk 0: offset = 0, location = 256, hikey location = 72, hikey = ('10', '(0,2)', '(40,50),(20,30)')      +
+     Item 0: offset = 264, tuple = ('1', '(0,1)', '(4,5),(2,3)')                                             +
+   Chunk 1: offset = 1, location = 328, hikey location = 120, hikey = ('100', '(0,3)', '(400,500),(200,300)')+
+     Item 1: offset = 336, tuple = ('10', '(0,2)', '(40,50),(20,30)')                                        +
    Chunk 2: offset = 2, location = 400, hikey location = 168                                                 +
-     Item 2: offset = 408, tuple = ('100', '(400,500),(200,300)', '(0,3)')                                   +
+     Item 2: offset = 408, tuple = ('100', '(0,3)', '(400,500),(200,300)')                                   +
                                                                                                              +
  Index toast: not loaded                                                                                     +
  

--- a/test/specs/include_pk_wait.spec
+++ b/test/specs/include_pk_wait.spec
@@ -1,0 +1,35 @@
+# Two rows that share the index key columns but differ in the primary key
+# (which sits in the INCLUDE list) are unrelated: the second insert must not
+# wait for the first transaction, and both must end up in the index.
+setup
+{
+	CREATE EXTENSION IF NOT EXISTS orioledb;
+	CREATE TABLE IF NOT EXISTS o_include_pk (
+		id text PRIMARY KEY,
+		grp text,
+		created_at timestamptz,
+		ttl int
+	) USING orioledb;
+	CREATE INDEX IF NOT EXISTS o_include_pk_ix ON o_include_pk (grp, created_at)
+		INCLUDE (id, ttl);
+	TRUNCATE o_include_pk;
+}
+
+teardown
+{
+	DROP TABLE o_include_pk;
+}
+
+session "s1"
+step "s1_begin"    { BEGIN; }
+step "s1_insert_a" { INSERT INTO o_include_pk VALUES ('a', 'g-0', '2026-01-01 00:00:00+00', 1); }
+step "s1_commit"   { COMMIT; }
+step "s1_rollback" { ROLLBACK; }
+
+session "s2"
+step "s2_insert_b" { INSERT INTO o_include_pk VALUES ('b', 'g-0', '2026-01-01 00:00:00+00', 1); }
+step "s2_update_b" { UPDATE o_include_pk SET ttl = 2 WHERE id = 'b'; }
+step "s2_select"   { SET enable_seqscan = off; SELECT id, ttl FROM o_include_pk WHERE grp = 'g-0' ORDER BY id; }
+
+permutation "s1_begin" "s1_insert_a" "s2_insert_b" "s2_update_b" "s1_commit" "s2_select"
+permutation "s1_begin" "s1_insert_a" "s2_insert_b" "s1_rollback" "s2_select"

--- a/test/sql/include_pk.sql
+++ b/test/sql/include_pk.sql
@@ -1,0 +1,92 @@
+-- A primary key column named in an INCLUDE list is stored once, in the
+-- INCLUDE position, but it must still take part in the index key: two rows
+-- that agree on the key columns are two distinct entries.
+CREATE SCHEMA include_pk;
+SET SESSION search_path = 'include_pk';
+CREATE EXTENSION orioledb;
+
+CREATE TABLE o_test_include_pk
+(
+	id text PRIMARY KEY,
+	grp text,
+	created_at timestamptz,
+	ttl bigint,
+	deleted bool NOT NULL DEFAULT false
+) USING orioledb;
+CREATE INDEX o_test_include_pk_ix ON o_test_include_pk (grp, created_at)
+	INCLUDE (id, ttl) WHERE NOT deleted AND ttl IS NOT NULL;
+
+INSERT INTO o_test_include_pk VALUES ('a', 'g-0', '2026-01-01 00:00:00+00', 3600);
+INSERT INTO o_test_include_pk VALUES ('b', 'g-0', '2026-01-01 00:00:00+00', 3600);
+INSERT INTO o_test_include_pk VALUES ('c', 'g-0', '2026-01-01 00:00:00+00', 3600)
+	ON CONFLICT (id) DO NOTHING;
+INSERT INTO o_test_include_pk VALUES ('d', 'g-1', '2026-01-01 00:00:00+00', NULL);
+
+SET enable_seqscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT id FROM o_test_include_pk
+		WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+SELECT id, grp FROM o_test_include_pk
+	WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk'::regclass, 'ne');
+
+-- leaving the predicate must remove exactly this row's entry
+UPDATE o_test_include_pk SET deleted = true WHERE id = 'b';
+UPDATE o_test_include_pk SET deleted = true WHERE id = 'a';
+-- and coming back must add it again
+UPDATE o_test_include_pk SET deleted = false WHERE id = 'b';
+SET enable_seqscan = off;
+SELECT id, grp FROM o_test_include_pk
+	WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+RESET enable_seqscan;
+DELETE FROM o_test_include_pk WHERE id = 'c';
+SET enable_seqscan = off;
+SELECT id, grp FROM o_test_include_pk
+	WHERE NOT deleted AND ttl IS NOT NULL ORDER BY grp, created_at, id;
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk'::regclass, 'ne');
+
+-- non-partial variant, and a UNIQUE index whose INCLUDE list names the key
+CREATE TABLE o_test_include_pk2
+(
+	id int PRIMARY KEY,
+	grp int,
+	payload text
+) USING orioledb;
+CREATE INDEX o_test_include_pk2_grp ON o_test_include_pk2 (grp) INCLUDE (id, payload);
+CREATE UNIQUE INDEX o_test_include_pk2_payload ON o_test_include_pk2 (payload) INCLUDE (id);
+INSERT INTO o_test_include_pk2 SELECT i, i % 3, 'p' || i FROM generate_series(1, 9) i;
+SET enable_seqscan = off;
+SELECT grp, id FROM o_test_include_pk2 WHERE grp = 1 ORDER BY id;
+SELECT id FROM o_test_include_pk2 WHERE payload = 'p5';
+RESET enable_seqscan;
+UPDATE o_test_include_pk2 SET grp = 1 WHERE id = 6;
+DELETE FROM o_test_include_pk2 WHERE id = 4;
+SET enable_seqscan = off;
+SELECT grp, id FROM o_test_include_pk2 WHERE grp = 1 ORDER BY id;
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk2'::regclass, 'ne');
+
+-- composite primary key with only one of its columns included
+CREATE TABLE o_test_include_pk3
+(
+	a int,
+	b int,
+	v int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+CREATE INDEX o_test_include_pk3_v ON o_test_include_pk3 (v) INCLUDE (b);
+INSERT INTO o_test_include_pk3 VALUES (1, 1, 7), (1, 2, 7), (2, 1, 7), (2, 2, 8);
+SET enable_seqscan = off;
+SELECT a, b FROM o_test_include_pk3 WHERE v = 7 ORDER BY a, b;
+RESET enable_seqscan;
+DELETE FROM o_test_include_pk3 WHERE a = 1 AND b = 2;
+SET enable_seqscan = off;
+SELECT a, b FROM o_test_include_pk3 WHERE v = 7 ORDER BY a, b;
+RESET enable_seqscan;
+SELECT orioledb_tbl_structure('o_test_include_pk3'::regclass, 'ne');
+
+DROP EXTENSION orioledb CASCADE;
+DROP SCHEMA include_pk CASCADE;
+RESET search_path;

--- a/test/sql/include_pk.sql
+++ b/test/sql/include_pk.sql
@@ -1,6 +1,5 @@
 -- A primary key column named in an INCLUDE list is stored once, in the
--- INCLUDE position, but it must still take part in the index key: two rows
--- that agree on the key columns are two distinct entries.
+-- deduplicated PK segment, and remains available to index-only scans.
 CREATE SCHEMA include_pk;
 SET SESSION search_path = 'include_pk';
 CREATE EXTENSION orioledb;
@@ -86,6 +85,50 @@ SET enable_seqscan = off;
 SELECT a, b FROM o_test_include_pk3 WHERE v = 7 ORDER BY a, b;
 RESET enable_seqscan;
 SELECT orioledb_tbl_structure('o_test_include_pk3'::regclass, 'ne');
+
+-- composite PK delete correctness without any secondary index
+CREATE TABLE o_test_include_pk4
+(
+	a int,
+	b int,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+INSERT INTO o_test_include_pk4 VALUES (1, 1), (1, 2), (2, 1), (2, 2);
+SELECT a, b FROM o_test_include_pk4 ORDER BY a, b;
+DELETE FROM o_test_include_pk4 WHERE a = 1 AND b = 2;
+SELECT a, b FROM o_test_include_pk4 ORDER BY a, b;
+
+-- PK fields can be interleaved with INCLUDE fields of different types.
+-- Exercise both secondary-to-primary lookup and ON CONFLICT row locking.
+CREATE TABLE o_test_include_pk5
+(
+	a text,
+	b int,
+	v int,
+	token text,
+	note text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+CREATE INDEX o_test_include_pk5_v ON o_test_include_pk5 (v)
+	INCLUDE (b, note);
+CREATE UNIQUE INDEX o_test_include_pk5_token ON o_test_include_pk5 (token)
+	INCLUDE (b);
+INSERT INTO o_test_include_pk5 VALUES
+	('one', 1, 7, 'first', repeat('x', 10000)),
+	('two', 2, 7, 'second', repeat('y', 10000));
+SET enable_seqscan = off;
+SELECT a, b, token, length(note) FROM o_test_include_pk5
+	WHERE v = 7 ORDER BY a, b;
+RESET enable_seqscan;
+INSERT INTO o_test_include_pk5 VALUES
+	('unused', 9, 9, 'first', 'updated')
+	ON CONFLICT (token) DO UPDATE SET note = EXCLUDED.note
+	RETURNING a, b, token, note;
+DELETE FROM o_test_include_pk5 WHERE a = 'two' AND b = 2;
+SET enable_seqscan = off;
+SELECT a, b, token, length(note) FROM o_test_include_pk5
+	WHERE v = 7 ORDER BY a, b;
+RESET enable_seqscan;
 
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA include_pk CASCADE;


### PR DESCRIPTION
Store secondary-index fields in [key][PK][INCLUDE] physical order so
INCLUDE columns form a positional tail that comparison, sort, and hash
code can skip via OIgnoreColumn.  Add a persisted IndexAM attnum map
(indexAmAttnums) so INSERT/UPDATE/DELETE and index-only scans translate
between PostgreSQL's declared field order and the new physical layout,
replacing the old duplicate-compaction logic.  Bump
ORIOLEDB_SYS_TREE_VERSION to 2 and guard OIgnoreColumn with an upper
bound so toast/bridge sortstates whose keys extend past nFields are not
falsely collapsed as ignored INCLUDE columns.

Alternative approach to #1127