### PR TITLE
Add apt fallback for Ubuntu mirror outages

### DIFF
--- a/.github/workflows/dockertest.yml
+++ b/.github/workflows/dockertest.yml
@@ -54,6 +54,7 @@ jobs:
           build-args: |
             ALPINE_VERSION=${{ matrix.distr == 'alpine' && matrix.distr-version || '' }}
             UBUNTU_VERSION=${{ matrix.distr == 'ubuntu' && matrix.distr-version || '' }}
+            UBUNTU_APT_FALLBACK=${{ matrix.distr == 'ubuntu' && 'azure.archive.ubuntu.com' || '' }}
             PG_MAJOR=${{ matrix.postgres }}
             BUILD_CC_COMPILER=${{ matrix.compiler }}
             DOCKER_PG_LLVM_DEPS=llvm-dev clang

--- a/ci/prerequisites.sh
+++ b/ci/prerequisites.sh
@@ -24,9 +24,54 @@ while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
 	sleep 3
 done
 
-sudo apt-get update -qq
+apt_update()
+{
+	sudo apt-get \
+		-o APT::Update::Error-Mode=any \
+		-o Acquire::http::Timeout=30 \
+		-o Acquire::https::Timeout=30 \
+		update -qq
+}
 
-sudo apt-get -y install -qq wget ca-certificates
+use_azure_mirror()
+{
+	echo "Ubuntu mirrors unavailable, retrying with azure.archive.ubuntu.com"
+	for source_file in /etc/apt/sources.list \
+		/etc/apt/sources.list.d/*.list \
+		/etc/apt/sources.list.d/*.sources; do
+		[ -f "$source_file" ] || continue
+		sudo sed -Ei \
+			-e 's|://([a-z0-9-]+\.)?archive\.ubuntu\.com|://azure.archive.ubuntu.com|g' \
+			-e 's|://security\.ubuntu\.com|://azure.archive.ubuntu.com|g' \
+			"$source_file"
+	done
+	apt_update
+}
+
+apt_install()
+{
+	if sudo apt-get \
+		-o Dpkg::Options::="--force-confdef" \
+		-o Dpkg::Options::="--force-confold" \
+		-o Acquire::http::Timeout=30 \
+		-o Acquire::https::Timeout=30 \
+		-y install -qq "$@"; then
+		return
+	fi
+	use_azure_mirror
+	sudo apt-get \
+		-o Dpkg::Options::="--force-confdef" \
+		-o Dpkg::Options::="--force-confold" \
+		-o Acquire::http::Timeout=30 \
+		-o Acquire::https::Timeout=30 \
+		-y install -qq "$@"
+}
+
+if ! apt_update; then
+	use_azure_mirror
+fi
+
+apt_install wget ca-certificates
 
 apt_packages="build-essential flex bison pkg-config libreadline-dev make gdb libipc-run-perl libicu-dev python3-full python3-pip python3-setuptools python3-testresources libzstd1 libzstd-dev libcurl4-openssl-dev libssl-dev lcov"
 
@@ -47,7 +92,7 @@ if [ $CHECK_TYPE = "dm_log_writes" ]; then
 fi
 
 # install required packages
-sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y install -qq $apt_packages
+apt_install $apt_packages
 
 if [ $CHECK_TYPE = "dm_log_writes" ]; then
 	# dm-log-writes is built into the CI runner kernels; abort early if a

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -8,6 +8,7 @@ ARG UBUNTU_VERSION=noble
 FROM ubuntu:${UBUNTU_VERSION}
 
 ARG UBUNTU_VERSION
+ARG UBUNTU_APT_FALLBACK
 
 # Set PG_MAJOR = [ 17 16 ]
 ARG PG_MAJOR=17
@@ -39,7 +40,25 @@ RUN set -eux; \
 	chown -R postgres:postgres /var/lib/postgresql
 
 RUN set -eux; \
-	apt-get update; \
+	apt_update() { \
+		apt-get \
+			-o APT::Update::Error-Mode=any \
+			-o Acquire::http::Timeout=30 \
+			-o Acquire::https::Timeout=30 \
+			update; \
+	}; \
+	if ! apt_update; then \
+		test -n "${UBUNTU_APT_FALLBACK:-}"; \
+		echo "Ubuntu mirrors unavailable, retrying with $UBUNTU_APT_FALLBACK"; \
+		for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do \
+			[ -f "$source_file" ] || continue; \
+			sed -Ei \
+				-e "s|://([a-z0-9-]+\.)?archive\.ubuntu\.com|://${UBUNTU_APT_FALLBACK}|g" \
+				-e "s|://security\.ubuntu\.com|://${UBUNTU_APT_FALLBACK}|g" \
+				"$source_file"; \
+		done; \
+		apt_update; \
+	fi; \
 	DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y; \
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		ca-certificates \


### PR DESCRIPTION
Canonical's Ubuntu mirrors can intermittently fail or hang on Blacksmith runners. Detect update failures and retry through azure.archive.ubuntu.com before installing CI prerequisites.