### PR TITLE
Fix ordered-scan assertion for non-leading PK columns

### DIFF
--- a/src/btree/scan.c
+++ b/src/btree/scan.c
@@ -244,7 +244,7 @@ struct BTreeSeqScan
 	 * mode.
 	 */
 	bool		haveOrderedPrev;
-	OFixedKey	orderedPrevKey;
+	OFixedTuple orderedPrevTuple;
 #endif
 
 	/*
@@ -3171,8 +3171,8 @@ btree_seq_scan_getnext(BTreeSeqScan *scan, MemoryContext mctx,
 				if (scan->haveOrderedPrev)
 				{
 					int			cmp = o_btree_cmp(scan->desc,
-												  &scan->orderedPrevKey.tuple,
-												  BTreeKeyNonLeafKey,
+												  &scan->orderedPrevTuple.tuple,
+												  BTreeKeyLeafTuple,
 												  &tuple, BTreeKeyLeafTuple);
 
 					/* forward: prev <= cur; backward: prev >= cur */
@@ -3181,7 +3181,7 @@ btree_seq_scan_getnext(BTreeSeqScan *scan, MemoryContext mctx,
 					else
 						Assert(cmp <= 0);
 				}
-				copy_fixed_key(scan->desc, &scan->orderedPrevKey, tuple);
+				copy_fixed_tuple(scan->desc, &scan->orderedPrevTuple, tuple);
 				scan->haveOrderedPrev = true;
 			}
 #endif

--- a/test/expected/parallel_scan.out
+++ b/test/expected/parallel_scan.out
@@ -1697,8 +1697,63 @@ SELECT * FROM
 
 RESET enable_material;
 COMMIT;
+-- Parallel ordered scan on primary index with non-leading PK columns.
+-- PK (c, a) on table (a, b, c): leaf tuples store columns in table order,
+-- nonLeafKeys in index key order.  The ordered-scan assertion must compare
+-- both sides as BTreeKeyLeafTuple, not mix leaf vs nonLeaf formats.
+BEGIN;
+CREATE TABLE o_test_nonlead_pk (
+	a int NOT NULL,
+	b int NOT NULL,
+	c int NOT NULL,
+	PRIMARY KEY (c, a)
+) USING orioledb;
+INSERT INTO o_test_nonlead_pk
+	SELECT i * 1000, i * 10, i FROM generate_series(1, 50000) i;
+ANALYZE o_test_nonlead_pk;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_nonlead_pk
+		WHERE sqrt(a::float8) >= 0
+		ORDER BY c, a
+		LIMIT 10;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
+         Workers Planned: 3
+         ->  Parallel Custom Scan (o_scan) on o_test_nonlead_pk
+               Filter: (sqrt((a)::double precision) >= '0'::double precision)
+               Forward index scan of: o_test_nonlead_pk_pkey
+(6 rows)
+
+SELECT * FROM o_test_nonlead_pk
+	WHERE sqrt(a::float8) >= 0
+	ORDER BY c, a
+	LIMIT 10;
+   a   |  b  | c  
+-------+-----+----
+  1000 |  10 |  1
+  2000 |  20 |  2
+  3000 |  30 |  3
+  4000 |  40 |  4
+  5000 |  50 |  5
+  6000 |  60 |  6
+  7000 |  70 |  7
+  8000 |  80 |  8
+  9000 |  90 |  9
+ 10000 | 100 | 10
+(10 rows)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 22 other objects
+NOTICE:  drop cascades to 23 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1721,6 +1776,7 @@ drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
 drop cascades to table o_test_parallel_bitmap_bridged
+drop cascades to table o_test_nonlead_pk
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_1.out
+++ b/test/expected/parallel_scan_1.out
@@ -1694,8 +1694,63 @@ SELECT * FROM
 
 RESET enable_material;
 COMMIT;
+-- Parallel ordered scan on primary index with non-leading PK columns.
+-- PK (c, a) on table (a, b, c): leaf tuples store columns in table order,
+-- nonLeafKeys in index key order.  The ordered-scan assertion must compare
+-- both sides as BTreeKeyLeafTuple, not mix leaf vs nonLeaf formats.
+BEGIN;
+CREATE TABLE o_test_nonlead_pk (
+	a int NOT NULL,
+	b int NOT NULL,
+	c int NOT NULL,
+	PRIMARY KEY (c, a)
+) USING orioledb;
+INSERT INTO o_test_nonlead_pk
+	SELECT i * 1000, i * 10, i FROM generate_series(1, 50000) i;
+ANALYZE o_test_nonlead_pk;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_nonlead_pk
+		WHERE sqrt(a::float8) >= 0
+		ORDER BY c, a
+		LIMIT 10;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
+         Workers Planned: 3
+         ->  Parallel Custom Scan (o_scan) on o_test_nonlead_pk
+               Filter: (sqrt((a)::double precision) >= '0'::double precision)
+               Forward index scan of: o_test_nonlead_pk_pkey
+(6 rows)
+
+SELECT * FROM o_test_nonlead_pk
+	WHERE sqrt(a::float8) >= 0
+	ORDER BY c, a
+	LIMIT 10;
+   a   |  b  | c  
+-------+-----+----
+  1000 |  10 |  1
+  2000 |  20 |  2
+  3000 |  30 |  3
+  4000 |  40 |  4
+  5000 |  50 |  5
+  6000 |  60 |  6
+  7000 |  70 |  7
+  8000 |  80 |  8
+  9000 |  90 |  9
+ 10000 | 100 | 10
+(10 rows)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 22 other objects
+NOTICE:  drop cascades to 23 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1718,6 +1773,7 @@ drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
 drop cascades to table o_test_parallel_bitmap_bridged
+drop cascades to table o_test_nonlead_pk
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/expected/parallel_scan_2.out
+++ b/test/expected/parallel_scan_2.out
@@ -1694,8 +1694,63 @@ SELECT * FROM
 
 RESET enable_material;
 COMMIT;
+-- Parallel ordered scan on primary index with non-leading PK columns.
+-- PK (c, a) on table (a, b, c): leaf tuples store columns in table order,
+-- nonLeafKeys in index key order.  The ordered-scan assertion must compare
+-- both sides as BTreeKeyLeafTuple, not mix leaf vs nonLeaf formats.
+BEGIN;
+CREATE TABLE o_test_nonlead_pk (
+	a int NOT NULL,
+	b int NOT NULL,
+	c int NOT NULL,
+	PRIMARY KEY (c, a)
+) USING orioledb;
+INSERT INTO o_test_nonlead_pk
+	SELECT i * 1000, i * 10, i FROM generate_series(1, 50000) i;
+ANALYZE o_test_nonlead_pk;
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_nonlead_pk
+		WHERE sqrt(a::float8) >= 0
+		ORDER BY c, a
+		LIMIT 10;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
+         Workers Planned: 3
+         ->  Parallel Custom Scan (o_scan) on o_test_nonlead_pk
+               Filter: (sqrt((a)::double precision) >= '0'::double precision)
+               Forward index scan of: o_test_nonlead_pk_pkey
+(6 rows)
+
+SELECT * FROM o_test_nonlead_pk
+	WHERE sqrt(a::float8) >= 0
+	ORDER BY c, a
+	LIMIT 10;
+   a   |  b  | c  
+-------+-----+----
+  1000 |  10 |  1
+  2000 |  20 |  2
+  3000 |  30 |  3
+  4000 |  40 |  4
+  5000 |  50 |  5
+  6000 |  60 |  6
+  7000 |  70 |  7
+  8000 |  80 |  8
+  9000 |  90 |  9
+ 10000 | 100 | 10
+(10 rows)
+
+COMMIT;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 22 other objects
+NOTICE:  drop cascades to 23 other objects
 DETAIL:  drop cascades to table seq_scan_test
 drop cascades to table o_test_o_scan_register
 drop cascades to table o_test_1
@@ -1718,6 +1773,7 @@ drop cascades to table o_test_ordered_scan
 drop cascades to table o_test_parallel_bitmap
 drop cascades to table o_test_parallel_bitmap_fixed
 drop cascades to table o_test_parallel_bitmap_bridged
+drop cascades to table o_test_nonlead_pk
 DROP SCHEMA parallel_scan CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to function pseudo_random(bigint,bigint)

--- a/test/sql/parallel_scan.sql
+++ b/test/sql/parallel_scan.sql
@@ -863,6 +863,40 @@ SELECT * FROM
 RESET enable_material;
 COMMIT;
 
+-- Parallel ordered scan on primary index with non-leading PK columns.
+-- PK (c, a) on table (a, b, c): leaf tuples store columns in table order,
+-- nonLeafKeys in index key order.  The ordered-scan assertion must compare
+-- both sides as BTreeKeyLeafTuple, not mix leaf vs nonLeaf formats.
+BEGIN;
+CREATE TABLE o_test_nonlead_pk (
+	a int NOT NULL,
+	b int NOT NULL,
+	c int NOT NULL,
+	PRIMARY KEY (c, a)
+) USING orioledb;
+INSERT INTO o_test_nonlead_pk
+	SELECT i * 1000, i * 10, i FROM generate_series(1, 50000) i;
+ANALYZE o_test_nonlead_pk;
+
+SET LOCAL max_parallel_workers_per_gather = 3;
+SET LOCAL min_parallel_table_scan_size = 1;
+SET LOCAL min_parallel_index_scan_size = 1;
+SET LOCAL parallel_setup_cost = 0;
+SET LOCAL parallel_tuple_cost = 0;
+SET LOCAL enable_seqscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+	SELECT * FROM o_test_nonlead_pk
+		WHERE sqrt(a::float8) >= 0
+		ORDER BY c, a
+		LIMIT 10;
+SELECT * FROM o_test_nonlead_pk
+	WHERE sqrt(a::float8) >= 0
+	ORDER BY c, a
+	LIMIT 10;
+COMMIT;
+
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA parallel_scan CASCADE;
 RESET search_path;


### PR DESCRIPTION
Store and compare the previous value as a full leaf tuple (OFixedTuple / BTreeKeyLeafTuple / copy_fixed_tuple) instead of truncating it to a nonLeafKey. Follow-up for parallel ordered scan feature.

The ordered-scan debug check in btree_seq_scan_getnext() stored the previous leaf tuple via copy_fixed_key (OKeyLength, i.e. nonLeafSpec->len bytes) and then compared it as BTreeKeyNonLeafKey against the next BTreeKeyLeafTuple.  For a primary index whose key columns are not the leading table columns (e.g. PRIMARY KEY (c, a) on table (a, b, c)), leaf tuples store fields in table order while nonLeafKeys use index key order, so the copied bytes were not a valid nonLeafKey.  The comparison read wrong field values and could report cmp > 0 on a correctly ordered stream, crashing all parallel workers with Assert(cmp <= 0).

Fixes: #1138 