### PR TITLE
Bound compressed page metadata in read_page_from_disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,7 @@ TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \
 						test/t/seq_scan_own_write_test.py \
 						test/t/seq_scan_resowner_test.py \
 						test/t/seq_scan_undo_test.py \
+						test/t/compress_page_bounds_test.py \
 						test/t/temp_local_pool_test.py \
 						test/t/wal_savepoint_buffer_test.py \
 						test/t/toast_index_test.py \

--- a/include/btree/io.h
+++ b/include/btree/io.h
@@ -62,7 +62,9 @@ typedef enum
 	/* the page could not be read from the disk at all */
 	OReadPageResultIOError,
 	/* the page was read, but its checksum didn't match */
-	OReadPageResultChecksumFailed
+	OReadPageResultChecksumFailed,
+	/* the page metadata (extent length / compressed size) is malformed */
+	OReadPageResultCorrupted
 } OReadPageResult;
 
 extern OReadPageResult read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink, FileExtent *extent);

--- a/sql/orioledb--1.8--1.9_dev.sql
+++ b/sql/orioledb--1.8--1.9_dev.sql
@@ -18,6 +18,16 @@ RETURNS text
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
 
+CREATE FUNCTION orioledb_test_corrupt_downlink_len(relid oid, new_len int4)
+RETURNS int8
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_test_corrupt_compressed_page_size(relid oid)
+RETURNS int8
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;
+
 CREATE FUNCTION orioledb_check_pending_truncates()
 RETURNS VOID
 AS 'MODULE_PATHNAME'

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -1397,8 +1397,21 @@ read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 
 	/* for the checksum computation we need aligned buffer */
 	Assert(((uintptr_t) img % sizeof(uint32)) == 0);
-	Assert(FileExtentOffIsValid(offset));
-	Assert(FileExtentLenIsValid(len));
+
+	/*
+	 * The extent offset and length come from a parent downlink and are
+	 * attacker-controlled metadata.  Validate them before computing
+	 * read_size: a length above ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ would
+	 * make the compressed read below fetch len * ORIOLEDB_COMP_BLCKSZ bytes
+	 * into the 8 KB stack buffer OrioleDBChecksummablePage, smashing the
+	 * stack, and a zero length would read nothing and then decompress
+	 * uninitialized data.  A non-compressed index must always use a
+	 * single-block extent.  Raise a corruption error instead of asserting.
+	 */
+	if (!FileExtentOffIsValid(offset) || len == 0 ||
+		len > (ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ) ||
+		(!OCompressIsValid(desc->compress) && len != 1))
+		return OReadPageResultCorrupted;
 
 	extent->off = offset;
 	extent->len = len;
@@ -1460,6 +1473,18 @@ read_page_from_disk(BTreeDescr *desc, Pointer img, uint64 downlink,
 
 			needs_compress_version_convert = check_orioledb_compress_version(ondisk_page_header);
 			Assert(!needs_compress_version_convert);
+
+			/*
+			 * compress_page_size is read from the on-disk header.  Bound it
+			 * against the bytes actually fetched before handing it to
+			 * o_decompress_page(): otherwise a crafted header could make
+			 * decompression read past the fetched extent.
+			 */
+			if (ondisk_page_header.compress_page_size == 0 ||
+				(off_t) ondisk_page_header.compress_page_size >
+				read_size - (off_t) O_PAGE_HEADER_SIZE)
+				return OReadPageResultCorrupted;
+
 			o_decompress_page(buf + O_PAGE_HEADER_SIZE, ondisk_page_header.compress_page_size, img);
 			elog(DEBUG1, "Read disk page: checkpoint %u size %d", ondisk_page_header.checkpointNum, ondisk_page_header.compress_page_size);
 
@@ -1744,7 +1769,8 @@ load_page(OBTreeFindPageContext *context)
 		if (orioledb_s3_mode)
 			chkpNum = S3_GET_CHKP_NUM(page_desc->fileExtent.off);
 
-		if (read_result == OReadPageResultChecksumFailed)
+		if (read_result == OReadPageResultChecksumFailed ||
+			read_result == OReadPageResultCorrupted)
 			ereport(ERROR, (errcode(ERRCODE_DATA_CORRUPTED),
 							errmsg("invalid page with file offset " UINT64_FORMAT " in %s",
 								   DOWNLINK_GET_DISK_OFF(downlink),
@@ -3953,3 +3979,252 @@ try_to_punch_holes(BTreeDescr *desc)
 		chkp_num++;
 	}
 }
+
+#ifdef IS_DEV
+
+#include "btree/page_state.h"
+
+PG_FUNCTION_INFO_V1(orioledb_test_corrupt_downlink_len);
+
+/*
+ * Walk the primary index btree of the given relation down to its leftmost
+ * level-1 (leaf parent) page, find the first on-disk leaf downlink and
+ * overwrite the extent length stored in that downlink with new_len (masked
+ * to the 15 bits a downlink can hold).  This lets regression tests feed
+ * read_page_from_disk() a crafted extent length without touching on-disk
+ * bytes.  Returns the downlink's file offset, or NULL when the tree is too
+ * shallow to have an internal page or no on-disk leaf downlink was found
+ * (e.g. leaves were not evicted).
+ *
+ * Test-only; guarded by IS_DEV.
+ */
+Datum
+orioledb_test_corrupt_downlink_len(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	int			new_len = PG_GETARG_INT32(1);
+	Relation	rel;
+	OTableDescr *descr;
+	OIndexDescr *idx;
+	BTreeDescr *desc;
+	OInMemoryBlkno blkno;
+	uint64		result_offset = InvalidFileExtentOff;
+
+	orioledb_check_shmem();
+
+	rel = relation_open(relid, AccessShareLock);
+	descr = relation_get_descr(rel);
+	if (!descr)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation oid %u is not orioledb", relid)));
+
+	idx = descr->indices[0];
+	desc = &idx->desc;
+	o_btree_load_shmem(desc);
+	blkno = desc->rootInfo.rootPageBlkno;
+
+	lock_page(blkno);
+	while (true)
+	{
+		Page		p = O_GET_IN_MEMORY_PAGE(blkno);
+
+		if (O_PAGE_IS(p, LEAF))
+		{
+			/* Tree too shallow: root is a leaf, no internal downlink. */
+			unlock_page(blkno);
+			break;
+		}
+		else if (PAGE_GET_LEVEL(p) == 1)
+		{
+			BTreePageItemLocator loc;
+
+			BTREE_PAGE_FOREACH_ITEMS(p, &loc)
+			{
+				BTreeNonLeafTuphdr *tuphdr = (BTreeNonLeafTuphdr *)
+					BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
+
+				if (DOWNLINK_IS_ON_DISK(tuphdr->downlink))
+				{
+					FileExtent	fext;
+
+					fext.off = DOWNLINK_GET_DISK_OFF(tuphdr->downlink);
+					fext.len = (uint16) (new_len & 0x7FFF);
+					result_offset = fext.off;
+					tuphdr->downlink = MAKE_ON_DISK_DOWNLINK(fext);
+					break;
+				}
+			}
+			unlock_page(blkno);
+			break;
+		}
+		else
+		{
+			/* Descend to the leftmost child. */
+			BTreePageItemLocator loc;
+			BTreeNonLeafTuphdr *tuphdr;
+			OInMemoryBlkno child;
+
+			BTREE_PAGE_LOCATOR_FIRST(p, &loc);
+			tuphdr = (BTreeNonLeafTuphdr *)
+				BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
+
+			if (!DOWNLINK_IS_IN_MEMORY(tuphdr->downlink))
+			{
+				unlock_page(blkno);
+				ereport(ERROR,
+						(errmsg("leftmost child is not in memory")));
+			}
+			child = DOWNLINK_GET_IN_MEMORY_BLKNO(tuphdr->downlink);
+			lock_page(child);
+			unlock_page(blkno);
+			blkno = child;
+		}
+	}
+
+	relation_close(rel, AccessShareLock);
+
+	if (FileExtentOffIsValid(result_offset))
+		PG_RETURN_INT64((int64) result_offset);
+	PG_RETURN_NULL();
+}
+
+PG_FUNCTION_INFO_V1(orioledb_test_corrupt_compressed_page_size);
+
+/*
+ * Walk the primary index btree of the given relation to its leftmost
+ * level-1 page, find the first on-disk downlink whose extent length shows
+ * the leaf is actually compressed (len < ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ),
+ * read that page back from disk, overwrite its on-disk compress_page_size
+ * header field with the maximum uint16 value and recompute a matching
+ * checksum so the always-on checksum check passes on the next read.  This
+ * drives execution to the compress_page_size bound in read_page_from_disk().
+ * Returns the downlink's file offset, or NULL when no suitable compressed
+ * on-disk leaf was found.
+ *
+ * Test-only; guarded by IS_DEV.
+ */
+Datum
+orioledb_test_corrupt_compressed_page_size(PG_FUNCTION_ARGS)
+{
+	Oid			relid = PG_GETARG_OID(0);
+	Relation	rel;
+	OTableDescr *descr;
+	OIndexDescr *idx;
+	BTreeDescr *desc;
+	OInMemoryBlkno blkno;
+	FileExtent	extent;
+	bool		found = false;
+	uint64		result_offset = InvalidFileExtentOff;
+
+	Assert(!orioledb_s3_mode && !use_device && !use_mmap);
+
+	orioledb_check_shmem();
+
+	rel = relation_open(relid, AccessShareLock);
+	descr = relation_get_descr(rel);
+	if (!descr)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("relation oid %u is not orioledb", relid)));
+
+	idx = descr->indices[0];
+	desc = &idx->desc;
+	o_btree_load_shmem(desc);
+	blkno = desc->rootInfo.rootPageBlkno;
+
+	lock_page(blkno);
+	while (true)
+	{
+		Page		p = O_GET_IN_MEMORY_PAGE(blkno);
+
+		if (O_PAGE_IS(p, LEAF))
+		{
+			unlock_page(blkno);
+			break;
+		}
+		else if (PAGE_GET_LEVEL(p) == 1)
+		{
+			BTreePageItemLocator loc;
+
+			BTREE_PAGE_FOREACH_ITEMS(p, &loc)
+			{
+				BTreeNonLeafTuphdr *tuphdr = (BTreeNonLeafTuphdr *)
+					BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
+
+				if (DOWNLINK_IS_ON_DISK(tuphdr->downlink) &&
+					DOWNLINK_GET_DISK_LEN(tuphdr->downlink) <
+					(ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ))
+				{
+					extent.off = DOWNLINK_GET_DISK_OFF(tuphdr->downlink);
+					extent.len = DOWNLINK_GET_DISK_LEN(tuphdr->downlink);
+					found = true;
+					break;
+				}
+			}
+			unlock_page(blkno);
+			break;
+		}
+		else
+		{
+			BTreePageItemLocator loc;
+			BTreeNonLeafTuphdr *tuphdr;
+			OInMemoryBlkno child;
+
+			BTREE_PAGE_LOCATOR_FIRST(p, &loc);
+			tuphdr = (BTreeNonLeafTuphdr *)
+				BTREE_PAGE_LOCATOR_GET_ITEM(p, &loc);
+
+			if (!DOWNLINK_IS_IN_MEMORY(tuphdr->downlink))
+			{
+				unlock_page(blkno);
+				ereport(ERROR,
+						(errmsg("leftmost child is not in memory")));
+			}
+			child = DOWNLINK_GET_IN_MEMORY_BLKNO(tuphdr->downlink);
+			lock_page(child);
+			unlock_page(blkno);
+			blkno = child;
+		}
+	}
+
+	relation_close(rel, AccessShareLock);
+
+	if (!found)
+		PG_RETURN_NULL();
+
+	result_offset = extent.off;
+
+	{
+		off_t		byte_offset = (off_t) extent.off * (off_t) ORIOLEDB_COMP_BLCKSZ;
+		off_t		read_size = (off_t) extent.len * (off_t) ORIOLEDB_COMP_BLCKSZ;
+		char	   *buf;
+		OrioleDBOndiskPageHeader *hdr;
+
+		buf = (char *) palloc(read_size);
+		if (btree_smgr_read(desc, buf, 0, read_size, byte_offset) != read_size)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not read page to corrupt it")));
+
+		hdr = (OrioleDBOndiskPageHeader *) buf;
+		hdr->compress_page_size = UINT16_MAX;
+		hdr->checkSum = 0;
+		hdr->checkSum = (uint16) ((oriole_checksum_block(
+														 (const OrioleDBChecksummablePage *) buf,
+														 oriole_checksum_block_len((uint32) read_size)) % 65535) + 1);
+
+		if (btree_smgr_write(desc, buf, 0, read_size, byte_offset) != read_size)
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not write corrupted page")));
+
+		pfree(buf);
+	}
+
+	if (FileExtentOffIsValid(result_offset))
+		PG_RETURN_INT64((int64) result_offset);
+	PG_RETURN_NULL();
+}
+
+#endif							/* IS_DEV */

--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -1744,6 +1744,23 @@ read_disk_leaf_into_img(BTreeSeqScan *scan, uint64 downlinkLoc, CommitSeqNo csn)
 
 	read_result = read_page_from_disk(scan->desc, scan->leafImg, downlinkLoc,
 									  &extent);
+
+	/*
+	 * On a failed read scan->leafImg holds no valid page, so inspect its
+	 * header (and walk its undo chain) only after a successful read.
+	 */
+	if (read_result != OReadPageResultOk)
+	{
+		if (read_result == OReadPageResultChecksumFailed ||
+			read_result == OReadPageResultCorrupted)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg("invalid leaf page with file offset " UINT64_FORMAT " read from disk",
+							DOWNLINK_GET_DISK_OFF(downlinkLoc))));
+		else
+			elog(ERROR, "can not read leaf page from disk");
+	}
+
 	header = (BTreePageHeader *) scan->leafImg;
 
 	/*
@@ -1759,17 +1776,6 @@ read_disk_leaf_into_img(BTreeSeqScan *scan, uint64 downlinkLoc, CommitSeqNo csn)
 
 	STOPEVENT(STOPEVENT_SCAN_DISK_PAGE,
 			  btree_page_stopevent_params(scan->desc, scan->leafImg));
-
-	if (read_result != OReadPageResultOk)
-	{
-		if (read_result == OReadPageResultChecksumFailed)
-			ereport(ERROR,
-					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("invalid leaf page with file offset " UINT64_FORMAT " read from disk",
-							DOWNLINK_GET_DISK_OFF(downlinkLoc))));
-		else
-			elog(ERROR, "can not read leaf page from disk");
-	}
 }
 
 /*

--- a/src/checkpoint/checkpoint.c
+++ b/src/checkpoint/checkpoint.c
@@ -6121,7 +6121,8 @@ evictable_tree_init_meta(BTreeDescr *desc, EvictedTreeData **evicted_data,
 		if (read_result != OReadPageResultOk)
 		{
 			unlock_page(desc->rootInfo.rootPageBlkno);
-			if (read_result == OReadPageResultChecksumFailed)
+			if (read_result == OReadPageResultChecksumFailed ||
+				read_result == OReadPageResultCorrupted)
 				ereport(FATAL, (errcode(ERRCODE_DATA_CORRUPTED),
 								errmsg("invalid rootPageBlkno page in %s: %m",
 									   btree_smgr_filename(desc,

--- a/src/s3/worker.c
+++ b/src/s3/worker.c
@@ -803,6 +803,17 @@ s3_schedule_downlink_load(BTreeDescr *desc, uint64 downlink)
 	chkpNum = S3_GET_CHKP_NUM(offset);
 	offset &= S3_OFFSET_MASK;
 
+	/*
+	 * Apply the same extent bound as read_page_from_disk(): a crafted
+	 * downlink length would otherwise make the read_size loop below schedule
+	 * bogus parts from an attacker-controlled size.  Skip the prefetch; the
+	 * actual read rejects the corrupt page cleanly.
+	 */
+	if (len == 0 ||
+		len > (ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ) ||
+		(!OCompressIsValid(desc->compress) && len != 1))
+		return result;
+
 	if (!OCompressIsValid(desc->compress))
 	{
 		byte_offset = (off_t) offset * (off_t) ORIOLEDB_BLCKSZ;

--- a/test/t/compress_page_bounds_test.py
+++ b/test/t/compress_page_bounds_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import unittest
+
+from .base_test import BaseTest
+
+
+class CompressPageBoundsTest(BaseTest):
+	"""
+	Regression tests for ORI-263: read_page_from_disk() used the B-tree
+	downlink extent length and the on-disk compress_page_size header field
+	without bounds checking.  Crafted metadata could make it compute a
+	read_size far larger than the 8 KB stack buffer OrioleDBChecksummablePage
+	(stack smash) or hand o_decompress_page() a size beyond the bytes
+	actually fetched.  The fix rejects such metadata before any read or
+	decompression, raising ERRCODE_DATA_CORRUPTED instead of crashing.
+	"""
+
+	CONF = ("shared_preload_libraries = orioledb\n"
+	        "orioledb.main_buffers = 8MB\n"
+	        "orioledb.debug_disable_pools_limit = true\n"
+	        "orioledb.debug_disable_bgwriter = true\n")
+
+	def _make_compressed_table(self):
+		node = self.node
+		node.append_conf('postgresql.conf', self.CONF)
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+		node.safe_psql("""
+			CREATE TABLE o_bounds (
+				id int PRIMARY KEY,
+				payload text
+			) USING orioledb WITH (compress = 11);
+			INSERT INTO o_bounds
+				SELECT g, repeat('x', 200) FROM generate_series(1, 5000) g;
+		""")
+		# Evict leaves so the level-1 parent holds on-disk downlinks.
+		node.safe_psql("SELECT orioledb_evict_pages('o_bounds'::regclass, 0);")
+
+	def test_corrupt_downlink_len_overflow(self):
+		"""
+		A downlink length above ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ
+		(16) makes read_page_from_disk() compute read_size = len * 512 and
+		read that many bytes into the 8 KB stack buffer, smashing the stack.
+		The fix rejects the extent before the read; the backend raises
+		ERRCODE_DATA_CORRUPTED instead of crashing.  Without the fix this
+		overflows the stack (signal 6/11).
+		"""
+		self._make_compressed_table()
+		node = self.node
+
+		# 0x7FFF is the 15-bit maximum storable in a downlink.
+		self.assertIsNotNone(
+		    node.execute("SELECT orioledb_test_corrupt_downlink_len("
+		                 "'o_bounds'::regclass, 32767);")[0][0])
+
+		reader = node.connect()
+		reader.execute("SET LOCAL enable_indexscan = off;")
+		reader.execute("SET LOCAL enable_bitmapscan = off;")
+		with self.assertRaises(Exception) as cm:
+			reader.execute("SELECT * FROM o_bounds;")
+		self.assertIn("invalid leaf page", str(cm.exception))
+		reader.close()
+		node.stop()
+
+	def test_corrupt_downlink_len_zero(self):
+		"""
+		A zero downlink length is invalid metadata.  It is rejected before
+		read_size is computed, raising ERRCODE_DATA_CORRUPTED rather than
+		reading zero bytes and feeding garbage to decompression.
+		"""
+		self._make_compressed_table()
+		node = self.node
+
+		self.assertIsNotNone(
+		    node.execute("SELECT orioledb_test_corrupt_downlink_len("
+		                 "'o_bounds'::regclass, 0);")[0][0])
+
+		reader = node.connect()
+		reader.execute("SET LOCAL enable_indexscan = off;")
+		reader.execute("SET LOCAL enable_bitmapscan = off;")
+		with self.assertRaises(Exception) as cm:
+			reader.execute("SELECT * FROM o_bounds;")
+		self.assertIn("invalid leaf page", str(cm.exception))
+		reader.close()
+		node.stop()
+
+	def test_corrupt_compressed_page_size(self):
+		"""
+		An on-disk compress_page_size larger than the fetched extent makes
+		o_decompress_page() read past the bytes actually read.  The on-disk
+		page is rewritten with a matching checksum so the checksum check
+		(always on) passes and execution reaches the compress_page_size
+		bound, which rejects the page with ERRCODE_DATA_CORRUPTED.  Without
+		the fix zstd decompresses uninitialized stack and PANICs.
+		"""
+		self._make_compressed_table()
+		node = self.node
+
+		self.assertIsNotNone(
+		    node.execute("SELECT orioledb_test_corrupt_compressed_page_size("
+		                 "'o_bounds'::regclass);")[0][0])
+
+		reader = node.connect()
+		reader.execute("SET LOCAL enable_indexscan = off;")
+		reader.execute("SET LOCAL enable_bitmapscan = off;")
+		with self.assertRaises(Exception) as cm:
+			reader.execute("SELECT * FROM o_bounds;")
+		self.assertIn("invalid leaf page", str(cm.exception))
+		reader.close()
+		node.stop()
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
The downlink extent length and on-disk compress_page_size header field are attacker-controlled metadata. read_page_from_disk() used them to compute read_size and hand a size to o_decompress_page() without bounds checking: a length above ORIOLEDB_BLCKSZ / ORIOLEDB_COMP_BLCKSZ reads len * 512 bytes into the 8 KB stack buffer
OrioleDBChecksummablePage (stack smash), a zero length decompresses uninitialized data, and a crafted compress_page_size reads past the fetched extent.

Validate the extent offset/length before computing read_size and bound compress_page_size against the fetched bytes, raising ERRCODE_DATA_CORRUPTED (new OReadPageResultCorrupted) instead of crashing. Apply the same extent bound in s3_schedule_downlink_load(). Also fix read_disk_leaf_into_img() to check the read result before inspecting the (possibly garbage) page header and walking its undo chain. Add regression tests.