### PR TITLE
Fix flake in merge_into_concurrently_dropped_tree under VALGRIND

### DIFF
--- a/test/t/merge_test.py
+++ b/test/t/merge_test.py
@@ -88,6 +88,14 @@ class MergeTest(BaseTest):
 		ctrl.execute(
 		    "SELECT pg_stopevent_set('merge_after_target_unlock', 'true');")
 
+		# Under Valgrind the delete phase is slow enough for the clock sweep
+		# to evict every sparse o_mNN page before the stopevent is armed.
+		# Reload one leaf per tree so the presser can evict them.
+		with node.connect() as warmer:
+			for i in range(NTABLES):
+				warmer.execute("SELECT 1 FROM o_m%02d ORDER BY id LIMIT 1;" %
+				               i)
+
 		presser = node.connect()
 		running = {'go': True}
 


### PR DESCRIPTION
Warm buffer pool before presser in merge_into_concurrently_dropped_tree

Under Valgrind the delete phase takes ~11s (vs ~1-2s normally), giving the clock sweep enough time to evict all sparse o_mNN pages from the 8MB buffer pool before the stopevent is armed. The presser only scans o_filler, so no sparse pages re-enter the pool, no merge fires, and the test fails with "nothing parked in the merge window".

Reload one leaf per o_mNN tree after arming the stopevent but before starting the presser. A separate connection is used so no AccessShareLock is held when the dropper runs DROP TABLE.