### PR TITLE
Validate system-tree numbers before indexing fixed arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ TESTGRESCHECKS_PART_1 = test/t/amcheck_test.py \
 						test/t/page_fit_items_test.py \
 						test/t/page_level_guard_test.py \
 						test/t/proc_cache_guard_test.py \
+						test/t/sys_tree_guard_test.py \
 						test/t/move_database_test.py \
 						test/t/database_template_test.py
 TESTGRESCHECKS_PART_2 = test/t/checkpoint_concurrent_test.py \

--- a/sql/orioledb--1.9--1.10_dev.sql
+++ b/sql/orioledb--1.9--1.10_dev.sql
@@ -15,3 +15,9 @@ CREATE FUNCTION orioledb_test_corrupt_proc_cache(procoid oid,
 RETURNS text
 AS 'MODULE_PATHNAME'
 VOLATILE LANGUAGE C;
+
+CREATE FUNCTION orioledb_test_wal_parse_relation(datoid oid,
+												 relnode oid)
+RETURNS text
+AS 'MODULE_PATHNAME'
+VOLATILE LANGUAGE C;

--- a/src/btree/io.c
+++ b/src/btree/io.c
@@ -3034,6 +3034,14 @@ walk_page_prelock_check(OInMemoryBlkno blkno, bool evict,
 	 */
 	if (IS_SYS_TREE_OIDS(*oids))
 	{
+		/*
+		 * Defensively reject an out-of-range system-tree number before it
+		 * indexes fixed arrays.  Under normal operation the page descriptor
+		 * oids are stamped from a valid BTreeDescr, but a corrupted shared
+		 * memory state could carry a forged value.
+		 */
+		if (oids->relnode < 1 || oids->relnode > SYS_TREES_NUM)
+			return NULL;
 		if (sys_tree_get_storage_type(oids->relnode) != BTreeStorageInMemory)
 			desc = get_sys_tree(oids->relnode);
 		else

--- a/src/catalog/sys_trees.c
+++ b/src/catalog/sys_trees.c
@@ -477,6 +477,8 @@ sys_trees_shmem_init(Pointer ptr, bool found)
 BTreeDescr *
 get_sys_tree(int tree_num)
 {
+	if (tree_num < 1 || tree_num > SYS_TREES_NUM)
+		elog(ERROR, "invalid system tree number: %d", tree_num);
 	Assert(tree_num >= 1 && tree_num <= SYS_TREES_NUM);
 	sys_tree_init_if_needed(tree_num - 1);
 
@@ -486,6 +488,8 @@ get_sys_tree(int tree_num)
 BTreeDescr *
 get_sys_tree_no_init(int tree_num)
 {
+	if (tree_num < 1 || tree_num > SYS_TREES_NUM)
+		elog(ERROR, "invalid system tree number: %d", tree_num);
 	Assert(tree_num >= 1 && tree_num <= SYS_TREES_NUM);
 
 	if (!sysTreesDescrs[tree_num - 1].initialized)
@@ -671,24 +675,32 @@ orioledb_sys_tree_rows(PG_FUNCTION_ARGS)
 bool
 sys_tree_supports_transactions(int tree_num)
 {
+	if (tree_num < 1 || tree_num > SYS_TREES_NUM)
+		elog(ERROR, "invalid system tree number: %d", tree_num);
 	return sysTreesMeta[tree_num - 1].undoLogType != UndoLogNone;
 }
 
 BTreeStorageType
 sys_tree_get_storage_type(int tree_num)
 {
+	if (tree_num < 1 || tree_num > SYS_TREES_NUM)
+		elog(ERROR, "invalid system tree number: %d", tree_num);
 	return sysTreesMeta[tree_num - 1].storageType;
 }
 
 void
 sys_tree_set_extra(int tree_num, Pointer extra)
 {
+	if (tree_num < 1 || tree_num > SYS_TREES_NUM)
+		elog(ERROR, "invalid system tree number: %d", tree_num);
 	sysTreesMeta[tree_num - 1].extra = extra;
 }
 
 Pointer
 sys_tree_get_extra(int tree_num)
 {
+	if (tree_num < 1 || tree_num > SYS_TREES_NUM)
+		elog(ERROR, "invalid system tree number: %d", tree_num);
 	return sysTreesMeta[tree_num - 1].extra;
 }
 

--- a/src/orioledb.c
+++ b/src/orioledb.c
@@ -368,6 +368,112 @@ wal_desc_on_record(WalReaderState *r, WalRecord *rec)
 	}
 	return WALPARSE_OK;
 }
+
+/*
+ * Minimal on_record callback for the WAL parse test helper: accept every
+ * delivered record without touching its fields.
+ */
+static WalParseResult
+test_wal_on_record(WalReaderState *r, WalRecord *rec)
+{
+	return WALPARSE_OK;
+}
+
+PG_FUNCTION_INFO_V1(orioledb_test_wal_parse_relation);
+
+/*
+ * Test-only (IS_DEV): feed a hand-built WAL container holding a single
+ * WAL_REC_RELATION record to wal_parse_container() and return the parse
+ * result as text.  This exercises the relnode bounds check in
+ * wal_parse_rec_relation() without needing a running recovery stream.
+ *
+ * A forged container is assembled with version = ORIOLEDB_WAL_VERSION,
+ * no flags, and one RELATION record whose (datoid, relnode) come from
+ * the caller.  When datoid == SYS_TREES_DATOID and relnode is outside
+ * 1..SYS_TREES_NUM, the parser must reject it with WALPARSE_BAD_TYPE
+ * instead of accepting an out-of-range system-tree number that would
+ * index fixed arrays out of bounds.
+ */
+Datum
+orioledb_test_wal_parse_relation(PG_FUNCTION_ARGS)
+{
+	Oid			datoid = PG_GETARG_OID(0);
+	Oid			relnode = PG_GETARG_OID(1);
+	StringInfoData buf;
+	WalReaderState r;
+	WalParseResult st;
+	const char *result_name;
+
+	uint16		version = ORIOLEDB_WAL_VERSION;
+	uint8		flags = 0;
+	uint8		rec_type = WAL_REC_RELATION;
+	uint8		tree_type = 0;
+	Oid			reloid = relnode;
+	OXid		xmin = 0;
+	CommitSeqNo csn = COMMITSEQNO_FROZEN;
+	CommandId	cid = 0;
+	uint32		rel_version = 0;
+	uint32		base_version = 0;
+	Oid			spcoid = 0;
+
+	initStringInfo(&buf);
+
+	/* Container header: version + flags */
+	appendBinaryStringInfo(&buf, (char *) &version, sizeof(version));
+	appendBinaryStringInfo(&buf, (char *) &flags, sizeof(flags));
+
+	/* Record tag */
+	appendBinaryStringInfo(&buf, (char *) &rec_type, sizeof(rec_type));
+
+	/*
+	 * WAL_REC_RELATION payload (layout since ORIOLEDB_WAL_VERSION >= 17).
+	 * WR_PARSE() copies raw bytes via memcpy, so field order must match
+	 * wal_parse_rec_relation() exactly.
+	 */
+	appendBinaryStringInfo(&buf, (char *) &tree_type, sizeof(tree_type));
+	appendBinaryStringInfo(&buf, (char *) &datoid, sizeof(datoid));
+	appendBinaryStringInfo(&buf, (char *) &reloid, sizeof(reloid));
+	appendBinaryStringInfo(&buf, (char *) &relnode, sizeof(relnode));
+	appendBinaryStringInfo(&buf, (char *) &xmin, sizeof(xmin));
+	appendBinaryStringInfo(&buf, (char *) &csn, sizeof(csn));
+	appendBinaryStringInfo(&buf, (char *) &cid, sizeof(cid));
+	appendBinaryStringInfo(&buf, (char *) &rel_version, sizeof(rel_version));
+	appendBinaryStringInfo(&buf, (char *) &base_version, sizeof(base_version));
+	/* spcoid (since ORIOLEDB_REL_TABLESPACE_WAL_VERSION) */
+	appendBinaryStringInfo(&buf, (char *) &spcoid, sizeof(spcoid));
+
+	memset(&r, 0, sizeof(r));
+	r.start = (Pointer) buf.data;
+	r.end = (Pointer) (buf.data + buf.len);
+	r.ptr = (Pointer) buf.data;
+	r.on_record = test_wal_on_record;
+
+	st = wal_parse_container(&r, false);
+
+	switch (st)
+	{
+		case WALPARSE_OK:
+			result_name = "ok";
+			break;
+		case WALPARSE_STOP:
+			result_name = "stop";
+			break;
+		case WALPARSE_EOF:
+			result_name = "eof";
+			break;
+		case WALPARSE_BAD_TYPE:
+			result_name = "bad_type";
+			break;
+		case WALPARSE_BAD_VERSION:
+			result_name = "bad_version";
+			break;
+		default:
+			result_name = "unknown";
+			break;
+	}
+
+	PG_RETURN_TEXT_P(cstring_to_text(result_name));
+}
 #endif
 
 static void

--- a/src/recovery/wal_reader.c
+++ b/src/recovery/wal_reader.c
@@ -141,6 +141,18 @@ wal_parse_rec_relation(WalReaderState *r, WalRecord *rec)
 	WR_PARSE(r, &rec->oids.reloid);
 	WR_PARSE(r, &rec->oids.relnode);
 
+	/*
+	 * When the datoid marks this as a system-tree relation, relnode is
+	 * interpreted as a system-tree number and used to index fixed arrays
+	 * (sysTreesMeta, sysTreesDescrs).  A forged or truncated WAL container
+	 * could carry an out-of-range value; reject it here before any consumer
+	 * dereferences the array, returning WALPARSE_BAD_TYPE as for any other
+	 * unparseable record.
+	 */
+	if (rec->oids.datoid == SYS_TREES_DATOID &&
+		(rec->oids.relnode < 1 || rec->oids.relnode > SYS_TREES_NUM))
+		return WALPARSE_BAD_TYPE;
+
 	if (r->container.version >= 17)
 	{
 		OXid		xmin;

--- a/test/t/sys_tree_guard_test.py
+++ b/test/t/sys_tree_guard_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+from test.t.base_test import BaseTest
+
+SYS_TREES_DATOID = 1
+SYS_TREES_NUM = 23
+
+
+class SysTreeGuardTest(BaseTest):
+	"""
+	Regression coverage for unchecked system-tree index values.
+
+	Recovery and page-walking code accepts a serialized relation-node
+	value as a system-tree number after checking only the identifier
+	type (datoid == SYS_TREES_DATOID).  An out-of-range relnode indexes
+	fixed arrays (sysTreesMeta, sysTreesDescrs) without runtime bounds
+	validation, potentially crashing recovery or maintenance and
+	preventing cluster startup.
+
+	The IS_DEV helper orioledb_test_wal_parse_relation() feeds a
+	hand-built WAL container holding a single WAL_REC_RELATION record
+	to wal_parse_container() and returns the parse result.  When
+	datoid == SYS_TREES_DATOID and relnode is outside 1..SYS_TREES_NUM,
+	the parser must reject it with WALPARSE_BAD_TYPE instead of
+	accepting an out-of-range system-tree number.
+	"""
+
+	def test_out_of_range_sys_tree_relnode_rejected(self):
+		"""A WAL_REC_RELATION with datoid=SYS_TREES_DATOID and an
+		out-of-range relnode must be rejected as WALPARSE_BAD_TYPE."""
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+
+		con = node.connect()
+		try:
+			for relnode in (0, SYS_TREES_NUM + 1, 999999):
+				result = con.execute(
+				    "SELECT orioledb_test_wal_parse_relation(%s::oid, "
+				    "%s::oid);", SYS_TREES_DATOID, relnode)[0][0]
+				self.assertEqual(
+				    result, "bad_type",
+				    "out-of-range system-tree relnode %d was not "
+				    "rejected by the WAL parser (got %r, expected "
+				    "'bad_type')" % (relnode, result))
+		finally:
+			con.close()
+		node.stop()
+
+	def test_valid_sys_tree_relnode_accepted(self):
+		"""A WAL_REC_RELATION with datoid=SYS_TREES_DATOID and a
+		valid in-range relnode must be accepted by the parser."""
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+
+		con = node.connect()
+		try:
+			for tree_num in (1, SYS_TREES_NUM):
+				result = con.execute(
+				    "SELECT orioledb_test_wal_parse_relation(%s::oid, "
+				    "%s::oid);", SYS_TREES_DATOID, tree_num)[0][0]
+				self.assertEqual(
+				    result, "ok",
+				    "valid system-tree relnode %d was rejected by "
+				    "the WAL parser (got %r, expected 'ok')" %
+				    (tree_num, result))
+		finally:
+			con.close()
+		node.stop()
+
+	def test_non_sys_tree_datoid_not_rejected(self):
+		"""A WAL_REC_RELATION whose datoid is not SYS_TREES_DATOID
+		must not be rejected at the system-tree bounds check, even
+		with an unusual relnode, because the relnode is not
+		interpreted as a system-tree number in that case."""
+		node = self.node
+		node.start()
+		node.safe_psql("CREATE EXTENSION orioledb;")
+
+		con = node.connect()
+		try:
+			result = con.execute(
+			    "SELECT orioledb_test_wal_parse_relation(%s::oid, "
+			    "%s::oid);", SYS_TREES_DATOID + 1, SYS_TREES_NUM + 1)[0][0]
+			self.assertEqual(
+			    result, "ok",
+			    "non-system-tree datoid was incorrectly rejected by "
+			    "the WAL parser (got %r, expected 'ok')" % (result, ))
+		finally:
+			con.close()
+		node.stop()


### PR DESCRIPTION
Recovery and page-walking code accepted a serialized relnode value as a system-tree number after checking only the datoid identifier type, so an out-of-range value indexed the fixed sysTreesMeta/sysTreesDescrs arrays without runtime bounds validation.  Add a relnode bounds check in wal_parse_rec_relation() returning WALPARSE_BAD_TYPE, a defensive guard in walk_page_prelock_check(), and elog(ERROR) validation in the sys_trees array helpers.  An IS_DEV test helper and testgres coverage exercise the malformed-WAL path.

---

Not sure about tests, are they needed in that form, but leaving them