### PR TITLE
Validate WAL tuple length in logical decoding before fixed-buffer copy

### DIFF
--- a/src/recovery/wal_reader.c
+++ b/src/recovery/wal_reader.c
@@ -390,7 +390,12 @@ build_fixed_tuple_from_tuple_view(const OTuple *view, const OffsetNumber len, OF
 	Assert(tuple);
 
 	tuple->tuple.formatFlags = view->formatFlags;
-	Assert(tuple->fixedData);
+	if (unlikely(MAXALIGN(len) > sizeof(tuple->fixedData)))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg("WAL tuple length %u exceeds fixed buffer size %u",
+						(unsigned) len,
+						(unsigned) sizeof(tuple->fixedData))));
 	memcpy(tuple->fixedData, view->data, len);
 	if (len != MAXALIGN(len))
 		memset(&tuple->fixedData[len], 0, MAXALIGN(len) - len);


### PR DESCRIPTION
build_fixed_tuple_from_tuple_view() trusts the len parameter from WAL without runtime bounds checks. A forged modify record received via replication with len > O_BTREE_MAX_TUPLE_SIZE overwrites the stack-allocated OFixedTuple.fixedData buffer in both logical.c and recovery.c callers.

Replace the dead Assert(tuple->fixedData) (fixedData is char fixedData[O_BTREE_MAX_TUPLE_SIZE] — a fixed array
  member, not a pointer) with a runtime check that MAXALIGN(len) fits within sizeof(tuple->fixedData) before memcpy.

