### PR TITLE
Reject forged proc-cache native-code metadata before loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ sql/orioledb--1.5--1.6.sql
 sql/orioledb--1.6--1.7.sql
 sql/orioledb--1.7--1.8.sql
 sql/orioledb--1.8--1.9.sql
+sql/orioledb--1.9--1.10.sql
 
 # Exclude the PostGIS Docker build directory
 /docker-postgis

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
 						test/t/rewind_xid_evict_large_test.py \
 						test/t/page_fit_items_test.py \
 						test/t/page_level_guard_test.py \
+						test/t/proc_cache_guard_test.py \
 						test/t/move_database_test.py \
 						test/t/database_template_test.py
 TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \

--- a/sql/orioledb--1.9--1.10_dev.sql
+++ b/sql/orioledb--1.9--1.10_dev.sql
@@ -7,3 +7,11 @@ CREATE FUNCTION orioledb_test_corrupt_row_undo(relid oid)
 RETURNS text
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_test_corrupt_proc_cache(procoid oid,
+												 probin text,
+												 prosrc text,
+												 prolang oid)
+RETURNS text
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/src/catalog/o_proc_cache.c
+++ b/src/catalog/o_proc_cache.c
@@ -2094,6 +2094,86 @@ o_proc_cache_delete_if_stale(Oid datoid, Oid procoid)
 }
 
 /*
+ * o_proc_cache_verify_native_metadata
+ *
+ * The proc cache is backed by an on-disk system tree whose contents can be
+ * forged independently of the authoritative pg_proc catalog.  Before the
+ * cached prolanguage, source symbol and library path are used to load native
+ * code (C-language and internal-language functions), re-read the real pg_proc
+ * row and require the fields to match; on mismatch, refuse to load and fail
+ * closed instead of executing an attacker-selected native symbol.
+ *
+ * fmgr_symbol() reproduces exactly the (probin, prosrc) pair that
+ * o_proc_cache_fill_entry stored -- including the "fmgr_security_definer"
+ * substitution for SECURITY DEFINER / SET / hook-needing functions -- so a
+ * legitimate cache entry always compares equal and legitimate C functions keep
+ * working.
+ *
+ * Verification runs only when the regular catalog is the authoritative source
+ * of metadata, i.e. when OrioleDB's syscache hook is not installed.  In the
+ * catalog-free background paths (recovery, checkpointer) the hook is the only
+ * available source and the proc cache was populated from WAL validated on the
+ * primary, so the cached metadata is trusted there as before; this also keeps
+ * the hook from recursing back into the proc cache during the lookup.
+ */
+static void
+o_proc_cache_verify_native_metadata(Oid procoid, OProc *o_proc)
+{
+	HeapTuple	proctup;
+	Form_pg_proc procform;
+	char	   *auth_probin = NULL;
+	char	   *auth_prosrc = NULL;
+	Oid			auth_prolang;
+	bool		mismatch = false;
+
+	/* Only when the real catalog is reachable and authoritative. */
+	if (o_is_syscache_hooks_set())
+		return;
+
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(procoid));
+	if (!HeapTupleIsValid(proctup))
+		elog(ERROR, "cache lookup failed for function %u", procoid);
+	procform = (Form_pg_proc) GETSTRUCT(proctup);
+	auth_prolang = procform->prolang;
+
+	/*
+	 * fmgr_symbol() does its own pg_proc lookup; since the hook is not set
+	 * here, that reaches the real catalog rather than the (possibly forged)
+	 * cached tuple.
+	 */
+	fmgr_symbol(procoid, &auth_probin, &auth_prosrc);
+
+	if (o_proc->prolang != auth_prolang)
+		mismatch = true;
+	else if ((o_proc->prosrc == NULL) != (auth_prosrc == NULL) ||
+			 (o_proc->prosrc != NULL &&
+			  strcmp(o_proc->prosrc, auth_prosrc) != 0))
+		mismatch = true;
+	else if ((o_proc->probin == NULL) != (auth_probin == NULL) ||
+			 (o_proc->probin != NULL &&
+			  strcmp(o_proc->probin, auth_probin) != 0))
+		mismatch = true;
+
+	if (auth_probin != NULL)
+		pfree(auth_probin);
+	if (auth_prosrc != NULL)
+		pfree(auth_prosrc);
+	ReleaseSysCache(proctup);
+
+	if (mismatch)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("OrioleDB procedure cache metadata for function %u "
+						"does not match the system catalog",
+						procoid),
+				 errdetail("The cached function language, source symbol or "
+						   "library path differed from pg_proc."),
+				 errhint("The OrioleDB system tree may be corrupt; rebuild "
+						 "the affected index or run "
+						 "orioledb_upgrade_refresh().")));
+}
+
+/*
  * o_proc_cache_fill_finfo
  *
  * Fill FmgrInfo for procoid in the provided database context.
@@ -2131,6 +2211,7 @@ o_proc_cache_fill_finfo(FmgrInfo *finfo, Oid procoid, Oid datoid)
 	}
 	else if (o_proc->prolang == INTERNALlanguageId)
 	{
+		o_proc_cache_verify_native_metadata(procoid, o_proc);
 		fbp = fmgr_lookupByName(o_proc->prosrc);
 		if (fbp == NULL)
 			ereport(ERROR,
@@ -2143,6 +2224,7 @@ o_proc_cache_fill_finfo(FmgrInfo *finfo, Oid procoid, Oid datoid)
 	}
 	else if (o_proc->prolang == ClanguageId)
 	{
+		o_proc_cache_verify_native_metadata(procoid, o_proc);
 		finfo->fn_stats = TRACK_FUNC_PL;
 		finfo->fn_addr = load_external_function(o_proc->probin,
 												o_proc->prosrc,
@@ -2237,3 +2319,61 @@ o_proc_cache_search_htup(TupleDesc tupdesc, Oid procoid)
 	}
 	return result;
 }
+
+#ifdef IS_DEV
+PG_FUNCTION_INFO_V1(orioledb_test_corrupt_proc_cache);
+
+/*
+ * Test-only (IS_DEV): forge the in-memory proc-cache entry for procoid so its
+ * prolanguage / source symbol / library path differ from the authoritative
+ * pg_proc row, exercising o_proc_cache_fill_finfo's native-code verification
+ * guard.  A legitimate entry is populated from the catalog first, then this
+ * backend's fast-cache copy is overwritten in place.  The on-disk system tree
+ * is left untouched, so the effect is scoped to the current session.
+ */
+Datum
+orioledb_test_corrupt_proc_cache(PG_FUNCTION_ARGS)
+{
+	Oid			procoid = PG_GETARG_OID(0);
+	char	   *probin = PG_ARGISNULL(1) ? NULL :
+		text_to_cstring(PG_GETARG_TEXT_PP(1));
+	char	   *prosrc = PG_ARGISNULL(2) ? NULL :
+		text_to_cstring(PG_GETARG_TEXT_PP(2));
+	Oid			prolang = PG_GETARG_OID(3);
+	OProc	   *o_proc;
+	XLogRecPtr	cur_lsn;
+	Oid			datoid;
+	List	   *processed = NIL;
+	MemoryContext oldcxt;
+
+	orioledb_check_shmem();
+
+	/* Populate a legitimate entry from the catalog first. */
+	o_collect_function_by_oid(procoid, InvalidOid, &processed);
+	list_free_deep(processed);
+
+	o_sys_cache_set_datoid_lsn(&cur_lsn, &datoid);
+	o_proc = o_proc_cache_search(datoid, procoid, cur_lsn,
+								 proc_cache->nkeys);
+	if (o_proc == NULL)
+		elog(ERROR, "proc cache entry for function %u not found", procoid);
+
+	/*
+	 * Overwrite the in-memory copy of this backend's fast-cache entry.  The
+	 * on-disk system tree is left untouched, so the effect is scoped to the
+	 * current session and the caller must drive the subsequent descriptor
+	 * fill from the same connection.
+	 */
+	oldcxt = MemoryContextSwitchTo(o_proc->cxt);
+	if (o_proc->prosrc != NULL)
+		pfree(o_proc->prosrc);
+	if (o_proc->probin != NULL)
+		pfree(o_proc->probin);
+	o_proc->prolang = prolang;
+	o_proc->prosrc = (prosrc != NULL) ? pstrdup(prosrc) : NULL;
+	o_proc->probin = (probin != NULL) ? pstrdup(probin) : NULL;
+	MemoryContextSwitchTo(oldcxt);
+
+	PG_RETURN_TEXT_P(cstring_to_text("ok"));
+}
+#endif							/* IS_DEV */

--- a/test/t/proc_cache_guard_test.py
+++ b/test/t/proc_cache_guard_test.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import os
+
+from test.t.base_test import BaseTest
+from testgres.enums import NodeStatus
+from testgres.exceptions import QueryException
+
+GUARD_ERR_NEEDLE = "does not match the system catalog"
+
+
+class ProcCacheGuardTest(BaseTest):
+	"""
+	Regression coverage for forged procedure-cache native-code loading.
+
+	OrioleDB's procedure cache is backed by an on-disk system tree whose
+	contents can be tampered with independently of the authoritative pg_proc
+	catalog.  o_proc_cache_fill_finfo() must therefore re-read the real
+	pg_proc row (bypassing OrioleDB's hook on the alive node, where the hook
+	is not installed) and require the cached prolang / prosrc / probin to
+	match before it loads native code for a non-builtin C or internal-language
+	function; a mismatch is rejected with a controlled ERROR instead of
+	dlopen()-ing / fmgr_lookupByName()-ing an attacker-selected symbol.
+
+	Builtin functions (fixed bootstrap OIDs, served by fmgr_isbuiltin()) are
+	inherently immune -- their function pointer comes from a hardcoded table,
+	not the cache -- so the guard only matters for non-builtin procedures.
+	Core range support procs (e.g. range_cmp) are builtins, so the test
+	builds a custom btree opclass whose comparator is a user-defined C
+	function o_test_cmp (a fresh, non-builtin OID) that points at an existing
+	exported orioledb symbol.  A btree index on that opclass drives the guard.
+
+	The IS_DEV helper orioledb_test_corrupt_proc_cache() populates the legit
+	entry from the catalog and then overwrites this backend's in-memory copy
+	in place, simulating on-disk tampering that survived a restart.  Because
+	the procedure cache lives in per-process TopMemoryContext and a comparator
+	resolution is cached per backend, the corruption must run in the same
+	backend that performs the index build and before any descriptor fill has
+	cached the comparator; the forge tests hold a single autocommit
+	connection open for both.
+	"""
+
+	def _setup(self, node):
+		"""Create the extension, a table and a non-builtin C comparator
+		opclass on int4."""
+		node.safe_psql("CREATE EXTENSION IF NOT EXISTS orioledb;")
+		node.safe_psql("""
+			CREATE TABLE proc_guard (
+				id int PRIMARY KEY,
+				k int4
+			) USING orioledb;
+		""")
+		node.safe_psql("""
+			CREATE FUNCTION o_test_cmp(a int4, b int4) RETURNS int4
+			AS '$libdir/orioledb', 'orioledb_int4range_immutable'
+			LANGUAGE C IMMUTABLE;
+
+			CREATE OPERATOR CLASS o_test_int4_ops FOR TYPE int4 USING btree AS
+				OPERATOR 1 <,
+				OPERATOR 2 <=,
+				OPERATOR 3 =,
+				OPERATOR 4 >=,
+				OPERATOR 5 >,
+				FUNCTION 1 o_test_cmp(int4, int4);
+		""")
+
+	def _test_cmp_meta(self, con):
+		"""Return (probin, prosrc, prolang) of the real o_test_cmp row."""
+		return con.execute(
+		    "SELECT probin::text, prosrc, prolang::oid FROM pg_proc "
+		    "WHERE proname = 'o_test_cmp';")[0]
+
+	def _internal_lang_oid(self, con):
+		return con.execute(
+		    "SELECT oid FROM pg_language WHERE lanname = 'internal';")[0][0]
+
+	def _assert_no_crash(self, node):
+		self.assertEqual(
+		    node.status(), NodeStatus.Running,
+		    "node crashed while rejecting forged proc-cache "
+		    "metadata")
+		with open(os.path.join(node.logs_dir, 'postgresql.log')) as f:
+			log = f.read()
+		self.assertNotIn("TRAP: failed Assert", log)
+		self.assertNotIn("Segmentation fault", log)
+		self.assertNotIn("terminated by signal", log)
+
+	def test_legit_non_builtin_c_comparator_index_builds(self):
+		"""A legitimate non-builtin C comparator must not trip the guard."""
+		node = self.node
+		node.start()
+		self._setup(node)
+		# Empty table: the comparator is resolved (guard verifies the legit
+		# entry) but never called during the build.
+		node.safe_psql(
+		    "CREATE INDEX proc_guard_k_idx ON proc_guard (k o_test_int4_ops);")
+		valid = node.execute(
+		    "SELECT indisvalid FROM pg_index WHERE indexrelid = "
+		    "'proc_guard_k_idx'::regclass;")[0][0]
+		self.assertTrue(valid)
+		node.stop()
+
+	def _forge_and_expect_error(self, corrupt):
+		"""In one fresh backend: populate+forge the o_test_cmp cache entry,
+		then build a btree index on the custom opclass and assert the guard
+		rejects it without crashing.  ``corrupt`` maps the real (probin,
+		prosrc, prolang, con) to the forged triple."""
+		node = self.node
+		node.start()
+		self._setup(node)
+
+		# One persistent autocommit backend for the forge + the index build.
+		# The corruption must precede any descriptor fill in this backend so
+		# that the comparator resolution (cached per backend) reads the
+		# forged entry rather than a previously cached legit one.
+		con = node.connect(autocommit=True)
+		try:
+			probin, prosrc, prolang = self._test_cmp_meta(con)
+			fprobin, fprosrc, fprolang = corrupt(probin, prosrc, prolang, con)
+
+			oid = con.execute(
+			    "SELECT oid FROM pg_proc WHERE proname = 'o_test_cmp';")[0][0]
+			con.execute(
+			    "SELECT orioledb_test_corrupt_proc_cache(%s, %s, %s, %s);",
+			    oid, fprobin, fprosrc, fprolang)
+
+			raised = False
+			try:
+				con.execute("CREATE INDEX proc_guard_k_idx ON proc_guard "
+				            "(k o_test_int4_ops);")
+			except Exception as e:
+				raised = True
+				self.assertIn(
+				    GUARD_ERR_NEEDLE, str(e),
+				    "unexpected error for forged proc-cache "
+				    "metadata: " + str(e))
+			self.assertTrue(
+			    raised, "forged proc-cache metadata was loaded as native code "
+			    "without being rejected")
+			self._assert_no_crash(node)
+		finally:
+			con.close()
+		node.stop()
+
+	def test_forged_prosrc_rejected(self):
+		"""A forged source symbol must be rejected before dlopen()."""
+		self._forge_and_expect_error(lambda p, s, l, c: (p, 'evil_symbol', l))
+
+	def test_forged_probin_rejected(self):
+		"""A forged library path must be rejected before dlopen()."""
+		self._forge_and_expect_error(lambda p, s, l, c:
+		                             ('/tmp/evil_path', s, l))
+
+	def test_forged_prolang_rejected(self):
+		"""A forged language (C -> internal) must be rejected."""
+
+		def corrupt(p, s, l, c):
+			return (p, s, self._internal_lang_oid(c))
+
+		self._forge_and_expect_error(corrupt)


### PR DESCRIPTION
A forged procedure-cache entry can carry attacker-chosen prolang, source symbol and library path that load_external_function()/fmgr_lookupByName() would otherwise use to load and execute an attacker-selected native symbol during index descriptor fills. o_proc_cache_fill_finfo() now re-reads the authoritative pg_proc row (authoritative on the alive node, where the OrioleDB syscache hook is not installed) and requires prolang, prosrc and probin to match the cached entry, failing closed with a controlled error on mismatch; fmgr_symbol() reproduces the exact stored pair so legitimate C/INTERNAL support functions keep working, while catalog-free recovery paths keep trusting the WAL-validated cache. Adds an IS_DEV test helper and a testgres regression test.