### PR TITLE
Fix bridged expression index updates

### DIFF
--- a/src/tableam/operations.c
+++ b/src/tableam/operations.c
@@ -44,6 +44,7 @@
 #include "catalog/storage.h"
 #include "commands/vacuum.h"
 #include "nodes/execnodes.h"
+#include "optimizer/optimizer.h"
 #include "parser/parsetree.h"
 #include "pgstat.h"
 #if PG_VERSION_NUM >= 180000
@@ -1726,6 +1727,7 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 		ListCell   *indexId;
 		int			attnum;
 		TupleTableSlot *newSlot;
+		/* Match pull_varattnos()'s offset attribute-number representation. */
 		Bitmapset  *changed_attrs = NULL;
 
 		/*
@@ -1760,7 +1762,8 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 				 !datumIsEqual(oldSlot->tts_values[attnum], newSlot->tts_values[attnum],
 							   attr->attbyval, attr->attlen)))
 			{
-				changed_attrs = bms_add_member(changed_attrs, attnum);
+				changed_attrs = bms_add_member(changed_attrs,
+											   attnum + 1 - FirstLowInvalidHeapAttributeNumber);
 			}
 		}
 
@@ -1775,7 +1778,8 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 			{
 				 /* Assuming that tts_isnull big enough */ ;
 				oldSlot->tts_isnull[attnum] = true;
-				changed_attrs = bms_add_member(changed_attrs, attnum);
+				changed_attrs = bms_add_member(changed_attrs,
+											   attnum + 1 - FirstLowInvalidHeapAttributeNumber);
 			}
 		}
 
@@ -1793,48 +1797,29 @@ o_tbl_update(OTableDescr *descr, TupleTableSlot *slot,
 			}
 			if (interesting)
 			{
+				Bitmapset  *index_attrs = NULL;
+
 				for (attnum = 0; attnum < index_rel->rd_index->indnatts; attnum++)
 				{
 					AttrNumber	tbl_attnum = index_rel->rd_index->indkey.values[attnum];
 
-					if (index_rel->rd_indpred != NIL)
-					{
-						ExprState  *predicate;
-						EState	   *estate;
-						ExprContext *econtext;
-
-						estate = CreateExecutorState();
-						predicate = ExecPrepareQual(index_rel->rd_indpred, estate);
-
-						econtext = GetPerTupleExprContext(estate);
-						econtext->ecxt_scantuple = newSlot;
-
-						/*
-						 * Skip this index-update if the predicate isn't
-						 * satisfied
-						 */
-						if (!ExecQual(predicate, econtext))
-						{
-							FreeExecutorState(estate);
-							continue;
-						}
-						FreeExecutorState(estate);
-					}
-
 					if (AttributeNumberIsValid(tbl_attnum))
-					{
-						if (bms_is_member(tbl_attnum - 1, changed_attrs))
-							touched_indices = true;
-					}
-					else
-					{
-						Assert(false);	/* Expression indices not implemented
-										 * yet. */
-					}
-
-					if (touched_indices)
-						break;
+						index_attrs = bms_add_member(index_attrs,
+													 tbl_attnum - FirstLowInvalidHeapAttributeNumber);
 				}
+
+				pull_varattnos((Node *) index_rel->rd_indexprs, 1,
+							   &index_attrs);
+				pull_varattnos((Node *) index_rel->rd_indpred, 1,
+							   &index_attrs);
+
+				if ((!bms_is_empty(changed_attrs) &&
+					 bms_is_member(0 - FirstLowInvalidHeapAttributeNumber,
+								   index_attrs)) ||
+					bms_overlap(changed_attrs, index_attrs))
+					touched_indices = true;
+
+				bms_free(index_attrs);
 			}
 			index_close(index_rel, AccessExclusiveLock);
 		}

--- a/test/expected/index_bridging.out
+++ b/test/expected/index_bridging.out
@@ -5216,9 +5216,54 @@ SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
 (1 row)
 
 DROP TABLE o_bridge_pk2;
+-- Updates must maintain bridged expression indexes and enforce uniqueness.
+CREATE TABLE o_bridge_expr (
+	id int PRIMARY KEY,
+	value text,
+	payload text
+) USING orioledb;
+CREATE UNIQUE INDEX o_bridge_expr_lower_idx ON o_bridge_expr (lower(value))
+	WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_expr'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+INSERT INTO o_bridge_expr VALUES (1, 'Alpha', 'one'), (2, 'Beta', 'two');
+SELECT count(*) FROM btree_index_content('o_bridge_expr_lower_idx');
+ count 
+-------
+     2
+(1 row)
+
+UPDATE o_bridge_expr SET payload = 'changed' WHERE id = 1;
+SELECT count(*) FROM btree_index_content('o_bridge_expr_lower_idx');
+ count 
+-------
+     2
+(1 row)
+
+UPDATE o_bridge_expr SET value = 'Gamma' WHERE id = 1;
+SET enable_seqscan = off;
+SELECT id, value FROM o_bridge_expr WHERE lower(value) = 'gamma';
+ id | value 
+----+-------
+  1 | Gamma
+(1 row)
+
+UPDATE o_bridge_expr SET value = 'GAMMA' WHERE id = 2;
+ERROR:  duplicate key value violates unique constraint "o_bridge_expr_lower_idx"
+DETAIL:  Key (lower(value))=(gamma) already exists.
+SELECT id, value FROM o_bridge_expr ORDER BY id;
+ id | value 
+----+-------
+  1 | Gamma
+  2 | Beta
+(2 rows)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 39 other objects
+NOTICE:  drop cascades to 40 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -5258,6 +5303,7 @@ drop cascades to table o_bridge_sec_gin
 drop cascades to table o_bridge_sec_btree
 drop cascades to table o_bridge_ioc
 drop cascades to table o_bridge_mixed
+drop cascades to table o_bridge_expr
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/expected/index_bridging_1.out
+++ b/test/expected/index_bridging_1.out
@@ -5293,9 +5293,54 @@ SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
 (1 row)
 
 DROP TABLE o_bridge_pk2;
+-- Updates must maintain bridged expression indexes and enforce uniqueness.
+CREATE TABLE o_bridge_expr (
+	id int PRIMARY KEY,
+	value text,
+	payload text
+) USING orioledb;
+CREATE UNIQUE INDEX o_bridge_expr_lower_idx ON o_bridge_expr (lower(value))
+	WITH (orioledb_index=off);
+WARNING:  using bridged btree index for orioledb
+DETAIL:  This feature is intended for testing purposes and is not recommended for normal usage.
+NOTICE:  index bridging is enabled for orioledb table 'o_bridge_expr'
+DETAIL:  index access method 'btree' is requested with index bridging for OrioleDB table
+INSERT INTO o_bridge_expr VALUES (1, 'Alpha', 'one'), (2, 'Beta', 'two');
+SELECT count(*) FROM btree_index_content('o_bridge_expr_lower_idx');
+ count 
+-------
+     2
+(1 row)
+
+UPDATE o_bridge_expr SET payload = 'changed' WHERE id = 1;
+SELECT count(*) FROM btree_index_content('o_bridge_expr_lower_idx');
+ count 
+-------
+     2
+(1 row)
+
+UPDATE o_bridge_expr SET value = 'Gamma' WHERE id = 1;
+SET enable_seqscan = off;
+SELECT id, value FROM o_bridge_expr WHERE lower(value) = 'gamma';
+ id | value 
+----+-------
+  1 | Gamma
+(1 row)
+
+UPDATE o_bridge_expr SET value = 'GAMMA' WHERE id = 2;
+ERROR:  duplicate key value violates unique constraint "o_bridge_expr_lower_idx"
+DETAIL:  Key (lower(value))=(gamma) already exists.
+SELECT id, value FROM o_bridge_expr ORDER BY id;
+ id | value 
+----+-------
+  1 | Gamma
+  2 | Beta
+(2 rows)
+
+RESET enable_seqscan;
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
-NOTICE:  drop cascades to 39 other objects
+NOTICE:  drop cascades to 40 other objects
 DETAIL:  drop cascades to table o_test_ix_ams
 drop cascades to table o_test_bridging_with_regular_no_pkey
 drop cascades to table o_test_bridging_with_regular_pkey
@@ -5335,6 +5380,7 @@ drop cascades to table o_bridge_sec_gin
 drop cascades to table o_bridge_sec_btree
 drop cascades to table o_bridge_ioc
 drop cascades to table o_bridge_mixed
+drop cascades to table o_bridge_expr
 DROP SCHEMA index_bridging CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to function btree_index_content(name)

--- a/test/sql/index_bridging.sql
+++ b/test/sql/index_bridging.sql
@@ -1341,6 +1341,27 @@ SELECT count(*), sum(a * 1000 + b) FROM o_bridge_pk2
 	WHERE tags @> ARRAY[3] OR (a, b) IN ((0, 5), (7, 10), (20, 40), (39, 49));
 DROP TABLE o_bridge_pk2;
 
+-- Updates must maintain bridged expression indexes and enforce uniqueness.
+CREATE TABLE o_bridge_expr (
+	id int PRIMARY KEY,
+	value text,
+	payload text
+) USING orioledb;
+CREATE UNIQUE INDEX o_bridge_expr_lower_idx ON o_bridge_expr (lower(value))
+	WITH (orioledb_index=off);
+INSERT INTO o_bridge_expr VALUES (1, 'Alpha', 'one'), (2, 'Beta', 'two');
+
+SELECT count(*) FROM btree_index_content('o_bridge_expr_lower_idx');
+UPDATE o_bridge_expr SET payload = 'changed' WHERE id = 1;
+SELECT count(*) FROM btree_index_content('o_bridge_expr_lower_idx');
+
+UPDATE o_bridge_expr SET value = 'Gamma' WHERE id = 1;
+SET enable_seqscan = off;
+SELECT id, value FROM o_bridge_expr WHERE lower(value) = 'gamma';
+UPDATE o_bridge_expr SET value = 'GAMMA' WHERE id = 2;
+SELECT id, value FROM o_bridge_expr ORDER BY id;
+RESET enable_seqscan;
+
 DROP EXTENSION pageinspect;
 DROP EXTENSION orioledb CASCADE;
 DROP SCHEMA index_bridging CASCADE;


### PR DESCRIPTION
Track expression and predicate column dependencies during updates so bridged indexes receive new CTIDs only when needed, preserving uniqueness checks without rewriting unrelated entries.

Partial indexes remain handled by PostgreSQL's normal predicate evaluation: changes to predicate dependencies replace the bridge CTID, while unrelated updates retain the existing mapping.