### PR TITLE
Fix unsigned underflow in tableGetMaxChunkSize for large composite PKs

### DIFF
--- a/src/tuple/toast.c
+++ b/src/tuple/toast.c
@@ -286,7 +286,21 @@ tableGetMaxChunkSize(void *key, void *arg)
 	minTupleSize = o_new_tuple_size(toast->leafTupdesc, &toast->leafSpec,
 									NULL, NULL, 1, values, isnull, NULL);
 
-	return MAXALIGN_DOWN(O_BTREE_MAX_TUPLE_SIZE * 3 - MAXALIGN(minTupleSize)) / 3 - minTupleSize - sizeof(LocationIndex);
+	{
+		uint32		total = O_BTREE_MAX_TUPLE_SIZE * 3;
+		uint32		aligned = MAXALIGN(minTupleSize);
+		uint32		available;
+
+		if (aligned >= total)
+			return 0;
+
+		available = MAXALIGN_DOWN(total - aligned) / 3;
+
+		if (available <= minTupleSize + sizeof(LocationIndex))
+			return 0;
+
+		return available - minTupleSize - sizeof(LocationIndex);
+	}
 }
 
 static void
@@ -446,6 +460,9 @@ generic_toast_insert_optional_wal(ToastAPI *api, void *key, Pointer data,
 
 	Assert(data_size > 0);
 
+	if (max_length == 0)
+		return false;
+
 	while (data_size > 0)
 	{
 		OTuple		tup;
@@ -522,6 +539,9 @@ generic_toast_sort_add(ToastAPI *api, void *key,
 
 	Assert(data_size > 0);
 
+	if (max_length == 0)
+		return;
+
 	while (data_size > 0)
 	{
 		OTuple		tup;
@@ -596,6 +616,9 @@ generic_toast_update_optional_wal(ToastAPI *api, void *key, Pointer data,
 	};
 
 	Assert(data_size > 0);
+
+	if (max_length == 0)
+		return false;
 
 	while (data_size > 0)
 	{
@@ -961,6 +984,11 @@ o_toast_insert(OTableDescr *descr, OTuple pk, uint16 attn,
 
 	Assert(descr->toast->desc.type == oIndexToast);
 
+	if (tableGetMaxChunkSize(&tkey, &arg) == 0)
+		o_btree_check_size_of_tuple(O_BTREE_MAX_TUPLE_SIZE + 1,
+									NameStr(GET_PRIMARY(descr)->name),
+									false);
+
 	result = generic_toast_insert(&tableToastAPI, &tkey, data,
 								  data_size, oxid, csn, &arg);
 
@@ -980,6 +1008,11 @@ o_toast_sort_add(OTableDescr *descr, OTuple pk, uint16 attn,
 	tkey.chunknum = 0;
 
 	Assert(descr->toast->desc.type == oIndexToast);
+
+	if (tableGetMaxChunkSize(&tkey, &arg) == 0)
+		o_btree_check_size_of_tuple(O_BTREE_MAX_TUPLE_SIZE + 1,
+									NameStr(GET_PRIMARY(descr)->name),
+									false);
 
 	generic_toast_sort_add(&tableToastAPI, (Pointer) &tkey, data,
 						   data_size, sortstate, &arg);

--- a/test/expected/toast.out
+++ b/test/expected/toast.out
@@ -2398,6 +2398,23 @@ DROP TABLE o_sm_nulls;
 DROP TABLE o_sm_upsert;
 DROP FUNCTION generate_string(integer, integer);
 RESET max_parallel_workers_per_gather;
+-- Toast chunk underflow: composite PK with large text column leaves no room
+-- for toast chunk data.  Use STORAGE EXTERNAL to prevent compression.
+CREATE TABLE o_toast_large_pk (
+	a int NOT NULL,
+	b text NOT NULL,
+	payload text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+ALTER TABLE o_toast_large_pk ALTER COLUMN payload SET STORAGE EXTERNAL;
+INSERT INTO o_toast_large_pk VALUES (1, 'small', repeat('x', 5000));
+-- PK text column large enough that toast chunks can't fit
+INSERT INTO o_toast_large_pk VALUES (2, repeat('y', 2600), repeat('x', 5000));
+ERROR:  index row size 2689 exceeds orioledb maximum 2688 for table "o_toast_large_pk_pkey"
+-- UPDATE that enlarges the PK text column
+UPDATE o_toast_large_pk SET b = repeat('z', 2600) WHERE a = 1;
+ERROR:  index row size 2689 exceeds orioledb maximum 2688 for table "o_toast_large_pk_pkey"
+DROP TABLE o_toast_large_pk;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/expected/toast_1.out
+++ b/test/expected/toast_1.out
@@ -2401,6 +2401,23 @@ DROP TABLE o_sm_nulls;
 DROP TABLE o_sm_upsert;
 DROP FUNCTION generate_string(integer, integer);
 RESET max_parallel_workers_per_gather;
+-- Toast chunk underflow: composite PK with large text column leaves no room
+-- for toast chunk data.  Use STORAGE EXTERNAL to prevent compression.
+CREATE TABLE o_toast_large_pk (
+	a int NOT NULL,
+	b text NOT NULL,
+	payload text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+ALTER TABLE o_toast_large_pk ALTER COLUMN payload SET STORAGE EXTERNAL;
+INSERT INTO o_toast_large_pk VALUES (1, 'small', repeat('x', 5000));
+-- PK text column large enough that toast chunks can't fit
+INSERT INTO o_toast_large_pk VALUES (2, repeat('y', 2600), repeat('x', 5000));
+ERROR:  index row size 2689 exceeds orioledb maximum 2688 for table "o_toast_large_pk_pkey"
+-- UPDATE that enlarges the PK text column
+UPDATE o_toast_large_pk SET b = repeat('z', 2600) WHERE a = 1;
+ERROR:  index row size 2689 exceeds orioledb maximum 2688 for table "o_toast_large_pk_pkey"
+DROP TABLE o_toast_large_pk;
 SELECT orioledb_parallel_debug_stop();
  orioledb_parallel_debug_stop 
 ------------------------------

--- a/test/sql/toast.sql
+++ b/test/sql/toast.sql
@@ -1038,6 +1038,23 @@ DROP TABLE o_sm_upsert;
 DROP FUNCTION generate_string(integer, integer);
 RESET max_parallel_workers_per_gather;
 
+-- Toast chunk underflow: composite PK with large text column leaves no room
+-- for toast chunk data.  Use STORAGE EXTERNAL to prevent compression.
+CREATE TABLE o_toast_large_pk (
+	a int NOT NULL,
+	b text NOT NULL,
+	payload text,
+	PRIMARY KEY (a, b)
+) USING orioledb;
+ALTER TABLE o_toast_large_pk ALTER COLUMN payload SET STORAGE EXTERNAL;
+
+INSERT INTO o_toast_large_pk VALUES (1, 'small', repeat('x', 5000));
+-- PK text column large enough that toast chunks can't fit
+INSERT INTO o_toast_large_pk VALUES (2, repeat('y', 2600), repeat('x', 5000));
+-- UPDATE that enlarges the PK text column
+UPDATE o_toast_large_pk SET b = repeat('z', 2600) WHERE a = 1;
+DROP TABLE o_toast_large_pk;
+
 SELECT orioledb_parallel_debug_stop();
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA toast CASCADE;


### PR DESCRIPTION
tableGetMaxChunkSize() computed the maximum toast chunk data size with a single unsigned expression that silently wrapped to very big value when the composite primary key was large. With the underflowed max_length, generic_toast_insert_optional_wal() put the entire datum into one chunk whose tuple exceeded O_BTREE_MAX_TUPLE_SIZE. With cassert the assert at modify.c:882 fired (SIGABRT); without cassert the oversized tuple was written to the btree page, corrupting it.

E.g. a table with PRIMARY KEY (int, text) and a STORAGE EXTERNAL. INSERT with a ~2600-byte text key and a 5000-byte payload triggers the underflow because the toast chunk minimum tuple size (~2626 bytes, which embeds the full PK) is close to O_BTREE_MAX_TUPLE_SIZE (~2688 bytes), making the subtraction negative in unsigned arithmetic.

Fixes #1142 