### PR TITLE
Fix wrong transaction id used when removing CIC spool directory

### DIFF
--- a/src/catalog/indices.c
+++ b/src/catalog/indices.c
@@ -1078,7 +1078,7 @@ o_define_index_concurrent_finish(Relation heap, Relation index)
 	 * root, missing our drained/covering rows.
 	 */
 
-	cic_spool_drop_dir(tableOids, oxid);
+	cic_spool_drop_dir(tableOids, idx->builderOxid);
 
 	o_invalidate_oids(idx_oids);
 

--- a/test/t/concurrent_index_test.py
+++ b/test/t/concurrent_index_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import glob
 import os
 import time
 import unittest
@@ -59,6 +60,40 @@ class ConcurrentIndexTest(BaseTest):
 			self.assertEqual(cnt, 1)
 			cnt = node.execute("SELECT count(*) FROM o_cic_basic;")[0][0]
 			self.assertEqual(cnt, 1000)
+		finally:
+			try:
+				node.stop()
+			except Exception:
+				pass
+
+	def test_cic_no_leftover_spool_dir(self):
+		"""
+		Once a CIC build finishes normally, the cic_<...> spool
+		directory made for it must be gone. Otherwise, running CIC
+		over and over would keep leaving empty directories behind and
+		slowly use up disk space.
+		"""
+		node = self.node
+		node.start()
+		try:
+			node.safe_psql("""
+				CREATE EXTENSION orioledb;
+				CREATE TABLE o_cic_no_leftover (
+					id int NOT NULL,
+					val text NOT NULL,
+					PRIMARY KEY (id)
+				) USING orioledb;
+				INSERT INTO o_cic_no_leftover
+				SELECT g, 'v' || g FROM generate_series(1, 100) g;
+			""")
+			node.safe_psql("CREATE INDEX CONCURRENTLY o_cic_no_leftover_val_idx "
+			               "ON o_cic_no_leftover (val);")
+
+			data_dir = os.path.join(node.data_dir, "orioledb_data")
+			leftover = glob.glob(os.path.join(data_dir, "cic_*"))
+			self.assertEqual(leftover, [],
+			                 "CIC left a spool directory behind after "
+			                 "a successful build: %s" % leftover)
 		finally:
 			try:
 				node.stop()


### PR DESCRIPTION
When a `CREATE INDEX CONCURRENTLY` build finishes, we try to remove the temporary spool directory that was used to record changes made while the index was being built. The directory name is based on the transaction id of the build itself, but the cleanup code was passing the id of the current (finishing) transaction instead, which is a different one. Because of this, the cleanup call could not find the directory and did nothing, so it was left behind on disk. Every time a user ran `CREATE INDEX CONCURRENTLY`, another leftover directory would accumulate, slowly using up disk space.

This fix uses the same transaction id that was used to create the spool directory, so it is found and removed as intended. A test is added that runs a normal `CREATE INDEX CONCURRENTLY` and checks that no spool directory is left behind afterwards.